### PR TITLE
Ucc ctx create destroy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,7 +143,7 @@ if test $ucx_happy != "yes"; then
 fi
 
 includes="-I${UCC_TOP_SRCDIR}/src -I${UCC_TOP_BUILDDIR}/src"
-CFLAGS="-std=gnu11"
+CFLAGS="$CFLAGS -std=gnu11"
 CPPFLAGS="$UCS_CPPFLAGS $CPPFLAGS $includes -Wall -Werror"
 LDFLAGS="$LDFLAGS $UCS_LDFLAGS $UCS_LIBADD"
 

--- a/src/cl/basic/cl_basic.h
+++ b/src/cl/basic/cl_basic.h
@@ -26,7 +26,14 @@ typedef struct ucc_cl_basic_context_config {
 typedef struct ucc_cl_basic_lib {
     ucc_cl_lib_t super;
 } ucc_cl_basic_lib_t;
-
 UCC_CLASS_DECLARE(ucc_cl_basic_lib_t, ucc_cl_iface_t *,
                   const ucc_lib_config_t *, const ucc_cl_lib_config_t *);
+
+typedef struct ucc_cl_basic_context {
+    ucc_cl_context_t super;
+} ucc_cl_basic_context_t;
+UCC_CLASS_DECLARE(ucc_cl_basic_context_t, ucc_cl_lib_t *,
+                  const ucc_cl_context_params_t *,
+                  const ucc_cl_context_config_t *);
+
 #endif

--- a/src/cl/basic/cl_basic_lib.c
+++ b/src/cl/basic/cl_basic_lib.c
@@ -58,4 +58,36 @@ static ucc_status_t ucc_cl_basic_lib_finalize(ucc_cl_lib_t *cl_lib)
     return UCC_OK;
 }
 
+UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t, ucc_cl_lib_t *cl_lib,
+                    const ucc_cl_context_params_t *params,
+                    const ucc_cl_context_config_t *config)
+{
+    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_lib);
+    cl_info(cl_lib, "initialized cl context: %p", self);
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_context_t)
+{
+    cl_info(self->super.cl_lib, "finalizing cl context: %p", self);
+}
+
+UCC_CLASS_DEFINE(ucc_cl_basic_context_t, ucc_cl_context_t);
+
+static ucc_status_t ucc_cl_basic_context_create(
+    ucc_cl_lib_t *cl_lib, const ucc_cl_context_params_t *params,
+    const ucc_cl_context_config_t *config, ucc_cl_context_t **cl_ctx)
+{
+    return UCC_CLASS_NEW(ucc_cl_basic_context_t, cl_ctx, cl_lib, params,
+                         config);
+}
+
+static ucc_status_t ucc_cl_basic_context_destroy(ucc_cl_context_t *cl_ctx)
+{
+    ucc_cl_basic_context_t *ctx =
+        ucc_derived_of(cl_ctx, ucc_cl_basic_context_t);
+    UCC_CLASS_DELETE(ucc_cl_basic_context_t, ctx);
+    return UCC_OK;
+}
+
 UCC_CL_IFACE_DECLARE(basic, BASIC, 10);

--- a/src/cl/ucc_cl.c
+++ b/src/cl/ucc_cl.c
@@ -99,3 +99,14 @@ ucc_status_t ucc_parse_cls_string(const char *cls_str,
     return UCC_OK;
 }
 
+UCC_CLASS_INIT_FUNC(ucc_cl_context_t, ucc_cl_lib_t *cl_lib)
+{
+    self->cl_lib = cl_lib;
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_cl_context_t)
+{
+}
+
+UCC_CLASS_DEFINE(ucc_cl_context_t, void);

--- a/src/cl/ucc_cl_log.h
+++ b/src/cl/ucc_cl_log.h
@@ -8,7 +8,8 @@
 #define UCC_CL_LOG_H_
 #include "utils/ucc_log.h"
 #define ucc_log_component_cl(_cl_lib, _level, fmt, ...)                        \
-    ucc_log_component(_level, (_cl_lib)->log_component, fmt, ##__VA_ARGS__)
+    ucc_log_component(_level, ((ucc_cl_lib_t *)_cl_lib)->log_component, fmt,   \
+                      ##__VA_ARGS__)
 
 #define cl_error(_cl_lib, _fmt, ...)                                           \
     ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -13,10 +13,11 @@ typedef struct ucc_cl_context        ucc_cl_context_t;
 typedef struct ucc_cl_context_config ucc_cl_context_config_t;
 
 typedef struct ucc_context {
-    ucc_lib_info_t      *lib;
-    ucc_context_attr_t   attr;
-    ucc_cl_context_t   **cl_ctx;
-    int                  n_cl_ctx;
+    ucc_lib_info_t       *lib;
+    ucc_context_params_t  params;
+    ucc_context_attr_t    attr;
+    ucc_cl_context_t    **cl_ctx;
+    int                   n_cl_ctx;
 } ucc_context_t;
 
 typedef struct ucc_context_config {


### PR DESCRIPTION
## What
Adds ucc_context_create/destroy implementation
ucc_cl_context_t class
Minimal implementation for CL_BASIC

## Why ?
Part of API

## How ?

- Each ucc_context_t is a composition of cl_contexts. The logic is simple: just loop through all the CLs available on the lib_info object after filtering and create the corresponding cl contexts.
- If some CL requires shared UCP context then it is created as part of ucc_context_create. Then the shared UCP can be accessed through the ucc_ucp_ctx_get/put (see #35 )
