### PR TITLE
CORE: added memory component interface

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
 # This software product is a proprietary product of Mellanox Technologies Ltd.
 # (the "Company") and all right, title, and interest and to the software product,
 # including all associated intellectual property rights, are and shall
@@ -184,5 +184,6 @@ AC_CONFIG_FILES([
                  src/core/ucc_version.c
                  src/components/cl/basic/Makefile
                  src/components/tl/ucp/Makefile
+                 src/components/mc/cpu/Makefile
                  ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,14 +1,16 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
 #
+
 cl_dirs = components/cl/basic
 tl_dirs =
+mc_dirs = components/mc/cpu
 
 if HAVE_UCX
 tl_dirs += components/tl/ucp
 endif
 
-SUBDIRS = $(cl_dirs) $(tl_dirs)
+SUBDIRS = $(cl_dirs) $(tl_dirs) $(mc_dirs)
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =
 
@@ -26,6 +28,7 @@ noinst_HEADERS =                     \
 	core/ucc_global_opts.h           \
 	core/ucc_lib.h                   \
 	core/ucc_context.h               \
+	core/ucc_mc.h                    \
 	utils/ucc_compiler_def.h         \
 	utils/ucc_log.h                  \
 	utils/ucc_parser.h               \
@@ -37,8 +40,9 @@ noinst_HEADERS =                     \
 	components/cl/ucc_cl_log.h       \
 	components/cl/ucc_cl_type.h      \
 	components/tl/ucc_tl.h           \
-	components/tl/ucc_tl_log.h
-
+	components/tl/ucc_tl_log.h       \
+	components/mc/base/ucc_mc_base.h \
+	components/mc/ucc_mc_log.h
 
 libucc_la_SOURCES =                  \
 	core/ucc_lib.c                   \
@@ -46,9 +50,11 @@ libucc_la_SOURCES =                  \
 	core/ucc_global_opts.c           \
 	core/ucc_version.c               \
 	core/ucc_context.c               \
+	core/ucc_mc.c                    \
 	utils/ucc_component.c            \
 	components/base/ucc_base_iface.c \
 	components/cl/ucc_cl.c           \
-	components/tl/ucc_tl.c
+	components/tl/ucc_tl.c           \
+	components/mc/base/ucc_mc_base.c
 
 libucc_ladir = $(includedir)

--- a/src/components/mc/base/ucc_mc_base.c
+++ b/src/components/mc/base/ucc_mc_base.c
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_mc_base.h"
+
+ucc_config_field_t ucc_mc_config_table[] = {
+    {"LOG_LEVEL", "warn",
+     "UCC logging level. Messages with a level higher or equal to the "
+     "selected will be printed.\n"
+     "Possible values are: fatal, error, warn, info, debug, trace, data, func, "
+     "poll.",
+     ucc_offsetof(ucc_mc_config_t, log_component), UCC_CONFIG_TYPE_LOG_COMP},
+
+    {NULL}};
+
+const char *ucc_memory_type_names[] = {
+    [UCC_MEMORY_TYPE_HOST]         = "host",
+    [UCC_MEMORY_TYPE_CUDA]         = "cuda",
+    [UCC_MEMORY_TYPE_CUDA_MANAGED] = "cuda-managed",
+    [UCC_MEMORY_TYPE_ROCM]         = "rocm",
+    [UCC_MEMORY_TYPE_ROCM_MANAGED] = "rocm-managed",
+    [UCC_MEMORY_TYPE_LAST]         = "unknown"};

--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_MC_BASE_H_
+#define UCC_MC_BASE_H_
+
+#include "config.h"
+#include "utils/ucc_component.h"
+#include "utils/ucc_class.h"
+#include "utils/ucc_parser.h"
+#include "core/ucc_global_opts.h"
+
+typedef enum ucc_memory_type {
+    UCC_MEMORY_TYPE_HOST,         /**< Default system memory */
+    UCC_MEMORY_TYPE_CUDA,         /**< NVIDIA CUDA memory */
+    UCC_MEMORY_TYPE_CUDA_MANAGED, /**< NVIDIA CUDA managed memory */
+    UCC_MEMORY_TYPE_ROCM,         /**< AMD ROCM memory */
+    UCC_MEMORY_TYPE_ROCM_MANAGED, /**< AMD ROCM managed system memory */
+    UCC_MEMORY_TYPE_LAST,
+    UCC_MEMORY_TYPE_UNKNOWN = UCC_MEMORY_TYPE_LAST
+} ucc_memory_type_t;
+
+/**
+ * Array of string names for each memory type
+ */
+extern const char *ucc_memory_type_names[];
+
+typedef struct ucc_mc_config {
+    ucc_log_component_config_t log_component;
+} ucc_mc_config_t;
+extern ucc_config_field_t ucc_mc_config_table[];
+
+typedef struct ucc_mc_ops {
+    ucc_status_t (*mem_type)(const void *ptr, ucc_memory_type_t *mem_type);
+    ucc_status_t (*mem_alloc)(void **ptr, size_t size);
+    ucc_status_t (*mem_free)(void *ptr);
+    ucc_status_t (*reduce)(const void *src1, const void *src2, void *dst,
+                           size_t count, ucc_datatype_t dt,
+                           ucc_reduction_op_t op);
+ } ucc_mc_ops_t;
+
+typedef struct ucc_mc_base {
+    ucc_component_iface_t           super;
+    uint32_t                        ref_cnt;
+    ucc_memory_type_t               type;
+    ucc_mc_config_t                *config;
+    ucc_config_global_list_entry_t  config_table;
+    ucc_status_t                   (*init)();
+    ucc_status_t                   (*finalize)();
+    const ucc_mc_ops_t              ops;
+} ucc_mc_base_t;
+
+#endif

--- a/src/components/mc/cpu/Makefile.am
+++ b/src/components/mc/cpu/Makefile.am
@@ -1,0 +1,14 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+#
+
+sources =    \
+	mc_cpu.h \
+	mc_cpu.c
+
+module_LTLIBRARIES        = libucc_mc_cpu.la
+libucc_mc_cpu_la_SOURCES  = $(sources)
+libucc_mc_cpu_la_CPPFLAGS = $(AM_CPPFLAGS)
+libucc_mc_cpu_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
+
+include $(top_srcdir)/config/module.am

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "mc_cpu.h"
+#include "utils/ucc_malloc.h"
+
+static ucc_config_field_t ucc_mc_cpu_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_mc_cpu_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_mc_config_table)},
+
+    {NULL}};
+
+static ucc_status_t ucc_mc_cpu_init()
+{
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_cpu_finalize()
+{
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_cpu_mem_alloc(void **ptr, size_t size)
+{
+    (*ptr) = ucc_malloc(size, "mc cpu");
+    if (!(*ptr)) {
+        mc_error(&ucc_mc_cpu.super, "failed to allocate %zd bytes", size);
+        return UCC_ERR_NO_MEMORY;
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_cpu_mem_free(void *ptr)
+{
+    ucc_free(ptr);
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_cpu_mem_type(const void *ptr,
+                                        ucc_memory_type_t *mem_type)
+{
+    /* not supposed to be used */
+    mc_error(&ucc_mc_cpu.super, "host memory component shouldn't be used for"
+                                "mem type detection");
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+
+ucc_mc_cpu_t ucc_mc_cpu = {
+    .super.super.name = "cpu mc",
+    .super.ref_cnt    = 0,
+    .super.type       = UCC_MEMORY_TYPE_HOST,
+    .super.config_table =
+        {
+            .name   = "CPU memory component",
+            .prefix = "MC_CPU_",
+            .table  = ucc_mc_cpu_config_table,
+            .size   = sizeof(ucc_mc_cpu_config_t),
+        },
+    .super.init          = ucc_mc_cpu_init,
+    .super.finalize      = ucc_mc_cpu_finalize,
+    .super.ops.mem_type  = ucc_mc_cpu_mem_type,
+    .super.ops.mem_alloc = ucc_mc_cpu_mem_alloc,
+    .super.ops.mem_free  = ucc_mc_cpu_mem_free,
+};
+
+UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_mc_cpu.super.config_table,
+                                &ucc_config_global_list);

--- a/src/components/mc/cpu/mc_cpu.h
+++ b/src/components/mc/cpu/mc_cpu.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_MC_CPU_H_
+#define UCC_MC_CPU_H_
+
+#include "components/mc/base/ucc_mc_base.h"
+#include "components/mc/ucc_mc_log.h"
+
+typedef struct ucc_mc_cpu_config {
+    ucc_mc_config_t super;
+} ucc_mc_cpu_config_t;
+
+typedef struct ucc_mc_cpu {
+    ucc_mc_base_t super;
+} ucc_mc_cpu_t;
+
+extern ucc_mc_cpu_t ucc_mc_cpu;
+#endif

--- a/src/components/mc/ucc_mc_log.h
+++ b/src/components/mc/ucc_mc_log.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_MC_LOG_H_
+#define UCC_MC_LOG_H_
+
+#include "utils/ucc_log.h"
+
+#define ucc_log_component_mc(_mc, _level, fmt, ...)                      \
+    ucc_log_component(_level, ((_mc)->config)->log_component,            \
+                      fmt, ##__VA_ARGS__)
+
+#define mc_error(_mc, _fmt, ...)                                         \
+    ucc_log_component_mc(_mc, UCC_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
+#define mc_warn(_mc, _fmt, ...)                                          \
+    ucc_log_component_mc(_mc, UCC_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
+#define mc_info(_mc, _fmt, ...)                                          \
+    ucc_log_component_mc(_mc, UCC_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+#define mc_debug(_mc, _fmt, ...)                                         \
+    ucc_log_component_mc(_mc, UCC_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
+#define mc_trace(_mc, _fmt, ...)                                         \
+    ucc_log_component_mc(_mc, UCC_LOG_LEVEL_TRACE, _fmt, ##__VA_ARGS__)
+
+#endif

--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -67,15 +67,24 @@ ucc_status_t ucc_constructor(void)
         }
         status = ucc_components_load("cl", &ucc_global_config.cl_framework);
         if (UCC_OK != status) {
-            ucc_error("no CL components were found in the UCC_COMPONENT_PATH: %s",
+            ucc_error("no CL components were found in the "
+                      "UCC_COMPONENT_PATH: %s",
                       ucc_global_config.component_path);
             return status;
         }
         status = ucc_components_load("tl", &ucc_global_config.tl_framework);
         if (UCC_OK != status) {
             /* not critical - some CLs may operate w/o use of TL */
-            ucc_debug("no TL components were found in the UCC_COMPONENT_PATH: %s",
+            ucc_debug("no TL components were found in the "
+                      "UCC_COMPONENT_PATH: %s",
                       ucc_global_config.component_path);
+        }
+        status = ucc_components_load("mc", &ucc_global_config.mc_framework);
+        if (UCC_OK != status) {
+            ucc_debug("no memory components were found in the "
+                      "UCC_COMPONENT_PATH: %s",
+                      ucc_global_config.component_path);
+            return status;
         }
     }
     return UCC_OK;

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -17,6 +17,7 @@ typedef struct ucc_global_config {
     ucc_log_component_config_t log_component;
     ucc_component_framework_t  cl_framework;
     ucc_component_framework_t  tl_framework;
+    ucc_component_framework_t  mc_framework;
 
     /* Coll component libraries path */
     char *component_path;

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -12,6 +12,7 @@
 #include "utils/ucc_math.h"
 #include "components/cl/ucc_cl.h"
 #include "components/tl/ucc_tl.h"
+#include "ucc_mc.h"
 
 UCS_CONFIG_DEFINE_ARRAY(cl_types, sizeof(ucc_cl_type_t),
                         UCS_CONFIG_TYPE_ENUM(ucc_cl_names));
@@ -266,6 +267,9 @@ ucc_status_t ucc_init_version(unsigned api_major_version,
     if (UCC_OK != (status = ucc_constructor())) {
         return status;
     }
+    if (UCC_OK != (status = ucc_mc_init())) {
+        return status;
+    }
 
     ucc_get_version(&major_version, &minor_version, &release_number);
 
@@ -401,5 +405,6 @@ ucc_status_t ucc_finalize(ucc_lib_info_t *lib)
     }
     ucc_free(lib->cl_libs);
     ucc_free(lib);
+    ucc_mc_finalize();
     return UCC_OK;
 }

--- a/src/core/ucc_mc.c
+++ b/src/core/ucc_mc.c
@@ -1,0 +1,135 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "components/mc/base/ucc_mc_base.h"
+#include "ucc_mc.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_log.h"
+
+static const ucc_mc_ops_t *mc_ops[UCC_MEMORY_TYPE_LAST];
+
+ucc_status_t ucc_mc_init()
+{
+    int            i, n_mcs;
+    ucc_mc_base_t *mc;
+    ucc_status_t   status;
+
+    memset(mc_ops, 0, UCC_MEMORY_TYPE_LAST * sizeof(ucc_mc_ops_t *));
+    n_mcs = ucc_global_config.mc_framework.n_components;
+    for (i = 0; i < n_mcs; i++) {
+        mc = ucc_derived_of(ucc_global_config.mc_framework.components[i],
+                            ucc_mc_base_t);
+        if (mc->ref_cnt == 0) {
+            mc->config = ucc_malloc(mc->config_table.size);
+            if (!mc->config) {
+                ucc_error("failed to allocate %zd bytes for mc config",
+                          mc->config_table.size);
+                continue;
+            }
+            status = ucc_config_parser_fill_opts(
+                mc->config, mc->config_table.table, "UCC_", NULL, 1);
+            if (UCC_OK != status) {
+                ucc_info("failed to parse config for component: %s (%d)",
+                         mc->super.name, status);
+                ucc_free(mc->config);
+                continue;
+            }
+            status = mc->init();
+            if (UCC_OK != status) {
+                ucc_info("mc_init failed for component: %s, skipping (%d)",
+                         mc->super.name, status);
+                ucc_config_parser_release_opts(mc->config,
+                                               mc->config_table.table);
+                ucc_free(mc->config);
+                continue;
+            }
+            ucc_debug("%s initialized", mc->super.name);
+        }
+        mc->ref_cnt++;
+        mc_ops[mc->type] = &mc->ops;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_mc_type(const void *ptr, ucc_memory_type_t *mem_type)
+{
+    ucc_memory_type_t mt;
+    ucc_status_t      status;
+
+    /* by default assume memory type host */
+    *mem_type = UCC_MEMORY_TYPE_HOST;
+    for (mt = UCC_MEMORY_TYPE_HOST + 1; mt < UCC_MEMORY_TYPE_LAST; mt++) {
+        if (NULL != mc_ops[mt]) {
+            status = mc_ops[mt]->mem_type(ptr, mem_type);
+            if (UCC_OK == status) {
+                /* found memory type for ptr */
+                return UCC_OK;
+            }
+        }
+    }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_mc_alloc(void **ptr, size_t size, ucc_memory_type_t mem_type)
+{
+    ucc_status_t status;
+
+    if (NULL == mc_ops[mem_type]) {
+        ucc_error("no components supported memory type %s available",
+                  ucc_memory_type_names[mem_type]);
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    status = mc_ops[mem_type]->mem_alloc(ptr, size);
+
+    return status;
+}
+
+ucc_status_t ucc_mc_reduce(const void *src1, ucc_memory_type_t src1_mt,
+                           const void *src2, ucc_memory_type_t src2_mt,
+                           void *dst, ucc_memory_type_t dst_mt, size_t count,
+                           ucc_datatype_t dt, ucc_reduction_op_t op)
+{
+    //TODO
+
+    return UCC_ERR_NOT_IMPLEMENTED;
+}
+
+ucc_status_t ucc_mc_free(void *ptr, ucc_memory_type_t mem_type)
+{
+    ucc_status_t status;
+
+    if (NULL == mc_ops[mem_type]) {
+        ucc_error("no components supported memory type %s available",
+                  ucc_memory_type_names[mem_type]);
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    status = mc_ops[mem_type]->mem_free(ptr);
+
+    return status;
+}
+
+ucc_status_t ucc_mc_finalize()
+{
+   ucc_memory_type_t  mt;
+   ucc_mc_base_t     *mc;
+
+    for (mt = UCC_MEMORY_TYPE_HOST; mt < UCC_MEMORY_TYPE_LAST; mt++) {
+        if (NULL != mc_ops[mt]) {
+            mc = ucc_container_of(mc_ops[mt], ucc_mc_base_t, ops);
+            mc->ref_cnt--;
+            if (mc->ref_cnt == 0) {
+                mc->finalize();
+                ucc_config_parser_release_opts(mc->config,
+                                               mc->config_table.table);
+                ucc_free(mc->config);
+                mc_ops[mt] = NULL;
+            }
+        }
+    }
+
+    return UCC_OK;
+}

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_MC_H_
+#define UCC_MC_H_
+
+#include "ucc/api/ucc.h"
+#include "components/mc/base/ucc_mc_base.h"
+
+ucc_status_t ucc_mc_init();
+
+ucc_status_t ucc_mc_type(const void *ptr, ucc_memory_type_t *mem_type);
+
+ucc_status_t ucc_mc_alloc(void **ptr, size_t len, ucc_memory_type_t mem_type);
+
+ucc_status_t ucc_mc_free(void *ptr, ucc_memory_type_t mem_type);
+
+ucc_status_t ucc_mc_finalize();
+
+#endif

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -71,7 +71,8 @@ gtest_SOURCES =                 \
 	core/test_lib_config.cc     \
 	core/test_lib.cc            \
 	core/test_context_config.cc \
-	core/test_context.cc
+	core/test_context.cc        \
+	core/test_mc.cc
 
 noinst_HEADERS =          \
 	common/gtest.h        \

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -30,8 +30,7 @@ UCC_TEST_F(test_obj_size, size) {
     UCC_TEST_SKIP_R("Assert enabled");
 #else
 
-    EXPECTED_SIZE(ucc_global_config_t, 96);
+    EXPECTED_SIZE(ucc_global_config_t, 120);
 
 #endif
 }
-

--- a/test/gtest/core/test_mc.cc
+++ b/test/gtest/core/test_mc.cc
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include <core/ucc_mc.h>
+}
+#include <common/test.h>
+
+class test_mc : public ucc::test {
+};
+
+UCC_TEST_F(test_mc, init_finalize)
+{
+    EXPECT_EQ(UCC_OK, ucc_constructor());
+    EXPECT_EQ(UCC_OK, ucc_mc_init());
+    EXPECT_EQ(UCC_OK, ucc_mc_finalize());
+}
+
+UCC_TEST_F(test_mc, init_is_required)
+{
+    void *ptr;
+
+    EXPECT_NE(UCC_OK, ucc_mc_alloc(&ptr, 1, UCC_MEMORY_TYPE_HOST));
+    EXPECT_NE(UCC_OK, ucc_mc_free(ptr, UCC_MEMORY_TYPE_HOST));
+}
+
+UCC_TEST_F(test_mc, can_alloc_and_free_host_mem)
+{
+    void *ptr = NULL;
+    size_t size = 4096;
+
+    EXPECT_EQ(UCC_OK, ucc_constructor());
+    EXPECT_EQ(UCC_OK, ucc_mc_init());
+    EXPECT_EQ(UCC_OK, ucc_mc_alloc(&ptr, size, UCC_MEMORY_TYPE_HOST));
+    memset(ptr, 0, size);
+    EXPECT_EQ(UCC_OK, ucc_mc_free(ptr, UCC_MEMORY_TYPE_HOST));
+    EXPECT_EQ(UCC_OK, ucc_mc_finalize());
+}
+
+UCC_TEST_F(test_mc, init_twice)
+{
+    ucc_lib_config_h cfg;
+    ucc_lib_params_t lib_params;
+    ucc_lib_h lib1, lib2;
+    ucc_mc_base_t *mc;
+
+
+    EXPECT_EQ(UCC_OK, ucc_lib_config_read(NULL, NULL, &cfg));
+    lib_params.mask        = UCC_LIB_PARAM_FIELD_THREAD_MODE;
+    lib_params.thread_mode = UCC_THREAD_SINGLE;
+    EXPECT_EQ(UCC_OK, ucc_init(&lib_params, cfg, &lib1));
+    mc = ucc_derived_of(ucc_global_config.mc_framework.components[0],
+                        ucc_mc_base_t);
+    EXPECT_EQ(1, mc->ref_cnt);
+    EXPECT_EQ(UCC_OK, ucc_init(&lib_params, cfg, &lib2));
+    EXPECT_EQ(2, mc->ref_cnt);
+    EXPECT_EQ(UCC_OK, ucc_finalize(lib1));
+    EXPECT_EQ(1, mc->ref_cnt);
+    EXPECT_EQ(UCC_OK, ucc_finalize(lib2));
+    EXPECT_EQ(0, mc->ref_cnt);
+
+    ucc_lib_config_release(cfg);
+}


### PR DESCRIPTION
## What
Memory components (MC) interface to work with different kinds of memory

## Why ?
Provides functionality for CLs and TLs to allocate memory and perform reduce for predefined datatypes and operations.

## How ?
Each MC is loadable object to avoid dependency on third party libraries (e.g. libcudart). There is exactly one instance of MC per library. Functions in core provides proxy to access each MC.