### PR TITLE
UCC constructor/destructor

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,7 +15,16 @@ nobase_dist_libucc_la_HEADERS = \
 	api/ucc_version.h           \
 	api/ucc_status.h            
 
-libucc_la_SOURCES = core/ucc_lib.c 
+noinst_HEADERS =             \
+	core/ucc_global_opts.h   \
+	utils/ucc_compiler_def.h \
+	utils/ucc_log.h          \
+	utils/ucc_parser.h
+
+libucc_la_SOURCES =        \
+	core/ucc_lib.c         \
+	core/ucc_constructor.c \
+	core/ucc_global_opts.c
 
 libucc_ladir = $(includedir)
 

--- a/src/api/ucc_status.h
+++ b/src/api/ucc_status.h
@@ -17,13 +17,11 @@
 
 typedef enum {
     /* Operation completed successfully */
-    UCC_OK                              =   0,
+    UCC_OK                              =    0,
 
-    /* Operation is posted and is in progress */
-    UCC_INPROGRESS                      =   1,
+    UCC_INPROGRESS                      =    1, /*!< Operation is posted and is in progress */
 
-    /* Operation initialized but not posted */
-    UCC_OPERATION_INITIALIZED           =   2,
+    UCC_OPERATION_INITIALIZED           =    2, /*!< Operation initialized but not posted */
 
     /* Error status codes */
     UCC_ERR_OP_NOT_SUPPORTED            =   -1,
@@ -31,6 +29,7 @@ typedef enum {
     UCC_ERR_INVALID_PARAM               =   -3,
     UCC_ERR_NO_MEMORY                   =   -4,
     UCC_ERR_NO_RESOURCE                 =   -5,
+    UCC_ERR_NO_MESSAGE                  =   -6, /*!< General purpose return code without specific error */
     UCC_ERR_LAST                        = -100,
 } ucc_status_t;
 

--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "ucc_global_opts.h"
+#include "utils/ucc_malloc.h"
+#include <link.h>
+#include <dlfcn.h>
+#include <string.h>
+
+static int callback(struct dl_phdr_info *info, size_t size, void *data)
+{
+    char *str;
+    char *component_path;
+    if (NULL != (str = strstr(info->dlpi_name, "libucc.so"))) {
+        int pos        = (int)(str - info->dlpi_name);
+        component_path = (char *)ucc_malloc(pos + 8);
+        if (!component_path) {
+            //TODO add ucc_error(msg) when logging as added
+            return -1;
+        }
+        ucc_strncpy_safe(component_path, info->dlpi_name, pos);
+        component_path[pos] = '\0';
+        strcat(component_path, "ucc");
+        ucc_global_config.component_path =
+            ucc_global_config.component_path_default = component_path;
+    }
+    return 0;
+}
+
+static void get_default_lib_path()
+{
+    dl_iterate_phdr(callback, NULL);
+}
+
+ucc_status_t ucc_constructor(void)
+{
+    ucc_status_t status;
+    if (!ucc_global_config.initialized) {
+        ucc_global_config.initialized            = 1;
+        ucc_global_config.component_path_default = NULL;
+
+        status = ucc_config_parser_fill_opts(
+            &ucc_global_config, ucc_global_config_table, "UCC_", NULL, 1);
+        if (UCC_OK != status) {
+            //TODO add ucc_error(msg) when logging is added
+            return status;
+        }
+        if (strlen(ucc_global_config.component_path) == 0) {
+            get_default_lib_path();
+        }
+    }
+    return UCC_OK;
+}
+
+__attribute__((destructor)) static void ucc_destructor(void)
+{
+    if (ucc_global_config.component_path_default) {
+        ucc_free(ucc_global_config.component_path_default);
+    }
+}

--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_global_opts.h"
+#include "utils/ucc_compiler_def.h"
+
+ucc_global_config_t ucc_global_config = {
+    .log_component  = {UCC_LOG_LEVEL_WARN, "UCC"},
+    .component_path = "",
+    .initialized    = 0,
+};
+
+ucc_config_field_t ucc_global_config_table[] = {
+    {"LOG_LEVEL", "warn",
+     "UCC logging level. Messages with a level higher or equal to the selected "
+     "will be printed.\n"
+     "Possible values are: fatal, error, warn, info, debug, trace, data, func, "
+     "poll.",
+     ucc_offsetof(ucc_global_config_t, log_component),
+     UCC_CONFIG_TYPE_LOG_COMP},
+
+    {"COMPONENT_PATH", "", "Specifies dynamic components location",
+     ucc_offsetof(ucc_global_config_t, component_path), UCC_CONFIG_TYPE_STRING},
+
+    NULL};
+UCC_CONFIG_REGISTER_TABLE(ucc_global_config_table, "UCC global", NULL,
+                          ucc_global_config)

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_GLOBAL_OPTS_H_
+#define UCC_GLOBAL_OPTS_H_
+
+#include "config.h"
+
+#include "utils/ucc_parser.h"
+#include "utils/ucc_log.h"
+
+typedef struct ucc_global_config {
+    /* Log level above which log messages will be printed*/
+    ucc_log_component_config_t log_component;
+
+    /* Coll component libraries path */
+    char *component_path;
+    char *component_path_default;
+    int   initialized;
+} ucc_global_config_t;
+
+extern ucc_global_config_t ucc_global_config;
+extern ucc_config_field_t  ucc_global_config_table[];
+
+ucc_status_t ucc_constructor(void);
+
+#endif

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -8,8 +8,9 @@
 #  include "config.h"
 #endif
 
-#include <api/ucc.h>
-#include <api/ucc_status.h>
+#include "ucc_global_opts.h"
+#include "api/ucc.h"
+#include "api/ucc_status.h"
 
 ucc_status_t ucc_init_version(unsigned api_major_version,
                               unsigned api_minor_version,

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -4,9 +4,7 @@
  * See file LICENSE for terms.
  */
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
+#include "config.h"
 
 #include "ucc_global_opts.h"
 #include "api/ucc.h"

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_COMPILER_DEF_H_
+#define UCC_COMPILER_DEF_H_
+
+#include "config.h"
+#include "api/ucc_status.h"
+#include <ucs/type/status.h>
+#include <ucs/sys/string.h>
+
+#define ucc_offsetof ucs_offsetof
+#define ucc_container_of ucs_container_of
+#define ucc_strncpy_safe ucs_strncpy_safe
+
+static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
+{
+    switch (status) {
+    case UCS_OK:
+        return UCC_OK;
+    case UCS_INPROGRESS:
+        return UCC_INPROGRESS;
+    case UCS_ERR_NO_MEMORY:
+        return UCC_ERR_NO_MEMORY;
+    case UCS_ERR_INVALID_PARAM:
+        return UCC_ERR_INVALID_PARAM;
+    case UCS_ERR_NO_RESOURCE:
+        return UCC_ERR_NO_RESOURCE;
+    default:
+        break;
+    }
+    return UCC_ERR_NO_MESSAGE;
+}
+#endif

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_LOG_H_
+#define UCC_LOG_H_
+
+#include "config.h"
+#include <ucs/debug/log_def.h>
+
+typedef ucs_log_component_config_t ucc_log_component_config_t;
+#define UCC_LOG_LEVEL_WARN UCS_LOG_LEVEL_WARN
+
+#endif

--- a/src/utils/ucc_malloc.h
+++ b/src/utils/ucc_malloc.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_MALLOC_H_
+#define UCC_MALLOC_H_
+
+#include "config.h"
+
+#define ucc_malloc(_s, ...) malloc(_s)
+#define ucc_calloc(_n, _s, ...) calloc(_n, _s)
+#define ucc_realloc(_p, _s, ...) realloc(_p, _s)
+#define ucc_free(_p) free(_p)
+
+#endif

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PARSER_H_
+#define UCC_PARSER_H_
+
+#include "config.h"
+#include "api/ucc_status.h"
+#include "ucc_compiler_def.h"
+
+#include <ucs/config/parser.h>
+#include <ucs/sys/preprocessor.h>
+#include <ucs/sys/compiler_def.h>
+#include <ucs/config/types.h>
+#include <ucs/config/parser.h>
+
+typedef ucs_config_field_t ucc_config_field_t;
+#define UCC_CONFIG_TYPE_LOG_COMP UCS_CONFIG_TYPE_LOG_COMP
+#define UCC_CONFIG_REGISTER_TABLE UCS_CONFIG_REGISTER_TABLE
+#define UCC_CONFIG_TYPE_STRING UCS_CONFIG_TYPE_STRING
+
+static inline ucc_status_t
+ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,
+                            const char *env_prefix, const char *table_prefix,
+                            int ignore_errors)
+{
+    ucs_status_t status = ucs_config_parser_fill_opts(
+        opts, fields, env_prefix, table_prefix, ignore_errors);
+    return ucs_status_to_ucc_status(status);
+}
+
+#endif


### PR DESCRIPTION
Depends on #8 and #11 

**What?**

- ucc_constructor/ucc_destructor. Constructor just reads global options now.
- Global options definition: log_level, component path