### PR TITLE
Collective init

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -34,7 +34,7 @@ jobs:
               return 1
             fi
           fi
-          if ! echo $msg | grep -qP '^Merge |^((REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD)|(CL/|TL/|UCP|UCG|BASIC))+: \w'
+          if ! echo $msg | grep -qP '^Merge |^((CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD)|(CL/|TL/|UCP|UCG|BASIC))+: \w'
           then
             echo "Wrong header"
             return 1

--- a/configure.ac
+++ b/configure.ac
@@ -192,5 +192,6 @@ AC_CONFIG_FILES([
                  src/components/tl/ucp/Makefile
                  src/components/mc/cpu/Makefile
                  src/components/mc/cuda/Makefile
+                 test/mpi/Makefile
                  ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,6 +34,7 @@ noinst_HEADERS =                     \
 	core/ucc_context.h               \
 	core/ucc_mc.h                    \
 	core/ucc_team.h                  \
+	schedule/ucc_schedule.h          \
 	utils/ucc_compiler_def.h         \
 	utils/ucc_log.h                  \
 	utils/ucc_parser.h               \
@@ -57,6 +58,7 @@ libucc_la_SOURCES =                  \
 	core/ucc_context.c               \
 	core/ucc_mc.c                    \
 	core/ucc_team.c                  \
+	schedule/ucc_schedule.c          \
 	utils/ucc_component.c            \
 	components/base/ucc_base_iface.c \
 	components/cl/ucc_cl.c           \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,6 +58,7 @@ libucc_la_SOURCES =                  \
 	core/ucc_context.c               \
 	core/ucc_mc.c                    \
 	core/ucc_team.c                  \
+	core/ucc_coll.c                  \
 	schedule/ucc_schedule.c          \
 	utils/ucc_component.c            \
 	components/base/ucc_base_iface.c \

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -16,6 +16,7 @@
 #include "utils/ucc_class.h"
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_log.h"
+#include "schedule/ucc_schedule.h"
 
 typedef struct ucc_base_lib {
     ucc_log_component_config_t log_component;
@@ -80,6 +81,16 @@ typedef struct ucc_base_team_iface {
     ucc_status_t (*destroy)(ucc_base_team_t *team);
 } ucc_base_team_iface_t;
 
+typedef struct ucc_base_coll_op_args {
+    ucc_coll_op_args_t args;
+} ucc_base_coll_op_args_t;
+
+typedef struct ucc_base_coll_iface {
+    ucc_status_t (*init)(ucc_base_coll_op_args_t *coll_args,
+                         ucc_base_team_t *team,
+                         ucc_coll_task_t **task);
+} ucc_base_coll_iface_t;
+
 ucc_status_t ucc_base_config_read(const char *full_prefix,
                                   ucc_config_global_list_entry_t *cfg_entry,
                                   ucc_base_config_t **config);
@@ -118,7 +129,8 @@ static inline void ucc_base_config_release(ucc_base_config_t *config)
         .super.team.create_post =                                              \
             UCC_CLASS_NEW_FUNC_NAME(ucc_##_f##_name##_team_t),                 \
         .super.team.create_test = ucc_##_f##_name##_team_create_test,          \
-        .super.team.destroy     = ucc_##_f##_name##_team_destroy};             \
+        .super.team.destroy     = ucc_##_f##_name##_team_destroy,              \
+        .super.coll.init        = ucc_##_f##_name##_coll_init};                \
     UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_##_f##_name.super._f##lib_config,     \
                                     &ucc_config_global_list);                  \
     UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_##_f##_name.super._f##context_config, \

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -87,8 +87,7 @@ typedef struct ucc_base_coll_op_args {
 
 typedef struct ucc_base_coll_iface {
     ucc_status_t (*init)(ucc_base_coll_op_args_t *coll_args,
-                         ucc_base_team_t *team,
-                         ucc_coll_task_t **task);
+                         ucc_base_team_t *team, ucc_coll_task_t **task);
 } ucc_base_coll_iface_t;
 
 ucc_status_t ucc_base_config_read(const char *full_prefix,

--- a/src/components/cl/basic/Makefile.am
+++ b/src/components/cl/basic/Makefile.am
@@ -7,7 +7,8 @@ sources =              \
 	cl_basic.c         \
 	cl_basic_lib.c     \
 	cl_basic_context.c \
-	cl_basic_team.c
+	cl_basic_team.c    \
+	cl_basic_coll.c
 
 module_LTLIBRARIES          = libucc_cl_basic.la
 libucc_cl_basic_la_SOURCES  = $(sources)

--- a/src/components/cl/basic/cl_basic.c
+++ b/src/components/cl/basic/cl_basic.c
@@ -44,4 +44,7 @@ UCC_CLASS_DEFINE_NEW_FUNC(ucc_cl_basic_team_t, ucc_base_team_t,
 
 ucc_status_t ucc_cl_basic_team_create_test(ucc_base_team_t *cl_team);
 ucc_status_t ucc_cl_basic_team_destroy(ucc_base_team_t *cl_team);
+ucc_status_t ucc_cl_basic_coll_init(ucc_base_coll_op_args_t *coll_args,
+                                    ucc_base_team_t *team,
+                                    ucc_coll_task_t **task);
 UCC_CL_IFACE_DECLARE(basic, BASIC);

--- a/src/components/cl/basic/cl_basic_coll.c
+++ b/src/components/cl/basic/cl_basic_coll.c
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "cl_basic.h"
+
+ucc_status_t ucc_cl_basic_coll_init(ucc_base_coll_op_args_t *coll_args,
+                                    ucc_base_team_t *team,
+                                    ucc_coll_task_t **task)
+{
+    ucc_cl_basic_team_t *cl_team = ucc_derived_of(team, ucc_cl_basic_team_t);
+    return UCC_TL_TEAM_IFACE(cl_team->tl_ucp_team)->coll.init(
+        coll_args, &cl_team->tl_ucp_team->super, task);
+}

--- a/src/components/cl/basic/cl_basic_coll.c
+++ b/src/components/cl/basic/cl_basic_coll.c
@@ -11,6 +11,6 @@ ucc_status_t ucc_cl_basic_coll_init(ucc_base_coll_op_args_t *coll_args,
                                     ucc_coll_task_t **task)
 {
     ucc_cl_basic_team_t *cl_team = ucc_derived_of(team, ucc_cl_basic_team_t);
-    return UCC_TL_TEAM_IFACE(cl_team->tl_ucp_team)->coll.init(
-        coll_args, &cl_team->tl_ucp_team->super, task);
+    return UCC_TL_TEAM_IFACE(cl_team->tl_ucp_team)
+        ->coll.init(coll_args, &cl_team->tl_ucp_team->super, task);
 }

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -65,6 +65,7 @@ typedef struct ucc_cl_iface {
     ucc_base_lib_iface_t           lib;
     ucc_base_context_iface_t       context;
     ucc_base_team_iface_t          team;
+    ucc_base_coll_iface_t          coll;
 } ucc_cl_iface_t;
 
 typedef struct ucc_cl_lib {

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -57,6 +57,7 @@ typedef struct ucc_tl_iface {
     ucc_base_lib_iface_t           lib;
     ucc_base_context_iface_t       context;
     ucc_base_team_iface_t          team;
+    ucc_base_coll_iface_t          coll;
 } ucc_tl_iface_t;
 
 typedef struct ucc_tl_lib {

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -11,7 +11,8 @@ sources =            \
 	tl_ucp_ep.h      \
 	tl_ucp_ep.c      \
 	tl_ucp_addr.h    \
-	tl_ucp_addr.c
+	tl_ucp_addr.c    \
+	tl_ucp_coll.c
 
 module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -46,4 +46,8 @@ UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_ucp_team_t, ucc_base_team_t,
 
 ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team);
 ucc_status_t ucc_tl_ucp_team_destroy(ucc_base_team_t *tl_team);
+ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_op_args_t *coll_args,
+                                  ucc_base_team_t *team,
+                                  ucc_coll_task_t **task);
+
 UCC_TL_IFACE_DECLARE(ucp, UCP);

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -37,14 +37,14 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *,
 
 typedef struct ucc_tl_ucp_addr_storage ucc_tl_ucp_addr_storage_t;
 typedef struct ucc_tl_ucp_context {
-    ucc_tl_context_t super;
-    ucp_context_h    ucp_context;
-    ucp_worker_h     ucp_worker;
-    size_t           ucp_addrlen;
-    ucp_address_t   *worker_address;
-    uint32_t         preconnect;
+    ucc_tl_context_t            super;
+    ucp_context_h               ucp_context;
+    ucp_worker_h                ucp_worker;
+    size_t                      ucp_addrlen;
+    ucp_address_t              *worker_address;
+    uint32_t                    preconnect;
     ucc_tl_ucp_ep_close_state_t ep_close_state;
-    ucc_mpool_t      req_mp;
+    ucc_mpool_t                 req_mp;
 } ucc_tl_ucp_context_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -9,6 +9,8 @@
 #include "components/tl/ucc_tl.h"
 #include "components/tl/ucc_tl_log.h"
 #include "tl_ucp_ep.h"
+#include "utils/ucc_mpool.h"
+
 #include <ucp/api/ucp.h>
 #include <ucs/memory/memory_type.h>
 
@@ -42,6 +44,7 @@ typedef struct ucc_tl_ucp_context {
     ucp_address_t   *worker_address;
     uint32_t         preconnect;
     ucc_tl_ucp_ep_close_state_t ep_close_state;
+    ucc_mpool_t      req_mp;
 } ucc_tl_ucp_context_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -35,8 +35,8 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_op_args_t *coll_args,
     ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
     ucc_tl_ucp_task_t    *task    = ucc_tl_ucp_get_task(ctx);
     task->team                    = tl_team;
-    task->super.super.post        = ucc_tl_ucp_coll_post;
-    task->super.super.finalize    = ucc_tl_ucp_coll_finalize;
+    task->super.post              = ucc_tl_ucp_coll_post;
+    task->super.finalize          = ucc_tl_ucp_coll_finalize;
     *task_h                       = &task->super;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -5,11 +5,38 @@
  */
 
 #include "tl_ucp.h"
+#include "tl_ucp_coll.h"
+
+static ucc_status_t ucc_tl_ucp_coll_finalize(ucc_coll_req_t *request)
+{
+    ucc_tl_ucp_task_t *task = ucc_derived_of(request, ucc_tl_ucp_task_t);
+    tl_info(task->team->super.super.context->lib,
+            "finalizing coll req %p", request);
+    ucc_tl_ucp_put_task(task);
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_tl_ucp_coll_post(ucc_coll_req_t *request)
+{
+    /*This is an example fn, the actual post fn for a request should be set
+      during init */
+    ucc_tl_ucp_task_t *task = ucc_derived_of(request, ucc_tl_ucp_task_t);
+    tl_info(task->team->super.super.context->lib,
+            "posting coll req %p", request);
+    request->status = UCC_OK;
+    return UCC_OK;
+}
 
 ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_op_args_t *coll_args,
                                   ucc_base_team_t *team,
-                                  ucc_coll_task_t **task)
+                                  ucc_coll_task_t **task_h)
 {
-    fprintf(stderr,"[%d][%s] -- [%d]\n",111,__FUNCTION__,__LINE__);
+    ucc_tl_ucp_team_t    *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_tl_ucp_task_t    *task    = ucc_tl_ucp_get_task(ctx);
+    task->team                 = tl_team;
+    task->super.super.post     = ucc_tl_ucp_coll_post;
+    task->super.super.finalize = ucc_tl_ucp_coll_finalize;
+    *task_h = &task->super;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_ucp.h"
+
+ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_op_args_t *coll_args,
+                                  ucc_base_team_t *team,
+                                  ucc_coll_task_t **task)
+{
+    fprintf(stderr,"[%d][%s] -- [%d]\n",111,__FUNCTION__,__LINE__);
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -10,8 +10,8 @@
 static ucc_status_t ucc_tl_ucp_coll_finalize(ucc_coll_req_t *request)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(request, ucc_tl_ucp_task_t);
-    tl_info(task->team->super.super.context->lib,
-            "finalizing coll req %p", request);
+    tl_info(task->team->super.super.context->lib, "finalizing coll req %p",
+            request);
     ucc_tl_ucp_put_task(task);
     return UCC_OK;
 }
@@ -21,8 +21,8 @@ static ucc_status_t ucc_tl_ucp_coll_post(ucc_coll_req_t *request)
     /*This is an example fn, the actual post fn for a request should be set
       during init */
     ucc_tl_ucp_task_t *task = ucc_derived_of(request, ucc_tl_ucp_task_t);
-    tl_info(task->team->super.super.context->lib,
-            "posting coll req %p", request);
+    tl_info(task->team->super.super.context->lib, "posting coll req %p",
+            request);
     request->status = UCC_OK;
     return UCC_OK;
 }
@@ -34,9 +34,9 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_op_args_t *coll_args,
     ucc_tl_ucp_team_t    *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
     ucc_tl_ucp_task_t    *task    = ucc_tl_ucp_get_task(ctx);
-    task->team                 = tl_team;
-    task->super.super.post     = ucc_tl_ucp_coll_post;
-    task->super.super.finalize = ucc_tl_ucp_coll_finalize;
-    *task_h = &task->super;
+    task->team                    = tl_team;
+    task->super.super.post        = ucc_tl_ucp_coll_post;
+    task->super.super.finalize    = ucc_tl_ucp_coll_finalize;
+    *task_h                       = &task->super;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -13,16 +13,16 @@ typedef struct ucc_tl_ucp_task {
     ucc_tl_ucp_team_t *team;
 } ucc_tl_ucp_task_t;
 
-static inline ucc_tl_ucp_task_t*
-ucc_tl_ucp_get_task(ucc_tl_ucp_context_t *ctx) {
-    ucc_tl_ucp_task_t* task;
-    task = ucc_mpool_get(&ctx->req_mp);
+static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_context_t *ctx)
+{
+    ucc_tl_ucp_task_t *task;
+    task                     = ucc_mpool_get(&ctx->req_mp);
     task->super.super.status = UCC_OPERATION_INITIALIZED;
     return task;
 }
 
-static inline void
-ucc_tl_ucp_put_task(ucc_tl_ucp_task_t *task) {
+static inline void ucc_tl_ucp_put_task(ucc_tl_ucp_task_t *task)
+{
     ucc_mpool_put(task);
 }
 #endif

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_UCP_COLL_H_
+#define UCC_TL_UCP_COLL_H_
+#include "tl_ucp.h"
+#include "schedule/ucc_schedule.h"
+typedef struct ucc_tl_ucp_task {
+    ucc_coll_task_t    super;
+    ucc_tl_ucp_team_t *team;
+} ucc_tl_ucp_task_t;
+
+static inline ucc_tl_ucp_task_t*
+ucc_tl_ucp_get_task(ucc_tl_ucp_context_t *ctx) {
+    ucc_tl_ucp_task_t* task;
+    task = ucc_mpool_get(&ctx->req_mp);
+    task->super.super.status = UCC_OPERATION_INITIALIZED;
+    return task;
+}
+
+static inline void
+ucc_tl_ucp_put_task(ucc_tl_ucp_task_t *task) {
+    ucc_mpool_put(task);
+}
+#endif

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -7,7 +7,7 @@
 #include "tl_ucp.h"
 #include "tl_ucp_tag.h"
 #include "tl_ucp_coll.h"
-#include  <limits.h>
+#include <limits.h>
 
 static void ucc_tl_ucp_req_init(void *request)
 {
@@ -116,7 +116,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
                                 UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL, NULL,
                                 "tl_ucp_req_mp");
     if (UCC_OK != ucc_status) {
-        tl_error(self->super.super.lib, "failed to initialize tl_ucp_req mpool");
+        tl_error(self->super.super.lib,
+                 "failed to initialize tl_ucp_req mpool");
         goto err_thread_mode;
     }
     tl_info(self->super.super.lib, "initialized tl context: %p", self);

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -28,8 +28,8 @@ ucc_status_t ucc_collective_init(ucc_coll_op_args_t *coll_args,
     /* TO discuss: maybe we want to pass around user pointer ? */
     memcpy(&op_args.args, coll_args, sizeof(ucc_coll_op_args_t));
     cl_team = ucc_select_cl_team(coll_args, team);
-    status = UCC_CL_TEAM_IFACE(cl_team)->coll.init(&op_args, &cl_team->super,
-                                                   &task);
+    status =
+        UCC_CL_TEAM_IFACE(cl_team)->coll.init(&op_args, &cl_team->super, &task);
     if (status != UCC_OK) {
         //TODO more descriptive error msg
         ucc_error("failed to init collective");

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -9,6 +9,7 @@
 #include "components/cl/ucc_cl.h"
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_log.h"
+#include "schedule/ucc_schedule.h"
 
 static ucc_cl_team_t *ucc_select_cl_team(ucc_coll_op_args_t *coll_args,
                                          ucc_team_t *team)
@@ -38,3 +39,16 @@ ucc_status_t ucc_collective_init(ucc_coll_op_args_t *coll_args,
     *request = &task->super;
     return UCC_OK;
 }
+
+ucc_status_t ucc_collective_post(ucc_coll_req_h request)
+{
+    ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
+    return task->post(request);
+}
+
+ucc_status_t ucc_collective_finalize(ucc_coll_req_h request)
+{
+    ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
+    return task->finalize(request);
+}
+

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "ucc_team.h"
+#include "ucc_context.h"
+#include "components/cl/ucc_cl.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_log.h"
+
+static ucc_cl_team_t *ucc_select_cl_team(ucc_coll_op_args_t *coll_args,
+                                         ucc_team_t *team)
+{
+    /* TODO: collective CL selection logic will be there.
+       for now just return 1st CL on a list */
+    return team->cl_teams[0];
+}
+
+ucc_status_t ucc_collective_init(ucc_coll_op_args_t *coll_args,
+                                 ucc_coll_req_h *request, ucc_team_h team)
+{
+    ucc_cl_team_t          *cl_team;
+    ucc_base_coll_op_args_t op_args;
+    ucc_status_t            status;
+    ucc_coll_task_t        *task;
+    /* TO discuss: maybe we want to pass around user pointer ? */
+    memcpy(&op_args.args, coll_args, sizeof(ucc_coll_op_args_t));
+    cl_team = ucc_select_cl_team(coll_args, team);
+    status = UCC_CL_TEAM_IFACE(cl_team)->coll.init(&op_args, &cl_team->super,
+                                                   &task);
+    if (status != UCC_OK) {
+        //TODO more descriptive error msg
+        ucc_error("failed to init collective");
+        return status;
+    }
+    *request = &task->super;
+    return UCC_OK;
+}

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -13,8 +13,7 @@ void ucc_event_manager_init(ucc_event_manager_t *em)
     }
 }
 
-void ucc_event_manager_subscribe(ucc_event_manager_t *em,
-                                 ucc_event_t event,
+void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
                                  ucc_coll_task_t *task)
 {
     em->listeners[event][em->listeners_size[event]] = task;
@@ -57,7 +56,8 @@ static ucc_status_t ucc_schedule_completed_handler(ucc_coll_task_t *task)
 void ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx)
 {
     ucc_coll_task_init(&schedule->super);
-    schedule->super.handlers[UCC_EVENT_COMPLETED] = ucc_schedule_completed_handler;
+    schedule->super.handlers[UCC_EVENT_COMPLETED] =
+        ucc_schedule_completed_handler;
     schedule->n_completed_tasks = 0;
     schedule->ctx               = ctx;
     schedule->n_tasks           = 0;
@@ -65,7 +65,8 @@ void ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx)
 
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task)
 {
-    ucc_event_manager_subscribe(&task->em, UCC_EVENT_COMPLETED, &schedule->super);
+    ucc_event_manager_subscribe(&task->em, UCC_EVENT_COMPLETED,
+                                &schedule->super);
     task->schedule = schedule;
     schedule->n_tasks++;
 }

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -7,7 +7,7 @@
 
 #include "ucc/api/ucc.h"
 #include "utils/ucc_list.h"
-#define MAX_LISTENERS 8
+#define MAX_LISTENERS 4
 
 typedef enum {
     UCC_EVENT_COMPLETED = 0,
@@ -18,6 +18,8 @@ typedef enum {
 typedef struct ucc_coll_task ucc_coll_task_t;
 
 typedef ucc_status_t (*ucc_task_event_handler_p)(ucc_coll_task_t *task);
+typedef ucc_status_t (*ucc_coll_post_fn_t)(ucc_coll_req_h request);
+typedef ucc_status_t (*ucc_coll_finalize_fn_t)(ucc_coll_req_h request);
 
 typedef struct ucc_event_manager {
     ucc_coll_task_t *listeners[UCC_EVENT_LAST][MAX_LISTENERS];
@@ -26,6 +28,8 @@ typedef struct ucc_event_manager {
 
 typedef struct ucc_coll_task {
     ucc_coll_req_t             super;
+    ucc_coll_post_fn_t         post;
+    ucc_coll_finalize_fn_t     finalize;
     ucc_event_manager_t        em;
     ucc_task_event_handler_p   handlers[UCC_EVENT_LAST];
     ucc_status_t             (*progress)(struct ucc_coll_task *self);
@@ -42,13 +46,13 @@ typedef struct ucc_schedule {
     ucc_context_t  *ctx;
 } ucc_schedule_t;
 
-void ucc_event_manager_init(ucc_event_manager_t *em);
-void ucc_coll_task_init(ucc_coll_task_t *task);
+ucc_status_t ucc_event_manager_init(ucc_event_manager_t *em);
+ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task);
 void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
                                  ucc_coll_task_t *task);
 ucc_status_t ucc_event_manager_notify(ucc_event_manager_t *em,
                                       ucc_event_t event);
-void         ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx);
+ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx);
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
 ucc_status_t ucc_schedule_start(ucc_schedule_t *schedule);
 #endif

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -36,19 +36,19 @@ typedef struct ucc_coll_task {
 
 typedef struct ucc_context ucc_context_t;
 typedef struct ucc_schedule {
-    ucc_coll_task_t    super;
-    int                n_completed_tasks;
-    int                n_tasks;
-    ucc_context_t     *ctx;
+    ucc_coll_task_t super;
+    int             n_completed_tasks;
+    int             n_tasks;
+    ucc_context_t  *ctx;
 } ucc_schedule_t;
 
 void ucc_event_manager_init(ucc_event_manager_t *em);
 void ucc_coll_task_init(ucc_coll_task_t *task);
-void ucc_event_manager_subscribe(ucc_event_manager_t *em,
-                                 ucc_event_t event,
+void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
                                  ucc_coll_task_t *task);
-ucc_status_t ucc_event_manager_notify(ucc_event_manager_t *em, ucc_event_t event);
-void ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx);
+ucc_status_t ucc_event_manager_notify(ucc_event_manager_t *em,
+                                      ucc_event_t event);
+void         ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx);
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
 ucc_status_t ucc_schedule_start(ucc_schedule_t *schedule);
 #endif

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#ifndef UCC_SCHEDULE_H_
+#define UCC_SCHEDULE_H_
+
+#include "ucc/api/ucc.h"
+#include "utils/ucc_list.h"
+#define MAX_LISTENERS 8
+
+typedef enum {
+    UCC_EVENT_COMPLETED = 0,
+    UCC_EVENT_SCHEDULE_STARTED,
+    UCC_EVENT_LAST
+} ucc_event_t;
+
+typedef struct ucc_coll_task ucc_coll_task_t;
+
+typedef ucc_status_t (*ucc_task_event_handler_p)(ucc_coll_task_t *task);
+
+typedef struct ucc_event_manager {
+    ucc_coll_task_t *listeners[UCC_EVENT_LAST][MAX_LISTENERS];
+    int              listeners_size[UCC_EVENT_LAST];
+} ucc_event_manager_t;
+
+typedef struct ucc_coll_task {
+    ucc_coll_req_t             super;
+    ucc_event_manager_t        em;
+    ucc_task_event_handler_p   handlers[UCC_EVENT_LAST];
+    ucc_status_t             (*progress)(struct ucc_coll_task *self);
+    struct ucc_schedule       *schedule;
+    /* used for progress queue */
+    ucc_list_link_t            list_elem;
+} ucc_coll_task_t;
+
+typedef struct ucc_context ucc_context_t;
+typedef struct ucc_schedule {
+    ucc_coll_task_t    super;
+    int                n_completed_tasks;
+    int                n_tasks;
+    ucc_context_t     *ctx;
+} ucc_schedule_t;
+
+void ucc_event_manager_init(ucc_event_manager_t *em);
+void ucc_coll_task_init(ucc_coll_task_t *task);
+void ucc_event_manager_subscribe(ucc_event_manager_t *em,
+                                 ucc_event_t event,
+                                 ucc_coll_task_t *task);
+ucc_status_t ucc_event_manager_notify(ucc_event_manager_t *em, ucc_event_t event);
+void ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx);
+void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
+ucc_status_t ucc_schedule_start(ucc_schedule_t *schedule);
+#endif

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1476,7 +1476,10 @@ ucc_status_t ucc_collective_init(ucc_coll_op_args_t *coll_args,
  *
  *  @return Error code as defined by ucc_status_t
  */
-ucc_status_t ucc_collective_post(ucc_coll_req_h request);
+static inline ucc_status_t ucc_collective_post(ucc_coll_req_h request)
+{
+    return request->post(request);
+}
 
 
 /**
@@ -1526,7 +1529,10 @@ ucc_status_t ucc_collective_init_and_post(ucc_coll_op_args_t *coll_args,
  *
  *  @return Error code as defined by ucc_status_t
  */
-ucc_status_t ucc_collective_test(ucc_coll_req_h request);
+static inline ucc_status_t ucc_collective_test(ucc_coll_req_h request)
+{
+    return request->status;
+}
 
 /**
  *  @ingroup UCC_COLLECTIVES
@@ -1546,7 +1552,10 @@ ucc_status_t ucc_collective_test(ucc_coll_req_h request);
  *
  *  @return Error code as defined by ucc_status_t
  */
-ucc_status_t ucc_collective_finalize(ucc_coll_req_h request);
+static inline ucc_status_t ucc_collective_finalize(ucc_coll_req_h request)
+{
+    return request->finalize(request);
+}
 
 END_C_DECLS
 #endif

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1476,10 +1476,7 @@ ucc_status_t ucc_collective_init(ucc_coll_op_args_t *coll_args,
  *
  *  @return Error code as defined by ucc_status_t
  */
-static inline ucc_status_t ucc_collective_post(ucc_coll_req_h request)
-{
-    return request->post(request);
-}
+ucc_status_t ucc_collective_post(ucc_coll_req_h request);
 
 
 /**
@@ -1552,10 +1549,7 @@ static inline ucc_status_t ucc_collective_test(ucc_coll_req_h request)
  *
  *  @return Error code as defined by ucc_status_t
  */
-static inline ucc_status_t ucc_collective_finalize(ucc_coll_req_h request)
-{
-    return request->finalize(request);
-}
+ucc_status_t ucc_collective_finalize(ucc_coll_req_h request);
 
 END_C_DECLS
 #endif

--- a/src/ucc/api/ucc_def.h
+++ b/src/ucc/api/ucc_def.h
@@ -66,10 +66,15 @@ typedef struct ucc_team*            ucc_team_h;
  * status of the collective operation, progress, or complete the collective
  * operation.
  */
+typedef struct ucc_coll_req* ucc_coll_req_h;
+typedef ucc_status_t (*ucc_coll_post_fn_t)(ucc_coll_req_h request);
+typedef ucc_status_t (*ucc_coll_finalize_fn_t)(ucc_coll_req_h request);
 typedef struct ucc_coll_req {
-    ucc_status_t status;
+    ucc_status_t           status;
+    ucc_coll_post_fn_t     post;
+    ucc_coll_finalize_fn_t finalize;
 } ucc_coll_req_t;
-typedef struct ucc_coll_req*        ucc_coll_req_h;
+
 
 /**
  * @ingroup UCC_COLLECTIVES

--- a/src/ucc/api/ucc_def.h
+++ b/src/ucc/api/ucc_def.h
@@ -66,6 +66,9 @@ typedef struct ucc_team*            ucc_team_h;
  * status of the collective operation, progress, or complete the collective
  * operation.
  */
+typedef struct ucc_coll_req {
+    ucc_status_t status;
+} ucc_coll_req_t;
 typedef struct ucc_coll_req*        ucc_coll_req_h;
 
 /**

--- a/src/ucc/api/ucc_def.h
+++ b/src/ucc/api/ucc_def.h
@@ -67,14 +67,9 @@ typedef struct ucc_team*            ucc_team_h;
  * operation.
  */
 typedef struct ucc_coll_req* ucc_coll_req_h;
-typedef ucc_status_t (*ucc_coll_post_fn_t)(ucc_coll_req_h request);
-typedef ucc_status_t (*ucc_coll_finalize_fn_t)(ucc_coll_req_h request);
 typedef struct ucc_coll_req {
-    ucc_status_t           status;
-    ucc_coll_post_fn_t     post;
-    ucc_coll_finalize_fn_t finalize;
+    ucc_status_t status;
 } ucc_coll_req_t;
-
 
 /**
  * @ingroup UCC_COLLECTIVES

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -56,4 +56,5 @@ static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
 #define ucc_assert(_cond)
 #endif
 
+#define UCC_CACHE_LINE_SIZE 128 //TODO detect it
 #endif

--- a/src/utils/ucc_list.h
+++ b/src/utils/ucc_list.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_LIST_H_
+#define UCC_LIST_H_
+
+#include "config.h"
+#include <ucs/datastruct/list.h>
+
+#define ucc_list_link_t ucs_list_link_t
+
+#endif

--- a/src/utils/ucc_mpool.h
+++ b/src/utils/ucc_mpool.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_MPOOL_H_
+#define UCC_MPOOL_H_
+
+#include "config.h"
+#include <ucs/datastruct/mpool.h>
+#include "ucc_compiler_def.h"
+
+typedef ucs_mpool_t ucc_mpool_t;
+#define ucc_mpool_get(_mp) ucs_mpool_get((_mp))
+#define ucc_mpool_put(_obj) ucs_mpool_put((_obj))
+
+typedef void (*ucc_mpool_obj_init_fn_t)(ucc_mpool_t *mp, void *obj, void *chunk);
+typedef void (*ucc_mpool_obj_cleanup_fn_t)(ucc_mpool_t *mp, void *obj);
+
+static inline
+ucc_status_t ucc_mpool_init(ucc_mpool_t *mp, size_t elem_size,
+                            size_t alignment, unsigned elems_per_chunk,
+                            unsigned max_elems,
+                            ucc_mpool_obj_init_fn_t init_fn,
+                            ucc_mpool_obj_cleanup_fn_t cleanup_fn,
+                            const char *name)
+{
+    ucs_mpool_ops_t *ops = ucc_malloc(sizeof(*ops), "mpool_ops");
+    if (!ops) {
+        ucc_error("failed to allocate %zd bytes for mpool ops", sizeof(*ops));
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    ops->chunk_alloc   = ucs_mpool_hugetlb_malloc;
+    ops->chunk_release = ucs_mpool_hugetlb_free;
+    ops->obj_init      = init_fn;
+    ops->obj_cleanup   = cleanup_fn;
+    return ucs_status_to_ucc_status(ucs_mpool_init(mp, 0, elem_size, 0,
+                                                   alignment, elems_per_chunk, max_elems,
+                                                   ops, name));
+}
+
+static inline void ucc_mpool_cleanup(ucc_mpool_t *mp, int leak_check)
+{
+    ucs_mpool_ops_t *ops = mp->data->ops;
+    ucs_mpool_cleanup(mp, leak_check);
+    ucc_free(ops);
+}
+
+#endif

--- a/src/utils/ucc_mpool.h
+++ b/src/utils/ucc_mpool.h
@@ -14,16 +14,15 @@ typedef ucs_mpool_t ucc_mpool_t;
 #define ucc_mpool_get(_mp) ucs_mpool_get((_mp))
 #define ucc_mpool_put(_obj) ucs_mpool_put((_obj))
 
-typedef void (*ucc_mpool_obj_init_fn_t)(ucc_mpool_t *mp, void *obj, void *chunk);
+typedef void (*ucc_mpool_obj_init_fn_t)(ucc_mpool_t *mp, void *obj,
+                                        void *chunk);
 typedef void (*ucc_mpool_obj_cleanup_fn_t)(ucc_mpool_t *mp, void *obj);
 
-static inline
-ucc_status_t ucc_mpool_init(ucc_mpool_t *mp, size_t elem_size,
-                            size_t alignment, unsigned elems_per_chunk,
-                            unsigned max_elems,
-                            ucc_mpool_obj_init_fn_t init_fn,
-                            ucc_mpool_obj_cleanup_fn_t cleanup_fn,
-                            const char *name)
+static inline ucc_status_t
+ucc_mpool_init(ucc_mpool_t *mp, size_t elem_size, size_t alignment,
+               unsigned elems_per_chunk, unsigned max_elems,
+               ucc_mpool_obj_init_fn_t    init_fn,
+               ucc_mpool_obj_cleanup_fn_t cleanup_fn, const char *name)
 {
     ucs_mpool_ops_t *ops = ucc_malloc(sizeof(*ops), "mpool_ops");
     if (!ops) {
@@ -35,9 +34,8 @@ ucc_status_t ucc_mpool_init(ucc_mpool_t *mp, size_t elem_size,
     ops->chunk_release = ucs_mpool_hugetlb_free;
     ops->obj_init      = init_fn;
     ops->obj_cleanup   = cleanup_fn;
-    return ucs_status_to_ucc_status(ucs_mpool_init(mp, 0, elem_size, 0,
-                                                   alignment, elems_per_chunk, max_elems,
-                                                   ops, name));
+    return ucs_status_to_ucc_status(ucs_mpool_init(
+        mp, 0, elem_size, 0, alignment, elems_per_chunk, max_elems, ops, name));
 }
 
 static inline void ucc_mpool_cleanup(ucc_mpool_t *mp, int leak_check)

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Mellanox Technologies.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+bin_PROGRAMS = test_mpi_barrier
+
+test_mpi_barrier_SOURCES=test_mpi_barrier.c test_mpi.c
+
+CC=mpicc
+CFLAGS+=-I${top_builddir}/src -std=c11
+
+LDFLAGS=-L${top_builddir}/src/.libs -lucc

--- a/test/mpi/test_mpi.c
+++ b/test/mpi/test_mpi.c
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "test_mpi.h"
+#include <assert.h>
+
+ucc_team_h       ucc_world_team;
+ucc_context_h    team_ctx;
+static ucc_lib_h lib;
+
+
+static ucc_status_t oob_allgather(void *sbuf, void *rbuf, size_t msglen,
+                                   void *coll_info, void **req)
+{
+    MPI_Comm comm = (MPI_Comm)coll_info;
+    MPI_Request request;
+    MPI_Iallgather(sbuf, msglen, MPI_BYTE, rbuf, msglen, MPI_BYTE,
+                   comm, &request);
+    *req = (void*)request;
+    return UCC_OK;
+}
+
+static ucc_status_t oob_allgather_test(void *req) {
+    MPI_Request request = (MPI_Request)req;
+    int completed;
+    MPI_Test(&request, &completed, MPI_STATUS_IGNORE);
+    return completed ? UCC_OK : UCC_INPROGRESS;
+}
+
+static ucc_status_t oob_allgather_free(void *req) {
+    return UCC_OK;
+}
+
+int ucc_mpi_create_comm_nb(MPI_Comm comm, ucc_team_h *team) {
+    int rank, size;
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+
+    /* Create UCC TEAM for comm world */
+    ucc_team_params_t team_params = {
+        .mask               = UCC_TEAM_PARAM_FIELD_EP |
+                              UCC_TEAM_PARAM_FIELD_OOB,
+        .oob   = {
+            .allgather      = oob_allgather,
+            .req_test       = oob_allgather_test,
+            .req_free       = oob_allgather_free,
+            .coll_info      = (void*)comm,
+            .participants   = size
+        },
+        .ep                 = rank
+    };
+
+    UCC_CHECK(ucc_team_create_post(&team_ctx, 1, &team_params, team));
+    return 0;
+}
+
+int ucc_mpi_create_comm(MPI_Comm comm, ucc_team_h *team) {
+    ucc_mpi_create_comm_nb(comm, team);
+    while (UCC_INPROGRESS == ucc_team_create_test(*team)) {;};
+    return 0;
+}
+
+int ucc_mpi_test_init(int argc, char **argv,
+                       uint64_t coll_types, unsigned thread_mode) {
+    char     *var;
+    int      rank, size, provided;
+    int required = (thread_mode == UCC_THREAD_SINGLE) ?
+        MPI_THREAD_SINGLE : MPI_THREAD_MULTIPLE;
+    MPI_Init_thread(&argc, &argv, required, &provided);
+    assert(provided == required);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    /* Init ucc library */
+    var = getenv("UCC_TEST_CLS");
+
+    ucc_lib_params_t lib_params = {
+        .mask =  UCC_LIB_PARAM_FIELD_THREAD_MODE,
+        /* .coll_types = coll_types, */
+    };
+
+    ucc_lib_config_h lib_config;
+
+
+    /* Init ucc context for a specified UCC_TEST_TLS */
+    ucc_context_params_t ctx_params = {
+        .mask      = UCC_CONTEXT_PARAM_FIELD_TYPE,
+        .ctx_type  = UCC_CONTEXT_EXCLUSIVE,
+    };
+    UCC_CHECK(ucc_lib_config_read(NULL, NULL, &lib_config));
+    if (var) {
+        UCC_CHECK(ucc_lib_config_modify(lib_config, "CLS", var));
+    }
+    UCC_CHECK(ucc_init(&lib_params, lib_config, &lib));
+    ucc_lib_config_release(lib_config);
+
+    ucc_context_config_h ctx_config;
+    UCC_CHECK(ucc_context_config_read(lib, NULL, &ctx_config));
+    UCC_CHECK(ucc_context_create(lib, &ctx_params, ctx_config, &team_ctx));
+    ucc_context_config_release(ctx_config);
+    ucc_mpi_create_comm(MPI_COMM_WORLD, &ucc_world_team);
+    return 0;
+}
+
+void ucc_mpi_test_finalize(void) {
+    UCC_CHECK(ucc_team_destroy(ucc_world_team));
+    UCC_CHECK(ucc_context_destroy(team_ctx));
+    UCC_CHECK(ucc_finalize(lib));
+    MPI_Finalize();
+}
+
+void ucc_mpi_test_progress(void)
+{
+    /* ucc_context_progress(team_ctx); */
+}

--- a/test/mpi/test_mpi.c
+++ b/test/mpi/test_mpi.c
@@ -81,6 +81,7 @@ int ucc_mpi_test_init(int argc, char **argv, uint64_t coll_types,
 
     ucc_lib_params_t lib_params = {
         .mask = UCC_LIB_PARAM_FIELD_THREAD_MODE,
+        .thread_mode = thread_mode,
         /* .coll_types = coll_types, */
     };
 

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef TEST_MPI_H
+#define TEST_MPI_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <mpi.h>
+#include <ucc/api/ucc.h>
+
+#define STR(x) # x
+#define UCC_CHECK(_call) if (UCC_OK != (_call)) {                \
+        fprintf(stderr, "*** UCC TEST FAIL: %s\n", STR(_call));  \
+        MPI_Abort(MPI_COMM_WORLD, -1);                           \
+    }
+
+extern ucc_team_h    ucc_world_team;
+extern ucc_context_h team_ctx;
+
+int ucc_mpi_test_init(int argc, char **argv,
+                       uint64_t coll_types, unsigned thread_mode);
+
+void ucc_mpi_test_finalize(void);
+
+int ucc_mpi_create_comm_nb(MPI_Comm comm, ucc_team_h *team);
+
+int ucc_mpi_create_comm(MPI_Comm comm, ucc_team_h *team);
+
+void ucc_mpi_test_progress(void);
+
+#endif

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -14,17 +14,18 @@
 #include <mpi.h>
 #include <ucc/api/ucc.h>
 
-#define STR(x) # x
-#define UCC_CHECK(_call) if (UCC_OK != (_call)) {                \
-        fprintf(stderr, "*** UCC TEST FAIL: %s\n", STR(_call));  \
-        MPI_Abort(MPI_COMM_WORLD, -1);                           \
+#define STR(x) #x
+#define UCC_CHECK(_call)                                                       \
+    if (UCC_OK != (_call)) {                                                   \
+        fprintf(stderr, "*** UCC TEST FAIL: %s\n", STR(_call));                \
+        MPI_Abort(MPI_COMM_WORLD, -1);                                         \
     }
 
 extern ucc_team_h    ucc_world_team;
 extern ucc_context_h team_ctx;
 
-int ucc_mpi_test_init(int argc, char **argv,
-                       uint64_t coll_types, unsigned thread_mode);
+int ucc_mpi_test_init(int argc, char **argv, uint64_t coll_types,
+                      unsigned thread_mode);
 
 void ucc_mpi_test_finalize(void);
 

--- a/test/mpi/test_mpi_barrier.c
+++ b/test/mpi/test_mpi_barrier.c
@@ -16,6 +16,8 @@ do_barrier(ucc_team_h team) {
         .coll_type = UCC_COLL_TYPE_BARRIER,
     };
     UCC_CHECK(ucc_collective_init(&coll, &request, team));
+    UCC_CHECK(ucc_collective_post(request));
+    UCC_CHECK(ucc_collective_finalize(request));
 }
 
 int main (int argc, char **argv) {

--- a/test/mpi/test_mpi_barrier.c
+++ b/test/mpi/test_mpi_barrier.c
@@ -9,9 +9,9 @@
 #include <time.h>
 #include <unistd.h>
 
-static inline void
-do_barrier(ucc_team_h team) {
-    ucc_coll_req_h request;
+static inline void do_barrier(ucc_team_h team)
+{
+    ucc_coll_req_h     request;
     ucc_coll_op_args_t coll = {
         .coll_type = UCC_COLL_TYPE_BARRIER,
     };
@@ -20,11 +20,12 @@ do_barrier(ucc_team_h team) {
     UCC_CHECK(ucc_collective_finalize(request));
 }
 
-int main (int argc, char **argv) {
+int main(int argc, char **argv)
+{
     int rank, size;
 
-    UCC_CHECK(ucc_mpi_test_init(argc, argv, UCC_COLL_TYPE_BARRIER
-                                , UCC_THREAD_SINGLE));
+    UCC_CHECK(ucc_mpi_test_init(argc, argv, UCC_COLL_TYPE_BARRIER,
+                                UCC_THREAD_SINGLE));
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 

--- a/test/mpi/test_mpi_barrier.c
+++ b/test/mpi/test_mpi_barrier.c
@@ -1,0 +1,43 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+#define _BSD_SOURCE
+#include "test_mpi.h"
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+static inline void
+do_barrier(ucc_team_h team) {
+    ucc_coll_req_h request;
+    ucc_coll_op_args_t coll = {
+        .coll_type = UCC_COLL_TYPE_BARRIER,
+    };
+    UCC_CHECK(ucc_collective_init(&coll, &request, team));
+}
+
+int main (int argc, char **argv) {
+    int rank, size;
+
+    UCC_CHECK(ucc_mpi_test_init(argc, argv, UCC_COLL_TYPE_BARRIER
+                                , UCC_THREAD_SINGLE));
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    srand(time(NULL));
+    /* for (i=0; i<size; i++) { */
+    /*     sleep_us = rand() % 1000; */
+    /*     usleep(sleep_us); */
+    /*     if (i == rank) { */
+    /*         printf("Rank %d checks in\n", rank); */
+    /*         fflush(stdout); */
+    /*         usleep(100); */
+    /*     } */
+    /*     do_barrier(ucc_world_team); */
+    /* } */
+    do_barrier(ucc_world_team);
+    ucc_mpi_test_finalize();
+    return 0;
+}


### PR DESCRIPTION
## What
Implements ucc_collective_init/post/test/finalize

## Why ?
Core API

## How ?
Firstly, the ucc_coll_req_t is defined in ucc_def.h to have ucc_status_t status field. All the internally allocated requests (during collective_init) will inherit from ucc_coll_req_t. Then ucc_collective_test is just inline "status == UCC_OK".
Second: we define ucc_coll_task_t and ucc_schedule_t. Both eventually inherit from ucc_coll_req_t. So both task and schedule can be used as user request. Why? - because, in case of, for example, basic CL we don't need any complicated schedules and might want to have as thin layer as possible on top of TL UCP (returning tl_ucp-task_t to user). At the same time we can still build schedules (both at CL and TL levels) and use them with the same interface.
Thirdly, to reduce number of branches in a fast path (collective_post, test, finalize) collreq has pointers to internal post/finalize implementations. Those pointers are initialized during collective_init (by the owner of a request - CL or TL).
Finally, the ucc_coll_task and schedule will be progressed via internal progress_queue interface - this is done in the next PR.

Additionally this PR adds:
mpool infrastructure, tl_ucp task allocation and init using mpool, cl basic implementation of coll_init using tl_ucp_team, 
mpi based test - simple infra and barrier test stubs

