### PR TITLE
CORE: redefine ucc class functions

### DIFF
--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -113,7 +113,7 @@ static ucc_status_t ucc_lib_init_filtered(const ucc_lib_params_t *user_params,
         if (params.thread_mode > cl_iface->attr.thread_mode) {
             /* Requested THREAD_MODE is not supported by the CL:
                1. If cls == "all" - just skip this CL
-               2. If specific CLs are requested: continue and user will 
+               2. If specific CLs are requested: continue and user will
                   have to query result attributes and check thread mode*/
             if (!lib->specific_cls_requested) {
                 ucc_info("requested thread_mode is not supported by the CL: %s",
@@ -172,7 +172,7 @@ static ucc_status_t ucc_lib_init_filtered(const ucc_lib_params_t *user_params,
     }
     lib->attr.coll_types  = supported_coll_types;
     lib->attr.thread_mode = ucc_min(supported_tm, params.thread_mode);
-    return UCS_OK;
+    return UCC_OK;
 
 error_cl_init:
     ucc_base_config_release(&cl_config->super);

--- a/src/utils/ucc_class.h
+++ b/src/utils/ucc_class.h
@@ -10,13 +10,20 @@
 #include <ucs/type/class.h>
 #include "utils/ucc_compiler_def.h"
 
-#define UCC_CLASS_DECLARE         UCS_CLASS_DECLARE
 #define UCC_CLASS_DEFINE          UCS_CLASS_DEFINE
 #define UCC_CLASS_DELETE          UCS_CLASS_DELETE
-#define UCC_CLASS_INIT_FUNC       UCS_CLASS_INIT_FUNC
 #define UCC_CLASS_CLEANUP_FUNC    UCS_CLASS_CLEANUP_FUNC
 #define UCC_CLASS_CLEANUP         UCS_CLASS_CLEANUP
 #define UCC_CLASS_NEW_FUNC_NAME   UCS_CLASS_NEW_FUNC_NAME
+
+#define UCC_CLASS_INIT_FUNC(_type, ...)                                        \
+    ucc_status_t _UCS_CLASS_INIT_NAME(_type)(_type *self,                      \
+                                             ucs_class_t *_myclass,            \
+                                             int *_init_count, ## __VA_ARGS__) \
+
+#define UCC_CLASS_DECLARE(_type, ...)                                          \
+    extern ucs_class_t _UCS_CLASS_DECL_NAME(_type);                            \
+    UCC_CLASS_INIT_FUNC(_type, ## __VA_ARGS__);                                \
 
 #define UCC_CLASS_NEW(...)                                                     \
     ({                                                                         \


### PR DESCRIPTION
## What
Redefine UCC_CLASS_INIT_FUNC and UCC_CLASS_DECLARE 

## Why ?
Original versions of these macros in UCS define ucs_status_t as return code. It is not consistent with CL and TL implementation in which we return ucc_status_t
