### PR TITLE
Context progress

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,6 +34,7 @@ noinst_HEADERS =                     \
 	core/ucc_context.h               \
 	core/ucc_mc.h                    \
 	core/ucc_team.h                  \
+	core/ucc_progress_queue.h        \
 	schedule/ucc_schedule.h          \
 	utils/ucc_compiler_def.h         \
 	utils/ucc_log.h                  \
@@ -59,6 +60,8 @@ libucc_la_SOURCES =                  \
 	core/ucc_mc.c                    \
 	core/ucc_team.c                  \
 	core/ucc_coll.c                  \
+	core/ucc_progress_queue.c        \
+	core/ucc_progress_queue_st.c     \
 	schedule/ucc_schedule.c          \
 	utils/ucc_component.c            \
 	components/base/ucc_base_iface.c \

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -53,6 +53,7 @@ typedef struct ucc_base_context_params {
 } ucc_base_context_params_t;
 
 typedef struct ucc_base_context {
+    ucc_context_t  *ucc_context;
     ucc_base_lib_t *lib;
 } ucc_base_context_t;
 

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -14,7 +14,8 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
     ucc_status_t status;
     const ucc_cl_context_config_t *cl_config =
         ucc_derived_of(config, ucc_cl_context_config_t);
-    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_config->cl_lib);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_config->cl_lib,
+                              params->context);
     status = ucc_tl_context_get(params->context, UCC_TL_UCP,
                                 &self->tl_ucp_ctx);
     if (UCC_OK != status) {

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -98,10 +98,11 @@ ucc_status_t ucc_parse_cls_string(const char *cls_str,
     return UCC_OK;
 }
 
-UCC_CLASS_INIT_FUNC(ucc_cl_context_t, ucc_cl_lib_t *cl_lib)
+UCC_CLASS_INIT_FUNC(ucc_cl_context_t, ucc_cl_lib_t *cl_lib, ucc_context_t *ucc_context)
 {
     UCC_CLASS_CALL_BASE_INIT();
-    self->super.lib = &cl_lib->super;
+    self->super.lib         = &cl_lib->super;
+    self->super.ucc_context = ucc_context;
     return UCC_OK;
 }
 

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -98,7 +98,8 @@ ucc_status_t ucc_parse_cls_string(const char *cls_str,
     return UCC_OK;
 }
 
-UCC_CLASS_INIT_FUNC(ucc_cl_context_t, ucc_cl_lib_t *cl_lib, ucc_context_t *ucc_context)
+UCC_CLASS_INIT_FUNC(ucc_cl_context_t, ucc_cl_lib_t *cl_lib,
+                    ucc_context_t *ucc_context)
 {
     UCC_CLASS_CALL_BASE_INIT();
     self->super.lib         = &cl_lib->super;

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -79,7 +79,7 @@ UCC_CLASS_DECLARE(ucc_cl_lib_t, ucc_cl_iface_t *, const ucc_cl_lib_config_t *,
 typedef struct ucc_cl_context {
     ucc_base_context_t super;
 } ucc_cl_context_t;
-UCC_CLASS_DECLARE(ucc_cl_context_t, ucc_cl_lib_t *);
+UCC_CLASS_DECLARE(ucc_cl_context_t, ucc_cl_lib_t *, ucc_context_t *);
 
 typedef struct ucc_cl_team {
     ucc_base_team_t super;

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -36,7 +36,8 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_lib_t)
 
 UCC_CLASS_DEFINE(ucc_tl_lib_t, void);
 
-UCC_CLASS_INIT_FUNC(ucc_tl_context_t, ucc_tl_lib_t *tl_lib, ucc_context_t *ucc_context)
+UCC_CLASS_INIT_FUNC(ucc_tl_context_t, ucc_tl_lib_t *tl_lib,
+                    ucc_context_t *ucc_context)
 {
     UCC_CLASS_CALL_BASE_INIT();
     self->super.lib         = &tl_lib->super;

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -36,10 +36,11 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_lib_t)
 
 UCC_CLASS_DEFINE(ucc_tl_lib_t, void);
 
-UCC_CLASS_INIT_FUNC(ucc_tl_context_t, ucc_tl_lib_t *tl_lib)
+UCC_CLASS_INIT_FUNC(ucc_tl_context_t, ucc_tl_lib_t *tl_lib, ucc_context_t *ucc_context)
 {
     UCC_CLASS_CALL_BASE_INIT();
-    self->super.lib = &tl_lib->super;
+    self->super.lib         = &tl_lib->super;
+    self->super.ucc_context = ucc_context;
     self->ref_count = 0;
     return UCC_OK;
 }

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -70,7 +70,7 @@ typedef struct ucc_tl_context {
     ucc_base_context_t super;
     int                ref_count;
 } ucc_tl_context_t;
-UCC_CLASS_DECLARE(ucc_tl_context_t, ucc_tl_lib_t *);
+UCC_CLASS_DECLARE(ucc_tl_context_t, ucc_tl_lib_t *, ucc_context_t *);
 
 typedef struct ucc_tl_team {
     ucc_base_team_t super;
@@ -91,5 +91,4 @@ ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context);
     (ucc_derived_of((_tl_team)->super.context->lib, ucc_tl_lib_t))->iface
 
 #define UCC_TL_TEAM_LIB(_tl_team) (_tl_team)->super.super.context->lib
-
 #endif

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -2,6 +2,11 @@
 # Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
 #
 
+barrier =                     \
+	barrier/barrier.h         \
+	barrier/barrier.c         \
+	barrier/barrier_knomial.c
+
 sources =            \
 	tl_ucp.h         \
 	tl_ucp.c         \
@@ -13,6 +18,7 @@ sources =            \
 	tl_ucp_addr.h    \
 	tl_ucp_addr.c    \
 	tl_ucp_coll.c
+	$(barrier)
 
 module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)

--- a/src/components/tl/ucp/barrier/barrier.c
+++ b/src/components/tl/ucp/barrier/barrier.c
@@ -1,0 +1,13 @@
+#include "config.h"
+#include "tl_ucp.h"
+#include "barrier.h"
+
+ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_req_t *req);
+ucc_status_t ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_ucp_barrier_init(ucc_tl_ucp_task_t *task)
+{
+    task->super.super.post = ucc_tl_ucp_barrier_knomial_start;
+    task->super.progress   = ucc_tl_ucp_barrier_knomial_progress;
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/barrier/barrier.h
+++ b/src/components/tl/ucp/barrier/barrier.h
@@ -1,0 +1,8 @@
+#ifndef BARRIER_H_
+#define BARRIER_H_
+#include "../tl_ucp.h"
+#include "../tl_ucp_coll.h"
+
+ucc_status_t ucc_tl_ucp_barrier_init(ucc_tl_ucp_task_t *task);
+
+#endif

--- a/src/components/tl/ucp/barrier/barrier_knomial.c
+++ b/src/components/tl/ucp/barrier/barrier_knomial.c
@@ -3,8 +3,7 @@
 #include "barrier.h"
 #include "core/ucc_progress_queue.h"
 
-ucc_status_t
-ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *coll_task)
+ucc_status_t ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     /* TODO implement main logic */
@@ -16,6 +15,7 @@ ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_req_t *req)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(req, ucc_tl_ucp_task_t);
     /* TODO implement main logic */
-    ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(task->team)->pq, &task->super);
+    ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(task->team)->pq,
+                         &task->super);
     return UCC_OK;
 }

--- a/src/components/tl/ucp/barrier/barrier_knomial.c
+++ b/src/components/tl/ucp/barrier/barrier_knomial.c
@@ -1,0 +1,21 @@
+#include "config.h"
+#include "tl_ucp.h"
+#include "barrier.h"
+#include "core/ucc_progress_queue.h"
+
+ucc_status_t
+ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    /* TODO implement main logic */
+    task->super.super.status = UCC_OK;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_req_t *req)
+{
+    ucc_tl_ucp_task_t *task = ucc_derived_of(req, ucc_tl_ucp_task_t);
+    /* TODO implement main logic */
+    ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(task->team)->pq, &task->super);
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/barrier/barrier_knomial.c
+++ b/src/components/tl/ucp/barrier/barrier_knomial.c
@@ -11,9 +11,9 @@ ucc_status_t ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *coll_task)
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_req_t *req)
+ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t *task = ucc_derived_of(req, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     /* TODO implement main logic */
     ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(task->team)->pq,
                          &task->super);

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -71,4 +71,8 @@ typedef struct ucc_tl_ucp_req {
 
 #define UCC_TL_UCP_TEAM_CTX(_team)                                             \
     (ucc_derived_of((_team)->super.super.context, ucc_tl_ucp_context_t))
+
+#define UCC_TL_UCP_TEAM_CORE_CTX(_team)                                      \
+    ((_team)->super.super.context->ucc_context)
+
 #endif

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -72,7 +72,7 @@ typedef struct ucc_tl_ucp_req {
 #define UCC_TL_UCP_TEAM_CTX(_team)                                             \
     (ucc_derived_of((_team)->super.super.context, ucc_tl_ucp_context_t))
 
-#define UCC_TL_UCP_TEAM_CORE_CTX(_team)                                      \
+#define UCC_TL_UCP_TEAM_CORE_CTX(_team)                                        \
     ((_team)->super.super.context->ucc_context)
 
 #endif

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -8,11 +8,11 @@
 #include "tl_ucp_coll.h"
 #include "barrier/barrier.h"
 
-static ucc_status_t ucc_tl_ucp_coll_finalize(ucc_coll_req_t *request)
+static ucc_status_t ucc_tl_ucp_coll_finalize(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t *task = ucc_derived_of(request, ucc_tl_ucp_task_t);
-    tl_info(task->team->super.super.context->lib, "finalizing coll req %p",
-            request);
+    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    tl_info(task->team->super.super.context->lib, "finalizing coll task %p",
+            task);
     ucc_tl_ucp_put_task(task);
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -33,8 +33,8 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_op_args_t *coll_args,
         status = ucc_tl_ucp_barrier_init(task);
         break;
     default:
-        status = UCC_ERR_NOT_SUPPORTED;
-        break;
+        ucc_tl_ucp_put_task(task);
+        return UCC_ERR_NOT_SUPPORTED;
     }
     *task_h = &task->super;
     return status;

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -6,6 +6,7 @@
 
 #include "tl_ucp.h"
 #include "tl_ucp_coll.h"
+#include "barrier/barrier.h"
 
 static ucc_status_t ucc_tl_ucp_coll_finalize(ucc_coll_req_t *request)
 {
@@ -16,17 +17,6 @@ static ucc_status_t ucc_tl_ucp_coll_finalize(ucc_coll_req_t *request)
     return UCC_OK;
 }
 
-static ucc_status_t ucc_tl_ucp_coll_post(ucc_coll_req_t *request)
-{
-    /*This is an example fn, the actual post fn for a request should be set
-      during init */
-    ucc_tl_ucp_task_t *task = ucc_derived_of(request, ucc_tl_ucp_task_t);
-    tl_info(task->team->super.super.context->lib, "posting coll req %p",
-            request);
-    request->status = UCC_OK;
-    return UCC_OK;
-}
-
 ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_op_args_t *coll_args,
                                   ucc_base_team_t *team,
                                   ucc_coll_task_t **task_h)
@@ -34,9 +24,18 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_op_args_t *coll_args,
     ucc_tl_ucp_team_t    *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
     ucc_tl_ucp_task_t    *task    = ucc_tl_ucp_get_task(ctx);
-    task->team                    = tl_team;
-    task->super.post              = ucc_tl_ucp_coll_post;
-    task->super.finalize          = ucc_tl_ucp_coll_finalize;
-    *task_h                       = &task->super;
-    return UCC_OK;
+    ucc_status_t          status;
+    memcpy(&task->args, &coll_args->args, sizeof(ucc_coll_op_args_t));
+    task->team           = tl_team;
+    task->super.finalize = ucc_tl_ucp_coll_finalize;
+    switch (coll_args->args.coll_type) {
+    case UCC_COLL_TYPE_BARRIER:
+        status = ucc_tl_ucp_barrier_init(task);
+        break;
+    default:
+        status = UCC_ERR_NOT_SUPPORTED;
+        break;
+    }
+    *task_h = &task->super;
+    return status;
 }

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -9,8 +9,9 @@
 #include "tl_ucp.h"
 #include "schedule/ucc_schedule.h"
 typedef struct ucc_tl_ucp_task {
-    ucc_coll_task_t    super;
-    ucc_tl_ucp_team_t *team;
+    ucc_coll_task_t     super;
+    ucc_coll_op_args_t  args;
+    ucc_tl_ucp_team_t  *team;
 } ucc_tl_ucp_task_t;
 
 static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_context_t *ctx)

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -9,9 +9,9 @@
 #include "tl_ucp.h"
 #include "schedule/ucc_schedule.h"
 typedef struct ucc_tl_ucp_task {
-    ucc_coll_task_t     super;
-    ucc_coll_op_args_t  args;
-    ucc_tl_ucp_team_t  *team;
+    ucc_coll_task_t    super;
+    ucc_coll_op_args_t args;
+    ucc_tl_ucp_team_t *team;
 } ucc_tl_ucp_task_t;
 
 static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_context_t *ctx)

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -34,7 +34,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     ucp_worker_h        ucp_worker;
     ucs_status_t        status;
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_ucp_config->super.tl_lib);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_ucp_config->super.tl_lib,
+                              params->context);
     self->preconnect = tl_ucp_config->preconnect;
     self->ep_close_state.close_req = NULL;
     self->ep_close_state.ep        = 0;

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -45,11 +45,11 @@ ucc_status_t ucc_collective_init(ucc_coll_op_args_t *coll_args,
 ucc_status_t ucc_collective_post(ucc_coll_req_h request)
 {
     ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
-    return task->post(request);
+    return task->post(task);
 }
 
 ucc_status_t ucc_collective_finalize(ucc_coll_req_h request)
 {
     ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
-    return task->finalize(request);
+    return task->finalize(task);
 }

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -328,9 +328,10 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
        if context is EXCLUSIVE then thread_mode is always SINGLE,
        otherwise it is  inherited from lib */
     ctx->thread_mode = ((params->ctx_type == UCC_CONTEXT_EXCLUSIVE) &&
-                        (params->mask & UCC_CONTEXT_PARAM_FIELD_TYPE)) ?
-        UCC_THREAD_SINGLE : lib->attr.thread_mode;
-    status = ucc_progress_queue_init(&ctx->pq, ctx->thread_mode);
+                        (params->mask & UCC_CONTEXT_PARAM_FIELD_TYPE))
+                           ? UCC_THREAD_SINGLE
+                           : lib->attr.thread_mode;
+    status           = ucc_progress_queue_init(&ctx->pq, ctx->thread_mode);
     if (UCC_OK != status) {
         ucc_error("failed to init progress queue for context %p", ctx);
         goto error_ctx_create;
@@ -379,17 +380,21 @@ ucc_status_t ucc_context_destroy(ucc_context_t *context)
     return UCC_OK;
 }
 
-ucc_status_t ucc_context_progress_register(ucc_context_t *ctx, ucc_context_progress_fn_t fn,
+ucc_status_t ucc_context_progress_register(ucc_context_t *ctx,
+                                           ucc_context_progress_fn_t fn,
                                            void *progress_arg)
 {
     int next_pos = ctx->progress_array_size;
     if (next_pos == ctx->progress_array_max_size) {
         ctx->progress_array_max_size += 8;
         ctx->progress_array = ucc_realloc(ctx->progress_array,
-                                          ctx->progress_array_max_size*sizeof(ucc_context_progress_t), "progress_array");
+                                          ctx->progress_array_max_size *
+                                              sizeof(ucc_context_progress_t),
+                                          "progress_array");
         if (!ctx->progress_array) {
             ucc_error("failed to allocate %zd bytes for progress array",
-                      ctx->progress_array_max_size*sizeof(ucc_context_progress_t));
+                      ctx->progress_array_max_size *
+                          sizeof(ucc_context_progress_t));
             return UCC_ERR_NO_MEMORY;
         }
     }
@@ -399,7 +404,8 @@ ucc_status_t ucc_context_progress_register(ucc_context_t *ctx, ucc_context_progr
     return UCC_OK;
 }
 
-void ucc_context_progress_deregister(ucc_context_t *ctx, ucc_context_progress_fn_t fn,
+void ucc_context_progress_deregister(ucc_context_t *ctx,
+                                     ucc_context_progress_fn_t fn,
                                      void *progress_arg)
 {
     int i, j;
@@ -407,7 +413,7 @@ void ucc_context_progress_deregister(ucc_context_t *ctx, ucc_context_progress_fn
         if (ctx->progress_array[i].progress_fn == fn &&
             ctx->progress_array[i].progress_arg == progress_arg) {
             for (j = i; j < ctx->progress_array_size - 1; j++) {
-                ctx->progress_array[j] = ctx->progress_array[j+1];
+                ctx->progress_array[j] = ctx->progress_array[j + 1];
             }
             ctx->progress_array_size--;
             return;
@@ -415,7 +421,6 @@ void ucc_context_progress_deregister(ucc_context_t *ctx, ucc_context_progress_fn
     }
     ucc_assert(0);
 }
-
 
 ucc_status_t ucc_context_progress(ucc_context_h context)
 {

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -13,14 +13,24 @@ typedef struct ucc_cl_context        ucc_cl_context_t;
 typedef struct ucc_tl_context        ucc_tl_context_t;
 typedef struct ucc_cl_context_config ucc_cl_context_config_t;
 
+typedef int (*ucc_context_progress_fn_t)(void *progress_arg);
+typedef struct ucc_context_progress {
+    ucc_context_progress_fn_t  progress_fn;
+    void                      *progress_arg;
+} ucc_context_progress_t;
+
 typedef struct ucc_context {
-    ucc_lib_info_t      *lib;
-    ucc_context_params_t params;
-    ucc_context_attr_t   attr;
-    ucc_cl_context_t   **cl_ctx;
-    ucc_tl_context_t   **tl_ctx;
-    int                  n_cl_ctx;
-    int                  n_tl_ctx;
+    ucc_lib_info_t         *lib;
+    ucc_context_params_t    params;
+    ucc_context_attr_t      attr;
+    ucc_thread_mode_t       thread_mode;
+    ucc_cl_context_t      **cl_ctx;
+    ucc_tl_context_t      **tl_ctx;
+    int                     n_cl_ctx;
+    int                     n_tl_ctx;
+    ucc_context_progress_t *progress_array;
+    int                     progress_array_max_size;
+    int                     progress_array_size;
 } ucc_context_t;
 
 typedef struct ucc_context_config {
@@ -29,4 +39,12 @@ typedef struct ucc_context_config {
     int                       n_cl_cfg;
 } ucc_context_config_t;
 
+/* Any internal UCC component (TL, CL, etc) may register its own
+   progress callback fn (and argument for the callback) into core
+   ucc context. Those callbacks will be triggered as part of
+   ucc_context_progress. */
+ucc_status_t ucc_context_progress_register(ucc_context_t *ctx, ucc_context_progress_fn_t fn,
+                                           void *progress_arg);
+void ucc_context_progress_deregister(ucc_context_t *ctx, ucc_context_progress_fn_t fn,
+                                     void *progress_arg);
 #endif

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -8,7 +8,7 @@
 
 #include "ucc/api/ucc.h"
 #include "ucc_progress_queue.h"
-
+#include "utils/ucc_list.h"
 typedef struct ucc_lib_info          ucc_lib_info_t;
 typedef struct ucc_cl_context        ucc_cl_context_t;
 typedef struct ucc_tl_context        ucc_tl_context_t;
@@ -29,9 +29,7 @@ typedef struct ucc_context {
     ucc_tl_context_t      **tl_ctx;
     int                     n_cl_ctx;
     int                     n_tl_ctx;
-    ucc_context_progress_t *progress_array;
-    int                     progress_array_max_size;
-    int                     progress_array_size;
+    ucc_list_link_t         progress_list;
     ucc_progress_queue_t   *pq;
 } ucc_context_t;
 

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -7,13 +7,14 @@
 #define UCC_CONTEXT_H_
 
 #include "ucc/api/ucc.h"
+#include "ucc_progress_queue.h"
 
 typedef struct ucc_lib_info          ucc_lib_info_t;
 typedef struct ucc_cl_context        ucc_cl_context_t;
 typedef struct ucc_tl_context        ucc_tl_context_t;
 typedef struct ucc_cl_context_config ucc_cl_context_config_t;
 
-typedef int (*ucc_context_progress_fn_t)(void *progress_arg);
+typedef unsigned (*ucc_context_progress_fn_t)(void *progress_arg);
 typedef struct ucc_context_progress {
     ucc_context_progress_fn_t  progress_fn;
     void                      *progress_arg;
@@ -31,6 +32,7 @@ typedef struct ucc_context {
     ucc_context_progress_t *progress_array;
     int                     progress_array_max_size;
     int                     progress_array_size;
+    ucc_progress_queue_t   *pq;
 } ucc_context_t;
 
 typedef struct ucc_context_config {

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -16,8 +16,8 @@ typedef struct ucc_cl_context_config ucc_cl_context_config_t;
 
 typedef unsigned (*ucc_context_progress_fn_t)(void *progress_arg);
 typedef struct ucc_context_progress {
-    ucc_context_progress_fn_t  progress_fn;
-    void                      *progress_arg;
+    ucc_context_progress_fn_t progress_fn;
+    void                     *progress_arg;
 } ucc_context_progress_t;
 
 typedef struct ucc_context {
@@ -45,8 +45,10 @@ typedef struct ucc_context_config {
    progress callback fn (and argument for the callback) into core
    ucc context. Those callbacks will be triggered as part of
    ucc_context_progress. */
-ucc_status_t ucc_context_progress_register(ucc_context_t *ctx, ucc_context_progress_fn_t fn,
+ucc_status_t ucc_context_progress_register(ucc_context_t *ctx,
+                                           ucc_context_progress_fn_t fn,
                                            void *progress_arg);
-void ucc_context_progress_deregister(ucc_context_t *ctx, ucc_context_progress_fn_t fn,
-                                     void *progress_arg);
+void         ucc_context_progress_deregister(ucc_context_t *ctx,
+                                             ucc_context_progress_fn_t fn,
+                                             void *progress_arg);
 #endif

--- a/src/core/ucc_progress_queue.c
+++ b/src/core/ucc_progress_queue.c
@@ -9,9 +9,9 @@
 ucc_status_t ucc_pq_st_init(ucc_progress_queue_t **pq);
 
 ucc_status_t ucc_progress_queue_init(ucc_progress_queue_t **pq,
-                                     ucc_thread_mode_t      tm)
+                                     ucc_thread_mode_t      tm)      /* NOLINT */
 {
-    // TODO add branch if tm == THREAD_MULTIPLE return pq_mt_init
+    // TODO add branch if tm == THREAD_MULTIPLE return pq_mt_init and remove NOLINT
     return ucc_pq_st_init(pq);
 }
 

--- a/src/core/ucc_progress_queue.c
+++ b/src/core/ucc_progress_queue.c
@@ -9,7 +9,7 @@
 ucc_status_t ucc_pq_st_init(ucc_progress_queue_t **pq);
 
 ucc_status_t ucc_progress_queue_init(ucc_progress_queue_t **pq,
-                                     ucc_thread_mode_t tm)
+                                     ucc_thread_mode_t      tm)
 {
     // TODO add branch if tm == THREAD_MULTIPLE return pq_mt_init
     return ucc_pq_st_init(pq);
@@ -19,4 +19,3 @@ void ucc_progress_queue_finalize(ucc_progress_queue_t *pq)
 {
     return pq->finalize(pq);
 }
-

--- a/src/core/ucc_progress_queue.c
+++ b/src/core/ucc_progress_queue.c
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "ucc_progress_queue.h"
+
+ucc_status_t ucc_pq_st_init(ucc_progress_queue_t **pq);
+
+ucc_status_t ucc_progress_queue_init(ucc_progress_queue_t **pq,
+                                     ucc_thread_mode_t tm)
+{
+    // TODO add branch if tm == THREAD_MULTIPLE return pq_mt_init
+    return ucc_pq_st_init(pq);
+}
+
+void ucc_progress_queue_finalize(ucc_progress_queue_t *pq)
+{
+    return pq->finalize(pq);
+}
+

--- a/src/core/ucc_progress_queue.h
+++ b/src/core/ucc_progress_queue.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PROGRESS_QUEUE_H_
+#define UCC_PROGRESS_QUEUE_H_
+
+#include "ucc/api/ucc.h"
+#include "schedule/ucc_schedule.h"
+typedef struct ucc_progress_queue ucc_progress_queue_t;
+struct ucc_progress_queue {
+    void (*enqueue)(ucc_progress_queue_t *pq, ucc_coll_task_t *task);
+    int  (*progress)(ucc_progress_queue_t *pq);
+    void (*finalize)(ucc_progress_queue_t *pq);
+};
+
+ucc_status_t ucc_progress_queue_init(ucc_progress_queue_t **pq,
+                                     ucc_thread_mode_t tm);
+
+static inline void ucc_progress_enqueue(ucc_progress_queue_t *pq,
+                                        ucc_coll_task_t *task)
+{
+    pq->enqueue(pq, task);
+}
+
+static inline int ucc_progress_queue(ucc_progress_queue_t *pq)
+{
+    return pq->progress(pq);
+}
+
+void ucc_progress_queue_finalize(ucc_progress_queue_t *pq);
+
+#endif

--- a/src/core/ucc_progress_queue_st.c
+++ b/src/core/ucc_progress_queue_st.c
@@ -15,10 +15,10 @@ typedef struct ucc_pq_st {
 
 static int ucc_pq_st_progress(ucc_progress_queue_t *pq)
 {
-    ucc_pq_st_t *pq_st        = ucc_derived_of(pq, ucc_pq_st_t);
-    int          n_progressed = 0;    
+    ucc_pq_st_t     *pq_st        = ucc_derived_of(pq, ucc_pq_st_t);
+    int              n_progressed = 0;
     ucc_coll_task_t *task, *tmp;
-    ucc_status_t status;
+    ucc_status_t     status;
 
     ucc_list_for_each_safe(task, tmp, &pq_st->list, list_elem) {
         if (task->progress) { //TODO maybe dummy empty progress fn is better than branch?
@@ -62,7 +62,6 @@ ucc_status_t ucc_pq_st_init(ucc_progress_queue_t **pq)
     pq_st->super.enqueue  = ucc_pq_st_enqueue;
     pq_st->super.progress = ucc_pq_st_progress;
     pq_st->super.finalize = ucc_pq_st_finalize;
-    *pq = &pq_st->super;
+    *pq                   = &pq_st->super;
     return UCC_OK;
 }
-

--- a/src/core/ucc_progress_queue_st.c
+++ b/src/core/ucc_progress_queue_st.c
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "ucc_progress_queue.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_log.h"
+
+typedef struct ucc_pq_st {
+    ucc_progress_queue_t super;
+    ucc_list_link_t      list;
+} ucc_pq_st_t;
+
+static int ucc_pq_st_progress(ucc_progress_queue_t *pq)
+{
+    ucc_pq_st_t *pq_st        = ucc_derived_of(pq, ucc_pq_st_t);
+    int          n_progressed = 0;    
+    ucc_coll_task_t *task, *tmp;
+    ucc_status_t status;
+
+    ucc_list_for_each_safe(task, tmp, &pq_st->list, list_elem) {
+        if (task->progress) { //TODO maybe dummy empty progress fn is better than branch?
+            status = task->progress(task);
+            if (status < 0) {
+                return status;
+            }
+        }
+        if (UCC_OK == task->super.status) {
+            n_progressed++;
+            status = ucc_event_manager_notify(&task->em, UCC_EVENT_COMPLETED);
+            if (status != UCC_OK) {
+                return status;
+            }
+            ucc_list_del(&task->list_elem);
+        }
+    }
+    return n_progressed;
+}
+
+static void ucc_pq_st_enqueue(ucc_progress_queue_t *pq, ucc_coll_task_t *task)
+{
+    ucc_pq_st_t *pq_st = ucc_derived_of(pq, ucc_pq_st_t);
+    ucc_list_add_tail(&pq_st->list, &task->list_elem);
+}
+
+static void ucc_pq_st_finalize(ucc_progress_queue_t *pq)
+{
+    ucc_pq_st_t *pq_st = ucc_derived_of(pq, ucc_pq_st_t);
+    ucc_free(pq_st);
+}
+
+ucc_status_t ucc_pq_st_init(ucc_progress_queue_t **pq)
+{
+    ucc_pq_st_t *pq_st = ucc_malloc(sizeof(*pq_st), "pq_st");
+    if (!pq_st) {
+        ucc_error("failed to allocate %zd bytes for pq_st", sizeof(*pq_st));
+        return UCC_ERR_NO_MEMORY;
+    }
+    ucc_list_head_init(&pq_st->list);
+    pq_st->super.enqueue  = ucc_pq_st_enqueue;
+    pq_st->super.progress = ucc_pq_st_progress;
+    pq_st->super.finalize = ucc_pq_st_finalize;
+    *pq = &pq_st->super;
+    return UCC_OK;
+}
+

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -18,8 +18,8 @@ typedef enum {
 typedef struct ucc_coll_task ucc_coll_task_t;
 
 typedef ucc_status_t (*ucc_task_event_handler_p)(ucc_coll_task_t *task);
-typedef ucc_status_t (*ucc_coll_post_fn_t)(ucc_coll_req_h request);
-typedef ucc_status_t (*ucc_coll_finalize_fn_t)(ucc_coll_req_h request);
+typedef ucc_status_t (*ucc_coll_post_fn_t)(ucc_coll_task_t *task);
+typedef ucc_status_t (*ucc_coll_finalize_fn_t)(ucc_coll_task_t *task);
 
 typedef struct ucc_event_manager {
     ucc_coll_task_t *listeners[UCC_EVENT_LAST][MAX_LISTENERS];

--- a/src/utils/ucc_list.h
+++ b/src/utils/ucc_list.h
@@ -14,4 +14,5 @@
 #define ucc_list_add_tail      ucs_list_add_tail
 #define ucc_list_del           ucs_list_del
 #define ucc_list_for_each_safe ucs_list_for_each_safe
+#define ucc_list_for_each      ucs_list_for_each
 #endif

--- a/src/utils/ucc_list.h
+++ b/src/utils/ucc_list.h
@@ -9,6 +9,9 @@
 #include "config.h"
 #include <ucs/datastruct/list.h>
 
-#define ucc_list_link_t ucs_list_link_t
-
+#define ucc_list_link_t        ucs_list_link_t
+#define ucc_list_head_init     ucs_list_head_init
+#define ucc_list_add_tail      ucs_list_add_tail
+#define ucc_list_del           ucs_list_del
+#define ucc_list_for_each_safe ucs_list_for_each_safe
 #endif

--- a/test/mpi/test_mpi_barrier.c
+++ b/test/mpi/test_mpi_barrier.c
@@ -17,6 +17,9 @@ static inline void do_barrier(ucc_team_h team)
     };
     UCC_CHECK(ucc_collective_init(&coll, &request, team));
     UCC_CHECK(ucc_collective_post(request));
+    while (UCC_OK != ucc_collective_test(request)) {
+        UCC_CHECK(ucc_context_progress(team_ctx));
+    }
     UCC_CHECK(ucc_collective_finalize(request));
 }
 


### PR DESCRIPTION
## What
Implements ucc_context_progress

## Why ?
core api

## How ?
ucc_context_progress consists of 2 parts.

- Firstly, any internal component may register a progress callback fn that it needs. For example, TL UCP needs to call ucp_worker_progress (even if there are no active tasks locally), mcast needs to check for potential NACKs in a progress etc. So, this PR adds a simple interface to register/deregister progress callbacks into core ucc_context_t.
- Secondly, the actual collective requests (implemented as schedules & tasks) are progressed on a ucc_context_t via progress_queue. This PR adds basic progress_queue interface and single threaded implementation (linked list).
- TL UCP : adds barrier fn stubs. Basically now we can run ucc_barrier test that triggers all the flow: collective_init -> CL_BASIC->TL_UCP tl_ucp_task is taken from the mpool and return to user; collective_post->tl_ucp_knomial_barrier_post: the task state is set to inprogress and task is queued into progress_queue; collective_test + ucc_context_progress: moves the collective state to completion; collective_finalize: returns tl_ucp task to mpool. The actual implementation of barrier itself (p2p send/recv) is missing so far.
