### PR TITLE
TL framework

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -35,7 +35,7 @@ jobs:
               return 1
             fi
           fi
-          if ! echo $msg | grep -qP '^Merge |^((CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD)|(CL/|TL/|UCX|UCG|BASIC))+: \w'
+          if ! echo $msg | grep -qP '^Merge |^((CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD)|(CL/|TL/|UCP|UCG|BASIC))+: \w'
           then
             echo "Wrong header"
             return 1

--- a/config/m4/ucx.m4
+++ b/config/m4/ucx.m4
@@ -80,7 +80,7 @@ AS_IF([test "x$ucx_checked" != "xyes"],[
                 AC_SUBST(UCS_LDFLAGS, "-L$check_ucx_libdir")
             ])
 
-            AC_SUBST(UCX_LIBADD, "-lucp -lucs -lucm")
+            AC_SUBST(UCX_LIBADD, "-lucp -lucm")
             AC_SUBST(UCS_LIBADD, "-lucs")
         ],
         [

--- a/configure.ac
+++ b/configure.ac
@@ -183,5 +183,6 @@ AC_CONFIG_FILES([
                  src/ucc/api/ucc_version.h
                  src/core/ucc_version.c
                  src/components/cl/basic/Makefile
+                 src/components/tl/ucp/Makefile
                  ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,8 +28,10 @@ noinst_HEADERS =                     \
 	utils/ucc_math.h                 \
 	components/base/ucc_base_iface.h \
 	components/cl/ucc_cl.h           \
-	components/cl/ucc_cl_log.h
-
+	components/cl/ucc_cl_log.h       \
+	components/cl/ucc_cl_type.h      \
+	components/tl/ucc_tl.h           \
+	components/tl/ucc_tl_log.h
 
 
 libucc_la_SOURCES =                  \
@@ -40,6 +42,7 @@ libucc_la_SOURCES =                  \
 	core/ucc_context.c               \
 	utils/ucc_component.c            \
 	components/base/ucc_base_iface.c \
-	components/cl/ucc_cl.c
+	components/cl/ucc_cl.c           \
+	components/tl/ucc_tl.c
 
 libucc_ladir = $(includedir)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,8 +1,14 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
 #
-SUBDIRS = components/cl/basic
+cl_dirs = components/cl/basic
+tl_dirs =
 
+if HAVE_UCX
+tl_dirs += components/tl/ucp
+endif
+
+SUBDIRS = $(cl_dirs) $(tl_dirs)
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =
 

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -38,6 +38,10 @@ typedef struct ucc_base_lib_iface {
 
 typedef struct ucc_base_context_params {
     ucc_context_params_t params;
+    int                  estimated_num_eps;
+    int                  estimated_num_ppn;
+    ucc_thread_mode_t    thread_mode;
+    const char          *prefix;
 } ucc_base_context_params_t;
 
 typedef struct ucc_base_context {
@@ -60,5 +64,33 @@ static inline void ucc_base_config_release(ucc_base_config_t *config)
     ucc_config_parser_release_opts(config, config->cfg_entry->table);
     ucc_free(config);
 }
+
+#define UCC_IFACE_NAME_PREFIX(_F, _NAME, _cfg)                                 \
+    .name   = UCC_PP_MAKE_STRING(_F##_NAME) " " UCC_PP_MAKE_STRING(_cfg),      \
+    .prefix = UCC_PP_MAKE_STRING(_F##_NAME##_)
+
+#define UCC_IFACE_CFG(_F, _f, _cfg, _name, _NAME)                              \
+    .super._f##_cfg##_config = {                                               \
+        UCC_IFACE_NAME_PREFIX(_F, _NAME, _cfg),                                \
+        .table = ucc_##_f##_name##_##_cfg##_config_table,                      \
+        .size  = sizeof(ucc_##_f##_name##_##_cfg##_config_t)}
+
+#define UCC_BASE_IFACE_DECLARE(_F, _f, _name, _NAME, ...)                      \
+    ucc_##_f##_name##_iface_t ucc_##_f##_name = {                              \
+        UCC_IFACE_CFG(_F, _f, lib, _name, _NAME),                              \
+        UCC_IFACE_CFG(_F, _f, context, _name, _NAME),                          \
+        .super.super.name = UCC_PP_MAKE_STRING(_name),                         \
+        __VA_ARGS__                                                            \
+        .super.lib.init   = UCC_CLASS_NEW_FUNC_NAME(ucc_##_f##_name##_lib_t),  \
+        .super.lib.finalize =                                                  \
+            UCC_CLASS_DELETE_FUNC_NAME(ucc_##_f##_name##_lib_t),               \
+        .super.context.create =                                                \
+            UCC_CLASS_NEW_FUNC_NAME(ucc_##_f##_name##_context_t),              \
+        .super.context.destroy =                                               \
+        UCC_CLASS_DELETE_FUNC_NAME(ucc_##_f##_name##_context_t)};              \
+    UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_##_f##_name.super._f##lib_config,     \
+                                    &ucc_config_global_list);                  \
+    UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_##_f##_name.super._f##context_config, \
+                                    &ucc_config_global_list)
 
 #endif

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -63,32 +63,8 @@ typedef struct ucc_cl_context {
 
 UCC_CLASS_DECLARE(ucc_cl_context_t, ucc_cl_lib_t *);
 
-#define UCC_CL_IFACE_NAME_PREFIX(_NAME, _cfg)                                  \
-    .name   = UCC_PP_MAKE_STRING(CL_##_NAME) " " UCC_PP_MAKE_STRING(_cfg),     \
-    .prefix = UCC_PP_MAKE_STRING(CL_##_NAME##_)
-
-#define UCC_CL_IFACE_CFG(_cfg, _name, _NAME)                                   \
-    .super.cl_##_cfg##_config = {                                              \
-        UCC_CL_IFACE_NAME_PREFIX(_NAME, _cfg),                                 \
-        .table = ucc_cl_##_name##_##_cfg##_config_table,                       \
-        .size  = sizeof(ucc_cl_##_name##_##_cfg##_config_t)}
+#define UCC_CL_IFACE_EXT(_NAME) .super.type = UCC_CL_ ## _NAME,
 
 #define UCC_CL_IFACE_DECLARE(_name, _NAME)                                     \
-    ucc_cl_##_name##_iface_t ucc_cl_##_name = {                                \
-        UCC_CL_IFACE_CFG(lib, _name, _NAME),                                   \
-        UCC_CL_IFACE_CFG(context, _name, _NAME),                               \
-        .super.super.name = UCC_PP_MAKE_STRING(_name),                         \
-        .super.type       = UCC_CL_##_NAME,                                    \
-        .super.lib.init   = UCC_CLASS_NEW_FUNC_NAME(ucc_cl_##_name##_lib_t),   \
-        .super.lib.finalize =                                                  \
-            UCC_CLASS_DELETE_FUNC_NAME(ucc_cl_##_name##_lib_t),                \
-        .super.context.create =                                                \
-            UCC_CLASS_NEW_FUNC_NAME(ucc_cl_##_name##_context_t),               \
-        .super.context.destroy =                                               \
-            UCC_CLASS_DELETE_FUNC_NAME(ucc_cl_##_name##_context_t)};           \
-    UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_cl_##_name.super.cl_lib_config,       \
-                                    &ucc_config_global_list);                  \
-    UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_cl_##_name.super.cl_context_config,   \
-                                    &ucc_config_global_list)
-
+    UCC_BASE_IFACE_DECLARE(CL_, cl_, _name, _NAME, UCC_CL_IFACE_EXT(_NAME))
 #endif

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -12,6 +12,23 @@
 #include "components/base/ucc_base_iface.h"
 #include "ucc_cl_type.h"
 
+/** CL (collective layer) is an internal collective interface reflecting the
+    public UCC API and extensions to support modularity, the composition of
+    multiple collective implementations, and functionality that bridges the
+    gap between hardware implementation of communication primitives and the
+    programming models.
+
+    The CL layer will build upon TL for the communication transport requirements.
+    The CL can include a basic implementation, which provides minimal
+    functionality over the TL, or can provide more optimized implementation such
+    as hierarchical implementation that leverages multiple TL components.
+
+    The different implementations of CL are realized as different CL components.
+    The CL components are loaded dynamically, and their names should match the
+    predefined pattern “ucc_cl_.so”. The CL that is used for a given application
+    invocation can be selected with the UCC_CLS lib parameter.
+*/
+
 typedef struct ucc_cl_lib     ucc_cl_lib_t;
 typedef struct ucc_cl_iface   ucc_cl_iface_t;
 typedef struct ucc_cl_context ucc_cl_context_t;

--- a/src/components/cl/ucc_cl_log.h
+++ b/src/components/cl/ucc_cl_log.h
@@ -12,14 +12,14 @@
                       ##__VA_ARGS__)
 
 #define cl_error(_cl_lib, _fmt, ...)                                           \
-    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
+    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
 #define cl_warn(_cl_lib, _fmt, ...)                                            \
-    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
+    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
 #define cl_info(_cl_lib, _fmt, ...)                                            \
-    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
 #define cl_debug(_cl_lib, _fmt, ...)                                           \
-    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
+    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
 #define cl_trace(_cl_lib, _fmt, ...)                                           \
-    ucc_log_component_cl(_cl_lib, UCS_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
 
 #endif

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_tl.h"
+#include "utils/ucc_log.h"
+
+ucc_config_field_t ucc_tl_lib_config_table[] = {
+    {NULL}
+};
+
+ucc_config_field_t ucc_tl_context_config_table[] = {
+    {NULL}
+};
+
+UCC_CLASS_INIT_FUNC(ucc_tl_lib_t, ucc_tl_iface_t *tl_iface,
+                    const ucc_tl_lib_config_t *tl_config)
+{
+    self->iface         = tl_iface;
+    self->super.log_component = tl_config->super.log_component;
+    ucc_strncpy_safe(self->super.log_component.name,
+                     tl_iface->tl_lib_config.name,
+                     sizeof(self->super.log_component.name));
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_lib_t)
+{
+}
+
+UCC_CLASS_DEFINE(ucc_tl_lib_t, void);
+
+UCC_CLASS_INIT_FUNC(ucc_tl_context_t, ucc_tl_lib_t *tl_lib)
+{
+    self->super.lib = &tl_lib->super;
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_context_t)
+{
+}
+
+UCC_CLASS_DEFINE(ucc_tl_context_t, void);
+
+ucc_status_t ucc_tl_context_config_read(ucc_tl_lib_t *tl_lib,
+                                        const ucc_context_config_t *config,
+                                        ucc_tl_context_config_t **tl_config)
+{
+    ucc_status_t status;
+    status = ucc_base_config_read(config->lib->full_prefix,
+                                  &tl_lib->iface->tl_context_config,
+                                  (ucc_base_config_t **)tl_config);
+    if (UCC_OK == status) {
+        (*tl_config)->tl_lib = tl_lib;
+    }
+    return status;
+}
+
+ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface,
+                                    const char *full_prefix,
+                                    const ucc_lib_config_t *config,
+                                    ucc_tl_lib_config_t **tl_config)
+{
+    return ucc_base_config_read(full_prefix, &iface->tl_lib_config,
+                                (ucc_base_config_t **)tl_config);
+}

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -11,6 +11,15 @@
 
 #include "components/base/ucc_base_iface.h"
 
+/** TL (transport layer) is an internal interface that provides a basic
+    implementation of collectives and p2p primitives. It differs from CL in that
+    it focuses on the abstraction over hardware transport rather than the
+    programming model. These collectives can leverage either p2p communication
+    transport or collective transport. The primary example of p2p communication
+    transport is UCX, and the primary example of collective transport is SHARP,
+    MCAST, and shared memory.
+ */
+
 typedef struct ucc_tl_lib     ucc_tl_lib_t;
 typedef struct ucc_tl_iface   ucc_tl_iface_t;
 typedef struct ucc_tl_context ucc_tl_context_t;

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+
+#ifndef UCC_TL_H_
+#define UCC_TL_H_
+
+#include "components/base/ucc_base_iface.h"
+
+typedef struct ucc_tl_lib     ucc_tl_lib_t;
+typedef struct ucc_tl_iface   ucc_tl_iface_t;
+typedef struct ucc_tl_context ucc_tl_context_t;
+
+typedef struct ucc_tl_lib_config {
+    ucc_base_config_t  super;
+    ucc_tl_iface_t    *iface;
+} ucc_tl_lib_config_t;
+extern ucc_config_field_t ucc_tl_lib_config_table[];
+
+typedef struct ucc_tl_context_config {
+    ucc_base_config_t super;
+    ucc_tl_lib_t     *tl_lib;
+} ucc_tl_context_config_t;
+extern ucc_config_field_t ucc_tl_context_config_table[];
+
+ucc_status_t ucc_tl_context_config_read(ucc_tl_lib_t *tl_lib,
+                                        const ucc_context_config_t *config,
+                                        ucc_tl_context_config_t **cl_config);
+
+ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface, const char *full_prefix,
+                                    const ucc_lib_config_t *config,
+                                    ucc_tl_lib_config_t **cl_config);
+
+typedef struct ucc_tl_iface {
+    ucc_component_iface_t          super;
+    ucs_config_global_list_entry_t tl_lib_config;
+    ucs_config_global_list_entry_t tl_context_config;
+    ucc_base_lib_iface_t           lib;
+    ucc_base_context_iface_t       context;
+} ucc_tl_iface_t;
+
+typedef struct ucc_tl_lib {
+    ucc_base_lib_t              super;
+    ucc_tl_iface_t             *iface;
+} ucc_tl_lib_t;
+UCC_CLASS_DECLARE(ucc_tl_lib_t, ucc_tl_iface_t *, const ucc_tl_lib_config_t *);
+
+typedef struct ucc_tl_context {
+    ucc_base_context_t super;
+} ucc_tl_context_t;
+UCC_CLASS_DECLARE(ucc_tl_context_t, ucc_tl_lib_t *);
+
+#define UCC_TL_IFACE_DECLARE(_name, _NAME)                                     \
+    UCC_BASE_IFACE_DECLARE(TL_, tl_, _name, _NAME)
+#endif

--- a/src/components/tl/ucc_tl_log.h
+++ b/src/components/tl/ucc_tl_log.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_LOG_H_
+#define UCC_TL_LOG_H_
+#include "utils/ucc_log.h"
+#define ucc_log_component_tl(_tl_ctx, _level, fmt, ...)                        \
+    ucc_log_component(_level, ((ucc_base_context_t *)_tl_ctx)->lib->log_component, fmt, \
+                      ##__VA_ARGS__)
+
+#define tl_error(_tl_ctx, _fmt, ...)                                           \
+    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
+#define tl_warn(_tl_ctx, _fmt, ...)                                            \
+    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
+#define tl_info(_tl_ctx, _fmt, ...)                                            \
+    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+#define tl_debug(_tl_ctx, _fmt, ...)                                           \
+    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
+#define tl_trace(_tl_ctx, _fmt, ...)                                           \
+    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+
+#endif

--- a/src/components/tl/ucc_tl_log.h
+++ b/src/components/tl/ucc_tl_log.h
@@ -12,14 +12,14 @@
                       ##__VA_ARGS__)
 
 #define tl_error(_tl_ctx, _fmt, ...)                                           \
-    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
+    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
 #define tl_warn(_tl_ctx, _fmt, ...)                                            \
-    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
+    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
 #define tl_info(_tl_ctx, _fmt, ...)                                            \
-    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
 #define tl_debug(_tl_ctx, _fmt, ...)                                           \
-    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
+    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
 #define tl_trace(_tl_ctx, _fmt, ...)                                           \
-    ucc_log_component_tl(_tl_ctx, UCS_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
 
 #endif

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -1,0 +1,16 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+#
+
+sources =            \
+	tl_ucp.h         \
+	tl_ucp.c         \
+	tl_ucp_lib.c     \
+	tl_ucp_context.c
+
+libucc_tl_ucp_la_SOURCES  = $(sources)
+libucc_tl_ucp_la_CPPFLAGS = $(AM_CPPFLAGS) $(UCX_CPPFLAGS)
+libucc_tl_ucp_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(UCX_LDFLAGS)
+libucc_tl_ucp_la_LIBADD   = $(UCX_LIBADD)
+
+pkglib_LTLIBRARIES = libucc_tl_ucp.la

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_ucp.h"
+#include "utils/ucc_malloc.h"
+
+static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_tl_ucp_lib_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)},
+
+    {NULL}
+};
+
+static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_tl_ucp_context_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_tl_context_config_table)},
+
+    {"TEST_PARAM", "5", "For dbg test purpuse : don't commit",
+     ucc_offsetof(ucc_tl_ucp_context_config_t, test_param),
+     UCC_CONFIG_TYPE_UINT},
+
+    {NULL}
+};
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_ucp_lib_t, ucc_base_lib_t,
+                          const ucc_base_lib_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_ucp_lib_t, ucc_base_lib_t);
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_ucp_context_t, ucc_base_context_t,
+                          const ucc_base_context_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_ucp_context_t, ucc_base_context_t);
+
+UCC_TL_IFACE_DECLARE(ucp, UCP);

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_UCP_H_
+#define UCC_TL_UCP_H_
+#include "components/tl/ucc_tl.h"
+#include "components/tl/ucc_tl_log.h"
+#include <ucp/api/ucp.h>
+#include <ucs/memory/memory_type.h>
+
+typedef struct ucc_tl_ucp_iface {
+    ucc_tl_iface_t super;
+} ucc_tl_ucp_iface_t;
+/* Extern iface should follow the pattern: ucc_tl_<tl_name> */
+extern ucc_tl_ucp_iface_t ucc_tl_ucp;
+
+typedef struct ucc_tl_ucp_lib_config {
+    ucc_tl_lib_config_t super;
+} ucc_tl_ucp_lib_config_t;
+
+typedef struct ucc_tl_ucp_context_config {
+    ucc_tl_context_config_t super;
+    int                     test_param;
+} ucc_tl_ucp_context_config_t;
+
+typedef struct ucc_tl_ucp_lib {
+    ucc_tl_lib_t super;
+} ucc_tl_ucp_lib_t;
+UCC_CLASS_DECLARE(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_ucp_context {
+    ucc_tl_context_t super;
+    ucp_context_h    ucp_context;
+    ucp_worker_h     ucp_worker;
+    size_t           ucp_addrlen;
+} ucc_tl_ucp_context_t;
+UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_ucp_req {
+    ucc_status_t status;
+} ucc_tl_ucp_req_t;
+#endif

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_ucp.h"
+#include "tl_ucp_tag.h"
+
+static void ucc_tl_ucp_req_init(void *request)
+{
+    ucc_tl_ucp_req_t *req = (ucc_tl_ucp_req_t *)request;
+    req->status           = UCC_OPERATION_INITIALIZED;
+}
+
+static void ucc_tl_ucp_req_cleanup(void *request)
+{
+}
+
+UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
+                    const ucc_base_context_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    ucc_tl_context_config_t *tl_config =
+        ucc_derived_of(config, ucc_tl_context_config_t);
+    ucc_status_t        ucc_status = UCC_OK;
+    ucp_worker_params_t worker_params;
+    ucp_worker_attr_t   worker_attr;
+    ucp_params_t        ucp_params;
+    ucp_config_t       *ucp_config;
+    ucp_context_h       ucp_context;
+    ucp_worker_h        ucp_worker;
+    ucs_status_t        status;
+
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_config->tl_lib);
+    status = ucp_config_read(params->prefix, NULL, &ucp_config);
+    if (UCS_OK != status) {
+        tl_error(&self->super, "failed to read ucp configuration, %s",
+                 ucs_status_string(status));
+        ucc_status = ucs_status_to_ucc_status(status);
+        goto err_cfg;
+    }
+
+    ucp_params.field_mask =
+        UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_REQUEST_SIZE |
+        UCP_PARAM_FIELD_REQUEST_INIT | UCP_PARAM_FIELD_REQUEST_CLEANUP |
+        UCP_PARAM_FIELD_TAG_SENDER_MASK;
+    ucp_params.features        = UCP_FEATURE_TAG | UCP_FEATURE_RMA;
+    ucp_params.request_size    = sizeof(ucc_tl_ucp_req_t);
+    ucp_params.request_init    = ucc_tl_ucp_req_init;
+    ucp_params.request_cleanup = ucc_tl_ucp_req_cleanup;
+    ucp_params.tag_sender_mask = UCC_TL_UCP_TAG_SENDER_MASK;
+
+    if (params->estimated_num_ppn > 0) {
+        ucp_params.field_mask |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
+        ucp_params.estimated_num_ppn = params->estimated_num_ppn;
+    }
+
+    if (params->estimated_num_eps > 0) {
+        ucp_params.field_mask |= UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
+        ucp_params.estimated_num_eps = params->estimated_num_eps;
+    }
+
+    status = ucp_init(&ucp_params, ucp_config, &ucp_context);
+    ucp_config_release(ucp_config);
+    if (UCS_OK != status) {
+        tl_error(&self->super, "failed to init ucp context, %s",
+                 ucs_status_string(status));
+        ucc_status = ucs_status_to_ucc_status(status);
+        goto err_cfg;
+    }
+
+    worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+    switch (params->thread_mode) {
+    case UCC_THREAD_SINGLE:
+    case UCC_THREAD_FUNNELED:
+        worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
+        break;
+    case UCC_THREAD_MULTIPLE:
+        worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
+        break;
+    default:
+        /* unreachable */
+        ucc_assert(0);
+        break;
+    }
+    status = ucp_worker_create(ucp_context, &worker_params, &ucp_worker);
+    if (UCS_OK != status) {
+        tl_error(&self->super, "failed to create ucp worker, %s",
+                 ucs_status_string(status));
+        ucc_status = ucs_status_to_ucc_status(status);
+        goto err_worker_create;
+    }
+
+    if (params->thread_mode == UCC_THREAD_MULTIPLE) {
+        worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_THREAD_MODE;
+        ucp_worker_query(ucp_worker, &worker_attr);
+        if (worker_attr.thread_mode != UCS_THREAD_MODE_MULTI) {
+            tl_error(&self->super,
+                     "thread mode multiple is not supported by ucp worker");
+            ucc_status = UCC_ERR_NOT_SUPPORTED;
+            goto err_thread_mode;
+        }
+    }
+
+    self->ucp_context = ucp_context;
+    self->ucp_worker  = ucp_worker;
+    tl_info(&self->super, "initialized cl context: %p", self);
+    return UCC_OK;
+
+err_thread_mode:
+    ucp_worker_destroy(ucp_worker);
+err_worker_create:
+    ucp_cleanup(ucp_context);
+err_cfg:
+    return ucc_status;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_context_t)
+{
+    tl_info(&self->super.super.lib, "finalizing cl context: %p", self);
+    ucp_worker_destroy(self->ucp_worker);
+    ucp_cleanup(self->ucp_context);
+}
+
+UCC_CLASS_DEFINE(ucc_tl_ucp_context_t, ucc_tl_context_t);

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_ucp.h"
+#include "utils/ucc_malloc.h"
+
+UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    const ucc_tl_lib_config_t *tl_config =
+        ucc_derived_of(config, ucc_tl_lib_config_t);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_ucp.super, tl_config);
+    tl_info(&self->super, "initialized lib object: %p", self);
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_lib_t)
+{
+    tl_info(&self->super, "finalizing lib object: %p", self);
+}
+
+UCC_CLASS_DEFINE(ucc_tl_ucp_lib_t, ucc_tl_lib_t);

--- a/src/components/tl/ucp/tl_ucp_tag.h
+++ b/src/components/tl/ucp/tl_ucp_tag.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#ifndef UCC_TL_UCP_TAG_H_
+#define UCC_TL_UCP_TAG_H_
+#include "utils/ucc_compiler_def.h"
+
+/*
+ * UCP tag structure:
+ *
+ *    01234           567     01234567 01234567 01234567 01234567 01234567 01234567 01234567
+ *                |         |                  |                          |
+ *   RESERVED (5) | CTX (3) | message tag (16) |     source rank (24)     |  team id (16)
+ */
+
+#define UCC_TL_UCP_RESERVED_BITS 5
+#define UCC_TL_UCP_CTX_BITS 3
+#define UCC_TL_UCP_TAG_BITS 16
+#define UCC_TL_UCP_SENDER_BITS 24
+#define UCC_TL_UCP_ID_BITS 16
+
+#define UCC_TL_UCP_RESERVED_BITS_OFFSET                                        \
+    (UCC_TL_UCP_ID_BITS + UCC_TL_UCP_SENDER_BITS + UCC_TL_UCP_TAG_BITS +       \
+     UCC_TL_UCP_CTX_BITS)
+
+#define UCC_TL_UCP_CTX_BITS_OFFSET                                             \
+    (UCC_TL_UCP_ID_BITS + UCC_TL_UCP_SENDER_BITS + UCC_TL_UCP_TAG_BITS)
+
+#define UCC_TL_UCP_TAG_BITS_OFFSET (UCC_TL_UCP_ID_BITS + UCC_TL_UCP_SENDER_BITS)
+#define UCC_TL_UCP_SENDER_BITS_OFFSET (UCC_TL_UCP_ID_BITS)
+#define UCC_TL_UCP_ID_BITS_OFFSET 0
+
+#define UCC_TL_UCP_MAX_TAG UCC_MASK(UCC_TL_UCP_TAG_BITS)
+#define UCC_TL_UCP_MAX_SENDER UCC_MASK(UCC_TL_UCP_SENDER_BITS)
+#define UCC_TL_UCP_MAX_ID UCC_MASK(UCC_TL_UCP_ID_BITS)
+
+#define UCC_TL_UCP_TAG_SENDER_MASK                                             \
+    UCC_MASK(UCC_TL_UCP_ID_BITS + UCC_TL_UCP_SENDER_BITS)
+#endif

--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -71,6 +71,12 @@ ucc_status_t ucc_constructor(void)
                       ucc_global_config.component_path);
             return status;
         }
+        status = ucc_components_load("tl", &ucc_global_config.tl_framework);
+        if (UCC_OK != status) {
+            /* not critical - some CLs may operate w/o use of TL */
+            ucc_debug("no TL components were found in the UCC_COMPONENT_PATH: %s",
+                      ucc_global_config.component_path);
+        }
     }
     return UCC_OK;
 }

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -16,6 +16,7 @@ typedef struct ucc_global_config {
     /* Log level above which log messages will be printed*/
     ucc_log_component_config_t log_component;
     ucc_component_framework_t  cl_framework;
+    ucc_component_framework_t  tl_framework;
 
     /* Coll component libraries path */
     char *component_path;

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -29,6 +29,7 @@ typedef ucs_log_component_config_t ucc_log_component_config_t;
 #define _UCC_PP_MAKE_STRING(x) #x
 #define UCC_PP_MAKE_STRING(x)  _UCC_PP_MAKE_STRING(x)
 #define UCC_PP_QUOTE UCS_PP_QUOTE
+#define UCC_MASK     UCS_MASK
 
 static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
 {

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -10,7 +10,11 @@
 #include "core/ucc_global_opts.h"
 #include <ucs/debug/log_def.h>
 
-#define UCC_LOG_LEVEL_WARN UCS_LOG_LEVEL_WARN
+#define UCC_LOG_LEVEL_ERROR UCS_LOG_LEVEL_ERROR
+#define UCC_LOG_LEVEL_WARN  UCS_LOG_LEVEL_WARN
+#define UCC_LOG_LEVEL_INFO  UCS_LOG_LEVEL_INFO
+#define UCC_LOG_LEVEL_DEBUG UCS_LOG_LEVEL_DEBUG
+#define UCC_LOG_LEVEL_TRACE UCS_LOG_LEVEL_TRACE
 
 /* Generic wrapper macro to invoke ucs logging backend */
 #define ucc_log_component(_level, _component, _fmt, ...)                       \

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -30,7 +30,7 @@ UCC_TEST_F(test_obj_size, size) {
     UCC_TEST_SKIP_R("Assert enabled");
 #else
 
-    EXPECTED_SIZE(ucc_global_config_t, 72);
+    EXPECTED_SIZE(ucc_global_config_t, 96);
 
 #endif
 }


### PR DESCRIPTION
## What
Adds TL Framework and interface
Adds TL/UCP lib init/finalize, context create/destroy

## Why ?
TLs are internal "transport" layers. Their interface is very similar to CL and it is inherited from the "base" interface (similarly to CL)


