### PR TITLE
CORE: basic ucc_lib_init implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@
 
 define([ucc_ver_major], 1)
 define([ucc_ver_minor], 0)
+define([ucc_ver_patch], 0)
 define([ucc_ver_micro], esyscmd([sh -c "git rev-list HEAD | wc -l | sed -e 's/ *//g' | xargs -n1 printf"]))
 define([ucc_git_sha], esyscmd([sh -c "git rev-parse --short HEAD"]))
 
@@ -52,12 +53,14 @@ RPM_RELEASE=1
 MAJOR_VERSION=ucc_ver_major
 MINOR_VERSION=ucc_ver_minor
 MICRO_VERSION=ucc_ver_micro
+PATCH_VERSION=ucc_ver_micro
 UCC_GIT_SHA=ucc_git_sha
 VERSION=$MAJOR_VERSION.$MINOR_VERSION.$MICRO_VERSION
 SOVERSION=libucc_so_version
 AC_SUBST(MAJOR_VERSION)
 AC_SUBST(MINOR_VERSION)
 AC_SUBST(MICRO_VERSION)
+AC_SUBST(PATCH_VERSION)
 AC_SUBST(RPM_RELEASE)
 AC_SUBST(SOVERSION)
 AC_SUBST(UCC_GIT_SHA)
@@ -143,5 +146,6 @@ AC_CONFIG_FILES([
                  src/Makefile
                  src/api/ucc_version.h
                  tools/info/Makefile
+                 src/core/ucc_version.c
                  ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,13 +22,16 @@ noinst_HEADERS =             \
 	utils/ucc_log.h          \
 	utils/ucc_parser.h       \
 	utils/ucc_component.h    \
-	utils/ucc_datastruct.h
+	utils/ucc_datastruct.h   \
+	utils/ucc_math.h         \
+	cl/ucc_cl.h
 
 libucc_la_SOURCES =        \
 	core/ucc_lib.c         \
 	core/ucc_constructor.c \
 	core/ucc_global_opts.c \
 	core/ucc_version.c     \
-	utils/ucc_component.c
+	utils/ucc_component.c  \
+	cl/ucc_cl.c
 
 libucc_ladir = $(includedir)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,6 +28,7 @@ libucc_la_SOURCES =        \
 	core/ucc_lib.c         \
 	core/ucc_constructor.c \
 	core/ucc_global_opts.c \
+	core/ucc_version.c     \
 	utils/ucc_component.c
 
 libucc_ladir = $(includedir)

--- a/src/api/ucc.h
+++ b/src/api/ucc.h
@@ -485,7 +485,7 @@ ucc_status_t ucc_lib_config_modify(ucc_lib_config_h config, const char *name,
 ucc_status_t ucc_init_version(unsigned api_major_version,
                               unsigned api_minor_version,
                               const ucc_lib_params_t *params,
-                              const ucc_lib_config_h *config,
+                              const ucc_lib_config_h config,
                               ucc_lib_h *lib_p);
 
 
@@ -518,7 +518,7 @@ ucc_status_t ucc_init_version(unsigned api_major_version,
  *  @return Error code as defined by ucc_status_t
  */
 static inline ucc_status_t ucc_init(const ucc_lib_params_t *params,
-                                    const ucc_lib_config_h *config,
+                                    const ucc_lib_config_h config,
                                     ucc_lib_h *lib_p)
 {
     return ucc_init_version(UCC_API_MAJOR, UCC_API_MINOR, params, config,

--- a/src/api/ucc_def.h
+++ b/src/api/ucc_def.h
@@ -29,7 +29,7 @@
  * resources associated  with the library. The library handle cannot be passed
  * from one library instance to another.
  */
-typedef struct ucc_lib_info_t*       ucc_lib_h;
+typedef struct ucc_lib_info*       ucc_lib_h;
 
 /**
  * @ingroup UCC_CONTEXT_DT

--- a/src/api/ucc_status.h
+++ b/src/api/ucc_status.h
@@ -24,7 +24,7 @@ typedef enum {
     UCC_OPERATION_INITIALIZED           =    2, /*!< Operation initialized but not posted */
 
     /* Error status codes */
-    UCC_ERR_OP_NOT_SUPPORTED            =   -1,
+    UCC_ERR_NOT_SUPPORTED               =   -1,
     UCC_ERR_NOT_IMPLEMENTED             =   -2,
     UCC_ERR_INVALID_PARAM               =   -3,
     UCC_ERR_NO_MEMORY                   =   -4,

--- a/src/cl/ucc_cl.c
+++ b/src/cl/ucc_cl.c
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_cl.h"
+
+ucc_config_field_t ucc_cl_lib_config_table[] = {
+    {"LOG_LEVEL", "warn",
+     "UCC CL logging level. Messages with a level higher or equal to the "
+     "selected will be printed.\n"
+     "Possible values are: fatal, error, warn, info, debug, trace, data, func, "
+     "poll.",
+     ucc_offsetof(ucc_cl_lib_config_t, log_component),
+     UCC_CONFIG_TYPE_LOG_COMP},
+
+    {"PRIORITY", "-1",
+     "UCC CL priority.\n"
+     "Possible values are: [1,inf]",
+     ucc_offsetof(ucc_cl_lib_config_t, priority), UCC_CONFIG_TYPE_INT},
+
+    {NULL}
+};

--- a/src/cl/ucc_cl.c
+++ b/src/cl/ucc_cl.c
@@ -22,3 +22,9 @@ ucc_config_field_t ucc_cl_lib_config_table[] = {
 
     {NULL}
 };
+
+const char *ucc_cl_names[] = {
+    [UCC_CL_BASIC] = "basic",
+    [UCC_CL_ALL]   = "all",
+    [UCC_CL_LAST]  = NULL
+};

--- a/src/cl/ucc_cl.h
+++ b/src/cl/ucc_cl.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+
+#ifndef UCC_CL_H_
+#define UCC_CL_H_
+
+#include "api/ucc.h"
+#include "core/ucc_lib.h"
+#include "utils/ucc_component.h"
+#include "utils/ucc_parser.h"
+
+typedef struct ucc_cl_lib   ucc_cl_lib_t;
+typedef struct ucc_cl_iface ucc_cl_iface_t;
+
+typedef struct ucc_cl_lib_config {
+    /* Log level above which log messages will be printed */
+    ucc_log_component_config_t log_component;
+    /* Team library priority */
+    int                        priority;
+} ucc_cl_lib_config_t;
+
+extern ucc_config_field_t ucc_cl_lib_config_table[];
+
+typedef struct ucc_cl_iface {
+    ucc_component_iface_t          super;
+    int                            priority;
+    ucc_lib_attr_t                 attr;
+    ucc_config_global_list_entry_t cl_lib_config;
+    ucc_status_t                   (*init)(const ucc_lib_params_t *params,
+                                           const ucc_lib_config_t *config,
+                                           const ucc_cl_lib_config_t *cl_config,
+                                           ucc_cl_lib_t **cl_lib);
+    ucc_status_t                   (*finalize)(ucc_cl_lib_t *cl_lib);
+} ucc_cl_iface_t;
+
+typedef struct ucc_cl_lib {
+    ucc_cl_iface_t             *iface;
+    ucc_log_component_config_t  log_component;
+    int                         priority;
+} ucc_cl_lib_t;
+
+#endif

--- a/src/cl/ucc_cl.h
+++ b/src/cl/ucc_cl.h
@@ -11,6 +11,7 @@
 
 #include "api/ucc.h"
 #include "core/ucc_lib.h"
+#include "ucc_cl_type.h"
 #include "utils/ucc_component.h"
 #include "utils/ucc_parser.h"
 
@@ -28,6 +29,7 @@ extern ucc_config_field_t ucc_cl_lib_config_table[];
 
 typedef struct ucc_cl_iface {
     ucc_component_iface_t          super;
+    ucc_cl_type_t                  type;
     int                            priority;
     ucc_lib_attr_t                 attr;
     ucc_config_global_list_entry_t cl_lib_config;

--- a/src/cl/ucc_cl_type.h
+++ b/src/cl/ucc_cl_type.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#ifndef UCC_CL_TYPE_H_
+#define UCC_CL_TYPE_H_
+
+typedef enum {
+    UCC_CL_BASIC,
+    UCC_CL_ALL,
+    UCC_CL_LAST
+} ucc_cl_type_t;
+
+extern const char *ucc_cl_names[];
+
+#endif

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -27,5 +27,6 @@ extern ucc_global_config_t ucc_global_config;
 extern ucc_config_field_t  ucc_global_config_table[];
 
 ucc_status_t ucc_constructor(void);
+extern ucs_list_link_t ucc_config_global_list;
 
 #endif

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -11,6 +11,8 @@
 #include "ucc_lib.h"
 #include "utils/ucc_log.h"
 #include "utils/ucc_malloc.h"
+#include "utils/ucc_math.h"
+#include "cl/ucc_cl.h"
 
 static ucc_config_field_t ucc_lib_config_table[] = {
     {"CLS", "all", "Comma separated list of CL components to be used",
@@ -19,14 +21,187 @@ static ucc_config_field_t ucc_lib_config_table[] = {
     {NULL}
 };
 
+UCC_CONFIG_REGISTER_TABLE(ucc_lib_config_table, "UCC", NULL, ucc_lib_config_t)
+
+static inline ucc_status_t ucc_cl_component_is_loaded(const char *cl_name)
+{
+    if (NULL == ucc_get_component(&ucc_global_config.cl_framework, cl_name)) {
+        return UCC_ERR_NOT_FOUND;
+    } else {
+        return UCC_OK;
+    }
+}
+
+static inline ucc_status_t
+ucc_lib_config_cl_components_check(ucc_lib_info_t *lib,
+                                   ucc_config_names_array_t *cls)
+{
+    int i;
+    if (cls->count == 0) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    if (cls->count == 1 && 0 == strcmp(cls->names[0], "all")) {
+        return UCC_OK;
+    }
+    for (i = 0; i < cls->count; i++) {
+        if (UCC_OK != ucc_cl_component_is_loaded(cls->names[i])) {
+            ucc_error("Required TL: \"%s\" (ucc_cl_%s.so) is not available\n",
+                      cls->names[i], cls->names[i]);
+            return UCC_ERR_NO_MESSAGE;
+        }
+    }
+    return UCC_OK;
+}
+
+/* Core logic for the selection of CL components:
+   1. If user does not provide a set of required CLs then we try to
+   use only those components that support the required input params.
+   This means, if some component does not pass params check it is skipped.
+
+   2. In contrast, if user explicitly requests a list of CLs to use,
+   then we try to load ALL of them and report the supported attributes
+   based on that selection. */
+static ucc_status_t ucc_lib_init_filtered(const ucc_lib_params_t *user_params,
+                                          const ucc_lib_config_t *config,
+                                          ucc_lib_info_t *lib)
+{
+    int                  n_cls = ucc_global_config.cl_framework.n_components;
+    uint64_t             supported_coll_types = 0;
+    ucc_thread_mode_t    supported_tm         = UCC_THREAD_MULTIPLE;
+    ucc_lib_params_t     params               = *user_params;
+    ucc_cl_iface_t      *cl_iface;
+    ucc_cl_lib_t        *cl_lib;
+    ucc_cl_lib_config_t *cl_config;
+    ucc_status_t         status;
+    int                  i, specific_cls_requested;
+
+    lib->libs =
+        (ucc_cl_lib_t **)ucc_malloc(sizeof(ucc_cl_lib_t *) * n_cls, "cl_libs");
+    if (!lib->libs) {
+        ucc_error("failed to allocate %zd bytes for cl_libs",
+                  sizeof(ucc_cl_lib_t *) * n_cls);
+        status = UCC_ERR_NO_MEMORY;
+        goto error;
+    }
+    if (!(params.mask & UCC_LIB_PARAM_FIELD_THREAD_MODE)) {
+        params.mask |= UCC_LIB_PARAM_FIELD_THREAD_MODE;
+        params.thread_mode = UCC_THREAD_SINGLE;
+    }
+    ucc_assert(config->cls.count >= 1);
+    specific_cls_requested = (-1 == ucc_config_names_search(config->cls, "all"));
+    lib->n_libs_opened     = 0;
+    for (i = 0; i < n_cls; i++) {
+        cl_iface = ucc_derived_of(ucc_global_config.cl_framework.components[i],
+                                  ucc_cl_iface_t);
+        /* User requested specific list of CLs and current cl_iface is not part
+           of the list: skip it. */
+        if (specific_cls_requested &&
+            -1 == ucc_config_names_search(config->cls, cl_iface->super.name)) {
+            continue;
+        }
+        if (params.thread_mode > cl_iface->attr.thread_mode) {
+            /* Requested THREAD_MODE is not supported by the CL:
+               1. If cls == "all" - just skip this CL
+               2. If specific CLs are requested: continue and user will 
+                  have to query result attributes and check thread mode*/
+            if (!specific_cls_requested) {
+                ucc_info("requested thread_mode is not supported by the CL: %s",
+                         cl_iface->super.name);
+                continue;
+            }
+        }
+        cl_config = ucc_malloc(cl_iface->cl_lib_config.size, "cl_lib_config");
+        if (!cl_config) {
+            status = UCC_ERR_NO_MEMORY;
+            goto error_cl_cleanup;
+        }
+        status = ucc_config_parser_fill_opts(
+            cl_config, cl_iface->cl_lib_config.table, config->full_prefix,
+            cl_iface->cl_lib_config.prefix, 0);
+        if (UCC_OK != status) {
+            ucc_error("failed to parse CL %s lib configuration",
+                      cl_iface->super.name);
+            goto error_cl_config_parse;
+        }
+        status = cl_iface->init(&params, config, cl_config, &cl_lib);
+        if (UCC_OK != status) {
+            if (specific_cls_requested) {
+                ucc_error("lib_init failed for component: %s",
+                          cl_iface->super.name);
+                goto error_cl_init;
+            } else {
+                ucc_info("lib_init failed for component: %s, skipping",
+                         cl_iface->super.name);
+                ucc_config_parser_release_opts(cl_config,
+                                               cl_iface->cl_lib_config.table);
+                free(cl_config);
+                continue;
+            }
+        }
+        cl_lib->log_component = cl_config->log_component;
+        ucc_strncpy_safe(cl_lib->log_component.name,
+                         cl_iface->cl_lib_config.prefix,
+                         sizeof(cl_lib->log_component.name));
+        cl_lib->priority = (-1 == cl_config->priority) ? cl_iface->priority
+                                                       : cl_config->priority;
+        ucc_config_parser_release_opts(cl_config,
+                                       cl_iface->cl_lib_config.table);
+        free(cl_config);
+        lib->libs[lib->n_libs_opened++] = cl_lib;
+        supported_coll_types |= cl_iface->attr.coll_types;
+        if (cl_iface->attr.thread_mode < supported_tm) {
+            supported_tm = cl_iface->attr.thread_mode;
+        }
+        ucc_info("lib_prefix \"%s\": initialized component \"%s\" priority %d",
+                 config->full_prefix, cl_iface->super.name, cl_lib->priority);
+    }
+
+    if (lib->n_libs_opened == 0) {
+        ucc_error("lib_init failed: no CLs left after filtering");
+        status = UCC_ERR_NO_MESSAGE;
+        goto error;
+    }
+
+    /* Check if the combination of the selected CLs provides all the
+       requested coll_types: not an error, just print a message if not
+       all the colls are supproted */
+    if (params.mask & UCC_LIB_PARAM_FIELD_COLL_TYPES &&
+        ((params.coll_types & supported_coll_types) != params.coll_types)) {
+        ucc_debug("selected set of CLs does not provide all the requested "
+                  "coll_types");
+    }
+    if (params.thread_mode > supported_tm) {
+        ucc_debug("selected set of CLs does not provide the requested "
+                  "thread_mode");
+    }
+    lib->attr.coll_types  = supported_coll_types;
+    lib->attr.thread_mode = ucc_min(supported_tm, params.thread_mode);
+    return UCS_OK;
+
+error_cl_init:
+    ucc_config_parser_release_opts(cl_config, cl_iface->cl_lib_config.table);
+error_cl_config_parse:
+    free(cl_config);
+error_cl_cleanup:
+    for (i = 0; i < lib->n_libs_opened; i++) {
+        lib->libs[i]->iface->finalize(lib->libs[i]);
+    }
+error:
+    if (lib->libs)
+        free(lib->libs);
+    return status;
+}
+
 ucc_status_t ucc_init_version(unsigned api_major_version,
                               unsigned api_minor_version,
                               const ucc_lib_params_t *params,
-                              const ucc_lib_config_h *config,
-                              ucc_lib_h *lib_p)
+                              const ucc_lib_config_h config, ucc_lib_h *lib_p)
 {
-    unsigned major_version, minor_version, release_number;
-    ucc_status_t status;
+    unsigned        major_version, minor_version, release_number;
+    ucc_status_t    status;
+    ucc_lib_info_t *lib;
+
+    *lib_p = NULL;
 
     if (UCC_OK != (status = ucc_constructor())) {
         return status;
@@ -35,13 +210,42 @@ ucc_status_t ucc_init_version(unsigned api_major_version,
     ucc_get_version(&major_version, &minor_version, &release_number);
 
     if ((api_major_version != major_version) ||
-        ((api_major_version == major_version) && (api_minor_version > minor_version))) {
-        ucc_warn("UCC version is incompatible, required: %d.%d, actual: %d.%d.%d",
-                  api_major_version, api_minor_version,
-                  major_version, minor_version, release_number);
+        ((api_major_version == major_version) &&
+         (api_minor_version > minor_version))) {
+        ucc_warn(
+            "UCC version is incompatible, required: %d.%d, actual: %d.%d.%d",
+            api_major_version, api_minor_version, major_version, minor_version,
+            release_number);
     }
 
-    return UCC_ERR_NOT_IMPLEMENTED;
+    lib = ucc_malloc(sizeof(ucc_lib_info_t), "lib_info");
+    if (!lib) {
+        ucc_error("failed to allocate %zd bytes for lib_info",
+                  sizeof(ucc_lib_info_t));
+        return UCC_ERR_NO_MEMORY;
+    }
+    lib->full_prefix = strdup(config->full_prefix);
+    if (!lib->full_prefix) {
+        ucc_error("failed strdup for full_prefix");
+        status = UCC_ERR_NO_MEMORY;
+        goto error;
+    }
+    /* Initialize ucc lib handle using requirements from the user
+       provided via params/config and available CLs in the
+       CL component framework.
+
+       The lib_p object will contain the array of ucc_cl_lib_t objects
+       that are allocated using CL init/finalize interface. */
+    status = ucc_lib_init_filtered(params, config, lib);
+    if (UCC_OK != status) {
+        goto error;
+    }
+
+    *lib_p = lib;
+    return UCC_OK;
+error:
+    free(lib);
+    return status;
 }
 
 ucc_status_t ucc_lib_config_read(const char *env_prefix, const char *filename,
@@ -105,7 +309,8 @@ void ucc_lib_config_release(ucc_lib_config_t *config)
 }
 
 void ucc_lib_config_print(const ucc_lib_config_h config, FILE *stream,
-                          const char *title, ucc_config_print_flags_t print_flags)
+                          const char *title,
+                          ucc_config_print_flags_t print_flags)
 {
     ucc_config_parser_print_opts(stream, title, config, ucc_lib_config_table,
                                  NULL, config->full_prefix, print_flags);
@@ -116,4 +321,24 @@ ucc_status_t ucc_lib_config_modify(ucc_lib_config_h config, const char *name,
 {
     return ucc_config_parser_set_value(config, ucc_lib_config_table, name,
                                        value);
+}
+
+ucc_status_t ucc_finalize(ucc_lib_info_t *lib)
+{
+    int i;
+    ucc_status_t status, return_status = UCC_OK;
+    ucc_assert(lib->n_libs_opened > 0);
+    ucc_assert(lib->libs);
+    /* If some CL components fails in finalize we will return
+       its failure status to the user, however we will still
+       try to continue and finalize other CLs */
+    for (i = 0; i < lib->n_libs_opened; i++) {
+        status = lib->libs[i]->iface->finalize(lib->libs[i]);
+        if (UCC_OK == return_status && UCC_OK != status) {
+            return_status = status;
+        }
+    }
+    free(lib->libs);
+    free(lib);
+    return return_status;
 }

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -25,6 +25,22 @@ ucc_status_t ucc_init_version(unsigned api_major_version,
                               const ucc_lib_config_h *config,
                               ucc_lib_h *lib_p)
 {
+    unsigned major_version, minor_version, release_number;
+    ucc_status_t status;
+
+    if (UCC_OK != (status = ucc_constructor())) {
+        return status;
+    }
+
+    ucc_get_version(&major_version, &minor_version, &release_number);
+
+    if ((api_major_version != major_version) ||
+        ((api_major_version == major_version) && (api_minor_version > minor_version))) {
+        ucc_warn("UCC version is incompatible, required: %d.%d, actual: %d.%d.%d",
+                  api_major_version, api_minor_version,
+                  major_version, minor_version, release_number);
+    }
+
     return UCC_ERR_NOT_IMPLEMENTED;
 }
 

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -8,12 +8,16 @@
 
 #include "config.h"
 #include "api/ucc.h"
+#include "cl/ucc_cl_type.h"
 #include "utils/ucc_parser.h"
 
 typedef struct ucc_cl_lib ucc_cl_lib_t;
 typedef struct ucc_lib_config {
     char                    *full_prefix;
-    ucc_config_names_array_t cls;
+    struct {
+        ucc_cl_type_t *types;
+        unsigned       count;
+    } cls;
 } ucc_lib_config_t;
 
 typedef struct ucc_lib_info {

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -10,10 +10,18 @@
 #include "api/ucc.h"
 #include "utils/ucc_parser.h"
 
+typedef struct ucc_cl_lib ucc_cl_lib_t;
 typedef struct ucc_lib_config {
     char                    *full_prefix;
     ucc_config_names_array_t cls;
 } ucc_lib_config_t;
+
+typedef struct ucc_lib_info {
+    int            n_libs_opened;
+    char          *full_prefix;
+    ucc_cl_lib_t **libs;
+    ucc_lib_attr_t attr;
+} ucc_lib_info_t;
 
 void ucc_get_version(unsigned *major_version, unsigned *minor_version,
                      unsigned *release_number);
@@ -21,4 +29,3 @@ void ucc_get_version(unsigned *major_version, unsigned *minor_version,
 const char *ucc_get_version_string(void);
 
 #endif
-

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -15,5 +15,10 @@ typedef struct ucc_lib_config {
     ucc_config_names_array_t cls;
 } ucc_lib_config_t;
 
+void ucc_get_version(unsigned *major_version, unsigned *minor_version,
+                     unsigned *release_number);
+
+const char *ucc_get_version_string(void);
+
 #endif
 

--- a/src/core/ucc_version.c.in
+++ b/src/core/ucc_version.c.in
@@ -1,0 +1,18 @@
+/*
+* Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+
+
+void ucc_get_version(unsigned *major_version, unsigned *minor_version,
+                     unsigned *release_number)
+{
+    *major_version  = @MAJOR_VERSION@;
+    *minor_version  = @MINOR_VERSION@;
+    *release_number = @PATCH_VERSION@;
+}
+
+const char *ucc_get_version_string()
+{
+	return "@MAJOR_VERSION@.@MINOR_VERSION@.@PATCH_VERSION@";
+}

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -10,10 +10,17 @@
 #include "api/ucc_status.h"
 #include <ucs/type/status.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/preprocessor.h>
+#include <ucs/sys/compiler_def.h>
 #include <ucs/debug/log_def.h>
+#if ENABLE_DEBUG == 1
+#include <assert.h>
+#endif
+
 
 #define ucc_offsetof      ucs_offsetof
 #define ucc_container_of  ucs_container_of
+#define ucc_derived_of    ucs_derived_of
 #define ucc_strncpy_safe  ucs_strncpy_safe
 #define ucc_snprintf_safe snprintf
 
@@ -21,6 +28,7 @@ typedef ucs_log_component_config_t ucc_log_component_config_t;
 
 #define _UCC_PP_MAKE_STRING(x) #x
 #define UCC_PP_MAKE_STRING(x)  _UCC_PP_MAKE_STRING(x)
+#define UCC_PP_QUOTE UCS_PP_QUOTE
 
 static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
 {
@@ -40,4 +48,11 @@ static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
     }
     return UCC_ERR_NO_MESSAGE;
 }
+
+#if ENABLE_DEBUG == 1
+#define ucc_assert(_cond) assert(_cond)
+#else
+#define ucc_assert(_cond)
+#endif
+
 #endif

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -139,3 +139,15 @@ ucc_status_t ucc_components_load(const char *framework_name,
         return UCC_ERR_NOT_FOUND;
     }
 }
+
+ucc_component_iface_t* ucc_get_component(ucc_component_framework_t *framework,
+                                         const char *component_name)
+{
+    int i;
+    for (i = 0; i < framework->n_components; i++) {
+        if (0 == strcmp(framework->components[i]->name, component_name)) {
+            return framework->components[i];
+        }
+    }
+    return NULL;
+}

--- a/src/utils/ucc_component.h
+++ b/src/utils/ucc_component.h
@@ -13,6 +13,7 @@
 #define UCC_MAX_COMPONENT_NAME_LEN 64
 
 typedef struct ucc_component_iface {
+    const char *name;
     void *dl_handle;
 } ucc_component_iface_t;
 
@@ -31,4 +32,10 @@ typedef struct ucc_component_framework {
    ucc_<framework_name>_<component_name>. */
 ucc_status_t ucc_components_load(const char *framework_name,
                                  ucc_component_framework_t *framework);
+
+/* get the component_iface_t from the initialized framework
+   using the iface name. Returns NULL if the iface with the given
+   name is not found in the framework. */
+ucc_component_iface_t* ucc_get_component(ucc_component_framework_t *framework,
+                                         const char *component_name);
 #endif

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_MATH_H_
+#define UCC_MATH_H_
+
+#include "config.h"
+#include <ucs/sys/math.h>
+
+#define ucc_min(_a, _b) ucs_min((_a), (_b))
+#define ucc_max(_a, _b) ucs_max((_a), (_b))
+
+#endif

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -17,12 +17,15 @@
 #include <ucs/config/types.h>
 #include <ucs/config/parser.h>
 
-typedef ucs_config_field_t ucc_config_field_t;
-typedef ucs_config_names_array_t ucc_config_names_array_t;
+typedef ucs_config_field_t             ucc_config_field_t;
+typedef ucs_config_names_array_t       ucc_config_names_array_t;
+typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
 
-#define UCC_CONFIG_TYPE_LOG_COMP UCS_CONFIG_TYPE_LOG_COMP
-#define UCC_CONFIG_REGISTER_TABLE UCS_CONFIG_REGISTER_TABLE
-#define UCC_CONFIG_TYPE_STRING UCS_CONFIG_TYPE_STRING
+#define ucc_config_names_search      ucs_config_names_search
+#define UCC_CONFIG_TYPE_LOG_COMP     UCS_CONFIG_TYPE_LOG_COMP
+#define UCC_CONFIG_REGISTER_TABLE    UCS_CONFIG_REGISTER_TABLE
+#define UCC_CONFIG_TYPE_STRING       UCS_CONFIG_TYPE_STRING
+#define UCC_CONFIG_TYPE_INT          UCS_CONFIG_TYPE_INT
 #define UCC_CONFIG_TYPE_STRING_ARRAY UCS_CONFIG_TYPE_STRING_ARRAY
 
 static inline ucc_status_t

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -27,6 +27,7 @@ typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
 #define UCC_CONFIG_TYPE_STRING       UCS_CONFIG_TYPE_STRING
 #define UCC_CONFIG_TYPE_INT          UCS_CONFIG_TYPE_INT
 #define UCC_CONFIG_TYPE_STRING_ARRAY UCS_CONFIG_TYPE_STRING_ARRAY
+#define UCC_CONFIG_TYPE_ARRAY        UCS_CONFIG_TYPE_ARRAY
 
 static inline ucc_status_t
 ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,


### PR DESCRIPTION
**What?**
- UCC/CORE: check version compatibility during lib_init (similarly to ucp)
- API: pass handle to lib_config inti ucc_init. Not a pointer to a handle (ie pointer to a pointer)
- API: thread mode should be UCC_BIT. This way CL components may defined the mask of supported thread modes
- CORE: basic lib_init implementation:
       - Check UCC_CLS: parse the requested list of CLs and check if the
        corresponding dynamic objects have been successfully loaded
        - Filter/select only those components that satisfy params/config
        requirements
        - Initialize the CL lib objects using cl_iface: init

**Why?**
Implementation of UCC API ucc_lib_init/finalize.