### PR TITLE
CORE: init TL contexts

### DIFF
--- a/src/components/cl/basic/Makefile.am
+++ b/src/components/cl/basic/Makefile.am
@@ -13,6 +13,4 @@ libucc_cl_basic_la_SOURCES  = $(sources)
 libucc_cl_basic_la_CPPFLAGS = $(AM_CPPFLAGS)
 libucc_cl_basic_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
 
-
-
 include $(top_srcdir)/config/module.am

--- a/src/components/cl/basic/cl_basic.c
+++ b/src/components/cl/basic/cl_basic.c
@@ -6,6 +6,8 @@
 
 #include "cl_basic.h"
 #include "utils/ucc_malloc.h"
+ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *base_attr);
+ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context, ucc_base_attr_t *base_attr);
 
 static ucc_config_field_t ucc_cl_basic_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_basic_lib_config_t, super),

--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -8,6 +8,7 @@
 #define UCC_CL_BASIC_H_
 #include "components/cl/ucc_cl.h"
 #include "components/cl/ucc_cl_log.h"
+#include "components/tl/ucc_tl.h"
 
 #define UCC_CL_BASIC_DEFAULT_PRIORITY 10
 
@@ -34,6 +35,7 @@ UCC_CLASS_DECLARE(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *,
 
 typedef struct ucc_cl_basic_context {
     ucc_cl_context_t super;
+    ucc_tl_context_t *tl_ucp_ctx;
 } ucc_cl_basic_context_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -11,9 +11,16 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
                     const ucc_base_context_params_t *params,
                     const ucc_base_config_t *config)
 {
+    ucc_status_t status;
     const ucc_cl_context_config_t *cl_config =
         ucc_derived_of(config, ucc_cl_context_config_t);
     UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_config->cl_lib);
+    status = ucc_tl_context_get(params->context, UCC_TL_UCP,
+                                &self->tl_ucp_ctx);
+    if (UCC_OK != status) {
+        cl_warn(cl_config->cl_lib, "TL UCP context is not available, CL BASIC can't proceed");
+        return UCC_ERR_NOT_FOUND;
+    }
     cl_info(cl_config->cl_lib, "initialized cl context: %p", self);
     return UCC_OK;
 }
@@ -21,6 +28,13 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_context_t)
 {
     cl_info(self->super.super.lib, "finalizing cl context: %p", self);
+    ucc_tl_context_put(self->tl_ucp_ctx);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_basic_context_t, ucc_cl_context_t);
+
+ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context,
+                                           ucc_base_attr_t *attr)
+{
+    return UCC_OK;
+}

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -6,6 +6,7 @@
 
 #include "cl_basic.h"
 #include "utils/ucc_malloc.h"
+#include "components/tl/ucc_tl.h"
 
 UCC_CLASS_INIT_FUNC(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *params,
                     const ucc_base_config_t *config)
@@ -24,3 +25,9 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 }
 
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
+
+ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *base_attr) {
+    ucc_cl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
+    attr->tls = UCC_TL_UCP;
+    return UCC_OK;
+}

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -80,8 +80,11 @@ typedef struct ucc_cl_context {
 
 UCC_CLASS_DECLARE(ucc_cl_context_t, ucc_cl_lib_t *);
 
-#define UCC_CL_IFACE_EXT(_NAME) .super.type = UCC_CL_ ## _NAME,
+typedef struct ucc_cl_lib_attr {
+    ucc_base_attr_t super;
+    uint64_t tls;
+} ucc_cl_lib_attr_t;
 
 #define UCC_CL_IFACE_DECLARE(_name, _NAME)                                     \
-    UCC_BASE_IFACE_DECLARE(CL_, cl_, _name, _NAME, UCC_CL_IFACE_EXT(_NAME))
+    UCC_BASE_IFACE_DECLARE(CL_, cl_, _name, _NAME)
 #endif

--- a/src/components/cl/ucc_cl_log.h
+++ b/src/components/cl/ucc_cl_log.h
@@ -6,20 +6,12 @@
 
 #ifndef UCC_CL_LOG_H_
 #define UCC_CL_LOG_H_
-#include "utils/ucc_log.h"
-#define ucc_log_component_cl(_cl_lib, _level, fmt, ...)                        \
-    ucc_log_component(_level, ((ucc_base_lib_t *)_cl_lib)->log_component, fmt, \
-                      ##__VA_ARGS__)
+#include "components/base/ucc_base_iface.h"
 
-#define cl_error(_cl_lib, _fmt, ...)                                           \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
-#define cl_warn(_cl_lib, _fmt, ...)                                            \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
-#define cl_info(_cl_lib, _fmt, ...)                                            \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
-#define cl_debug(_cl_lib, _fmt, ...)                                           \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
-#define cl_trace(_cl_lib, _fmt, ...)                                           \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+#define cl_error(_cl_lib, _fmt, ...) base_error((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
+#define cl_warn(_cl_lib, _fmt, ...)  base_warn((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
+#define cl_info(_cl_lib, _fmt, ...)  base_info((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
+#define cl_debug(_cl_lib, _fmt, ...) base_debug((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
+#define cl_trace(_cl_lib, _fmt, ...) base_trace((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
 
 #endif

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -8,7 +8,9 @@
 #include "utils/ucc_log.h"
 
 ucc_config_field_t ucc_tl_lib_config_table[] = {
-    {NULL}
+    {"", "", NULL, ucc_offsetof(ucc_tl_lib_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_base_config_table)},
+
 };
 
 ucc_config_field_t ucc_tl_context_config_table[] = {
@@ -35,6 +37,7 @@ UCC_CLASS_DEFINE(ucc_tl_lib_t, void);
 UCC_CLASS_INIT_FUNC(ucc_tl_context_t, ucc_tl_lib_t *tl_lib)
 {
     self->super.lib = &tl_lib->super;
+    self->ref_count = 0;
     return UCC_OK;
 }
 
@@ -65,4 +68,26 @@ ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface,
 {
     return ucc_base_config_read(full_prefix, &iface->tl_lib_config,
                                 (ucc_base_config_t **)tl_config);
+}
+
+ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, ucc_tl_type_t type,
+                                ucc_tl_context_t **tl_context)
+{
+    int i;
+    ucc_tl_lib_t *tl_lib;
+    for (i = 0; i < ctx->n_tl_ctx; i++) {
+        tl_lib = ucc_derived_of(ctx->tl_ctx[i]->super.lib, ucc_tl_lib_t);
+        if (tl_lib->iface->type == type) {
+            ctx->tl_ctx[i]->ref_count++;
+            *tl_context = ctx->tl_ctx[i];
+            return UCC_OK;
+        }
+    }
+    return UCC_ERR_NOT_FOUND;
+}
+
+ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context)
+{
+    tl_context->ref_count--;
+    return UCC_OK;
 }

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -24,6 +24,10 @@ typedef struct ucc_tl_lib     ucc_tl_lib_t;
 typedef struct ucc_tl_iface   ucc_tl_iface_t;
 typedef struct ucc_tl_context ucc_tl_context_t;
 
+typedef enum ucc_tl_type {
+    UCC_TL_UCP = UCC_BIT(0),
+} ucc_tl_type_t;
+
 typedef struct ucc_tl_lib_config {
     ucc_base_config_t  super;
     ucc_tl_iface_t    *iface;
@@ -46,6 +50,7 @@ ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface, const char *full_pref
 
 typedef struct ucc_tl_iface {
     ucc_component_iface_t          super;
+    ucc_tl_type_t                  type;
     ucs_config_global_list_entry_t tl_lib_config;
     ucs_config_global_list_entry_t tl_context_config;
     ucc_base_lib_iface_t           lib;
@@ -60,9 +65,14 @@ UCC_CLASS_DECLARE(ucc_tl_lib_t, ucc_tl_iface_t *, const ucc_tl_lib_config_t *);
 
 typedef struct ucc_tl_context {
     ucc_base_context_t super;
+    int                ref_count;
 } ucc_tl_context_t;
 UCC_CLASS_DECLARE(ucc_tl_context_t, ucc_tl_lib_t *);
 
 #define UCC_TL_IFACE_DECLARE(_name, _NAME)                                     \
     UCC_BASE_IFACE_DECLARE(TL_, tl_, _name, _NAME)
+
+ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, ucc_tl_type_t type,
+                                ucc_tl_context_t **tl_context);
+ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context);
 #endif

--- a/src/components/tl/ucc_tl_log.h
+++ b/src/components/tl/ucc_tl_log.h
@@ -6,20 +6,12 @@
 
 #ifndef UCC_TL_LOG_H_
 #define UCC_TL_LOG_H_
-#include "utils/ucc_log.h"
-#define ucc_log_component_tl(_tl_ctx, _level, fmt, ...)                        \
-    ucc_log_component(_level, ((ucc_base_context_t *)_tl_ctx)->lib->log_component, fmt, \
-                      ##__VA_ARGS__)
+#include "components/base/ucc_base_iface.h"
 
-#define tl_error(_tl_ctx, _fmt, ...)                                           \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
-#define tl_warn(_tl_ctx, _fmt, ...)                                            \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
-#define tl_info(_tl_ctx, _fmt, ...)                                            \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
-#define tl_debug(_tl_ctx, _fmt, ...)                                           \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
-#define tl_trace(_tl_ctx, _fmt, ...)                                           \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+#define tl_error(_tl_lib, _fmt, ...) base_error((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
+#define tl_warn(_tl_lib, _fmt, ...)  base_warn((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
+#define tl_info(_tl_lib, _fmt, ...)  base_info((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
+#define tl_debug(_tl_lib, _fmt, ...) base_debug((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
+#define tl_trace(_tl_lib, _fmt, ...) base_trace((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
 
 #endif

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -8,9 +8,10 @@ sources =            \
 	tl_ucp_lib.c     \
 	tl_ucp_context.c
 
+module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)
 libucc_tl_ucp_la_CPPFLAGS = $(AM_CPPFLAGS) $(UCX_CPPFLAGS)
 libucc_tl_ucp_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(UCX_LDFLAGS)
 libucc_tl_ucp_la_LIBADD   = $(UCX_LIBADD)
 
-pkglib_LTLIBRARIES = libucc_tl_ucp.la
+include $(top_srcdir)/config/module.am

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -6,6 +6,8 @@
 
 #include "tl_ucp.h"
 #include "utils/ucc_malloc.h"
+ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *base_attr);
+ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context, ucc_base_attr_t *base_attr);
 
 static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_ucp_lib_config_t, super),

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -35,7 +35,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_config->tl_lib);
     status = ucp_config_read(params->prefix, NULL, &ucp_config);
     if (UCS_OK != status) {
-        tl_error(&self->super, "failed to read ucp configuration, %s",
+        tl_error(self->super.super.lib, "failed to read ucp configuration, %s",
                  ucs_status_string(status));
         ucc_status = ucs_status_to_ucc_status(status);
         goto err_cfg;
@@ -64,7 +64,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     status = ucp_init(&ucp_params, ucp_config, &ucp_context);
     ucp_config_release(ucp_config);
     if (UCS_OK != status) {
-        tl_error(&self->super, "failed to init ucp context, %s",
+        tl_error(self->super.super.lib, "failed to init ucp context, %s",
                  ucs_status_string(status));
         ucc_status = ucs_status_to_ucc_status(status);
         goto err_cfg;
@@ -86,7 +86,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     }
     status = ucp_worker_create(ucp_context, &worker_params, &ucp_worker);
     if (UCS_OK != status) {
-        tl_error(&self->super, "failed to create ucp worker, %s",
+        tl_error(self->super.super.lib, "failed to create ucp worker, %s",
                  ucs_status_string(status));
         ucc_status = ucs_status_to_ucc_status(status);
         goto err_worker_create;
@@ -96,7 +96,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
         worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_THREAD_MODE;
         ucp_worker_query(ucp_worker, &worker_attr);
         if (worker_attr.thread_mode != UCS_THREAD_MODE_MULTI) {
-            tl_error(&self->super,
+            tl_error(self->super.super.lib,
                      "thread mode multiple is not supported by ucp worker");
             ucc_status = UCC_ERR_NOT_SUPPORTED;
             goto err_thread_mode;
@@ -105,7 +105,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
 
     self->ucp_context = ucp_context;
     self->ucp_worker  = ucp_worker;
-    tl_info(&self->super, "initialized cl context: %p", self);
+    tl_info(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 
 err_thread_mode:
@@ -118,9 +118,15 @@ err_cfg:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_context_t)
 {
-    tl_info(&self->super.super.lib, "finalizing cl context: %p", self);
+    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
     ucp_worker_destroy(self->ucp_worker);
     ucp_cleanup(self->ucp_context);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_ucp_context_t, ucc_tl_context_t);
+
+ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
+                                         ucc_base_attr_t *attr)
+{
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -23,3 +23,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_lib_t)
 }
 
 UCC_CLASS_DEFINE(ucc_tl_ucp_lib_t, ucc_tl_lib_t);
+
+ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *attr) {
+    return UCC_OK;
+}

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -6,6 +6,7 @@
 #include "config.h"
 #include "ucc_context.h"
 #include "components/cl/ucc_cl.h"
+#include "components/tl/ucc_tl.h"
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_log.h"
 
@@ -26,7 +27,7 @@ ucc_status_t ucc_context_config_read(ucc_lib_info_t *lib, const char *filename,
     }
     config->lib     = lib;
     config->configs = (ucc_cl_context_config_t **)ucc_calloc(
-        lib->n_libs_opened, sizeof(ucc_cl_context_config_t *),
+        lib->n_cl_libs_opened, sizeof(ucc_cl_context_config_t *),
         "cl_configs_array");
     if (config->configs == NULL) {
         ucc_error("failed to allocate %zd bytes for cl configs array",
@@ -36,13 +37,13 @@ ucc_status_t ucc_context_config_read(ucc_lib_info_t *lib, const char *filename,
     }
 
     config->n_cl_cfg = 0;
-    for (i = 0; i < lib->n_libs_opened; i++) {
-        ucc_assert(NULL != lib->libs[i]->iface->cl_context_config.table);
+    for (i = 0; i < lib->n_cl_libs_opened; i++) {
+        ucc_assert(NULL != lib->cl_libs[i]->iface->cl_context_config.table);
         status =
-            ucc_cl_context_config_read(lib->libs[i], config, &cl_config);
+            ucc_cl_context_config_read(lib->cl_libs[i], config, &cl_config);
         if (UCC_OK != status) {
             ucc_error("failed to read CL \"%s\" context configuration",
-                      lib->libs[i]->iface->super.name);
+                      lib->cl_libs[i]->iface->super.name);
             goto err_config_i;
         }
         config->configs[config->n_cl_cfg]         = cl_config;
@@ -123,12 +124,12 @@ ucc_status_t ucc_context_config_modify(ucc_context_config_t *config,
             if (config->configs[i]) {
                 status = ucc_config_parser_set_value(
                     config->configs[i],
-                    config->lib->libs[i]->iface->cl_context_config.table, name,
+                    config->lib->cl_libs[i]->iface->cl_context_config.table, name,
                     value);
                 if (UCC_OK != status) {
                     ucc_error("failed to modify CL \"%s\" configuration, name "
                               "%s, value %s",
-                              config->lib->libs[i]->iface->super.name, name,
+                              config->lib->cl_libs[i]->iface->super.name, name,
                               value);
                     return status;
                 }
@@ -177,16 +178,16 @@ void ucc_context_config_print(const ucc_context_config_h config, FILE *stream,
             print_header = 0;
             ucc_config_parser_print_opts(
                 stream, title, config->configs[i],
-                config->lib->libs[i]->iface->cl_context_config.table,
-                config->lib->libs[i]->iface->cl_context_config.prefix,
+                config->lib->cl_libs[i]->iface->cl_context_config.table,
+                config->lib->cl_libs[i]->iface->cl_context_config.prefix,
                 config->lib->full_prefix, UCC_CONFIG_PRINT_HEADER);
         }
 
         ucc_config_parser_print_opts(
-            stream, config->lib->libs[i]->iface->cl_context_config.name,
+            stream, config->lib->cl_libs[i]->iface->cl_context_config.name,
             config->configs[i],
-            config->lib->libs[i]->iface->cl_context_config.table,
-            config->lib->libs[i]->iface->cl_context_config.prefix,
+            config->lib->cl_libs[i]->iface->cl_context_config.table,
+            config->lib->cl_libs[i]->iface->cl_context_config.prefix,
             config->lib->full_prefix, (ucc_config_print_flags_t)flags);
     }
 }
@@ -200,6 +201,54 @@ static inline void ucc_copy_context_params(ucc_context_params_t *dst,
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_ID, ctx_id);
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_COLL_SYNC_TYPE,
                             sync_type);
+}
+
+static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
+                                           ucc_context_config_t *ctx_config)
+{
+    ucc_lib_info_t *lib = ctx->lib;
+    ucc_tl_lib_t *tl_lib;
+    ucc_tl_context_config_t *tl_config;
+    ucc_base_context_params_t b_params;
+    ucc_base_context_t       *b_ctx;
+    int i, num_tls;
+    ucc_status_t status;
+
+    num_tls = lib->n_tl_libs_opened;
+    ctx->tl_ctx = (ucc_tl_context_t **)ucc_malloc(
+        sizeof(ucc_tl_context_t *) * num_tls, "tl_ctx_array");
+    if (!ctx->tl_ctx) {
+        ucc_error("failed to allocate %zd bytes for tl_ctx array",
+                  sizeof(ucc_tl_context_t *) * num_tls);
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    ucc_copy_context_params(&b_params.params, &ctx->params);
+    b_params.prefix      = lib->full_prefix;
+    b_params.thread_mode = lib->attr.thread_mode;
+    ctx->n_tl_ctx        = 0;
+    for (i = 0; i < lib->n_tl_libs_opened; i++) {
+        tl_lib = lib->tl_libs[i];
+        ucc_assert(NULL != tl_lib->iface->tl_context_config.table);
+        status =
+            ucc_tl_context_config_read(tl_lib, ctx_config, &tl_config);
+        if (UCC_OK != status) {
+            ucc_warn("failed to read TL \"%s\" context configuration",
+                     tl_lib->iface->super.name);
+            continue;
+        }
+        status = tl_lib->iface->context.create(
+            &b_params, &tl_config->super, &b_ctx);
+        ucc_base_config_release(&tl_config->super);
+        if (UCC_OK != status) {
+            ucc_warn("failed to create tl context for %s",
+                      tl_lib->iface->super.name);
+            continue;
+        }
+        ctx->tl_ctx[ctx->n_tl_ctx] = ucc_derived_of(b_ctx, ucc_tl_context_t);
+        ctx->n_tl_ctx++;
+    }
+    return UCC_OK;
 }
 
 ucc_status_t ucc_context_create(ucc_lib_h lib,
@@ -226,6 +275,14 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
     ctx->lib = lib;
     ucc_copy_context_params(&ctx->params, params);
     ucc_copy_context_params(&b_params.params, params);
+    b_params.context = ctx;
+    status = ucc_create_tl_contexts(ctx, config);
+    if (UCC_OK != status) {
+        /* only critical error could have happened - bail */
+        ucc_error("failed to create tl contexts");
+        goto error_ctx;
+    }
+
     ctx->cl_ctx = (ucc_cl_context_t **)ucc_malloc(
         sizeof(ucc_cl_context_t *) * num_cls, "cl_ctx_array");
     if (!ctx->cl_ctx) {
@@ -277,6 +334,8 @@ ucc_status_t ucc_context_destroy(ucc_context_t *context)
 {
     ucc_cl_context_t *cl_ctx;
     ucc_cl_lib_t     *cl_lib;
+    ucc_tl_context_t *tl_ctx;
+    ucc_tl_lib_t     *tl_lib;
     int               i;
     for (i = 0; i < context->n_cl_ctx; i++) {
         cl_ctx = context->cl_ctx[i];
@@ -284,6 +343,16 @@ ucc_status_t ucc_context_destroy(ucc_context_t *context)
         cl_lib->iface->context.destroy(&cl_ctx->super);
     }
     ucc_free(context->cl_ctx);
+
+    for (i = 0; i < context->n_tl_ctx; i++) {
+        tl_ctx = context->tl_ctx[i];
+        tl_lib = ucc_derived_of(tl_ctx->super.lib, ucc_tl_lib_t);
+        if (tl_ctx->ref_count != 0 ) {
+            ucc_warn("tl ctx %s is still in use", tl_lib->iface->super.name);
+        }
+        tl_lib->iface->context.destroy(&tl_ctx->super);
+    }
+    ucc_free(context->tl_ctx);
     ucc_free(context);
     return UCC_OK;
 }

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -10,6 +10,7 @@
 
 typedef struct ucc_lib_info          ucc_lib_info_t;
 typedef struct ucc_cl_context        ucc_cl_context_t;
+typedef struct ucc_tl_context        ucc_tl_context_t;
 typedef struct ucc_cl_context_config ucc_cl_context_config_t;
 
 typedef struct ucc_context {
@@ -17,7 +18,9 @@ typedef struct ucc_context {
     ucc_context_params_t params;
     ucc_context_attr_t   attr;
     ucc_cl_context_t   **cl_ctx;
+    ucc_tl_context_t   **tl_ctx;
     int                  n_cl_ctx;
+    int                  n_tl_ctx;
 } ucc_context_t;
 
 typedef struct ucc_context_config {

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -12,6 +12,8 @@
 #include "utils/ucc_parser.h"
 
 typedef struct ucc_cl_lib ucc_cl_lib_t;
+typedef struct ucc_tl_lib ucc_tl_lib_t;
+
 typedef struct ucc_lib_config {
     char                    *full_prefix;
     struct {
@@ -21,9 +23,11 @@ typedef struct ucc_lib_config {
 } ucc_lib_config_t;
 
 typedef struct ucc_lib_info {
-    int            n_libs_opened;
     char          *full_prefix;
-    ucc_cl_lib_t **libs;
+    int            n_cl_libs_opened;
+    int            n_tl_libs_opened;
+    ucc_cl_lib_t **cl_libs;
+    ucc_tl_lib_t **tl_libs;
     ucc_lib_attr_t attr;
     int            specific_cls_requested;
 } ucc_lib_info_t;


### PR DESCRIPTION
## What
Adds TL context creation/destruction logic

## Why ?
Core functionality

## How ?
Everything is handled by CORE: 
- core ucc_lib/context queries CLs which TLs are required
- CORE allocates necessary TL libs/contexts
- CLs can then get a pointer to TL context based on type enum value

This is one of the alternative approaches (#53 ) and it is more clear, logical and convenient imo.