### PR TITLE
API: protect headers for c++ usage

### DIFF
--- a/src/api/ucc.h
+++ b/src/api/ucc.h
@@ -14,6 +14,8 @@
 #include <api/ucc_status.h>
 #include <stdio.h>
 
+BEGIN_C_DECLS
+
 /** Unified Collective Communications (UCC) Library Specification
  *
  *  UCC is a collective communication operations API and library that is
@@ -1516,4 +1518,6 @@ ucc_status_t ucc_collective_test(ucc_coll_req_h request);
  *  @return Error code as defined by ucc_status_t
  */
 ucc_status_t ucc_collective_finalize(ucc_coll_req_h request);
+
+END_C_DECLS
 #endif

--- a/src/api/ucc_def.h
+++ b/src/api/ucc_def.h
@@ -12,6 +12,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+# define BEGIN_C_DECLS  extern "C" {
+# define END_C_DECLS    }
+#else
+# define BEGIN_C_DECLS
+# define END_C_DECLS
+#endif
+
 /**
  * @ingroup UCC_LIB_INIT_DT
  * @brief UCC library handle


### PR DESCRIPTION
## What
Adds extern "C" protection when c++ i used

## Why ?
Otherwise c++ app that uses libucc wouldn't link
