### PR TITLE
ucc config/lib gtests

### DIFF
--- a/config/module.am
+++ b/config/module.am
@@ -1,0 +1,27 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+# Automake silent rules
+AM_V_LN   = $(AM_V_LN_@AM_V@)
+AM_V_LN_  = $(AM_V_LN_@AM_DEFAULT_V@)
+AM_V_LN_0 = echo "  LN      "
+AM_V_LN_1 = true
+
+local_la_modules = $(patsubst %, $(localmoduledir)/%, $(module_LTLIBRARIES))
+
+all-local: $(local_la_modules)
+
+# Create symbolic links for the built modules under $(localmoduledir)
+# Link also *.la files to create proper makefile dependencies
+$(local_la_modules): $(module_LTLIBRARIES)
+	$(AM_V_at)$(MKDIR_P) $(localmoduledir)
+	$(AM_V_at)$(MKDIR_P) $(abs_top_builddir)/src/.libs
+	$(AM_V_at)$(LN_S) -f $(localmoduledir) $(abs_top_builddir)/src/.libs/$(modulesubdir)
+	$(AM_V_at)for lib in *.la $(objdir)/*$(shrext)*; do \
+		(cd $(localmoduledir) && $(LN_RS) -nf $(shell pwd)/$$lib); \
+	done
+	@for lib in *.la $(objdir)/*$(shrext)*; do \
+		$(AM_V_LN) $$lib; \
+	done

--- a/configure.ac
+++ b/configure.ac
@@ -143,7 +143,7 @@ if test $ucx_happy != "yes"; then
 fi
 
 includes="-I${UCC_TOP_SRCDIR}/src -I${UCC_TOP_BUILDDIR}/src"
-CFLAGS="-std=gnu11"
+CFLAGS="$CFLAGS -std=gnu11"
 CPPFLAGS="$UCS_CPPFLAGS $CPPFLAGS $includes -Wall -Werror"
 LDFLAGS="$LDFLAGS $UCS_LDFLAGS $UCS_LIBADD"
 

--- a/configure.ac
+++ b/configure.ac
@@ -70,10 +70,30 @@ CFLAGS_save="$CFLAGS"
 AC_PROG_CC
 AC_PROG_CXX
 AM_PROG_AS
+AC_PROG_LN_S
+AC_PROG_MKDIR_P
 AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_HEADER_STDC
 CFLAGS="$CFLAGS_save"
+
+#
+# Check if 'ln' supports creating relative links
+#
+AC_MSG_CHECKING([if ${LN_S} supports --relative])
+AS_IF([${LN_S} --relative symlinktest 2>/dev/null],
+      [AC_MSG_RESULT([yes])
+       AC_SUBST([LN_RS], ["${LN_S} --relative"])
+       rm symlinktest],
+      [AC_MSG_RESULT([no])
+       AC_SUBST([LN_RS], [${LN_S}])])
+
+AC_SUBST([modulesubdir],   [${PACKAGE_NAME}])               # module directory names
+AC_SUBST([moduledir],      [${libdir}/${modulesubdir}])     # module installation directory
+AC_SUBST([localmoduledir], ['$(abs_top_builddir)/modules']) # local directory for module symlinks
+AC_SUBST([objdir],         [${objdir}])                     # libtool objects dir, usually .libs
+AC_SUBST([shrext],         [${shrext_cmds}])                # libtool shared library extension
+AC_DEFINE_UNQUOTED([UCC_MODULE_SUBDIR], ["${modulesubdir}"], [UCC module sub-directory])
 
 #
 # Additional m4 files

--- a/src/cl/basic/Makefile.am
+++ b/src/cl/basic/Makefile.am
@@ -6,8 +6,11 @@ sources =          \
 	cl_basic.h     \
 	cl_basic_lib.c
 
-libucc_cl_basic_la_SOURCES =$(sources)
+module_LTLIBRARIES          = libucc_cl_basic.la
+libucc_cl_basic_la_SOURCES  = $(sources)
 libucc_cl_basic_la_CPPFLAGS = $(AM_CPPFLAGS)
-libucc_cl_basic_la_LDFLAGS = -version-info $(SOVERSION) --as-needed
+libucc_cl_basic_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
 
-pkglib_LTLIBRARIES = libucc_cl_basic.la
+
+
+include $(top_srcdir)/config/module.am

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -67,7 +67,8 @@ gtest_SOURCES = \
 	common/main.cc \
 	common/test.cc \
 	\
-	tl/tl_test.cc
+	tl/tl_test.cc \
+	core/test_lib_config.cc
 
 noinst_HEADERS = \
 	common/gtest.h \

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -61,14 +61,15 @@ gtest_CXXFLAGS = \
 	$(BASE_CXXFLAGS) $(GTEST_CXXFLAGS) \
 	-DGTEST_UCM_HOOK_LIB_DIR="\"${abs_builddir}/ucm/test_dlopen/.libs\""
 
-gtest_SOURCES = \
-	common/gtest-all.cc \
+gtest_SOURCES =             \
+	common/gtest-all.cc     \
 	common/test_obj_size.cc \
-	common/main.cc \
-	common/test.cc \
-	\
-	tl/tl_test.cc \
-	core/test_lib_config.cc
+	common/main.cc          \
+	common/test.cc          \
+	                        \
+	tl/tl_test.cc           \
+	core/test_lib_config.cc \
+	core/test_lib.cc
 
 noinst_HEADERS = \
 	common/gtest.h \

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -57,7 +57,7 @@ gtest_CPPFLAGS = \
 
 gtest_LDFLAGS  = $(GTEST_LDFLAGS) -pthread -no-install -Wl,-dynamic-list-data
 gtest_CFLAGS   = $(BASE_CFLAGS)
-gtest_CXXFLAGS = \
+gtest_CXXFLAGS = -std=gnu++11 \
 	$(BASE_CXXFLAGS) $(GTEST_CXXFLAGS) \
 	-DGTEST_UCM_HOOK_LIB_DIR="\"${abs_builddir}/ucm/test_dlopen/.libs\""
 

--- a/test/gtest/core/test_lib.cc
+++ b/test/gtest/core/test_lib.cc
@@ -4,17 +4,44 @@
  */
 
 #include <common/test.h>
-class test_lib : public ucc::test {};
+#include <vector>
+#include <algorithm>
+#include <random>
+
+class test_lib : public ucc::test {
+};
 
 UCC_TEST_F(test_lib, init_finalize)
 {
     ucc_lib_config_h cfg;
     ucc_lib_params_t lib_params;
-    ucc_lib_h lib;
+    ucc_lib_h        lib;
     EXPECT_EQ(UCC_OK, ucc_lib_config_read(NULL, NULL, &cfg));
-    lib_params.mask = UCC_LIB_PARAM_FIELD_THREAD_MODE;
+    lib_params.mask        = UCC_LIB_PARAM_FIELD_THREAD_MODE;
     lib_params.thread_mode = UCC_THREAD_SINGLE;
     EXPECT_EQ(UCC_OK, ucc_init(&lib_params, cfg, &lib));
     ucc_lib_config_release(cfg);
     EXPECT_EQ(UCC_OK, ucc_finalize(lib));
+}
+
+UCC_TEST_F(test_lib, init_multiple)
+{
+    const int              n_libs = 8;
+    ucc_lib_config_h       cfg;
+    ucc_lib_params_t       lib_params;
+    ucc_lib_h              lib_h;
+    std::vector<ucc_lib_h> libs;
+    EXPECT_EQ(UCC_OK, ucc_lib_config_read(NULL, NULL, &cfg));
+    lib_params.mask        = UCC_LIB_PARAM_FIELD_THREAD_MODE;
+    lib_params.thread_mode = UCC_THREAD_SINGLE;
+    for (int i = 0; i < n_libs; i++) {
+        EXPECT_EQ(UCC_OK, ucc_init(&lib_params, cfg, &lib_h));
+        libs.push_back(lib_h);
+    }
+    ucc_lib_config_release(cfg);
+    std::shuffle(libs.begin(), libs.end(), std::default_random_engine());
+
+    for (auto lib_h : libs) {
+        EXPECT_EQ(UCC_OK, ucc_finalize(lib_h));
+    }
 }

--- a/test/gtest/core/test_lib.cc
+++ b/test/gtest/core/test_lib.cc
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+class test_lib : public ucc::test {};
+
+UCC_TEST_F(test_lib, init_finalize)
+{
+    ucc_lib_config_h cfg;
+    ucc_lib_params_t lib_params;
+    ucc_lib_h lib;
+    EXPECT_EQ(UCC_OK, ucc_lib_config_read(NULL, NULL, &cfg));
+    lib_params.mask = UCC_LIB_PARAM_FIELD_THREAD_MODE;
+    lib_params.thread_mode = UCC_THREAD_SINGLE;
+    EXPECT_EQ(UCC_OK, ucc_init(&lib_params, cfg, &lib));
+    ucc_lib_config_release(cfg);
+    EXPECT_EQ(UCC_OK, ucc_finalize(lib));
+}

--- a/test/gtest/core/test_lib_config.cc
+++ b/test/gtest/core/test_lib_config.cc
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+class test_lib_config : public ucc::test {
+};
+
+UCC_TEST_F(test_lib_config, read_release)
+{
+    ucc_lib_config_h cfg;
+    EXPECT_EQ(UCC_OK, ucc_lib_config_read(NULL, NULL, &cfg));
+    ucc_lib_config_release(cfg);
+}
+
+UCC_TEST_F(test_lib_config, print)
+{
+    ucc_lib_config_h cfg;
+    unsigned         flags;
+    testing::internal::CaptureStdout();
+    EXPECT_EQ(UCC_OK, ucc_lib_config_read(NULL, NULL, &cfg));
+    flags = UCC_CONFIG_PRINT_CONFIG | UCC_CONFIG_PRINT_HEADER |
+            UCC_CONFIG_PRINT_DOC | UCC_CONFIG_PRINT_HIDDEN;
+    ucc_lib_config_print(cfg, stdout, "TEST_TITLE",
+                         (ucc_config_print_flags_t)flags);
+    ucc_lib_config_release(cfg);
+    std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_NE(std::string::npos, output.find("# TEST_TITLE"));
+    EXPECT_NE(std::string::npos, output.find("UCC_CLS="));
+}
+
+UCC_TEST_F(test_lib_config, modify)
+{
+    ucc_lib_config_h cfg;
+    unsigned         flags;
+    testing::internal::CaptureStdout();
+    EXPECT_EQ(UCC_OK, ucc_lib_config_read(NULL, NULL, &cfg));
+
+    /* modify known field to expected value */
+    EXPECT_EQ(UCC_OK, ucc_lib_config_modify(cfg, "CLS", "basic"));
+    flags = UCC_CONFIG_PRINT_CONFIG;
+    ucc_lib_config_print(cfg, stdout, "", (ucc_config_print_flags_t)flags);
+    std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_NE(std::string::npos, output.find("UCC_CLS=basic"));
+
+    /* modify known field to unexpected value */
+    /* temporarily commented out due to a bug in UCS which results in segv */
+    // EXPECT_NE(UCC_OK, ucc_lib_config_modify(cfg, "CLS", "_unknown_value"));
+
+    /* modify uknown field */
+    EXPECT_NE(UCC_OK,
+              ucc_lib_config_modify(cfg, "_UNKNOWN_FIELD", "_unknown_value"));
+    ucc_lib_config_release(cfg);
+}


### PR DESCRIPTION
## What
Adds first set of tests for ucc_lib_config_read/modify/release and ucc_lib_init/finalize

## Why ?
Minimal gtest coverage for already implemented API

## How ?
Straight forward gtest. The only comment: gtest binary is linked against libucc.la from ${top_builddir}/src/.libs/libucc.la. This is why in runtime ucc would search for dynamic modules in ${top_builddir}/src/.libs/ucc. So in order to have it working w/o specifying UCC_COMPONENT_PATH, i've added the config/module.am (logic borrowed from ucx) which would place all the dynamical modules into ${top_builddir}/modules and also make a symlink from that folder to ${top_builddir}/src/.libs/ucc.
