### PR TITLE
CORE: ucc_lib_config_read implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,7 @@ if test $ucx_happy != "yes"; then
 fi
 
 includes="-I${UCC_TOP_SRCDIR}/src"
-CPPFLAGS="$UCS_CPPFLAGS $CPPFLAGS $includes -std=gnu11"
+CPPFLAGS="$UCS_CPPFLAGS $CPPFLAGS $includes -std=gnu11 -Wall -Werror"
 LDFLAGS="$LDFLAGS $UCS_LDFLAGS $UCS_LIBADD"
 
 AC_CONFIG_FILES([

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,7 @@ nobase_dist_libucc_la_HEADERS = \
 
 noinst_HEADERS =             \
 	core/ucc_global_opts.h   \
+	core/ucc_lib.h           \
 	utils/ucc_compiler_def.h \
 	utils/ucc_log.h          \
 	utils/ucc_parser.h       \

--- a/src/api/ucc.h
+++ b/src/api/ucc.h
@@ -469,7 +469,7 @@ void ucc_lib_config_print(const ucc_lib_config_h config, FILE *stream,
  *  @return Error code as defined by ucc_status_t
  */
 
-ucc_status_t ucc_lib_config_modify(ucc_lib_config_h *config, const char *name,
+ucc_status_t ucc_lib_config_modify(ucc_lib_config_h config, const char *name,
                                    const char *value);
 
 

--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -1,6 +1,5 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
- *
  * See file LICENSE for terms.
  */
 
@@ -12,7 +11,6 @@
 
 #include <link.h>
 #include <dlfcn.h>
-#include <string.h>
 
 #define UCC_LIB_SO_NAME "libucc.so"
 #define UCC_COMPONENT_LIBDIR "ucc"
@@ -27,7 +25,7 @@ static int callback(struct dl_phdr_info *info, size_t size, void *data)
         component_path = (char *)ucc_malloc(pos + UCC_COMPONENT_LIBDIR_LEN + 1,
                                             "component_path");
         if (!component_path) {
-            ucc_error("failed to allocate %d bytes for component_path",
+            ucc_error("failed to allocate %zd bytes for component_path",
                       pos + UCC_COMPONENT_LIBDIR_LEN + 1);
             return -1;
         }

--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -1,6 +1,5 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
- *
  * See file LICENSE for terms.
  */
 
@@ -25,6 +24,8 @@ ucc_config_field_t ucc_global_config_table[] = {
     {"COMPONENT_PATH", "", "Specifies dynamic components location",
      ucc_offsetof(ucc_global_config_t, component_path), UCC_CONFIG_TYPE_STRING},
 
-    NULL};
+    {NULL}
+};
+
 UCC_CONFIG_REGISTER_TABLE(ucc_global_config_table, "UCC global", NULL,
                           ucc_global_config)

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -1,6 +1,5 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
- *
  * See file LICENSE for terms.
  */
 
@@ -9,6 +8,16 @@
 #include "ucc_global_opts.h"
 #include "api/ucc.h"
 #include "api/ucc_status.h"
+#include "ucc_lib.h"
+#include "utils/ucc_log.h"
+#include "utils/ucc_malloc.h"
+
+static ucc_config_field_t ucc_lib_config_table[] = {
+    {"CLS", "all", "Comma separated list of CL components to be used",
+     ucc_offsetof(ucc_lib_config_t, cls), UCC_CONFIG_TYPE_STRING_ARRAY},
+
+    {NULL}
+};
 
 ucc_status_t ucc_init_version(unsigned api_major_version,
                               unsigned api_minor_version,
@@ -17,4 +26,78 @@ ucc_status_t ucc_init_version(unsigned api_major_version,
                               ucc_lib_h *lib_p)
 {
     return UCC_ERR_NOT_IMPLEMENTED;
+}
+
+ucc_status_t ucc_lib_config_read(const char *env_prefix, const char *filename,
+                                 ucc_lib_config_t **config_p)
+{
+    ucc_lib_config_t *config;
+    ucc_status_t      status;
+    size_t            full_prefix_len;
+    const char       *base_prefix = "UCC_";
+
+    config = ucc_malloc(sizeof(*config), "lib_config");
+    if (config == NULL) {
+        ucc_error("failed to allocate %zd bytes for lib_config",
+                  sizeof(*config));
+        status = UCC_ERR_NO_MEMORY;
+        goto err;
+    }
+    /* full_prefix for a UCC lib config is either just
+          (i)  "UCC_" - if no "env_prefix" is provided, or
+          (ii) "AAA_UCC" - where AAA is the value of "env_prefix".
+       Allocate space to build prefix str and two characters ("_" and “\0”) */
+    full_prefix_len =
+        strlen(base_prefix) + (env_prefix ? strlen(env_prefix) : 0) + 2;
+    config->full_prefix = ucc_malloc(full_prefix_len, "full_prefix");
+    if (!config->full_prefix) {
+        ucc_error("failed to allocate %zd bytes for full_prefix",
+                  full_prefix_len);
+        status = UCC_ERR_NO_MEMORY;
+        goto err_free_config;
+    }
+    if (env_prefix) {
+        ucc_snprintf_safe(config->full_prefix, full_prefix_len, "%s_%s",
+                          env_prefix, base_prefix);
+    } else {
+        ucc_strncpy_safe(config->full_prefix, base_prefix,
+                         strlen(base_prefix) + 1);
+    }
+
+    status = ucc_config_parser_fill_opts(config, ucc_lib_config_table,
+                                         config->full_prefix, NULL, 0);
+    if (status != UCC_OK) {
+        ucc_error("failed to read UCC lib config");
+        goto err_free_prefix;
+    }
+    *config_p = config;
+    return UCC_OK;
+
+err_free_prefix:
+    free(config->full_prefix);
+err_free_config:
+    free(config);
+err:
+    return status;
+}
+
+void ucc_lib_config_release(ucc_lib_config_t *config)
+{
+    ucc_config_parser_release_opts(config, ucc_lib_config_table);
+    free(config->full_prefix);
+    free(config);
+}
+
+void ucc_lib_config_print(const ucc_lib_config_h config, FILE *stream,
+                          const char *title, ucc_config_print_flags_t print_flags)
+{
+    ucc_config_parser_print_opts(stream, title, config, ucc_lib_config_table,
+                                 NULL, config->full_prefix, print_flags);
+}
+
+ucc_status_t ucc_lib_config_modify(ucc_lib_config_h config, const char *name,
+                                   const char *value)
+{
+    return ucc_config_parser_set_value(config, ucc_lib_config_table, name,
+                                       value);
 }

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_LIB_H_
+#define UCC_LIB_H_
+
+#include "config.h"
+#include "api/ucc.h"
+#include "utils/ucc_parser.h"
+
+typedef struct ucc_lib_config {
+    char                    *full_prefix;
+    ucc_config_names_array_t cls;
+} ucc_lib_config_t;
+
+#endif
+

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
@@ -12,9 +12,10 @@
 #include <ucs/sys/string.h>
 #include <ucs/debug/log_def.h>
 
-#define ucc_offsetof ucs_offsetof
-#define ucc_container_of ucs_container_of
-#define ucc_strncpy_safe ucs_strncpy_safe
+#define ucc_offsetof      ucs_offsetof
+#define ucc_container_of  ucs_container_of
+#define ucc_strncpy_safe  ucs_strncpy_safe
+#define ucc_snprintf_safe snprintf
 
 typedef ucs_log_component_config_t ucc_log_component_config_t;
 

--- a/src/utils/ucc_component.h
+++ b/src/utils/ucc_component.h
@@ -1,7 +1,7 @@
-/*
-* Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
-* See file LICENSE for terms.
-*/
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
 
 #ifndef UCC_COMPONENT_H_
 #define UCC_COMPONENT_H_
@@ -10,6 +10,7 @@
 #include <api/ucc.h>
 
 #define UCC_MAX_FRAMEWORK_NAME_LEN 64
+#define UCC_MAX_COMPONENT_NAME_LEN 64
 
 typedef struct ucc_component_iface {
     void *dl_handle;

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/utils/ucc_malloc.h
+++ b/src/utils/ucc_malloc.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
@@ -17,9 +17,12 @@
 #include <ucs/config/parser.h>
 
 typedef ucs_config_field_t ucc_config_field_t;
+typedef ucs_config_names_array_t ucc_config_names_array_t;
+
 #define UCC_CONFIG_TYPE_LOG_COMP UCS_CONFIG_TYPE_LOG_COMP
 #define UCC_CONFIG_REGISTER_TABLE UCS_CONFIG_REGISTER_TABLE
 #define UCC_CONFIG_TYPE_STRING UCS_CONFIG_TYPE_STRING
+#define UCC_CONFIG_TYPE_STRING_ARRAY UCS_CONFIG_TYPE_STRING_ARRAY
 
 static inline ucc_status_t
 ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,
@@ -37,4 +40,36 @@ ucc_config_parser_release_opts(void *opts, ucc_config_field_t *fields)
     ucs_config_parser_release_opts(opts, fields);
 }
 
+static inline ucc_status_t
+ucc_config_parser_set_value(void *opts, ucc_config_field_t *fields,
+                            const char *name, const char *value)
+{
+    ucs_status_t status =
+        ucs_config_parser_set_value(opts, fields, name, value);
+    return ucs_status_to_ucc_status(status);
+}
+
+static inline void ucc_config_parser_print_opts(FILE *stream, const char *title,
+                                                const void *opts,
+                                                ucc_config_field_t *fields,
+                                                const char *table_prefix,
+                                                const char *prefix,
+                                                ucc_config_print_flags_t flags)
+{
+    ucs_config_print_flags_t ucs_flags = 0;
+    if (flags & UCC_CONFIG_PRINT_CONFIG) {
+        ucs_flags |= UCS_CONFIG_PRINT_CONFIG;
+    }
+    if (flags & UCC_CONFIG_PRINT_HEADER) {
+        ucs_flags |= UCS_CONFIG_PRINT_HEADER;
+    }
+    if (flags & UCC_CONFIG_PRINT_DOC) {
+        ucs_flags |= UCS_CONFIG_PRINT_DOC;
+    }
+    if (flags & UCC_CONFIG_PRINT_HIDDEN) {
+        ucs_flags |= UCS_CONFIG_PRINT_HIDDEN;
+    }
+    ucs_config_parser_print_opts(stream, title, opts, fields, table_prefix,
+                                 prefix, ucs_flags);
+}
 #endif


### PR DESCRIPTION
**What?**
Adds implementation of the ucc_lib_config_read API. Currently the lib config table only holds the list of CLs to use. To be extended in the future.

**Why?**
API function implementation

**How?**
Using ucs_lib_config_read. The only specialty is the construction of the "full_prefix".
full_prefix for a UCC lib config is either just  (i)  "UCC_" - if not "env_prefix" is provided, or (ii) "UCC_AAA_" - where AAA is the value of "env_prefix". If user specifies env_prefix when performs ucc_lib_config_read he then can control the configuration of his UCC job specifically using set of params prefixed with UCC_<ENV_PREFIX>_ w/o affecting other UCC lib objects (potentially co-existing in the same runtime).
