### PR TITLE
UCC/UTIL: Logger

### DIFF
--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -10,10 +10,13 @@
 #include "api/ucc_status.h"
 #include <ucs/type/status.h>
 #include <ucs/sys/string.h>
+#include <ucs/debug/log_def.h>
 
 #define ucc_offsetof ucs_offsetof
 #define ucc_container_of ucs_container_of
 #define ucc_strncpy_safe ucs_strncpy_safe
+
+typedef ucs_log_component_config_t ucc_log_component_config_t;
 
 static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
 {

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -17,6 +17,7 @@
 #include <glob.h>
 #include <unistd.h>
 #include <string.h>
+#include <assert.h>
 
 static ucc_status_t ucc_component_load_one(const char *so_path,
                                            const char *framework_pattern,
@@ -36,24 +37,17 @@ static ucc_status_t ucc_component_load_one(const char *so_path,
 
     handle = dlopen(so_path, RTLD_LAZY);
     if (!handle) {
-        //TODO use ucc_error
-        fprintf(stderr,
-                "Failed to load UCC component library: %s. "
-                "Check UCC_COMPONENT_PATH or LD_LIBRARY_PATH\n",
-                so_path);
+        ucc_debug("failed to load UCC component library: %s", so_path);
         goto error;
     }
     iface = (ucc_component_iface_t *)dlsym(handle, iface_struct);
     if ((error = dlerror()) != NULL) {
-        //TODO ucc_error
-        fprintf(stderr, "Failed to get iface %s from %s object\n", iface_struct,
-                so_path);
+        ucc_error("failed to get iface %s from %s object", iface_struct,
+                  so_path);
         goto iface_error;
     }
     if (!iface) {
-        //TODO ucc_error
-        fprintf(stderr, "iface %s is NULL in %s object\n", iface_struct,
-                so_path);
+        ucc_error("iface %s is NULL in %s object", iface_struct, so_path);
         goto iface_error;
     }
     iface->dl_handle = handle;
@@ -71,9 +65,10 @@ ucc_status_t ucc_components_load(const char *framework_name,
                                  ucc_component_framework_t *framework)
 {
     glob_t globbuf;
-    int    i, n_loaded, ifaces_array_size;
+    int    i, n_loaded;
     char  *full_pattern, framework_pattern[UCC_MAX_FRAMEWORK_NAME_LEN + 16];
     ucc_status_t            status;
+    size_t                  pattern_size;
     ucc_component_iface_t **ifaces = NULL;
 
     framework->n_components = 0;
@@ -81,18 +76,18 @@ ucc_status_t ucc_components_load(const char *framework_name,
 
     if (strlen(framework_name) == 0 ||
         strlen(framework_name) > UCC_MAX_FRAMEWORK_NAME_LEN) {
-        //TODO ucc_error
-        fprintf(stderr, "unsupported framework_name length: %d",
-                strlen(framework_name));
+        ucc_error("unsupported framework_name length: %s, len %d",
+                  framework_name, strlen(framework_name));
         return UCC_ERR_INVALID_PARAM;
     }
     sprintf(framework_pattern, "ucc_%s_", framework_name);
 
-    full_pattern = (char *)ucc_malloc(strlen(ucc_global_config.component_path) +
-                                          strlen(framework_name) + 16,
-                                      "full_pattern");
+    pattern_size =
+        strlen(ucc_global_config.component_path) + strlen(framework_name) + 16;
+    full_pattern = (char *)ucc_malloc(pattern_size, "full_pattern");
     if (!full_pattern) {
-        //TODO ucc_error
+        ucc_error("failed to allocate %zd bytes for full_pattern",
+                  pattern_size);
         return UCC_ERR_NO_MEMORY;
     }
     sprintf(full_pattern, "%s/ucc_%s_*.so", ucc_global_config.component_path,
@@ -100,19 +95,17 @@ ucc_status_t ucc_components_load(const char *framework_name,
     glob(full_pattern, 0, NULL, &globbuf);
     free(full_pattern);
     n_loaded          = 0;
-    ifaces_array_size = 0;
 
     dlerror(); /* Clear any existing error */
+    ifaces = (ucc_component_iface_t **)ucc_malloc(
+        globbuf.gl_pathc * sizeof(ucc_component_iface_t *), "ifaces");
+    if (!ifaces) {
+        ucc_error("failed to allocate %zd bytes for ifaces",
+                  globbuf.gl_pathc * sizeof(ucc_component_iface_t *));
+        return UCC_ERR_NO_MEMORY;
+    }
 
     for (i = 0; i < globbuf.gl_pathc; i++) {
-        if (n_loaded == ifaces_array_size) {
-            ifaces_array_size += 8;
-            ifaces = (ucc_component_iface_t **)ucc_realloc(
-                ifaces, ifaces_array_size * sizeof(ucc_component_iface_t *));
-            if (!ifaces) {
-                return UCC_ERR_NO_MEMORY;
-            }
-        }
         status = ucc_component_load_one(globbuf.gl_pathv[i], framework_pattern,
                                         &ifaces[n_loaded]);
         if (status != UCC_OK) {
@@ -125,6 +118,9 @@ ucc_status_t ucc_components_load(const char *framework_name,
         globfree(&globbuf);
     }
     if (n_loaded) {
+        assert(n_loaded <= globbuf.gl_pathc);
+        ifaces = ucc_realloc(ifaces, n_loaded * sizeof(ucc_component_iface_t *),
+                             "ifaces");
         framework->components   = ifaces;
         framework->n_components = n_loaded;
         return UCC_OK;

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -7,9 +7,41 @@
 #define UCC_LOG_H_
 
 #include "config.h"
+#include "core/ucc_global_opts.h"
 #include <ucs/debug/log_def.h>
 
-typedef ucs_log_component_config_t ucc_log_component_config_t;
 #define UCC_LOG_LEVEL_WARN UCS_LOG_LEVEL_WARN
+
+/* Generic wrapper macro to invoke ucs logging backend */
+#define ucc_log_component(_level, _component, _fmt, ...)                       \
+    do {                                                                       \
+        ucs_log_component(_level, &_component, _fmt, ##__VA_ARGS__);           \
+    } while (0)
+
+/* Global logger: to be used anywhere when special log level settings are not required */
+#define ucc_log_component_global(_level, fmt, ...)                             \
+    ucc_log_component(_level, ucc_global_config.log_component, fmt,            \
+                      ##__VA_ARGS__)
+#define ucc_error(_fmt, ...)                                                   \
+    ucc_log_component_global(UCS_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
+#define ucc_warn(_fmt, ...)                                                    \
+    ucc_log_component_global(UCS_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
+#define ucc_info(_fmt, ...)                                                    \
+    ucc_log_component_global(UCS_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+#define ucc_debug(_fmt, ...)                                                   \
+    ucc_log_component_global(UCS_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
+#define ucc_trace(_fmt, ...)                                                   \
+    ucc_log_component_global(UCS_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+#define ucc_trace_req(_fmt, ...)                                               \
+    ucc_log_component_global(UCS_LOG_LEVEL_TRACE_REQ, _fmt, ##__VA_ARGS__)
+#define ucc_trace_data(_fmt, ...)                                              \
+    ucc_log_component_global(UCS_LOG_LEVEL_TRACE_DATA, _fmt, ##__VA_ARGS__)
+#define ucc_trace_async(_fmt, ...)                                             \
+    ucc_log_component_global(UCS_LOG_LEVEL_TRACE_ASYNC, _fmt, ##__VA_ARGS__)
+#define ucc_trace_func(_fmt, ...)                                              \
+    ucc_log_component_global(UCS_LOG_LEVEL_TRACE_FUNC, "%s(" _fmt ")",         \
+                             __FUNCTION__, ##__VA_ARGS__)
+#define ucc_trace_poll(_fmt, ...)                                              \
+    ucc_log_component_global(UCS_LOG_LEVEL_TRACE_POLL, _fmt, ##__VA_ARGS__)
 
 #endif


### PR DESCRIPTION
**What?**
Adds utils/ucc_log.h: set of macros that define logging utils for the global UCC scope: ucc_error, ucc_info, etc. The global verbose level is controlled by UCC_LOG_LEVEL. Any component that requires its own log level (to be profiled separately when needed) should define similar macros: e.g. cl_basic_error and add separate log_component entry in the config table.

**Why?**
general purpose logging

**How?**
Using ucs logging infra
