### PR TITLE
TL/UCP: additional polling in the addr exchange

### DIFF
--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -39,6 +39,11 @@ static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_context_config_t, kn_barrier_radix),
      UCC_CONFIG_TYPE_UINT},
 
+    {"OOB_NPOLLS", "20",
+     "Number of polling cycles for oob allgather request",
+     ucc_offsetof(ucc_tl_ucp_context_config_t, oob_npolls),
+     UCC_CONFIG_TYPE_UINT},
+
     {NULL}};
 
 UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_ucp_lib_t, ucc_base_lib_t,

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -27,6 +27,7 @@ typedef struct ucc_tl_ucp_context_config {
     ucc_tl_context_config_t super;
     uint32_t                preconnect;
     uint32_t                n_polls;
+    uint32_t                oob_npolls;
     uint32_t                kn_barrier_radix;
 } ucc_tl_ucp_context_config_t;
 

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -32,6 +32,10 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
         self->status = UCC_INPROGRESS;
         status       = ucc_tl_ucp_addr_exchange_start(ctx, params->params.oob,
                                                       &self->addr_storage);
+        if (status == UCC_INPROGRESS) {
+            /* exchange started but not complete return UCC_OK from post */
+            status = UCC_OK;
+        }
     }
     tl_info(tl_context->lib, "posted tl team: %p", self);
     return status;


### PR DESCRIPTION
Speeds up address exchange during team creation by introducing more polling for oob allgather req. It is still non-blocking. Amount of polling is controlled with env var.