### PR TITLE
Shared ucp_context/worker for ucc_context_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,5 +154,6 @@ AC_CONFIG_FILES([
                  src/cl/basic/Makefile
                  src/api/ucc_version.h
                  src/core/ucc_version.c
+                 src/ucp_ctx/Makefile
                  ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
 #
-SUBDIRS = cl/basic
+SUBDIRS = cl/basic ucp_ctx
 
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =

--- a/src/cl/basic/cl_basic_lib.c
+++ b/src/cl/basic/cl_basic_lib.c
@@ -58,4 +58,4 @@ static ucc_status_t ucc_cl_basic_lib_finalize(ucc_cl_lib_t *cl_lib)
     return UCC_OK;
 }
 
-UCC_CL_IFACE_DECLARE(basic, BASIC, 10);
+UCC_CL_IFACE_DECLARE(basic, BASIC, 10, UCC_UCP_CTX_NOT_REQUIRED);

--- a/src/cl/ucc_cl.h
+++ b/src/cl/ucc_cl.h
@@ -15,6 +15,7 @@
 #include "utils/ucc_component.h"
 #include "utils/ucc_parser.h"
 #include "utils/ucc_class.h"
+#include "ucp_ctx/ucc_ucp_ctx.h"
 
 typedef struct ucc_cl_lib     ucc_cl_lib_t;
 typedef struct ucc_cl_iface   ucc_cl_iface_t;
@@ -39,6 +40,7 @@ typedef struct ucc_cl_iface {
     ucc_component_iface_t          super;
     ucc_cl_type_t                  type;
     int                            priority;
+    ucc_ucp_ctx_requirement_t      ucp_ctx_req;
     ucc_lib_attr_t                 attr;
     ucc_config_global_list_entry_t cl_lib_config;
     ucs_config_global_list_entry_t cl_context_config;
@@ -73,15 +75,16 @@ typedef struct ucc_cl_context {
         .table  = ucc_cl_ ## _name ## _ ## _cfg ## _config_table,       \
         .size   = sizeof(ucc_cl_ ## _name ## _ ## _cfg ## _config_t)}
 
-#define UCC_CL_IFACE_DECLARE(_name, _NAME, _priority)           \
-    ucc_cl_ ## _name ## _iface_t ucc_cl_ ## _name = {           \
-        UCC_CL_IFACE_CFG(lib, _name, _NAME),                    \
-        UCC_CL_IFACE_CFG(context, _name, _NAME),                \
-        .super.super.name = UCC_PP_MAKE_STRING(basic),          \
-        .super.type       = UCC_CL_ ## _NAME,                   \
-        .super.priority   = _priority,                          \
-        .super.init       = ucc_cl_ ## _name ## _lib_init,      \
-        .super.finalize   = ucc_cl_ ## _name ## _lib_finalize,  \
+#define UCC_CL_IFACE_DECLARE(_name, _NAME, _priority, _ucp_ctx_req)            \
+    ucc_cl_##_name##_iface_t ucc_cl_##_name = {                                \
+        UCC_CL_IFACE_CFG(lib, _name, _NAME),                                   \
+        UCC_CL_IFACE_CFG(context, _name, _NAME),                               \
+        .super.super.name  = UCC_PP_MAKE_STRING(basic),                        \
+        .super.type        = UCC_CL_##_NAME,                                   \
+        .super.priority    = _priority,                                        \
+        .super.ucp_ctx_req = _ucp_ctx_req,                                     \
+        .super.init        = ucc_cl_##_name##_lib_init,                        \
+        .super.finalize    = ucc_cl_##_name##_lib_finalize,                    \
     }
 
 #endif

--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -67,8 +67,15 @@ ucc_status_t ucc_constructor(void)
         }
         status = ucc_components_load("cl", &ucc_global_config.cl_framework);
         if (UCC_OK != status) {
-            ucc_error("no CL components were found in the UCC_COMPONENT_PATH: %s",
-                      ucc_global_config.component_path);
+            ucc_error(
+                "no CL components were found in the UCC_COMPONENT_PATH: %s",
+                ucc_global_config.component_path);
+            return status;
+        }
+        status = ucc_components_load("ucp_ctx",
+                                     &ucc_global_config.ucp_ctx_framework);
+        if (UCC_OK != status) {
+            ucc_error("could not load ucp ctx framework");
             return status;
         }
     }

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -7,16 +7,18 @@
 #define UCC_CONTEXT_H_
 
 #include "api/ucc.h"
+#include "ucp_ctx/ucc_ucp_ctx.h"
 
 typedef struct ucc_lib_info          ucc_lib_info_t;
 typedef struct ucc_cl_context        ucc_cl_context_t;
 typedef struct ucc_cl_context_config ucc_cl_context_config_t;
 
 typedef struct ucc_context {
-    ucc_lib_info_t      *lib;
-    ucc_context_attr_t   attr;
-    ucc_cl_context_t   **cl_ctx;
-    int                  n_cl_ctx;
+    ucc_lib_info_t       *lib;
+    ucc_context_attr_t    attr;
+    ucc_cl_context_t    **cl_ctx;
+    int                   n_cl_ctx;
+    ucc_ucp_ctx_handle_t *ucp_ctx_h;
 } ucc_context_t;
 
 typedef struct ucc_context_config {

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -16,7 +16,7 @@ typedef struct ucc_global_config {
     /* Log level above which log messages will be printed*/
     ucc_log_component_config_t log_component;
     ucc_component_framework_t  cl_framework;
-
+    ucc_component_framework_t  ucp_ctx_framework;
     /* Coll component libraries path */
     char *component_path;
     char *component_path_default;

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -13,6 +13,7 @@
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_math.h"
 #include "cl/ucc_cl.h"
+#include "ucp_ctx/ucc_ucp_ctx.h"
 
 UCS_CONFIG_DEFINE_ARRAY(cl_types, sizeof(ucc_cl_type_t),
                         UCS_CONFIG_TYPE_ENUM(ucc_cl_names));

--- a/src/ucp_ctx/Makefile.am
+++ b/src/ucp_ctx/Makefile.am
@@ -1,0 +1,14 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+
+sources =          \
+	ucc_ucp_ctx.h  \
+	ucc_ucp_ctx.c
+
+libucc_ucp_ctx_la_SOURCES  = $(sources)
+libucc_ucp_ctx_la_CPPFLAGS = $(AM_CPPFLAGS) $(UCX_CPPFLAGS)
+libucc_ucp_ctx_la_LDFLAGS  = $(UCX_LDFLAGS) -version-info $(SOVERSION) --as-needed
+libucc_ucp_ctx_la_LIBADD   = $(UCX_LIBADD)
+
+pkglib_LTLIBRARIES = libucc_ucp_ctx.la

--- a/src/ucp_ctx/ucc_ucp_ctx.c
+++ b/src/ucp_ctx/ucc_ucp_ctx.c
@@ -1,0 +1,171 @@
+#include "ucc_ucp_ctx.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_log.h"
+#include <ucp/api/ucp.h>
+
+#include <sys/types.h>
+#include <unistd.h>
+
+typedef struct ucc_ucp_ctx_handle {
+    ucc_ucp_ctx_t      ctx;
+    int                ref_count;
+} ucc_ucp_ctx_handle_t;
+
+static void ucc_ucp_req_init(void *request)
+{
+    ucc_ucp_req_t *req = (ucc_ucp_req_t *)request;
+    req->status        = UCC_OPERATION_INITIALIZED;
+}
+
+static void ucc_ucp_req_cleanup(void *request)
+{
+}
+
+ucc_status_t ucc_ucp_ctx_create(const ucc_ucp_ctx_create_params_t *params,
+                                ucc_ucp_ctx_handle_t **ctx)
+{
+    ucc_status_t          ucc_status = UCC_OK;
+    ucc_ucp_ctx_handle_t *ctx_h;
+    ucp_worker_params_t   worker_params;
+    ucp_worker_attr_t     worker_attr;
+    ucp_params_t          ucp_params;
+    ucp_config_t         *ucp_config;
+    ucp_context_h         ucp_context;
+    ucp_worker_h          ucp_worker;
+    ucs_status_t          status;
+
+    UCC_STATIC_ASSERT(UCC_UCP_CTX_LAST - 1 < UCC_BIT(UCC_UCP_CTX_BITS));
+
+    ctx_h = ucc_malloc(sizeof(*ctx_h), "ucc_ucp_ctx");
+    if (!ctx_h) {
+        ucc_error("failed to allocate %zd bytes for ucc_ucp_ctx",
+                  sizeof(*ctx_h));
+        return UCC_ERR_NO_MESSAGE;
+    }
+    status = ucp_config_read(params->prefix, NULL, &ucp_config);
+    if (UCS_OK != status) {
+        ucc_error("failed to read ucp configuration, %s",
+                  ucs_status_string(status));
+        ucc_status = ucs_status_to_ucc_status(status);
+        goto err_cfg_read;
+    }
+
+    ucp_params.field_mask =
+        UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_REQUEST_SIZE |
+        UCP_PARAM_FIELD_REQUEST_INIT | UCP_PARAM_FIELD_REQUEST_CLEANUP |
+        UCP_PARAM_FIELD_TAG_SENDER_MASK;
+    ucp_params.features          = UCP_FEATURE_TAG | UCP_FEATURE_RMA;
+    ucp_params.request_size      = sizeof(ucc_ucp_req_t);
+    ucp_params.request_init      = ucc_ucp_req_init;
+    ucp_params.request_cleanup   = ucc_ucp_req_cleanup;
+    ucp_params.tag_sender_mask   = UCC_UCP_TAG_SENDER_MASK;
+
+    if (params->mask & UCC_UCP_CTX_PARAM_FIELD_ESTIMATED_NUM_PPN) {
+        ucp_params.field_mask |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
+        ucp_params.estimated_num_ppn = params->estimated_num_ppn;
+    }
+
+    if (params->mask & UCC_UCP_CTX_PARAM_FIELD_ESTIMATED_NUM_EPS) {
+        ucp_params.field_mask |= UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
+        ucp_params.estimated_num_eps = params->estimated_num_eps;
+    }
+
+    if (params->mask & UCC_UCP_CTX_PARAM_FIELD_DEVICES) {
+        ucp_config_modify(ucp_config, "NET_DEVICES", params->devices);
+    }
+
+    status = ucp_init(&ucp_params, ucp_config, &ucp_context);
+    ucp_config_release(ucp_config);
+    if (UCS_OK != status) {
+        ucc_error("failed to init ucp context, %s", ucs_status_string(status));
+        ucc_status = ucs_status_to_ucc_status(status);
+        goto err_cfg_read;
+    }
+
+    worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+    ucc_assert(params->mask & UCC_UCP_CTX_PARAM_FIELD_THREAD_MODE);
+    switch (params->thread_mode) {
+    case UCC_THREAD_SINGLE:
+    case UCC_THREAD_FUNNELED:
+        worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
+        break;
+    case UCC_THREAD_MULTIPLE:
+        worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
+        break;
+    default:
+        /* unreachable */
+        ucc_assert(0);
+        break;
+    }
+    status = ucp_worker_create(ucp_context, &worker_params, &ucp_worker);
+    if (UCS_OK != status) {
+        ucc_error("failed to create ucp worker, %s", ucs_status_string(status));
+        ucc_status = ucs_status_to_ucc_status(status);
+        goto err_worker_create;
+    }
+
+    if (params->thread_mode == UCC_THREAD_MULTIPLE) {
+        worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_THREAD_MODE;
+        ucp_worker_query(ucp_worker, &worker_attr);
+        if (worker_attr.thread_mode != UCS_THREAD_MODE_MULTI) {
+            ucc_error("thread mode multiple is not supported by ucp worker");
+            status = UCC_ERR_NOT_SUPPORTED;
+            goto err_thread_mode;
+        }
+    }
+
+    ctx_h->ctx.ucp_context = (void *)ucp_context;
+    ctx_h->ctx.ucp_worker  = (void *)ucp_worker;
+    ctx_h->ref_count       = 0;
+    *ctx                   = ctx_h;
+    return UCC_OK;
+
+err_thread_mode:
+    ucp_worker_destroy(ucp_worker);
+err_worker_create:
+    ucp_cleanup(ucp_context);
+err_cfg_read:
+    free(ctx_h);
+    return ucc_status;
+}
+
+ucc_status_t ucc_ucp_ctx_destroy(ucc_ucp_ctx_handle_t *ctx_h)
+{
+    ucp_context_h ucp_context;
+    ucp_worker_h  ucp_worker;
+    if (ctx_h->ref_count != 0) {
+        ucc_warn(
+            "destroying ucc_ucp_ctx %p which is still in use, ref_count %d",
+            ctx_h, ctx_h->ref_count);
+    }
+    ucp_context = (ucp_context_h)ctx_h->ctx.ucp_context;
+    ucp_worker  = (ucp_worker_h)ctx_h->ctx.ucp_worker;
+
+    ucp_worker_destroy(ucp_worker);
+    ucp_cleanup(ucp_context);
+    free(ctx_h);
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_ucp_ctx_get(ucc_ucp_ctx_handle_t *ctx_handle,
+                             ucc_ucp_ctx_t **ctx)
+{
+    ctx_handle->ref_count++;
+    *ctx = &ctx_handle->ctx;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_ucp_ctx_put(ucc_ucp_ctx_handle_t *ctx_handle)
+{
+    ctx_handle->ref_count--;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_ucp_ctx_put(ucc_ucp_ctx_handle_t *ctx_handle);
+
+ucc_ucp_ctx_iface_t ucc_ucp_ctx = {
+    .super.name = "ucp_ctx",
+    .create     = ucc_ucp_ctx_create,
+    .destroy    = ucc_ucp_ctx_destroy,
+};

--- a/src/ucp_ctx/ucc_ucp_ctx.h
+++ b/src/ucp_ctx/ucc_ucp_ctx.h
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_UCP_CTX_H_
+#define UCC_UCP_CTX_H_
+
+#include "config.h"
+#include "utils/ucc_parser.h"
+#include "utils/ucc_compiler_def.h"
+#include "utils/ucc_component.h"
+#include "ucc_ucp_tag.h"
+
+typedef enum {
+    UCC_UCP_CTX_NOT_REQUIRED = 0,
+    UCC_UCP_CTX_REQUIRED,
+} ucc_ucp_ctx_requirement_t;
+
+typedef struct ucc_ucp_req {
+    ucc_status_t status;
+} ucc_ucp_req_t;
+
+typedef struct ucc_ucp_ctx ucc_ucp_ctx_t;
+
+enum ucc_ucp_ctx_param_field {
+    UCC_UCP_CTX_PARAM_FIELD_DEVICES           = UCC_BIT(0),
+    UCC_UCP_CTX_PARAM_FIELD_THREAD_MODE       = UCC_BIT(1),
+    UCC_UCP_CTX_PARAM_FIELD_ESTIMATED_NUM_PPN = UCC_BIT(2),
+    UCC_UCP_CTX_PARAM_FIELD_ESTIMATED_NUM_EPS = UCC_BIT(3),
+    UCC_UCP_CTX_PARAM_FIELD_PREFIX            = UCC_BIT(4),
+};
+
+typedef struct ucc_ucp_ctx_create_params {
+    uint64_t          mask;
+    char             *devices;
+    char             *prefix;
+    ucc_thread_mode_t thread_mode;
+    int               estimated_num_ppn;
+    int               estimated_num_eps;
+} ucc_ucp_ctx_create_params_t;
+
+typedef struct ucc_ucp_ctx {
+    void *ucp_context;
+    void *ucp_worker;
+} ucc_ucp_ctx_t;
+
+typedef struct ucc_ucp_ctx_handle ucc_ucp_ctx_handle_t;
+
+/* This is the interface for the dynamically loadable component
+   that holds the shared UCP context/worker. It is compiled into
+   stand alone component in order to avoid linking libucc against
+   libucp.
+
+   The component has just 2 APIs used to create a ucc_ucp_context
+   handle. There is 1-1 relation between ucc_context_t and
+   ucc_ucp_ctx_handle_t (ucc_context_t might not have the
+   ucc_ucp_ctx at all if it is not required by any other component).
+   Each independent component can than obtain an instance of ucc_ucp_ctx_t
+   (which is a pair of ucp_context/worker) via ucc_ucp_ctx_get/put.
+
+   Note, each component that wants to use Shared UCP CTX has to register
+   itself into the corresponding enum in ucc_ucp_tag.h in order to
+   guarantee the tag space sharing. */
+typedef struct ucc_ucp_ctx_iface {
+    ucc_component_iface_t super;
+    ucc_status_t (*create)(const ucc_ucp_ctx_create_params_t *params,
+                           ucc_ucp_ctx_handle_t **ctx_handle);
+    ucc_status_t (*destroy)(ucc_ucp_ctx_handle_t *ctx_handle);
+} ucc_ucp_ctx_iface_t;
+
+ucc_status_t ucc_ucp_ctx_get(ucc_ucp_ctx_handle_t *ctx_handle,
+                             ucc_ucp_ctx_t **ctx);
+ucc_status_t ucc_ucp_ctx_put(ucc_ucp_ctx_handle_t *ctx_handle);
+
+#endif

--- a/src/ucp_ctx/ucc_ucp_tag.h
+++ b/src/ucp_ctx/ucc_ucp_tag.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#ifndef UCC_UCP_TAG_H_
+#define UCC_UCP_TAG_H_
+/*
+ * UCP tag structure:
+ *
+ *    01234           567     01234567 01234567 01234567 01234567 01234567 01234567 01234567
+ *                |         |                  |                          |
+ *   RESERVED (5) | CTX (3) | message tag (16) |     source rank (24)     |  team id (16)
+ */
+
+typedef enum {
+    UCC_UCP_CTX_TL_UCX = 0,
+    UCC_UCP_CTX_CL_HIER,
+    UCC_UCP_CTX_CL_UCG,
+    UCC_UCP_CTX_LAST,
+} ucc_ucp_ctx_type_t;
+
+#define UCC_UCP_RESERVED_BITS 5
+#define UCC_UCP_CTX_BITS 3
+#define UCC_UCP_TAG_BITS 16
+#define UCC_UCP_SENDER_BITS 24
+#define UCC_UCP_ID_BITS 16
+
+#define UCC_UCP_RESERVED_BITS_OFFSET                                           \
+    (UCC_UCP_ID_BITS + UCC_UCP_SENDER_BITS + UCC_UCP_TAG_BITS +                \
+     UCC_UCP_CTX_BITS)
+
+#define UCC_UCP_CTX_BITS_OFFSET                                                \
+    (UCC_UCP_ID_BITS + UCC_UCP_SENDER_BITS + UCC_UCP_TAG_BITS)
+
+#define UCC_UCP_TAG_BITS_OFFSET    (UCC_UCP_ID_BITS + UCC_UCP_SENDER_BITS)
+#define UCC_UCP_SENDER_BITS_OFFSET (UCC_UCP_ID_BITS)
+#define UCC_UCP_ID_BITS_OFFSET     0
+
+#define UCC_UCP_MAX_TAG    UCC_MASK(UCC_UCP_TAG_BITS)
+#define UCC_UCP_MAX_SENDER UCC_MASK(UCC_UCP_SENDER_BITS)
+#define UCC_UCP_MAX_ID     UCC_MASK(UCC_UCP_ID_BITS)
+
+#define UCC_UCP_TAG_SENDER_MASK UCC_MASK(UCC_UCP_ID_BITS + UCC_UCP_SENDER_BITS)
+#endif

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -30,6 +30,8 @@ typedef ucs_log_component_config_t ucc_log_component_config_t;
 #define UCC_PP_MAKE_STRING(x)  _UCC_PP_MAKE_STRING(x)
 #define UCC_PP_QUOTE UCS_PP_QUOTE
 
+#define UCC_MASK UCS_MASK
+
 static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
 {
     switch (status) {
@@ -55,4 +57,5 @@ static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
 #define ucc_assert(_cond)
 #endif
 
+#define UCC_STATIC_ASSERT(_cond) UCS_STATIC_ASSERT(_cond)
 #endif

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -30,7 +30,7 @@ static ucc_status_t ucc_component_load_one(const char *so_path,
     ucc_component_iface_t *iface;
     size_t                 basename_start, iface_struct_name_len;
 
-    ucc_snprintf_safe(framework_pattern, sizeof(framework_pattern), "ucc_%s_",
+    ucc_snprintf_safe(framework_pattern, sizeof(framework_pattern), "ucc_%s",
                       framework_name);
     basename_start =
         ((ptrdiff_t)strstr(so_path, framework_pattern) - (ptrdiff_t)so_path);
@@ -100,7 +100,7 @@ ucc_status_t ucc_components_load(const char *framework_name,
                   pattern_size);
         return UCC_ERR_NO_MEMORY;
     }
-    ucc_snprintf_safe(full_pattern, pattern_size, "%s/libucc_%s_*.so",
+    ucc_snprintf_safe(full_pattern, pattern_size, "%s/libucc_%s*.so",
                       ucc_global_config.component_path, framework_name);
     glob(full_pattern, 0, NULL, &globbuf);
     free(full_pattern);

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -8,6 +8,7 @@
 
 #include "config.h"
 #include "api/ucc_status.h"
+#include "api/ucc_def.h"
 #include "utils/ucc_datastruct.h"
 #include "utils/ucc_compiler_def.h"
 

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -30,7 +30,7 @@ UCC_TEST_F(test_obj_size, size) {
     UCC_TEST_SKIP_R("Assert enabled");
 #else
 
-    EXPECTED_SIZE(ucc_global_config_t, 72);
+    EXPECTED_SIZE(ucc_global_config_t, 96);
 
 #endif
 }


### PR DESCRIPTION
## What
Adds a minimal interface and implementation of the dynamic component that holds UCP context/worker that can be shared among other internal UCC components (CLs, TLs)

## Why ?
Per multiple WG discussions we want to share UCP ctx/worker between multiple Cls,TLs

## How ?

- Firstly, we don't want to have a direct link dependency of libucc.so on libucp.so. So, all the code that initialized UCP worker/context is put into a stand alone .so dynamically loaded component called "libucc_ucp_ctx.so". It is loaded via ucc_component interfaces during ucc_constructor.
- The component has to interface to create and destroy the ucc_ucp_ctx_handle_t
- This handle is allocate during ucc_context creation a stored on the ucc_context
- Any other component can later grab an instance of ucc_ucp_ctx_t (which is a pair of ucp_context_h and ucp_worker_h) via ucc_ucp_ctx_get/put calls. Each component that want to use shared ucp context must register itself into the enum of ucc_ucp_ctx_type_t and provide its enum value during ucc_ucp_ctx_get() call. This will make sure that the ref_counting is done properly and the tag space is separated between components (there are several bits reserved, see ucc_ucp_tag.h)
