### PR TITLE
UCC/CL: cl basic starting implementation

### DIFF
--- a/config/m4/ucx.m4
+++ b/config/m4/ucx.m4
@@ -5,7 +5,7 @@
 
 AC_DEFUN([CHECK_UCX],[
 UCX_MIN_REQUIRED_MAJOR=1
-UCX_MIN_REQUIRED_MINOR=9
+UCX_MIN_REQUIRED_MINOR=10
 AS_IF([test "x$ucx_checked" != "xyes"],[
     ucx_happy="no"
 

--- a/configure.ac
+++ b/configure.ac
@@ -137,15 +137,16 @@ if test $ucx_happy != "yes"; then
    AC_MSG_ERROR([UCX is not available])
 fi
 
-includes="-I${UCC_TOP_SRCDIR}/src"
+includes="-I${UCC_TOP_SRCDIR}/src -I${UCC_TOP_BUILDDIR}/src"
 CPPFLAGS="$UCS_CPPFLAGS $CPPFLAGS $includes -std=gnu11 -Wall -Werror"
 LDFLAGS="$LDFLAGS $UCS_LDFLAGS $UCS_LIBADD"
 
 AC_CONFIG_FILES([
                  Makefile
                  src/Makefile
-                 src/api/ucc_version.h
                  tools/info/Makefile
+                 src/cl/basic/Makefile
+                 src/api/ucc_version.h
                  src/core/ucc_version.c
                  ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
 #
+SUBDIRS = cl/basic
 
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =
@@ -24,7 +25,8 @@ noinst_HEADERS =             \
 	utils/ucc_component.h    \
 	utils/ucc_datastruct.h   \
 	utils/ucc_math.h         \
-	cl/ucc_cl.h
+	cl/ucc_cl.h              \
+	cl/ucc_cl_log.h
 
 libucc_la_SOURCES =        \
 	core/ucc_lib.c         \

--- a/src/cl/basic/Makefile.am
+++ b/src/cl/basic/Makefile.am
@@ -1,0 +1,13 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+
+sources =          \
+	cl_basic.h     \
+	cl_basic_lib.c
+
+libucc_cl_basic_la_SOURCES =$(sources)
+libucc_cl_basic_la_CPPFLAGS = $(AM_CPPFLAGS)
+libucc_cl_basic_la_LDFLAGS = -version-info $(SOVERSION) --as-needed
+
+pkglib_LTLIBRARIES = libucc_cl_basic.la

--- a/src/cl/basic/cl_basic.h
+++ b/src/cl/basic/cl_basic.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_CL_BASIC_H_
+#define UCC_CL_BASIC_H_
+#include "cl/ucc_cl.h"
+
+typedef struct ucc_cl_basic_iface {
+    ucc_cl_iface_t super;
+} ucc_cl_basic_iface_t;
+/* Extern iface should follow the pattern: ucc_cl_<cl_name> */
+extern ucc_cl_basic_iface_t ucc_cl_basic;
+
+typedef struct ucc_cl_basic_lib_config {
+    ucc_cl_lib_config_t super;
+} ucc_cl_basic_lib_config_t;
+
+typedef struct ucc_cl_basic_lib {
+    ucc_cl_lib_t super;
+} ucc_cl_basic_lib_t;
+
+#endif

--- a/src/cl/basic/cl_basic.h
+++ b/src/cl/basic/cl_basic.h
@@ -22,4 +22,6 @@ typedef struct ucc_cl_basic_lib {
     ucc_cl_lib_t super;
 } ucc_cl_basic_lib_t;
 
+UCC_CLASS_DECLARE(ucc_cl_basic_lib_t, ucc_cl_iface_t *,
+                  const ucc_lib_config_t *, const ucc_cl_lib_config_t *);
 #endif

--- a/src/cl/basic/cl_basic_lib.c
+++ b/src/cl/basic/cl_basic_lib.c
@@ -15,40 +15,41 @@ static ucc_config_field_t ucc_cl_basic_lib_config_table[] = {
     {NULL}
 };
 
-static ucc_status_t ucc_basic_lib_init(const ucc_lib_params_t *params,
-                                       const ucc_lib_config_t *config,
-                                       const ucc_cl_lib_config_t *cl_config,
-                                       ucc_cl_lib_t **cl_lib)
+UCC_CLASS_INIT_FUNC(ucc_cl_basic_lib_t, ucc_cl_iface_t *cl_iface,
+                    const ucc_lib_config_t *config,
+                    const ucc_cl_lib_config_t *cl_config)
 {
-    ucc_cl_basic_lib_t *lib;
-    ucc_status_t        status;
-    lib = (ucc_cl_basic_lib_t *)ucc_malloc(sizeof(*lib), "basic_lib");
-    ucc_cl_lib_init(&lib->super, &ucc_cl_basic.super, cl_config);
-    if (!lib) {
-        cl_error(&lib->super, "failed to allocate %zd bytes for lib object",
-                 sizeof(*lib));
-        status = UCC_ERR_NO_MEMORY;
-        goto error;
-    }
-    lib->super.iface = &ucc_cl_basic.super;
-    cl_info(&lib->super, "initialized lib object: %p", lib);
-    *cl_lib = &lib->super;
+    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_lib_t, cl_iface, config, cl_config);
+    cl_info(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
-
-error:
-    return status;
 }
 
-static ucc_status_t ucc_basic_lib_finalize(ucc_cl_lib_t *cl_lib)
+UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
+{
+    cl_info(&self->super, "finalizing lib object: %p", self);
+}
+
+UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
+
+static ucc_status_t ucc_cl_basic_lib_init(const ucc_lib_params_t *params,
+                                          const ucc_lib_config_t *config,
+                                          const ucc_cl_lib_config_t *cl_config,
+                                          ucc_cl_lib_t **cl_lib)
+{
+    return UCC_CLASS_NEW(ucc_cl_basic_lib_t, cl_lib, &ucc_cl_basic.super,
+                         config, cl_config);
+}
+
+static ucc_status_t ucc_cl_basic_lib_finalize(ucc_cl_lib_t *cl_lib)
 {
     ucc_cl_basic_lib_t *lib = ucc_derived_of(cl_lib, ucc_cl_basic_lib_t);
-    cl_info(cl_lib, "finalizing lib object: %p", lib);
-    free(lib);
+    UCC_CLASS_DELETE(ucc_cl_basic_lib_t, lib);
     return UCC_OK;
 }
 
 ucc_cl_basic_iface_t ucc_cl_basic = {
     .super.super.name = "basic",
+    .super.type       = UCC_CL_BASIC,
     .super.priority   = 10,
     .super.cl_lib_config =
         {
@@ -57,6 +58,6 @@ ucc_cl_basic_iface_t ucc_cl_basic = {
             .table  = ucc_cl_basic_lib_config_table,
             .size   = sizeof(ucc_cl_basic_lib_config_t),
         },
-    .super.init     = ucc_basic_lib_init,
-    .super.finalize = ucc_basic_lib_finalize,
+    .super.init     = ucc_cl_basic_lib_init,
+    .super.finalize = ucc_cl_basic_lib_finalize,
 };

--- a/src/cl/basic/cl_basic_lib.c
+++ b/src/cl/basic/cl_basic_lib.c
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "cl_basic.h"
+#include "cl/ucc_cl_log.h"
+#include "utils/ucc_malloc.h"
+
+static ucc_config_field_t ucc_cl_basic_lib_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_cl_basic_lib_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(ucc_cl_lib_config_table)},
+
+    {NULL}
+};
+
+static ucc_status_t ucc_basic_lib_init(const ucc_lib_params_t *params,
+                                       const ucc_lib_config_t *config,
+                                       const ucc_cl_lib_config_t *cl_config,
+                                       ucc_cl_lib_t **cl_lib)
+{
+    ucc_cl_basic_lib_t *lib;
+    ucc_status_t        status;
+    lib = (ucc_cl_basic_lib_t *)ucc_malloc(sizeof(*lib), "basic_lib");
+    ucc_cl_lib_init(&lib->super, &ucc_cl_basic.super, cl_config);
+    if (!lib) {
+        cl_error(&lib->super, "failed to allocate %zd bytes for lib object",
+                 sizeof(*lib));
+        status = UCC_ERR_NO_MEMORY;
+        goto error;
+    }
+    lib->super.iface = &ucc_cl_basic.super;
+    cl_info(&lib->super, "initialized lib object: %p", lib);
+    *cl_lib = &lib->super;
+    return UCC_OK;
+
+error:
+    return status;
+}
+
+static ucc_status_t ucc_basic_lib_finalize(ucc_cl_lib_t *cl_lib)
+{
+    ucc_cl_basic_lib_t *lib = ucc_derived_of(cl_lib, ucc_cl_basic_lib_t);
+    cl_info(cl_lib, "finalizing lib object: %p", lib);
+    free(lib);
+    return UCC_OK;
+}
+
+ucc_cl_basic_iface_t ucc_cl_basic = {
+    .super.super.name = "basic",
+    .super.priority   = 10,
+    .super.cl_lib_config =
+        {
+            .name   = "CL_BASIC",
+            .prefix = "CL_BASIC_",
+            .table  = ucc_cl_basic_lib_config_table,
+            .size   = sizeof(ucc_cl_basic_lib_config_t),
+        },
+    .super.init     = ucc_basic_lib_init,
+    .super.finalize = ucc_basic_lib_finalize,
+};

--- a/src/cl/ucc_cl.c
+++ b/src/cl/ucc_cl.c
@@ -28,3 +28,22 @@ const char *ucc_cl_names[] = {
     [UCC_CL_ALL]   = "all",
     [UCC_CL_LAST]  = NULL
 };
+
+UCC_CLASS_INIT_FUNC(ucc_cl_lib_t, ucc_cl_iface_t *cl_iface,
+                    const ucc_lib_config_t *config,
+                    const ucc_cl_lib_config_t *cl_config)
+{
+    self->iface         = cl_iface;
+    self->log_component = cl_config->log_component;
+    ucc_strncpy_safe(self->log_component.name, cl_iface->cl_lib_config.name,
+                     sizeof(self->log_component.name));
+    self->priority =
+        (-1 == cl_config->priority) ? cl_iface->priority : cl_config->priority;
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_cl_lib_t)
+{
+}
+
+UCC_CLASS_DEFINE(ucc_cl_lib_t, void);

--- a/src/cl/ucc_cl.h
+++ b/src/cl/ucc_cl.h
@@ -46,4 +46,16 @@ typedef struct ucc_cl_lib {
     int                         priority;
 } ucc_cl_lib_t;
 
+/* Every component should call this init function during (*init) in order
+   to use common priority/logging mechanism */
+static inline void ucc_cl_lib_init(ucc_cl_lib_t *cl_lib, ucc_cl_iface_t *cl_iface,
+                                   const ucc_cl_lib_config_t *cl_config)
+{
+    cl_lib->log_component = cl_config->log_component;
+    ucc_strncpy_safe(cl_lib->log_component.name, cl_iface->cl_lib_config.name,
+                     sizeof(cl_lib->log_component.name));
+    cl_lib->priority =
+        (-1 == cl_config->priority) ? cl_iface->priority : cl_config->priority;
+}
+
 #endif

--- a/src/cl/ucc_cl.h
+++ b/src/cl/ucc_cl.h
@@ -14,6 +14,7 @@
 #include "ucc_cl_type.h"
 #include "utils/ucc_component.h"
 #include "utils/ucc_parser.h"
+#include "utils/ucc_class.h"
 
 typedef struct ucc_cl_lib   ucc_cl_lib_t;
 typedef struct ucc_cl_iface ucc_cl_iface_t;
@@ -39,23 +40,14 @@ typedef struct ucc_cl_iface {
                                            ucc_cl_lib_t **cl_lib);
     ucc_status_t                   (*finalize)(ucc_cl_lib_t *cl_lib);
 } ucc_cl_iface_t;
+UCC_CLASS_DECLARE(ucc_cl_iface_t);
 
 typedef struct ucc_cl_lib {
     ucc_cl_iface_t             *iface;
     ucc_log_component_config_t  log_component;
     int                         priority;
 } ucc_cl_lib_t;
-
-/* Every component should call this init function during (*init) in order
-   to use common priority/logging mechanism */
-static inline void ucc_cl_lib_init(ucc_cl_lib_t *cl_lib, ucc_cl_iface_t *cl_iface,
-                                   const ucc_cl_lib_config_t *cl_config)
-{
-    cl_lib->log_component = cl_config->log_component;
-    ucc_strncpy_safe(cl_lib->log_component.name, cl_iface->cl_lib_config.name,
-                     sizeof(cl_lib->log_component.name));
-    cl_lib->priority =
-        (-1 == cl_config->priority) ? cl_iface->priority : cl_config->priority;
-}
+UCC_CLASS_DECLARE(ucc_cl_lib_t, ucc_cl_iface_t *, const ucc_lib_config_t *,
+                  const ucc_cl_lib_config_t *);
 
 #endif

--- a/src/cl/ucc_cl_log.h
+++ b/src/cl/ucc_cl_log.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_CL_LOG_H_
+#define UCC_CL_LOG_H_
+#include "utils/ucc_log.h"
+#define ucc_log_component_cl(_cl_lib, _level, fmt, ...)                        \
+    ucc_log_component(_level, (_cl_lib)->log_component, fmt, ##__VA_ARGS__)
+
+#define cl_error(_cl_lib, _fmt, ...)                                           \
+    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
+#define cl_warn(_cl_lib, _fmt, ...)                                            \
+    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
+#define cl_info(_cl_lib, _fmt, ...)                                            \
+    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+#define cl_debug(_cl_lib, _fmt, ...)                                           \
+    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
+#define cl_trace(_cl_lib, _fmt, ...)                                           \
+    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+
+#endif

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -133,12 +133,6 @@ static ucc_status_t ucc_lib_init_filtered(const ucc_lib_params_t *user_params,
                 continue;
             }
         }
-        cl_lib->log_component = cl_config->log_component;
-        ucc_strncpy_safe(cl_lib->log_component.name,
-                         cl_iface->cl_lib_config.prefix,
-                         sizeof(cl_lib->log_component.name));
-        cl_lib->priority = (-1 == cl_config->priority) ? cl_iface->priority
-                                                       : cl_config->priority;
         ucc_config_parser_release_opts(cl_config,
                                        cl_iface->cl_lib_config.table);
         free(cl_config);

--- a/src/utils/ucc_class.h
+++ b/src/utils/ucc_class.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_CLASS_H_
+#define UCC_CLASS_H_
+
+#include "config.h"
+#include <ucs/type/class.h>
+#include "utils/ucc_compiler_def.h"
+
+#define UCC_CLASS_DECLARE         UCS_CLASS_DECLARE
+#define UCC_CLASS_DEFINE          UCS_CLASS_DEFINE
+#define UCC_CLASS_DELETE          UCS_CLASS_DELETE
+#define UCC_CLASS_INIT_FUNC       UCS_CLASS_INIT_FUNC
+#define UCC_CLASS_CLEANUP_FUNC    UCS_CLASS_CLEANUP_FUNC
+
+#define UCC_CLASS_NEW(...)                                                     \
+    ({                                                                         \
+        ucs_status_t _ucs_status = UCS_CLASS_NEW(__VA_ARGS__);                 \
+        ucc_status_t _status     = ucs_status_to_ucc_status(_ucs_status);      \
+        _status;                                                               \
+    })
+
+#define UCC_CLASS_CALL_SUPER_INIT(_superclass, ...)                            \
+    {                                                                          \
+        {                                                                      \
+            ucs_status_t _ucs_status = _UCS_CLASS_INIT_NAME(_superclass)(      \
+                &self->super, _myclass->superclass, _init_count,               \
+                ##__VA_ARGS__);                                                \
+            ucc_status_t _status = ucs_status_to_ucc_status(_ucs_status);      \
+            if (_status != UCC_OK) {                                           \
+                return _status;                                                \
+            }                                                                  \
+            if (_myclass->superclass != &_UCS_CLASS_DECL_NAME(void)) {         \
+                ++(*_init_count);                                              \
+            }                                                                  \
+        }                                                                      \
+    }
+
+#endif

--- a/src/utils/ucc_component.h
+++ b/src/utils/ucc_component.h
@@ -24,7 +24,7 @@ typedef struct ucc_component_framework {
 } ucc_component_framework_t;
 
 /* ucc_components_load searches for all available dynamic components 
-   with the name matching the pattern: ucc_<framework_name>_*.so. 
+   with the name matching the pattern: libucc_<framework_name>_*.so.
    The search is performed in the ucc_global_config.component_path.
    Each dynamic component must have a component interface structure defined.
    This structure must inherit from ucc_component_iface_t.


### PR DESCRIPTION
## What
 - Adds CL_BASIC component: build infra, lib_init/finalize, logging
 - Sets min required UCX version to 1.10
 - Minor change in ucc_framework: look for libucc_*.so objects instead of ucc_*.so (prefix lib appears due to libtool usage)

## Why ?
UCX 1.10 contains the UCS config table changes that used by UCC.


