### PR TITLE
CORE: init TL contexts

### DIFF
--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -15,6 +15,7 @@
 #include "utils/ucc_parser.h"
 #include "utils/ucc_class.h"
 #include "utils/ucc_malloc.h"
+#include "utils/ucc_log.h"
 
 typedef struct ucc_base_lib {
     ucc_log_component_config_t log_component;
@@ -25,6 +26,10 @@ typedef struct ucc_base_config {
     ucc_log_component_config_t      log_component;
 } ucc_base_config_t;
 
+typedef struct ucc_base_attr_t {
+    ucc_thread_mode_t thread_mode;
+} ucc_base_attr_t;
+
 typedef struct ucc_base_lib_params {
     ucc_lib_params_t params;
 } ucc_base_lib_params_t;
@@ -34,6 +39,7 @@ typedef struct ucc_base_lib_iface {
     ucc_status_t (*init)(const ucc_base_lib_params_t *params,
                          const ucc_base_config_t *config, ucc_base_lib_t **lib);
     void         (*finalize)(ucc_base_lib_t *lib);
+    ucc_status_t (*get_attr)(const ucc_base_lib_t *lib, ucc_base_attr_t *attr);
 } ucc_base_lib_iface_t;
 
 typedef struct ucc_base_context_params {
@@ -42,6 +48,7 @@ typedef struct ucc_base_context_params {
     int                  estimated_num_ppn;
     ucc_thread_mode_t    thread_mode;
     const char          *prefix;
+    ucc_context_t       *context;
 } ucc_base_context_params_t;
 
 typedef struct ucc_base_context {
@@ -53,6 +60,8 @@ typedef struct ucc_base_context_iface {
                            const ucc_base_config_t *config,
                            ucc_base_context_t **ctx);
     void         (*destroy)(ucc_base_context_t *ctx);
+    ucc_status_t (*get_attr)(const ucc_base_context_t *context,
+                             ucc_base_attr_t *attr);
 } ucc_base_context_iface_t;
 
 ucc_status_t ucc_base_config_read(const char *full_prefix,
@@ -65,32 +74,49 @@ static inline void ucc_base_config_release(ucc_base_config_t *config)
     ucc_free(config);
 }
 
-#define UCC_IFACE_NAME_PREFIX(_F, _NAME, _cfg)                                 \
-    .name   = UCC_PP_MAKE_STRING(_F##_NAME) " " UCC_PP_MAKE_STRING(_cfg),      \
+#define UCC_IFACE_NAME_PREFIX(_F, _NAME)                                       \
+    .name   = UCC_PP_MAKE_STRING(_F##_NAME),                                   \
     .prefix = UCC_PP_MAKE_STRING(_F##_NAME##_)
 
 #define UCC_IFACE_CFG(_F, _f, _cfg, _name, _NAME)                              \
     .super._f##_cfg##_config = {                                               \
-        UCC_IFACE_NAME_PREFIX(_F, _NAME, _cfg),                                \
+        UCC_IFACE_NAME_PREFIX(_F, _NAME),                                      \
         .table = ucc_##_f##_name##_##_cfg##_config_table,                      \
         .size  = sizeof(ucc_##_f##_name##_##_cfg##_config_t)}
 
-#define UCC_BASE_IFACE_DECLARE(_F, _f, _name, _NAME, ...)                      \
+#define UCC_BASE_IFACE_DECLARE(_F, _f, _name, _NAME)                           \
     ucc_##_f##_name##_iface_t ucc_##_f##_name = {                              \
         UCC_IFACE_CFG(_F, _f, lib, _name, _NAME),                              \
         UCC_IFACE_CFG(_F, _f, context, _name, _NAME),                          \
         .super.super.name = UCC_PP_MAKE_STRING(_name),                         \
-        __VA_ARGS__                                                            \
+        .super.type = UCC_ ## _F ## _NAME,                                     \
         .super.lib.init   = UCC_CLASS_NEW_FUNC_NAME(ucc_##_f##_name##_lib_t),  \
         .super.lib.finalize =                                                  \
             UCC_CLASS_DELETE_FUNC_NAME(ucc_##_f##_name##_lib_t),               \
+        .super.lib.get_attr = ucc_ ## _f ## _name ## _get_lib_attr,            \
         .super.context.create =                                                \
             UCC_CLASS_NEW_FUNC_NAME(ucc_##_f##_name##_context_t),              \
         .super.context.destroy =                                               \
-        UCC_CLASS_DELETE_FUNC_NAME(ucc_##_f##_name##_context_t)};              \
+        UCC_CLASS_DELETE_FUNC_NAME(ucc_##_f##_name##_context_t),               \
+       .super.context.get_attr = ucc_ ## _f ## _name ## _get_context_attr};    \
     UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_##_f##_name.super._f##lib_config,     \
                                     &ucc_config_global_list);                  \
     UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_##_f##_name.super._f##context_config, \
                                     &ucc_config_global_list)
+
+#define ucc_base_log(_lib, _level, fmt, ...)                           \
+    ucc_log_component(_level, (_lib)->log_component, fmt,              \
+                      ##__VA_ARGS__)
+
+#define base_error(_lib, _fmt, ...)                                 \
+    ucc_base_log(_lib, UCC_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
+#define base_warn(_lib, _fmt, ...)                                  \
+    ucc_base_log(_lib, UCC_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
+#define base_info(_lib, _fmt, ...)                                  \
+    ucc_base_log(_lib, UCC_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+#define base_debug(_lib, _fmt, ...)                                 \
+    ucc_base_log(_lib, UCC_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
+#define base_trace(_lib, _fmt, ...)                                 \
+    ucc_base_log(_lib, UCC_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
 
 #endif

--- a/src/components/cl/basic/Makefile.am
+++ b/src/components/cl/basic/Makefile.am
@@ -13,6 +13,4 @@ libucc_cl_basic_la_SOURCES  = $(sources)
 libucc_cl_basic_la_CPPFLAGS = $(AM_CPPFLAGS)
 libucc_cl_basic_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
 
-
-
 include $(top_srcdir)/config/module.am

--- a/src/components/cl/basic/cl_basic.c
+++ b/src/components/cl/basic/cl_basic.c
@@ -6,6 +6,8 @@
 
 #include "cl_basic.h"
 #include "utils/ucc_malloc.h"
+ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *base_attr);
+ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context, ucc_base_attr_t *base_attr);
 
 static ucc_config_field_t ucc_cl_basic_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_basic_lib_config_t, super),

--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -8,6 +8,7 @@
 #define UCC_CL_BASIC_H_
 #include "components/cl/ucc_cl.h"
 #include "components/cl/ucc_cl_log.h"
+#include "components/tl/ucc_tl.h"
 
 #define UCC_CL_BASIC_DEFAULT_PRIORITY 10
 
@@ -34,6 +35,7 @@ UCC_CLASS_DECLARE(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *,
 
 typedef struct ucc_cl_basic_context {
     ucc_cl_context_t super;
+    ucc_tl_context_t *tl_ucp_ctx;
 } ucc_cl_basic_context_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -11,9 +11,16 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
                     const ucc_base_context_params_t *params,
                     const ucc_base_config_t *config)
 {
+    ucc_status_t status;
     const ucc_cl_context_config_t *cl_config =
         ucc_derived_of(config, ucc_cl_context_config_t);
     UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_config->cl_lib);
+    status = ucc_tl_context_get(params->context, UCC_TL_UCP,
+                                &self->tl_ucp_ctx);
+    if (UCC_OK != status) {
+        cl_warn(cl_config->cl_lib, "TL UCP context is not available, CL BASIC can't proceed");
+        return UCC_ERR_NOT_FOUND;
+    }
     cl_info(cl_config->cl_lib, "initialized cl context: %p", self);
     return UCC_OK;
 }
@@ -21,6 +28,13 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_context_t)
 {
     cl_info(self->super.super.lib, "finalizing cl context: %p", self);
+    ucc_tl_context_put(self->tl_ucp_ctx);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_basic_context_t, ucc_cl_context_t);
+
+ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context,
+                                           ucc_base_attr_t *attr)
+{
+    return UCC_OK;
+}

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -6,6 +6,7 @@
 
 #include "cl_basic.h"
 #include "utils/ucc_malloc.h"
+#include "components/tl/ucc_tl.h"
 
 UCC_CLASS_INIT_FUNC(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *params,
                     const ucc_base_config_t *config)
@@ -24,3 +25,9 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 }
 
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
+
+ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *base_attr) {
+    ucc_cl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
+    attr->tls = UCC_TL_UCP;
+    return UCC_OK;
+}

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -80,8 +80,11 @@ typedef struct ucc_cl_context {
 
 UCC_CLASS_DECLARE(ucc_cl_context_t, ucc_cl_lib_t *);
 
-#define UCC_CL_IFACE_EXT(_NAME) .super.type = UCC_CL_ ## _NAME,
+typedef struct ucc_cl_lib_attr {
+    ucc_base_attr_t super;
+    int tls;
+} ucc_cl_lib_attr_t;
 
 #define UCC_CL_IFACE_DECLARE(_name, _NAME)                                     \
-    UCC_BASE_IFACE_DECLARE(CL_, cl_, _name, _NAME, UCC_CL_IFACE_EXT(_NAME))
+    UCC_BASE_IFACE_DECLARE(CL_, cl_, _name, _NAME)
 #endif

--- a/src/components/cl/ucc_cl_log.h
+++ b/src/components/cl/ucc_cl_log.h
@@ -6,20 +6,12 @@
 
 #ifndef UCC_CL_LOG_H_
 #define UCC_CL_LOG_H_
-#include "utils/ucc_log.h"
-#define ucc_log_component_cl(_cl_lib, _level, fmt, ...)                        \
-    ucc_log_component(_level, ((ucc_base_lib_t *)_cl_lib)->log_component, fmt, \
-                      ##__VA_ARGS__)
+#include "components/base/ucc_base_iface.h"
 
-#define cl_error(_cl_lib, _fmt, ...)                                           \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
-#define cl_warn(_cl_lib, _fmt, ...)                                            \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
-#define cl_info(_cl_lib, _fmt, ...)                                            \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
-#define cl_debug(_cl_lib, _fmt, ...)                                           \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
-#define cl_trace(_cl_lib, _fmt, ...)                                           \
-    ucc_log_component_cl(_cl_lib, UCC_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+#define cl_error(_cl_lib, _fmt, ...) base_error((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
+#define cl_warn(_cl_lib, _fmt, ...)  base_warn((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
+#define cl_info(_cl_lib, _fmt, ...)  base_info((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
+#define cl_debug(_cl_lib, _fmt, ...) base_debug((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
+#define cl_trace(_cl_lib, _fmt, ...) base_trace((ucc_base_lib_t*)(_cl_lib), _fmt, ## __VA_ARGS__)
 
 #endif

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -6,9 +6,16 @@
 
 #include "ucc_tl.h"
 #include "utils/ucc_log.h"
+#include <ucs/datastruct/khash.h>
+
+KHASH_MAP_INIT_INT64(tl_obj, void*)
+static khash_t(tl_obj) *tl_lib_map = NULL;
+static khash_t(tl_obj) *tl_ctx_map = NULL;
 
 ucc_config_field_t ucc_tl_lib_config_table[] = {
-    {NULL}
+    {"", "", NULL, ucc_offsetof(ucc_tl_lib_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_base_config_table)},
+
 };
 
 ucc_config_field_t ucc_tl_context_config_table[] = {
@@ -35,6 +42,7 @@ UCC_CLASS_DEFINE(ucc_tl_lib_t, void);
 UCC_CLASS_INIT_FUNC(ucc_tl_context_t, ucc_tl_lib_t *tl_lib)
 {
     self->super.lib = &tl_lib->super;
+    self->ref_count = 0;
     return UCC_OK;
 }
 
@@ -44,12 +52,12 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_context_t)
 
 UCC_CLASS_DEFINE(ucc_tl_context_t, void);
 
-ucc_status_t ucc_tl_context_config_read(ucc_tl_lib_t *tl_lib,
-                                        const ucc_context_config_t *config,
-                                        ucc_tl_context_config_t **tl_config)
+static ucc_status_t ucc_tl_context_config_read(ucc_tl_lib_t *tl_lib,
+                                               const char *full_prefix,
+                                               ucc_tl_context_config_t **tl_config)
 {
     ucc_status_t status;
-    status = ucc_base_config_read(config->lib->full_prefix,
+    status = ucc_base_config_read(full_prefix,
                                   &tl_lib->iface->tl_context_config,
                                   (ucc_base_config_t **)tl_config);
     if (UCC_OK == status) {
@@ -58,11 +66,175 @@ ucc_status_t ucc_tl_context_config_read(ucc_tl_lib_t *tl_lib,
     return status;
 }
 
-ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface,
-                                    const char *full_prefix,
-                                    const ucc_lib_config_t *config,
-                                    ucc_tl_lib_config_t **tl_config)
+static ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface,
+                                           const char *full_prefix,
+                                           ucc_tl_lib_config_t **tl_config)
 {
     return ucc_base_config_read(full_prefix, &iface->tl_lib_config,
                                 (ucc_base_config_t **)tl_config);
+}
+
+static ucc_tl_iface_t* get_tl_iface(ucc_tl_type_t type)
+{
+    int i;
+    ucc_tl_iface_t *tl_iface;
+    for (i=0; i < ucc_global_config.tl_framework.n_components; i++) {
+        tl_iface = ucc_derived_of(ucc_global_config.tl_framework.components[i],
+                                  ucc_tl_iface_t);
+        if (tl_iface->type == type) {
+            return tl_iface;
+        }
+    }
+    return NULL;
+}
+
+ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, ucc_tl_type_t type,
+                                ucc_tl_context_t **tl_context)
+{
+    ucc_lib_info_t *lib = ctx->lib;
+    khiter_t k;
+    ucc_tl_lib_t **tl_libs;
+    ucc_tl_lib_t *tl_lib;
+    ucc_tl_context_t **tl_ctxs;
+    ucc_tl_context_t *tl_ctx;
+    ucc_base_lib_t *      b_lib;
+    ucc_base_context_t *      b_ctx;
+    int ret;
+    ucc_status_t status;
+    ucc_tl_iface_t *tl_iface;
+    ucc_base_lib_params_t b_lib_params;
+    ucc_base_context_params_t b_ctx_params;
+    ucc_tl_lib_config_t  *tl_lib_config;
+    ucc_tl_context_config_t  *tl_ctx_config;
+
+    tl_iface = get_tl_iface(type);
+    if (NULL == tl_iface) {
+        /* Required tl dynamic component not available */
+        return UCC_ERR_NOT_FOUND;
+    }
+
+    if (NULL == tl_lib_map) {
+        /* Init hash to store the array of tl lib objects.
+           The key of the hash is the ucc_lib_info_t pointer */
+        tl_lib_map = kh_init(tl_obj);
+    }
+
+    k = kh_get(tl_obj, tl_lib_map, (int64_t)lib);
+    if (k == kh_end(tl_lib_map)) {
+        /* Given lib ptr is met for the first time:
+           allocate the array of tl lib pointers and add to the hash */
+        k = kh_put(tl_obj, tl_lib_map, (int64_t)lib, &ret);
+        ucc_assert(k != kh_end(tl_lib_map));
+        tl_libs = ucc_calloc(UCC_N_TLS, sizeof(ucc_tl_lib_t*), "tl_lib_ptr_array");
+        if (!tl_libs) {
+            return UCC_ERR_NO_MEMORY;
+        }
+        kh_value(tl_lib_map, k) = tl_libs;
+    } else {
+        /* Found lib ptr in the hash: get tl lib pointers array */
+        tl_libs = kh_value(tl_lib_map, k);
+    }
+
+    if (NULL == tl_libs[ucc_ilog2(type)]) {
+        /* Required TL was not initialized yet for this lib object */
+        status = ucc_tl_lib_config_read(tl_iface, lib->full_prefix,
+                                        &tl_lib_config);
+        if (UCC_OK != status) {
+            ucc_warn("failed to read TL \"%s\" lib configuration",
+                     tl_iface->super.name);
+            /* set to -1 to skip in the future if this TL is required by other CLs */
+            tl_libs[ucc_ilog2(type)] = (void*)-1;
+            return status;
+        }
+        ucc_copy_lib_params(&b_lib_params.params, &lib->params);
+        status = tl_iface->lib.init(&b_lib_params, &tl_lib_config->super, &b_lib);
+        ucc_base_config_release(&tl_lib_config->super);
+        if (UCC_OK != status) {
+            ucc_info("lib_init failed for tl component: %s",
+                     tl_iface->super.name);
+            tl_libs[ucc_ilog2(type)] = (void*)-1;
+            return status;
+        }
+        tl_lib = ucc_derived_of(b_lib, ucc_tl_lib_t);
+        tl_lib->ref_count = 0;
+        tl_lib->lib = lib;
+        tl_libs[ucc_ilog2(type)] = tl_lib;
+    } else if ((void*)-1 == tl_libs[ucc_ilog2(type)]) {
+        /* We already failed allocating this TL before */
+        return UCC_ERR_NOT_FOUND;
+    } else {
+        /* TL lib is available in the hash */
+        tl_lib = tl_libs[ucc_ilog2(type)];
+    }
+
+    if (NULL == tl_ctx_map) {
+        /* Init hash to store the array of tl context objects.
+           The key of the hash is the ucc_context_t pointer */
+        tl_ctx_map = kh_init(tl_obj);
+    }
+
+    k = kh_get(tl_obj, tl_ctx_map, (int64_t)ctx);
+    if (k == kh_end(tl_ctx_map)) {
+        /* Given context ptr is met for the first time:
+           allocate the array of tl context pointers and add to the hash */
+        k = kh_put(tl_obj, tl_ctx_map, (int64_t)ctx, &ret);
+        ucc_assert(k != kh_end(tl_ctx_map));
+        tl_ctxs = ucc_calloc(UCC_N_TLS, sizeof(ucc_tl_context_t*), "tl_context_ptr_array");
+        if (!tl_ctxs) {
+            return UCC_ERR_NO_MEMORY;
+        }
+        kh_value(tl_ctx_map, k) = tl_ctxs;
+    } else {
+        /* Found context ptr in the hash: get tl context pointers array */
+        tl_ctxs = kh_value(tl_ctx_map, k);
+    }
+
+    if (NULL == tl_ctxs[ucc_ilog2(type)]) {
+        /* Required TL was not initialized yet for this context object */
+        status = ucc_tl_context_config_read(tl_lib, lib->full_prefix,
+                                            &tl_ctx_config);
+        if (UCC_OK != status) {
+            ucc_warn("failed to read TL \"%s\" lib configuration",
+                     tl_iface->super.name);
+            tl_libs[ucc_ilog2(type)] = (void*)-1;
+            return status;
+        }
+        ucc_copy_context_params(&b_ctx_params.params, &ctx->params);
+        b_ctx_params.prefix      = lib->full_prefix;
+        b_ctx_params.thread_mode = lib->attr.thread_mode;
+
+        status = tl_iface->context.create(&b_ctx_params, &tl_ctx_config->super, &b_ctx);
+        ucc_base_config_release(&tl_ctx_config->super);
+        if (UCC_OK != status) {
+            ucc_info("context_init failed for tl component: %s",
+                     tl_iface->super.name);
+            tl_ctxs[ucc_ilog2(type)] = (void*)-1;
+            return status;
+        }
+        tl_ctx = ucc_derived_of(b_ctx, ucc_tl_context_t);
+        tl_ctx->ctx = ctx;
+        tl_lib->ref_count++;
+        tl_ctxs[ucc_ilog2(type)] = tl_ctx;
+    } else if ((void*)-1 == tl_ctxs[ucc_ilog2(type)]) {
+        return UCC_ERR_NOT_FOUND;
+    } else {
+        tl_ctx = tl_ctxs[ucc_ilog2(type)];
+    }
+    tl_ctx->ref_count++;
+    *tl_context = tl_ctx;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context)
+{
+    ucc_tl_lib_t *tl_lib = ucc_derived_of(tl_context->super.lib,
+                                          ucc_tl_lib_t);
+    ucc_tl_iface_t *tl_iface = tl_lib->iface;
+    tl_context->ref_count--;
+    if (tl_context->ref_count == 0) {
+        tl_iface->context.destroy(&tl_context->super);
+        
+        tl_lib->ref_count--;
+    }
+    return UCC_OK;
 }

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -24,6 +24,13 @@ typedef struct ucc_tl_lib     ucc_tl_lib_t;
 typedef struct ucc_tl_iface   ucc_tl_iface_t;
 typedef struct ucc_tl_context ucc_tl_context_t;
 
+typedef enum ucc_tl_type {
+    UCC_TL_UCP = UCC_BIT(0),
+    UCC_TL_LAST,
+} ucc_tl_type_t;
+
+#define UCC_N_TLS (ucc_ilog2(UCC_TL_LAST-1)+1)
+
 typedef struct ucc_tl_lib_config {
     ucc_base_config_t  super;
     ucc_tl_iface_t    *iface;
@@ -36,16 +43,9 @@ typedef struct ucc_tl_context_config {
 } ucc_tl_context_config_t;
 extern ucc_config_field_t ucc_tl_context_config_table[];
 
-ucc_status_t ucc_tl_context_config_read(ucc_tl_lib_t *tl_lib,
-                                        const ucc_context_config_t *config,
-                                        ucc_tl_context_config_t **cl_config);
-
-ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface, const char *full_prefix,
-                                    const ucc_lib_config_t *config,
-                                    ucc_tl_lib_config_t **cl_config);
-
 typedef struct ucc_tl_iface {
     ucc_component_iface_t          super;
+    ucc_tl_type_t                  type;
     ucs_config_global_list_entry_t tl_lib_config;
     ucs_config_global_list_entry_t tl_context_config;
     ucc_base_lib_iface_t           lib;
@@ -55,14 +55,22 @@ typedef struct ucc_tl_iface {
 typedef struct ucc_tl_lib {
     ucc_base_lib_t              super;
     ucc_tl_iface_t             *iface;
+    int ref_count;
+    ucc_lib_info_t *lib;
 } ucc_tl_lib_t;
 UCC_CLASS_DECLARE(ucc_tl_lib_t, ucc_tl_iface_t *, const ucc_tl_lib_config_t *);
 
 typedef struct ucc_tl_context {
     ucc_base_context_t super;
+    int                ref_count;
+    ucc_context_t *ctx;
 } ucc_tl_context_t;
 UCC_CLASS_DECLARE(ucc_tl_context_t, ucc_tl_lib_t *);
 
 #define UCC_TL_IFACE_DECLARE(_name, _NAME)                                     \
     UCC_BASE_IFACE_DECLARE(TL_, tl_, _name, _NAME)
+
+ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, ucc_tl_type_t type,
+                                ucc_tl_context_t **tl_context);
+ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context);
 #endif

--- a/src/components/tl/ucc_tl_log.h
+++ b/src/components/tl/ucc_tl_log.h
@@ -6,20 +6,12 @@
 
 #ifndef UCC_TL_LOG_H_
 #define UCC_TL_LOG_H_
-#include "utils/ucc_log.h"
-#define ucc_log_component_tl(_tl_ctx, _level, fmt, ...)                        \
-    ucc_log_component(_level, ((ucc_base_context_t *)_tl_ctx)->lib->log_component, fmt, \
-                      ##__VA_ARGS__)
+#include "components/base/ucc_base_iface.h"
 
-#define tl_error(_tl_ctx, _fmt, ...)                                           \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
-#define tl_warn(_tl_ctx, _fmt, ...)                                            \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
-#define tl_info(_tl_ctx, _fmt, ...)                                            \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
-#define tl_debug(_tl_ctx, _fmt, ...)                                           \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
-#define tl_trace(_tl_ctx, _fmt, ...)                                           \
-    ucc_log_component_tl(_tl_ctx, UCC_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+#define tl_error(_tl_lib, _fmt, ...) base_error((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
+#define tl_warn(_tl_lib, _fmt, ...)  base_warn((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
+#define tl_info(_tl_lib, _fmt, ...)  base_info((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
+#define tl_debug(_tl_lib, _fmt, ...) base_debug((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
+#define tl_trace(_tl_lib, _fmt, ...) base_trace((ucc_base_lib_t*)(_tl_lib), _fmt, ## __VA_ARGS__)
 
 #endif

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -8,9 +8,10 @@ sources =            \
 	tl_ucp_lib.c     \
 	tl_ucp_context.c
 
+module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)
 libucc_tl_ucp_la_CPPFLAGS = $(AM_CPPFLAGS) $(UCX_CPPFLAGS)
 libucc_tl_ucp_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(UCX_LDFLAGS)
 libucc_tl_ucp_la_LIBADD   = $(UCX_LIBADD)
 
-pkglib_LTLIBRARIES = libucc_tl_ucp.la
+include $(top_srcdir)/config/module.am

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -6,6 +6,8 @@
 
 #include "tl_ucp.h"
 #include "utils/ucc_malloc.h"
+ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *base_attr);
+ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context, ucc_base_attr_t *base_attr);
 
 static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_ucp_lib_config_t, super),

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -35,7 +35,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_config->tl_lib);
     status = ucp_config_read(params->prefix, NULL, &ucp_config);
     if (UCS_OK != status) {
-        tl_error(&self->super, "failed to read ucp configuration, %s",
+        tl_error(self->super.super.lib, "failed to read ucp configuration, %s",
                  ucs_status_string(status));
         ucc_status = ucs_status_to_ucc_status(status);
         goto err_cfg;
@@ -64,7 +64,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     status = ucp_init(&ucp_params, ucp_config, &ucp_context);
     ucp_config_release(ucp_config);
     if (UCS_OK != status) {
-        tl_error(&self->super, "failed to init ucp context, %s",
+        tl_error(self->super.super.lib, "failed to init ucp context, %s",
                  ucs_status_string(status));
         ucc_status = ucs_status_to_ucc_status(status);
         goto err_cfg;
@@ -86,7 +86,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     }
     status = ucp_worker_create(ucp_context, &worker_params, &ucp_worker);
     if (UCS_OK != status) {
-        tl_error(&self->super, "failed to create ucp worker, %s",
+        tl_error(self->super.super.lib, "failed to create ucp worker, %s",
                  ucs_status_string(status));
         ucc_status = ucs_status_to_ucc_status(status);
         goto err_worker_create;
@@ -96,7 +96,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
         worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_THREAD_MODE;
         ucp_worker_query(ucp_worker, &worker_attr);
         if (worker_attr.thread_mode != UCS_THREAD_MODE_MULTI) {
-            tl_error(&self->super,
+            tl_error(self->super.super.lib,
                      "thread mode multiple is not supported by ucp worker");
             ucc_status = UCC_ERR_NOT_SUPPORTED;
             goto err_thread_mode;
@@ -105,7 +105,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
 
     self->ucp_context = ucp_context;
     self->ucp_worker  = ucp_worker;
-    tl_info(&self->super, "initialized cl context: %p", self);
+    tl_info(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 
 err_thread_mode:
@@ -118,9 +118,15 @@ err_cfg:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_context_t)
 {
-    tl_info(&self->super.super.lib, "finalizing cl context: %p", self);
+    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
     ucp_worker_destroy(self->ucp_worker);
     ucp_cleanup(self->ucp_context);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_ucp_context_t, ucc_tl_context_t);
+
+ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
+                                         ucc_base_attr_t *attr)
+{
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -23,3 +23,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_lib_t)
 }
 
 UCC_CLASS_DEFINE(ucc_tl_ucp_lib_t, ucc_tl_lib_t);
+
+ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *attr) {
+    return UCC_OK;
+}

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -26,4 +26,7 @@ typedef struct ucc_context_config {
     int                       n_cl_cfg;
 } ucc_context_config_t;
 
+void ucc_copy_context_params(ucc_context_params_t *dst,
+                             const ucc_context_params_t *src);
+
 #endif

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -12,6 +12,7 @@
 #include "utils/ucc_parser.h"
 
 typedef struct ucc_cl_lib ucc_cl_lib_t;
+
 typedef struct ucc_lib_config {
     char                    *full_prefix;
     struct {
@@ -21,11 +22,12 @@ typedef struct ucc_lib_config {
 } ucc_lib_config_t;
 
 typedef struct ucc_lib_info {
-    int            n_libs_opened;
     char          *full_prefix;
-    ucc_cl_lib_t **libs;
+    int            n_cl_libs_opened;
+    ucc_cl_lib_t **cl_libs;
     ucc_lib_attr_t attr;
     int            specific_cls_requested;
+    ucc_lib_params_t params;
 } ucc_lib_info_t;
 
 void ucc_get_version(unsigned *major_version, unsigned *minor_version,
@@ -40,4 +42,6 @@ const char *ucc_get_version_string(void);
         }                                                                      \
     } while (0)
 
+void ucc_copy_lib_params(ucc_lib_params_t *dst,
+                         const ucc_lib_params_t *src);
 #endif

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -23,7 +23,7 @@
 #define ucc_derived_of    ucs_derived_of
 #define ucc_strncpy_safe  ucs_strncpy_safe
 #define ucc_snprintf_safe snprintf
-
+#define ucc_ilog2         ucs_ilog2
 typedef ucs_log_component_config_t ucc_log_component_config_t;
 
 #define _UCC_PP_MAKE_STRING(x) #x


### PR DESCRIPTION
Serves same purpose as #52 but with alternative implementation:

CORE knows nothing about TLs. CLs directly get TL context which is allocated internally and stored into a hash table.
Downsides (to discuss):
- Hash tables little bit messy
- Complicated TL cleanup logic (not implemented in this PR)
- how to implement local address packing function? - it is in CORE but CORE is not aware of TLs ..