### PR TITLE
TEST: fix clang-tidy warnings

### DIFF
--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -33,8 +33,9 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_context_t)
 
 UCC_CLASS_DEFINE(ucc_cl_basic_context_t, ucc_cl_context_t);
 
-ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context,
-                                           ucc_base_attr_t *attr)
+ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
+                                           ucc_base_attr_t *attr)             /* NOLINT */
 {
-    return UCC_OK;
+    /* TODO */
+    return UCC_ERR_NOT_IMPLEMENTED;
 }

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -8,6 +8,7 @@
 #include "utils/ucc_malloc.h"
 #include "components/tl/ucc_tl.h"
 
+/* NOLINTNEXTLINE  TODO params is not used*/
 UCC_CLASS_INIT_FUNC(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *params,
                     const ucc_base_config_t *config)
 {
@@ -26,7 +27,10 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
 
-ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *base_attr) {
+/* NOLINTNEXTLINE */
+ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
+                                       ucc_base_attr_t *base_attr)
+{
     ucc_cl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
     attr->tls = UCC_TL_UCP;
     return UCC_OK;

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -33,6 +33,7 @@ const char *ucc_cl_names[] = {
 UCC_CLASS_INIT_FUNC(ucc_cl_lib_t, ucc_cl_iface_t *cl_iface,
                     const ucc_cl_lib_config_t *cl_config, int default_priority)
 {
+    UCC_CLASS_CALL_BASE_INIT();
     self->iface         = cl_iface;
     self->super.log_component = cl_config->super.log_component;
     ucc_strncpy_safe(self->super.log_component.name,
@@ -76,7 +77,10 @@ ucc_status_t ucc_parse_cls_string(const char *cls_str,
         cl                    = strtok_r(NULL, ",", &saveptr);
     }
     ucc_free(cls_copy);
-
+    if (n_cls_selected == 0) {
+        ucc_error("incorrect value is passed as part of UCC_CLS list: %s", cl);
+        return UCC_ERR_INVALID_PARAM;
+    }
     cls = ucc_malloc(n_cls_selected * sizeof(ucc_cl_type_t), "cls_array");
     if (!cls) {
         ucc_error("failed to allocate %zd bytes for cls_array",
@@ -96,6 +100,7 @@ ucc_status_t ucc_parse_cls_string(const char *cls_str,
 
 UCC_CLASS_INIT_FUNC(ucc_cl_context_t, ucc_cl_lib_t *cl_lib)
 {
+    UCC_CLASS_CALL_BASE_INIT();
     self->super.lib = &cl_lib->super;
     return UCC_OK;
 }
@@ -122,7 +127,6 @@ ucc_status_t ucc_cl_context_config_read(ucc_cl_lib_t *cl_lib,
 
 ucc_status_t ucc_cl_lib_config_read(ucc_cl_iface_t *iface,
                                     const char *full_prefix,
-                                    const ucc_lib_config_t *config,
                                     ucc_cl_lib_config_t **cl_config)
 {
     return ucc_base_config_read(full_prefix, &iface->cl_lib_config,
@@ -131,6 +135,7 @@ ucc_status_t ucc_cl_lib_config_read(ucc_cl_iface_t *iface,
 
 UCC_CLASS_INIT_FUNC(ucc_cl_team_t, ucc_cl_context_t *cl_context)
 {
+    UCC_CLASS_CALL_BASE_INIT();
     self->super.context = &cl_context->super;
     return UCC_OK;
 }

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -52,8 +52,8 @@ ucc_status_t ucc_cl_context_config_read(ucc_cl_lib_t *cl_lib,
                                         const ucc_context_config_t *config,
                                         ucc_cl_context_config_t **cl_config);
 
-ucc_status_t ucc_cl_lib_config_read(ucc_cl_iface_t *iface, const char *full_prefix,
-                                    const ucc_lib_config_t *config,
+ucc_status_t ucc_cl_lib_config_read(ucc_cl_iface_t *iface,
+                                    const char *full_prefix,
                                     ucc_cl_lib_config_t **cl_config);
 
 typedef struct ucc_cl_iface {

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -42,6 +42,9 @@ static ucc_status_t ucc_mc_cpu_mem_free(void *ptr)
 static ucc_status_t ucc_mc_cpu_mem_type(const void *ptr,
                                         ucc_memory_type_t *mem_type)
 {
+    if (ptr == NULL) {
+        *mem_type = UCC_MEMORY_TYPE_HOST;
+    }
     /* not supposed to be used */
     mc_error(&ucc_mc_cpu.super, "host memory component shouldn't be used for"
                                 "mem type detection");

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -21,6 +21,7 @@ ucc_config_field_t ucc_tl_context_config_table[] = {
 UCC_CLASS_INIT_FUNC(ucc_tl_lib_t, ucc_tl_iface_t *tl_iface,
                     const ucc_tl_lib_config_t *tl_config)
 {
+    UCC_CLASS_CALL_BASE_INIT();
     self->iface         = tl_iface;
     self->super.log_component = tl_config->super.log_component;
     ucc_strncpy_safe(self->super.log_component.name,
@@ -37,6 +38,7 @@ UCC_CLASS_DEFINE(ucc_tl_lib_t, void);
 
 UCC_CLASS_INIT_FUNC(ucc_tl_context_t, ucc_tl_lib_t *tl_lib)
 {
+    UCC_CLASS_CALL_BASE_INIT();
     self->super.lib = &tl_lib->super;
     self->ref_count = 0;
     return UCC_OK;
@@ -64,7 +66,6 @@ ucc_status_t ucc_tl_context_config_read(ucc_tl_lib_t *tl_lib,
 
 ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface,
                                     const char *full_prefix,
-                                    const ucc_lib_config_t *config,
                                     ucc_tl_lib_config_t **tl_config)
 {
     return ucc_base_config_read(full_prefix, &iface->tl_lib_config,
@@ -95,6 +96,7 @@ ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context)
 
 UCC_CLASS_INIT_FUNC(ucc_tl_team_t, ucc_tl_context_t *tl_context)
 {
+    UCC_CLASS_CALL_BASE_INIT();
     self->super.context = &tl_context->super;
     return UCC_OK;
 }

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -45,8 +45,8 @@ ucc_status_t ucc_tl_context_config_read(ucc_tl_lib_t *tl_lib,
                                         const ucc_context_config_t *config,
                                         ucc_tl_context_config_t **cl_config);
 
-ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface, const char *full_prefix,
-                                    const ucc_lib_config_t *config,
+ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface,
+                                    const char *full_prefix,
                                     ucc_tl_lib_config_t **cl_config);
 
 typedef struct ucc_tl_iface {

--- a/src/components/tl/ucp/tl_ucp_addr.c
+++ b/src/components/tl/ucp/tl_ucp_addr.c
@@ -82,7 +82,7 @@ ucc_status_t ucc_tl_ucp_addr_exchange_test(ucc_tl_ucp_addr_storage_t *storage)
 
     switch (storage->state) {
     case UCC_TL_UCP_ADDR_EXCHANGE_MAX_ADDRLEN:
-        storage->max_addrlen = 0;
+        storage->max_addrlen = storage->addrlens[0];
         for (i = 0; i < oob->participants; i++) {
             if (storage->addrlens[i] > storage->max_addrlen) {
                 storage->max_addrlen = storage->addrlens[i];

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -141,8 +141,9 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_context_t)
 
 UCC_CLASS_DEFINE(ucc_tl_ucp_context_t, ucc_tl_context_t);
 
-ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
-                                         ucc_base_attr_t *attr)
+ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
+                                         ucc_base_attr_t *attr) /* NOLINT */
 {
-    return UCC_OK;
+    /* TODO */
+    return UCC_ERR_NOT_IMPLEMENTED;
 }

--- a/src/components/tl/ucp/tl_ucp_ep.c
+++ b/src/components/tl/ucp/tl_ucp_ep.c
@@ -16,7 +16,7 @@ ucc_status_t ucc_tl_ucp_connect_ep(ucc_tl_ucp_context_t *ctx,
         ucc_assert(team && team->eps);
         ep = &team->eps[rank];
     }
-    if (*ep) {
+    if ((ep != NULL) && (*ep)) {
         /* Already connected */
         return UCC_OK;
     }

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -7,6 +7,7 @@
 #include "tl_ucp.h"
 #include "utils/ucc_malloc.h"
 
+/* NOLINTNEXTLINE  params is not used*/
 UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
                     const ucc_base_config_t *config)
 {
@@ -24,6 +25,9 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_lib_t)
 
 UCC_CLASS_DEFINE(ucc_tl_ucp_lib_t, ucc_tl_lib_t);
 
-ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *attr) {
-    return UCC_OK;
+ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
+                                     ucc_base_attr_t *attr)     /* NOLINT */
+{
+    //TODO
+    return UCC_ERR_NOT_IMPLEMENTED;
 }

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -11,11 +11,13 @@
 #include "utils/ucc_log.h"
 #include "schedule/ucc_schedule.h"
 
+/* NOLINTNEXTLINE  */
 static ucc_cl_team_t *ucc_select_cl_team(ucc_coll_op_args_t *coll_args,
                                          ucc_team_t *team)
 {
-    /* TODO: collective CL selection logic will be there.
-       for now just return 1st CL on a list */
+    /* TODO1: collective CL selection logic will be there.
+       for now just return 1st CL on a list
+       TODO2: remove NOLINT once TODO1 is done */
     return team->cl_teams[0];
 }
 
@@ -51,4 +53,3 @@ ucc_status_t ucc_collective_finalize(ucc_coll_req_h request)
     ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
     return task->finalize(request);
 }
-

--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -20,6 +20,10 @@ static int callback(struct dl_phdr_info *info, size_t size, void *data)
 {
     char *str;
     char *component_path;
+
+    if ((data != NULL) || (size == 0)) {
+        return -1;
+    }
     if (NULL != (str = strstr(info->dlpi_name, UCC_LIB_SO_NAME))) {
         int pos        = (int)(str - info->dlpi_name);
         component_path = (char *)ucc_malloc(pos + UCC_COMPONENT_LIBDIR_LEN + 1,
@@ -33,7 +37,7 @@ static int callback(struct dl_phdr_info *info, size_t size, void *data)
            it'll always write '\0' to the end position of the dest string. */
         ucc_strncpy_safe(component_path, info->dlpi_name, pos + 1);
         component_path[pos] = '\0';
-        strcat(component_path, UCC_COMPONENT_LIBDIR);
+        strncat(component_path, UCC_COMPONENT_LIBDIR, UCC_COMPONENT_LIBDIR_LEN);
         ucc_global_config.component_path =
             ucc_global_config.component_path_default = component_path;
     }

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -17,6 +17,11 @@ ucc_status_t ucc_context_config_read(ucc_lib_info_t *lib, const char *filename,
     int                      i;
     ucc_status_t             status;
     ucc_context_config_t    *config;
+
+    if (filename != NULL) {
+        ucc_error("read from file is not implemented");
+        return UCC_ERR_NOT_IMPLEMENTED;
+    }
     config = (ucc_context_config_t *)ucc_malloc(sizeof(ucc_context_config_t),
                                                 "ctx_config");
     if (config == NULL) {
@@ -312,7 +317,8 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
     }
     if (0 == ctx->n_cl_ctx) {
         ucc_error("no CL context created in ucc_context_create");
-        return UCC_ERR_NO_MESSAGE;
+        status = UCC_ERR_NO_MESSAGE;
+        goto error_ctx;
     }
     ucc_info("created ucc context %p for lib %s", ctx, lib->full_prefix);
     *context = ctx;

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -113,8 +113,7 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
                 continue;
             }
         }
-        status = ucc_cl_lib_config_read(cl_iface, lib->full_prefix, config,
-                                        &cl_config);
+        status = ucc_cl_lib_config_read(cl_iface, lib->full_prefix, &cl_config);
         if (UCC_OK != status) {
             ucc_error("failed to read CL \"%s\" lib configuration",
                       cl_iface->super.name);
@@ -179,7 +178,6 @@ error:
 }
 
 static ucc_status_t ucc_tl_lib_init(const ucc_lib_params_t *user_params,
-                                    const ucc_lib_config_t *config,
                                     ucc_lib_info_t *lib)
 {
     ucc_status_t          status;
@@ -222,7 +220,7 @@ static ucc_status_t ucc_tl_lib_init(const ucc_lib_params_t *user_params,
            cl_context_create.
          */
         if (tl_iface->type & required_tls) {
-            status = ucc_tl_lib_config_read(tl_iface, lib->full_prefix, config,
+            status = ucc_tl_lib_config_read(tl_iface, lib->full_prefix,
                                             &tl_config);
             if (UCC_OK != status) {
                 ucc_warn("failed to read TL \"%s\" lib configuration",
@@ -295,7 +293,7 @@ ucc_status_t ucc_init_version(unsigned api_major_version,
         goto error;
     }
 
-    status = ucc_tl_lib_init(params, config, lib);
+    status = ucc_tl_lib_init(params, lib);
     if (UCC_OK != status) {
         goto error;
     }
@@ -315,6 +313,11 @@ ucc_status_t ucc_lib_config_read(const char *env_prefix, const char *filename,
     size_t            full_prefix_len;
     const char       *base_prefix = "UCC_";
 
+    if (filename != NULL) {
+        ucc_error("read from file is not implemented");
+        status = UCC_ERR_NOT_IMPLEMENTED;
+        goto err;
+    }
     config = ucc_malloc(sizeof(*config), "lib_config");
     if (config == NULL) {
         ucc_error("failed to allocate %zd bytes for lib_config",

--- a/src/utils/ucc_class.h
+++ b/src/utils/ucc_class.h
@@ -55,6 +55,15 @@
         }                                                                      \
     }
 
+#define UCC_CLASS_CALL_BASE_INIT()                                             \
+    {                                                                          \
+        {                                                                      \
+            if ((_init_count == NULL) || (_myclass == NULL)) {                 \
+                return UCC_ERR_INVALID_PARAM;                                  \
+            }                                                                  \
+        }                                                                      \
+    }
+
 #define UCC_CLASS_DECLARE_NAMED_NEW_FUNC(_name, _argtype, ...)                 \
     ucc_status_t _name(UCS_PP_FOREACH(                                         \
         _UCS_CLASS_INIT_ARG_DEFINE, _,                                         \

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -39,7 +39,7 @@ static ucc_status_t ucc_component_load_one(const char *so_path,
     }
     /* The name of the iface stract matches the basename of .so component
        object. basename_start - the starting position of the component name
-       in the full .so path. The name_len is also decreased by 3 to remove 
+       in the full .so path. The name_len is also decreased by 3 to remove
        ".so" extension from the name;
      */
     iface_struct_name_len = strlen(so_path) - basename_start - 3;
@@ -53,8 +53,8 @@ static ucc_status_t ucc_component_load_one(const char *so_path,
     }
     iface = (ucc_component_iface_t *)dlsym(handle, iface_struct);
     if ((error = dlerror()) != NULL) {
-        ucc_error("failed to get iface %s from %s object", iface_struct,
-                  so_path);
+        ucc_error("failed to get iface %s from %s object (%s)", iface_struct,
+                  so_path, error);
         goto iface_error;
     }
     if (!iface) {


### PR DESCRIPTION
## What
Fixes clang-tidy warnings

## How ?
Some functions are marked with NOLINT to suppress warnings because those functions are not fully implemented or not implemented at all