### PR TITLE
Tl ucp preconnect fix

### DIFF
--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -22,7 +22,7 @@ static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_ucp_context_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_tl_context_config_table)},
 
-    {"PRECONNECT", "1024",
+    {"PRECONNECT", "0",
      "Threshold that defines the number of ranks in the UCC team/context "
      "below which the team/context enpoints will be preconnected during "
      "corresponding team/context create call",

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -59,6 +59,7 @@ typedef struct ucc_tl_ucp_context {
 UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
 
+typedef struct ucc_tl_ucp_task ucc_tl_ucp_task_t;
 typedef struct ucc_tl_ucp_team {
     ucc_tl_team_t              super;
     ucc_status_t               status;
@@ -75,6 +76,7 @@ typedef struct ucc_tl_ucp_team {
     uint32_t                   scope;
     uint32_t                   scope_id;
     uint32_t                   seq_num;
+    ucc_tl_ucp_task_t         *preconnect_task;
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -50,14 +50,12 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_op_args_t *coll_args,
                                   ucc_coll_task_t **task_h)
 {
     ucc_tl_ucp_team_t    *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
-    ucc_tl_ucp_task_t    *task    = ucc_tl_ucp_get_task(ctx);
+    ucc_tl_ucp_task_t    *task    = ucc_tl_ucp_get_task(tl_team);
     ucc_status_t          status;
     ucc_coll_task_init(&task->super);
     memcpy(&task->args, &coll_args->args, sizeof(ucc_coll_op_args_t));
     task->team           = tl_team;
     task->tag            = tl_team->seq_num++; //TODO Wrap around over max tag
-    task->n_polls        = ctx->cfg.n_polls; //TODO set from base_coll_op_args?
     task->super.finalize = ucc_tl_ucp_coll_finalize;
     switch (coll_args->args.coll_type) {
     case UCC_COLL_TYPE_BARRIER:

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -28,8 +28,9 @@ typedef struct ucc_tl_ucp_task {
     };
 } ucc_tl_ucp_task_t;
 
-static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_context_t *ctx)
+static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_team_t *team)
 {
+    ucc_tl_ucp_context_t *ctx = UCC_TL_UCP_TEAM_CTX(team);
     ucc_tl_ucp_task_t *task;
     task                     = ucc_mpool_get(&ctx->req_mp);
     task->super.super.status = UCC_OPERATION_INITIALIZED;
@@ -37,6 +38,8 @@ static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_context_t *ctx)
     task->send_completed     = 0;
     task->recv_posted        = 0;
     task->recv_completed     = 0;
+    task->n_polls            = ctx->cfg.n_polls;
+    task->team               = team;
     return task;
 }
 

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -231,6 +231,29 @@ UccJob::UccJob(int _n_procs) : n_procs(_n_procs)
     }
 }
 
+UccJob::UccJob(int _n_procs, ucc_job_env_t vars) : n_procs(_n_procs)
+{
+    ucc_job_env_t env_bkp;
+    char *var;
+    for (auto &v : vars) {
+        var = std::getenv(v.first.c_str());
+        if (var) {
+            /* found env - back it up for later restore
+               after processes creation */
+            env_bkp.push_back(ucc_env_var_t(v.first, var));
+        }
+        setenv(v.first.c_str(), v.second.c_str(), 1);
+    }
+    for (int i = 0; i < n_procs; i++) {
+        procs.push_back(std::make_shared<UccProcess>());
+    }
+
+    for (auto &v : env_bkp) {
+        /*restore original env */
+        setenv(v.first.c_str(), v.second.c_str(), 1);
+    }
+}
+
 UccJob::~UccJob()
 {
 }

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -72,7 +72,8 @@ public:
     ~UccTeam();
 };
 typedef std::shared_ptr<UccTeam> UccTeam_h;
-
+typedef std::pair<std::string, std::string> ucc_env_var_t;
+typedef std::vector<ucc_env_var_t> ucc_job_env_t;
 /* UccJob - environent that has n_procs processes.
    Multiple UccTeams can be created from UccJob */
 class UccJob {
@@ -86,6 +87,7 @@ public:
     static const std::vector<UccTeam_h> &getStaticTeams();
     int n_procs;
     UccJob(int _n_procs = 2);
+    UccJob(int _n_procs, ucc_job_env_t vars);
     ~UccJob();
     std::vector<UccProcess_h> procs;
     UccTeam_h create_team(int n_procs);

--- a/test/gtest/core/test_team.cc
+++ b/test/gtest/core/test_team.cc
@@ -40,3 +40,19 @@ UCC_TEST_F(test_team, team_create_multiple)
     std::shuffle(teams.begin(), teams.end(), std::default_random_engine());
 }
 
+/* Create and destroy several coexisting teams */
+UCC_TEST_F(test_team, team_create_multiple_preconnect)
+{
+    int job_size = 16;
+    UccJob job(job_size,
+               {ucc_env_var_t("UCC_TL_UCP_PRECONNECT", "inf")});
+    int n_teams  = 4; /* how many teams to create */
+    std::vector<UccTeam_h> teams;
+    for (int i = 0; i < n_teams; i++) {
+        int team_size = 2 + (rand() % (job_size - 2 + 1));
+        teams.push_back(job.create_team(team_size));
+    }
+    /* shuffle vector so that teams are destroyed in different order */
+    std::shuffle(teams.begin(), teams.end(), std::default_random_engine());
+}
+


### PR DESCRIPTION
## What
Fixes tl/ucp team preconnect implementation. Additionally preconnect is set to 0 by-default (off). If RC TLS is used in UCP preconnect might result in O(N^2) RC QPs connection and will have a significant impact on the team create cost. Functionality is still used by some applications - it can be enabled manually there.

## Why ?
Need to complete actual p2p to guarantee a ucp wireup. 

## How ?
Preconnected is implemented as pairwise exchange with 0 len messages.

