### PR TITLE
TOOLS: ucc info print config variables

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
-  OPEN_UCX_BRANCH: v1.9.x
+  OPEN_UCX_BRANCH: master
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -24,5 +24,8 @@ jobs:
     - name: Build UCC
       run: |
         ./autogen.sh
-        ./configure --prefix=$PWD/install --with-ucx=/tmp/ucx/install
+        ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install
         make -j`nproc` install
+    - name: Run ucc_info
+      run: |
+        /tmp/ucc/install/bin/ucc_info -vc

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,8 @@ noinst_HEADERS =             \
 	utils/ucc_compiler_def.h \
 	utils/ucc_log.h          \
 	utils/ucc_parser.h       \
-	utils/ucc_component.h
+	utils/ucc_component.h    \
+	utils/ucc_datastruct.h
 
 libucc_la_SOURCES =        \
 	core/ucc_lib.c         \

--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -5,6 +5,9 @@
 
 #include "ucc_global_opts.h"
 #include "utils/ucc_compiler_def.h"
+#include "utils/ucc_datastruct.h"
+
+UCC_LIST_HEAD(ucc_config_global_list);
 
 ucc_global_config_t ucc_global_config = {
     .log_component  = {UCC_LOG_LEVEL_WARN, "UCC"},
@@ -28,4 +31,4 @@ ucc_config_field_t ucc_global_config_table[] = {
 };
 
 UCC_CONFIG_REGISTER_TABLE(ucc_global_config_table, "UCC global", NULL,
-                          ucc_global_config)
+                          ucc_global_config, &ucc_config_global_list)

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -19,6 +19,9 @@
 
 typedef ucs_log_component_config_t ucc_log_component_config_t;
 
+#define _UCC_PP_MAKE_STRING(x) #x
+#define UCC_PP_MAKE_STRING(x)  _UCC_PP_MAKE_STRING(x)
+
 static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
 {
     switch (status) {

--- a/src/utils/ucc_datastruct.h
+++ b/src/utils/ucc_datastruct.h
@@ -1,0 +1,12 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_DATASTRUCT_H_
+#define UCC_DATASTRUCT_H_
+
+#define UCC_LIST_HEAD UCS_LIST_HEAD
+#define ucc_list_link_t ucs_list_link_t
+
+#endif

--- a/src/utils/ucc_datastruct.h
+++ b/src/utils/ucc_datastruct.h
@@ -6,6 +6,8 @@
 #ifndef UCC_DATASTRUCT_H_
 #define UCC_DATASTRUCT_H_
 
+#include <ucs/datastruct/list.h>
+
 #define UCC_LIST_HEAD UCS_LIST_HEAD
 #define ucc_list_link_t ucs_list_link_t
 

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -8,7 +8,8 @@
 
 #include "config.h"
 #include "api/ucc_status.h"
-#include "ucc_compiler_def.h"
+#include "utils/ucc_datastruct.h"
+#include "utils/ucc_compiler_def.h"
 
 #include <ucs/config/parser.h>
 #include <ucs/sys/preprocessor.h>
@@ -49,14 +50,11 @@ ucc_config_parser_set_value(void *opts, ucc_config_field_t *fields,
     return ucs_status_to_ucc_status(status);
 }
 
-static inline void ucc_config_parser_print_opts(FILE *stream, const char *title,
-                                                const void *opts,
-                                                ucc_config_field_t *fields,
-                                                const char *table_prefix,
-                                                const char *prefix,
-                                                ucc_config_print_flags_t flags)
+static inline ucs_config_print_flags_t
+ucc_print_flags_to_ucs_print_flags(ucc_config_print_flags_t flags)
 {
     ucs_config_print_flags_t ucs_flags = 0;
+
     if (flags & UCC_CONFIG_PRINT_CONFIG) {
         ucs_flags |= UCS_CONFIG_PRINT_CONFIG;
     }
@@ -69,7 +67,33 @@ static inline void ucc_config_parser_print_opts(FILE *stream, const char *title,
     if (flags & UCC_CONFIG_PRINT_HIDDEN) {
         ucs_flags |= UCS_CONFIG_PRINT_HIDDEN;
     }
+
+    return ucs_flags;
+}
+
+static inline void ucc_config_parser_print_opts(FILE *stream, const char *title,
+                                                const void *opts,
+                                                ucc_config_field_t *fields,
+                                                const char *table_prefix,
+                                                const char *prefix,
+                                                ucc_config_print_flags_t flags)
+{
+    ucs_config_print_flags_t ucs_flags;
+
+    ucs_flags = ucc_print_flags_to_ucs_print_flags(flags);
     ucs_config_parser_print_opts(stream, title, opts, fields, table_prefix,
                                  prefix, ucs_flags);
 }
+
+static inline void
+ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
+                                 ucc_config_print_flags_t flags,
+                                 ucc_list_link_t *config_list)
+{
+    ucs_config_print_flags_t ucs_flags;
+
+    ucs_flags = ucc_print_flags_to_ucs_print_flags(flags);
+    ucs_config_parser_print_all_opts(stream, prefix, ucs_flags, config_list);
+}
+
 #endif

--- a/tools/info/Makefile.am
+++ b/tools/info/Makefile.am
@@ -1,17 +1,31 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+# Copyright (C) The University of Tennessee and the University of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
+
 bin_PROGRAMS = ucc_info
 
+BUILT_SOURCES  = build_config.h
+DISTCLEANFILES = build_config.h
+
+#
+# Produce a C header file which contains all defined variables from config.h
+#
+build_config.h: $(top_builddir)/config.h Makefile
+	$(SED) -nr 's:\s*#define\s+(\w+)(\s+(\w+)|\s+(".*")|\s*)$$:{"\1", UCC_PP_MAKE_STRING(\3\4)},:p' <$(top_builddir)/config.h >$@
+
 ucc_info_SOURCES  = \
-    build_info.c \
-    ucc_info.c
+	build_info.c \
+	ucc_info.c
 
 noinst_HEADERS = \
-    ucc_info.h
+	ucc_info.h
+
+nodist_ucc_info_SOURCES = \
+	build_config.h
 
 ucc_info_CPPFLAGS = $(AM_CPPFLAGS) -I${UCC_TOP_BUILDDIR}/src
 ucc_info_LDADD = \
-    $(UCC_TOP_BUILDDIR)/src/libucc.la
+	$(UCC_TOP_BUILDDIR)/src/libucc.la

--- a/tools/info/build_info.c
+++ b/tools/info/build_info.c
@@ -6,9 +6,27 @@
 
 #include "config.h"
 #include "ucc_info.h"
+#include "utils/ucc_compiler_def.h"
 
 void print_version()
 {
     printf("# UCC version=%s revision %s\n", UCC_VERSION_STRING,
            UCC_GIT_REVISION);
+}
+
+void print_build_config()
+{
+    typedef struct {
+        const char *name;
+        const char *value;
+    } config_var_t;
+    static config_var_t config_vars[] = {
+        #include <build_config.h>
+        {NULL, NULL}
+    };
+    config_var_t *var;
+
+    for (var = config_vars; var->name != NULL; ++var) {
+        printf("#define %-25s %s\n", var->name, var->value);
+    }
 }

--- a/tools/info/ucc_info.c
+++ b/tools/info/ucc_info.c
@@ -19,7 +19,10 @@ static void usage()
     printf("  -v Show version information\n");
     printf("  -b Show build configuration\n");
     printf("  -c Show UCC configuration\n");
+    printf("  -a Show also hidden configuration\n");
+    printf("  -f Display fully decorated output\n");
     printf("  -h Show this help message\n");
+
     printf("\n");
 }
 extern ucc_list_link_t ucc_config_global_list;
@@ -32,10 +35,18 @@ int main(int argc, char **argv)
 
     print_flags = (ucc_config_print_flags_t)0;
     print_opts  = 0;
-    while ((c = getopt(argc, argv, "vbch")) != -1) {
+    while ((c = getopt(argc, argv, "vbcafh")) != -1) {
         switch (c) {
+        case 'f':
+            print_flags |= UCC_CONFIG_PRINT_CONFIG |
+                           UCC_CONFIG_PRINT_HEADER |
+                           UCC_CONFIG_PRINT_DOC;
+            break;
         case 'c':
             print_flags |= UCC_CONFIG_PRINT_CONFIG;
+            break;
+        case 'a':
+            print_flags |= UCC_CONFIG_PRINT_HIDDEN;
             break;
         case 'v':
             print_opts |= PRINT_VERSION;

--- a/tools/info/ucc_info.c
+++ b/tools/info/ucc_info.c
@@ -17,8 +17,9 @@ static void usage()
     printf("Usage: ucc_info [options]\n");
     printf("At least one of the following options has to be set:\n");
     printf("  -v Show version information\n");
-    printf("  -h Show this help message\n");
+    printf("  -b Show build configuration\n");
     printf("  -c Show UCC configuration\n");
+    printf("  -h Show this help message\n");
     printf("\n");
 }
 extern ucc_list_link_t ucc_config_global_list;
@@ -31,13 +32,16 @@ int main(int argc, char **argv)
 
     print_flags = (ucc_config_print_flags_t)0;
     print_opts  = 0;
-    while ((c = getopt(argc, argv, "cvh")) != -1) {
+    while ((c = getopt(argc, argv, "vbch")) != -1) {
         switch (c) {
         case 'c':
             print_flags |= UCC_CONFIG_PRINT_CONFIG;
             break;
         case 'v':
             print_opts |= PRINT_VERSION;
+            break;
+        case 'b':
+            print_opts |= PRINT_BUILD_CONFIG;
             break;
         case 'h':
             usage();
@@ -55,6 +59,10 @@ int main(int argc, char **argv)
 
     if (print_opts & PRINT_VERSION) {
         print_version();
+    }
+
+    if (print_opts & PRINT_BUILD_CONFIG) {
+        print_build_config();
     }
 
     if (print_flags & UCC_CONFIG_PRINT_CONFIG) {

--- a/tools/info/ucc_info.c
+++ b/tools/info/ucc_info.c
@@ -8,6 +8,7 @@
 
 #include "ucc_info.h"
 #include "utils/ucc_parser.h"
+#include "utils/ucc_datastruct.h"
 #include <getopt.h>
 #include <stdlib.h>
 
@@ -17,17 +18,24 @@ static void usage()
     printf("At least one of the following options has to be set:\n");
     printf("  -v Show version information\n");
     printf("  -h Show this help message\n");
+    printf("  -c Show UCC configuration\n");
     printf("\n");
 }
+extern ucc_list_link_t ucc_config_global_list;
 
 int main(int argc, char **argv)
 {
+    ucc_config_print_flags_t print_flags;
     unsigned print_opts;
     int      c;
 
-    print_opts = 0;
-    while ((c = getopt(argc, argv, "vh")) != -1) {
+    print_flags = (ucc_config_print_flags_t)0;
+    print_opts  = 0;
+    while ((c = getopt(argc, argv, "cvh")) != -1) {
         switch (c) {
+        case 'c':
+            print_flags |= UCC_CONFIG_PRINT_CONFIG;
+            break;
         case 'v':
             print_opts |= PRINT_VERSION;
             break;
@@ -40,13 +48,18 @@ int main(int argc, char **argv)
         }
     }
 
-    if (print_opts == 0) {
+    if ((print_opts == 0) && (print_flags == 0)) {
         usage();
         return -2;
     }
 
     if (print_opts & PRINT_VERSION) {
         print_version();
+    }
+
+    if (print_flags & UCC_CONFIG_PRINT_CONFIG) {
+        ucc_config_parser_print_all_opts(stdout, "UCC_", print_flags,
+                                         &ucc_config_global_list);
     }
 
     return 0;

--- a/tools/info/ucc_info.h
+++ b/tools/info/ucc_info.h
@@ -10,9 +10,12 @@
 #include "api/ucc.h"
 
 enum {
-    PRINT_VERSION = UCC_BIT(0),
+    PRINT_VERSION      = UCC_BIT(0),
+    PRINT_BUILD_CONFIG = UCC_BIT(1),
 };
 
 void print_version();
+
+void print_build_config();
 
 #endif


### PR DESCRIPTION
## What
Add -c option to ucc_info to print UCC config variables
CI runs ucc_info

## Why ?
Convenient way to print all config variables in UCC 

## How ?
ucs_config_print_all_opts is used. Changes in this PR requires latest version of UCS to work properly (https://github.com/openucx/ucx/pull/5876).
config tables of UCC separated from UCX config tables
