### PR TITLE
Fix include installation path to include '/ucc'

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,4 +38,4 @@ libucc_la_SOURCES =        \
 	utils/ucc_component.c  \
 	cl/ucc_cl.c
 
-libucc_ladir = $(includedir)
+libucc_ladir = $(includedir)/ucc


### PR DESCRIPTION
Currently, the path is just `$includedir/api/ucc.h`, so if `$includedir` is `/usr/include` - the installed header will be at `/usr/include/api/ucc.h` ... makes much more sense to have it in `/usr/include/ucc/api/ucc.h` (which is also what UCX does, BTW).