### PR TITLE
CORE: context_config_read/modify/print/release

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,7 @@ nobase_dist_libucc_la_HEADERS = \
 noinst_HEADERS =             \
 	core/ucc_global_opts.h   \
 	core/ucc_lib.h           \
+	core/ucc_context.h       \
 	utils/ucc_compiler_def.h \
 	utils/ucc_log.h          \
 	utils/ucc_parser.h       \
@@ -33,6 +34,7 @@ libucc_la_SOURCES =        \
 	core/ucc_constructor.c \
 	core/ucc_global_opts.c \
 	core/ucc_version.c     \
+	core/ucc_context.c     \
 	utils/ucc_component.c  \
 	cl/ucc_cl.c
 

--- a/src/api/ucc.h
+++ b/src/api/ucc.h
@@ -737,6 +737,57 @@ ucc_status_t ucc_context_config_read(ucc_lib_h lib_handle,
 
 void ucc_context_config_release(ucc_context_config_h config);
 
+/**
+ *  @ingroup UCC_CONTEXT
+ *
+ *  @brief The @ref ucc_context_config_print routine prints the configuration information
+ *
+ *  @param [in]  config        ucc_context_config_h "Configuration descriptor"
+ *                             to print.
+ *  @param [in]  stream        Output stream to print the configuration to.
+ *  @param [in]  title         Configuration title to print.
+ *  @param [in]  print_flags   Flags that control various printing options.
+ *
+ *  @parblock
+ *
+ *  @b Description
+ *
+ *  The routine prints the configuration information that is stored in
+ *  ucc_context_config_h "configuration" descriptor.
+ *
+ *  @endparblock
+ *
+ */
+
+void ucc_context_config_print(const ucc_context_config_h config, FILE *stream,
+                              const char *title, ucc_config_print_flags_t print_flags);
+
+/**
+ *  @ingroup UCC_CONTEXT
+ *
+ *  @brief The @ref ucc_context_config_modify routine modifies the runtime configuration
+ *                  of UCC context (for a given CLS)
+ *
+ *  @param [in] config   Pointer to the configuration descriptor to be modified
+ *  @param [in] cls      Comma separated list of CLS
+ *  @param [in] name     Configuration variable to be modified
+ *  @param [in] value    Configuration value to set
+ *
+ *  @parblock
+ *
+ *  @b Description
+ *
+ *  The @ref ucc_context_config_modify routine sets the value of identifier "name"
+ *  to "value" for a specified CL.
+ *
+ *  @endparblock
+ *
+ *  @return Error code as defined by ucc_status_t
+ */
+
+ucc_status_t ucc_context_config_modify(ucc_context_config_h config,
+                                       const char *cls, const char *name,
+                                       const char *value);
 
 /**
  *  @ingroup UCC_CONTEXT

--- a/src/cl/basic/cl_basic.h
+++ b/src/cl/basic/cl_basic.h
@@ -18,6 +18,11 @@ typedef struct ucc_cl_basic_lib_config {
     ucc_cl_lib_config_t super;
 } ucc_cl_basic_lib_config_t;
 
+typedef struct ucc_cl_basic_context_config {
+    ucc_cl_context_config_t super;
+    int                     test_param;
+} ucc_cl_basic_context_config_t;
+
 typedef struct ucc_cl_basic_lib {
     ucc_cl_lib_t super;
 } ucc_cl_basic_lib_t;

--- a/src/cl/basic/cl_basic_lib.c
+++ b/src/cl/basic/cl_basic_lib.c
@@ -10,7 +10,18 @@
 
 static ucc_config_field_t ucc_cl_basic_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_basic_lib_config_t, super),
-     UCS_CONFIG_TYPE_TABLE(ucc_cl_lib_config_table)},
+     UCC_CONFIG_TYPE_TABLE(ucc_cl_lib_config_table)},
+
+    {NULL}
+};
+
+static ucs_config_field_t ucc_cl_basic_context_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_cl_basic_context_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_cl_context_config_table)},
+
+    {"TEST_PARAM", "5", "For dbg test purpuse : don't commit",
+     ucc_offsetof(ucc_cl_basic_context_config_t, test_param),
+     UCC_CONFIG_TYPE_UINT},
 
     {NULL}
 };
@@ -57,6 +68,13 @@ ucc_cl_basic_iface_t ucc_cl_basic = {
             .prefix = "CL_BASIC_",
             .table  = ucc_cl_basic_lib_config_table,
             .size   = sizeof(ucc_cl_basic_lib_config_t),
+        },
+    .super.cl_context_config =
+        {
+            .name   = "CL_BASIC",
+            .prefix = "CL_BASIC_",
+            .table  = ucc_cl_basic_context_config_table,
+            .size   = sizeof(ucc_cl_basic_context_config_t),
         },
     .super.init     = ucc_cl_basic_lib_init,
     .super.finalize = ucc_cl_basic_lib_finalize,

--- a/src/cl/basic/cl_basic_lib.c
+++ b/src/cl/basic/cl_basic_lib.c
@@ -58,24 +58,4 @@ static ucc_status_t ucc_cl_basic_lib_finalize(ucc_cl_lib_t *cl_lib)
     return UCC_OK;
 }
 
-ucc_cl_basic_iface_t ucc_cl_basic = {
-    .super.super.name = "basic",
-    .super.type       = UCC_CL_BASIC,
-    .super.priority   = 10,
-    .super.cl_lib_config =
-        {
-            .name   = "CL_BASIC",
-            .prefix = "CL_BASIC_",
-            .table  = ucc_cl_basic_lib_config_table,
-            .size   = sizeof(ucc_cl_basic_lib_config_t),
-        },
-    .super.cl_context_config =
-        {
-            .name   = "CL_BASIC",
-            .prefix = "CL_BASIC_",
-            .table  = ucc_cl_basic_context_config_table,
-            .size   = sizeof(ucc_cl_basic_context_config_t),
-        },
-    .super.init     = ucc_cl_basic_lib_init,
-    .super.finalize = ucc_cl_basic_lib_finalize,
-};
+UCC_CL_IFACE_DECLARE(basic, BASIC, 10);

--- a/src/cl/ucc_cl.h
+++ b/src/cl/ucc_cl.h
@@ -63,4 +63,25 @@ typedef struct ucc_cl_context {
     ucc_cl_lib_t *cl_lib;
 } ucc_cl_context_t;
 
+#define UCC_CL_IFACE_NAME_PREFIX(_NAME)                 \
+    .name   = UCC_PP_MAKE_STRING(CL_ ## _NAME),         \
+    .prefix = UCC_PP_MAKE_STRING(CL_ ## _NAME ##_)
+
+#define UCC_CL_IFACE_CFG(_cfg, _name, _NAME)                            \
+    .super.cl_ ## _cfg ## _config = {                                   \
+        UCC_CL_IFACE_NAME_PREFIX(_NAME),                                \
+        .table  = ucc_cl_ ## _name ## _ ## _cfg ## _config_table,       \
+        .size   = sizeof(ucc_cl_ ## _name ## _ ## _cfg ## _config_t)}
+
+#define UCC_CL_IFACE_DECLARE(_name, _NAME, _priority)           \
+    ucc_cl_ ## _name ## _iface_t ucc_cl_ ## _name = {           \
+        UCC_CL_IFACE_CFG(lib, _name, _NAME),                    \
+        UCC_CL_IFACE_CFG(context, _name, _NAME),                \
+        .super.super.name = UCC_PP_MAKE_STRING(basic),          \
+        .super.type       = UCC_CL_ ## _NAME,                   \
+        .super.priority   = _priority,                          \
+        .super.init       = ucc_cl_ ## _name ## _lib_init,      \
+        .super.finalize   = ucc_cl_ ## _name ## _lib_finalize,  \
+    }
+
 #endif

--- a/src/cl/ucc_cl.h
+++ b/src/cl/ucc_cl.h
@@ -16,8 +16,9 @@
 #include "utils/ucc_parser.h"
 #include "utils/ucc_class.h"
 
-typedef struct ucc_cl_lib   ucc_cl_lib_t;
-typedef struct ucc_cl_iface ucc_cl_iface_t;
+typedef struct ucc_cl_lib     ucc_cl_lib_t;
+typedef struct ucc_cl_iface   ucc_cl_iface_t;
+typedef struct ucc_cl_context ucc_cl_context_t;
 
 typedef struct ucc_cl_lib_config {
     /* Log level above which log messages will be printed */
@@ -26,7 +27,13 @@ typedef struct ucc_cl_lib_config {
     int                        priority;
 } ucc_cl_lib_config_t;
 
+typedef struct ucc_cl_context_config {
+    ucc_cl_iface_t *iface;
+    ucc_cl_lib_t   *cl_lib;
+} ucc_cl_context_config_t;
+
 extern ucc_config_field_t ucc_cl_lib_config_table[];
+extern ucc_config_field_t ucc_cl_context_config_table[];
 
 typedef struct ucc_cl_iface {
     ucc_component_iface_t          super;
@@ -34,6 +41,7 @@ typedef struct ucc_cl_iface {
     int                            priority;
     ucc_lib_attr_t                 attr;
     ucc_config_global_list_entry_t cl_lib_config;
+    ucs_config_global_list_entry_t cl_context_config;
     ucc_status_t                   (*init)(const ucc_lib_params_t *params,
                                            const ucc_lib_config_t *config,
                                            const ucc_cl_lib_config_t *cl_config,
@@ -47,7 +55,12 @@ typedef struct ucc_cl_lib {
     ucc_log_component_config_t  log_component;
     int                         priority;
 } ucc_cl_lib_t;
+
 UCC_CLASS_DECLARE(ucc_cl_lib_t, ucc_cl_iface_t *, const ucc_lib_config_t *,
                   const ucc_cl_lib_config_t *);
+
+typedef struct ucc_cl_context {
+    ucc_cl_lib_t *cl_lib;
+} ucc_cl_context_t;
 
 #endif

--- a/src/cl/ucc_cl_type.h
+++ b/src/cl/ucc_cl_type.h
@@ -6,6 +6,8 @@
 #ifndef UCC_CL_TYPE_H_
 #define UCC_CL_TYPE_H_
 
+#include <string.h>
+
 typedef enum {
     UCC_CL_BASIC,
     UCC_CL_ALL,
@@ -14,4 +16,20 @@ typedef enum {
 
 extern const char *ucc_cl_names[];
 
+static inline ucc_cl_type_t ucc_cl_name_to_type(const char *cl_name)
+{
+    int i;
+    for (i = 0; i < UCC_CL_LAST; i++) {
+        if (0 == strcmp(cl_name, ucc_cl_names[i])) {
+            break;
+        }
+    }
+    return (ucc_cl_type_t)i;
+}
+
+/* takes string of comma separated cls and returns and array of ucc_cl_type_t.
+   the checks for correct input are done.
+   the allocated should be freed by the user. */
+ucc_status_t ucc_parse_cls_string(const char *cls_str,
+                                  ucc_cl_type_t **cls_array, int *n_cls);
 #endif

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -1,0 +1,206 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "ucc_context.h"
+#include "cl/ucc_cl.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_log.h"
+#include "cl/ucc_cl_type.h"
+ucc_status_t ucc_context_config_read(ucc_lib_info_t *lib, const char *filename,
+                                     ucc_context_config_t **config_p)
+{
+    int                   i;
+    ucc_status_t          status;
+    ucc_context_config_t *config;
+
+    config = (ucc_context_config_t *)ucc_malloc(sizeof(ucc_context_config_t),
+                                                "ctx_config");
+    if (config == NULL) {
+        ucc_error("failed to allocate %zd bytes for context config",
+                  sizeof(ucc_context_config_t));
+        status = UCC_ERR_NO_MEMORY;
+        goto err_config;
+    }
+
+    config->configs = (ucc_cl_context_config_t **)ucc_calloc(
+        lib->n_libs_opened, sizeof(ucc_cl_context_config_t *),
+        "cl_configs_array");
+    if (config->configs == NULL) {
+        ucc_error("failed to allocate %zd bytes for cl configs array",
+                  sizeof(ucc_cl_context_config_t *));
+        status = UCC_ERR_NO_MEMORY;
+        goto err_configs;
+    }
+
+    config->n_cl_cfg = 0;
+    for (i = 0; i < lib->n_libs_opened; i++) {
+        ucc_assert(NULL != lib->libs[i]->iface->cl_context_config.table);
+        config->configs[i] = (ucc_cl_context_config_t *)ucc_malloc(
+            lib->libs[i]->iface->cl_context_config.size, "cl_config");
+        if (!config->configs[i]) {
+            ucc_error("failed to allocate %zd bytes for cl config",
+                      sizeof(lib->libs[i]->iface->cl_context_config.size));
+            status = UCC_ERR_NO_MEMORY;
+            goto err_config_i;
+        }
+        status = ucc_config_parser_fill_opts(
+            config->configs[config->n_cl_cfg],
+            lib->libs[i]->iface->cl_context_config.table, lib->full_prefix,
+            lib->libs[i]->iface->cl_context_config.prefix, 0);
+        if (UCC_OK != status) {
+            ucc_error("failed to read CL \"%s\" context configuration",
+                      lib->libs[i]->iface->super.name);
+            free(config->configs[i]);
+            goto err_config_i;
+        }
+        config->configs[config->n_cl_cfg]->iface  = lib->libs[i]->iface;
+        config->configs[config->n_cl_cfg]->cl_lib = lib->libs[i];
+        config->n_cl_cfg++;
+    }
+    config->lib = lib;
+    *config_p   = config;
+    return UCC_OK;
+
+err_config_i:
+    for (i = i - 1; i >= 0; i--) {
+        free(config->configs[i]);
+    }
+err_configs:
+    free(config->configs);
+
+err_config:
+    free(config);
+    return status;
+}
+
+/* Look up the cl_context_config in the array of configs based on the
+   cl_type. returns NULL if not found */
+static inline ucc_cl_context_config_t *
+find_cl_context_config(ucc_context_config_t *cfg, ucc_cl_type_t cl_type)
+{
+    int i;
+    for (i = 0; i < cfg->n_cl_cfg; i++) {
+        if (cfg->configs[i] && cl_type == cfg->configs[i]->iface->type) {
+            return cfg->configs[i];
+        }
+    }
+    return NULL;
+}
+
+/* Modifies the ucc_context configuration.
+   If user sets cls="all" then this means that the parameter  "name" should
+   be modified in ALL available CLS. In this case we loop over all of them,
+   and if error is reported by any CL we bail and report error to the user.
+
+   If user passes a comma separated list of CLs, then we go over the list
+   and apply modifications to the specified CLs only. */
+ucc_status_t ucc_context_config_modify(ucc_context_config_t *config,
+                                       const char *cls, const char *name,
+                                       const char *value)
+{
+    int                      i;
+    ucc_status_t             status;
+    ucc_cl_context_config_t *cl_cfg;
+    if (0 != strcmp(cls, "all")) {
+        ucc_cl_type_t *required_cls;
+        int            n_required_cls;
+        status = ucc_parse_cls_string(cls, &required_cls, &n_required_cls);
+        if (UCC_OK != status) {
+            ucc_error("failed to parse cls string: %s", cls);
+            return status;
+        }
+        for (i = 0; i < n_required_cls; i++) {
+            cl_cfg = find_cl_context_config(config, required_cls[i]);
+            if (!cl_cfg) {
+                ucc_error("required CL %s is not part of the context",
+                          ucc_cl_names[required_cls[i]]);
+                return UCC_ERR_INVALID_PARAM;
+            }
+            status = ucc_config_parser_set_value(
+                cl_cfg, cl_cfg->iface->cl_context_config.table, name, value);
+            if (UCC_OK != status) {
+                ucc_error("failed to modify CL \"%s\" configuration, name %s, "
+                          "value %s",
+                          cl_cfg->iface->super.name, name, value);
+                return status;
+            }
+        }
+        free(required_cls);
+    } else {
+        for (i = 0; i < config->n_cl_cfg; i++) {
+            if (config->configs[i]) {
+                status = ucc_config_parser_set_value(
+                    config->configs[i],
+                    config->lib->libs[i]->iface->cl_context_config.table, name,
+                    value);
+                if (UCC_OK != status) {
+                    ucc_error("failed to modify CL \"%s\" configuration, name "
+                              "%s, value %s",
+                              config->lib->libs[i]->iface->super.name, name,
+                              value);
+                    return status;
+                }
+            }
+        }
+    }
+    return UCC_OK;
+}
+
+void ucc_context_config_release(ucc_context_config_t *config)
+{
+    int i;
+    for (i = 0; i < config->n_cl_cfg; i++) {
+        if (!config->configs[i]) {
+            continue;
+        }
+        ucc_config_parser_release_opts(
+            config->configs[i],
+            config->lib->libs[i]->iface->cl_context_config.table);
+        free(config->configs[i]);
+    }
+    free(config->configs);
+    free(config);
+}
+
+/* The function prints the configuration of UCC context.
+   The ucc_context is a combination of contexts of different
+   (potentially multiple) CLs.
+
+   If HEADER flag is required - print it once passing user "title"
+   variable. For other cl_contexts use CL name as title so that
+   the printed output was clear for a user */
+void ucc_context_config_print(const ucc_context_config_h config, FILE *stream,
+                              const char *title,
+                              ucc_config_print_flags_t print_flags)
+{
+    int i;
+    int print_header = print_flags & UCC_CONFIG_PRINT_HEADER;
+    int flags        = print_flags;
+    /* cl_context_configs will always be printed with HEADER using
+       CL name as title */
+    flags |= UCC_CONFIG_PRINT_HEADER;
+
+    for (i = 0; i < config->n_cl_cfg; i++) {
+        if (!config->configs[i]) {
+            continue;
+        }
+        if (print_header) {
+            print_header = 0;
+            ucc_config_parser_print_opts(
+                stream, title, config->configs[i],
+                config->lib->libs[i]->iface->cl_context_config.table,
+                config->lib->libs[i]->iface->cl_context_config.prefix,
+                config->lib->full_prefix, UCC_CONFIG_PRINT_HEADER);
+        }
+
+        ucc_config_parser_print_opts(
+            stream, config->lib->libs[i]->iface->cl_context_config.name,
+            config->configs[i],
+            config->lib->libs[i]->iface->cl_context_config.table,
+            config->lib->libs[i]->iface->cl_context_config.prefix,
+            config->lib->full_prefix, (ucc_config_print_flags_t)flags);
+    }
+}

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_CONTEXT_H_
+#define UCC_CONTEXT_H_
+
+#include "api/ucc.h"
+
+typedef struct ucc_lib_info          ucc_lib_info_t;
+typedef struct ucc_cl_context        ucc_cl_context_t;
+typedef struct ucc_cl_context_config ucc_cl_context_config_t;
+
+typedef struct ucc_context {
+    ucc_lib_info_t      *lib;
+    ucc_context_attr_t   attr;
+    ucc_cl_context_t   **cl_ctx;
+    int                  n_cl_ctx;
+} ucc_context_t;
+
+typedef struct ucc_context_config {
+    ucc_lib_info_t           *lib;
+    ucc_cl_context_config_t **configs;
+    int                       n_cl_cfg;
+} ucc_context_config_t;
+
+#endif

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -26,8 +26,10 @@ typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
 #define UCC_CONFIG_REGISTER_TABLE    UCS_CONFIG_REGISTER_TABLE
 #define UCC_CONFIG_TYPE_STRING       UCS_CONFIG_TYPE_STRING
 #define UCC_CONFIG_TYPE_INT          UCS_CONFIG_TYPE_INT
+#define UCC_CONFIG_TYPE_UINT         UCS_CONFIG_TYPE_UINT
 #define UCC_CONFIG_TYPE_STRING_ARRAY UCS_CONFIG_TYPE_STRING_ARRAY
 #define UCC_CONFIG_TYPE_ARRAY        UCS_CONFIG_TYPE_ARRAY
+#define UCC_CONFIG_TYPE_TABLE        UCS_CONFIG_TYPE_TABLE
 
 static inline ucc_status_t
 ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,


### PR DESCRIPTION
## What
Implementation of CORE UCC functionality: ucc_context_config_read/release
Additionally added ucc_context_config_print and modify to UCC API.

## Why ?
context_config_print is needed both for consistency of the API and for usability (we will use it at least in ucc_info).
context_config_modify is a key functionality when user wants to tweak ctx from the code (not from the env var, use case - multiple rails hca setting). 

## How ?
Note ucc_context is a combination of cl_contexts, hence ucc_context_config is a combination of the corresponding cl_context_configs. Different CL contexts will have different configuration variables. This is why some modify parameters (name, value) will only be applicable to the specific CLS. Because of that the API ucc_context_config_modify also takes a const char* string  - comma separated list of CLs whose cl_contexts will be modified. 

For example:
1. ucc_context_config_modify(cfg, "all", "TEST_PARAM", "aaa") will try to modify the cl_configs of ALL active CLs (of the given ucc_lib), if one fails (param not found in some CL) than the error is returned. 

2. ucc_context_config_modify(cfg, "opt,basic", "NET_DEVICES", "mlx5_0:1") will try to set "NET_DEVICES" param for "opt" and "basic" CLs.