### PR TITLE
TEST: clang build and clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,16 @@
+---
+Checks: >
+    -*,
+    clang-analyzer-*,
+    -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+    -clang-analyzer-osx.*,
+    -clang-analyzer-optin.osx.*,
+    misc-redundant-expression,
+    misc-static-assert,
+    misc-unused-parameters,
+    readability-redundant-control-flow
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+...

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -1,0 +1,35 @@
+name: Linter
+
+on: [push, pull_request]
+
+env:
+  OPEN_UCX_LINK: https://github.com/openucx/ucx
+  OPEN_UCX_BRANCH: master
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common
+        sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+        sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-11 bear
+    - name: Get UCX
+      run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
+    - name: Build UCX
+      run: |
+        cd /tmp/ucx && ./autogen.sh
+        ./contrib/configure-release --without-java --disable-numa --prefix $PWD/install
+        make -j install
+    - uses: actions/checkout@v1
+    - name: Build UCC
+      run: |
+        ./autogen.sh
+        CC=clang-11 CXX=clang++-11 ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install
+        bear --cdb /tmp/compile_commands.json make
+    - name: Run clang-tidy
+      run: |
+        echo "Workspace: ${GITHUB_WORKSPACE}"
+        cd ${GITHUB_WORKSPACE}
+        run-clang-tidy-11 -p /tmp/

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -27,16 +27,6 @@ static ucc_config_field_t ucc_lib_config_table[] = {
 UCC_CONFIG_REGISTER_TABLE(ucc_lib_config_table, "UCC", NULL, ucc_lib_config_t,
                           &ucc_config_global_list)
 
-static inline ucc_status_t ucc_cl_component_is_loaded(ucc_cl_type_t cl_type)
-{
-    const char *cl_name = ucc_cl_names[cl_type];
-    if (NULL == ucc_get_component(&ucc_global_config.cl_framework, cl_name)) {
-        return UCC_ERR_NOT_FOUND;
-    } else {
-        return UCC_OK;
-    }
-}
-
 static inline int ucc_cl_requested(const ucc_lib_config_t *cfg, int cl_type)
 {
     int i;


### PR DESCRIPTION
## What
Additional CI check that build UCC with clang and runs clang-tidy

## Why ?
clang-tidy is open source linter performing static code analysis. Here what it was able to find with current codebase
https://gist.github.com/Sergei-Lebedev/96141700ddd9de008802602c32ba780f
Warnings looks relevant

## How ?
Github actions runs clang build and clang-tidy
