### PR TITLE
TEST: change git-clang-format link

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -3,7 +3,7 @@ name: Codestyle
 on: [pull_request]
 
 env:
-  GIT_CF: https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/git-clang-format
+  GIT_CF: https://raw.githubusercontent.com/llvm/llvm-project/release/11.x/clang/tools/clang-format/git-clang-format
 jobs:
   check-codestyle:
     runs-on: ubuntu-latest
@@ -14,8 +14,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common
         sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-        sudo wget -O /usr/bin/git-clang-format $GIT_CF
-        sudo chmod +x /usr/bin/git-clang-format
+        curl -OL $GIT_CF && chmod +x ./git-clang-format && sudo mv ./git-clang-format /usr/bin/git-clang-format
     - name: Checking out repository
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
## What
Change git-clang-format link from svn to github

## Why ?
LLVM SVN seems to be down for quite some time already

Should fix CI issues in https://github.com/openucx/ucc/pull/46 and https://github.com/openucx/ucc/pull/47