### PR TITLE
TL/UCP: context create with OOB

### DIFF
--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -53,6 +53,9 @@ typedef struct ucc_tl_ucp_context {
     ucp_address_t              *worker_address;
     ucc_tl_ucp_ep_close_state_t ep_close_state;
     ucc_mpool_t                 req_mp;
+    uint32_t                    rank; /* context level rank. only valid if ctx
+                                         has oob */
+    uint32_t                    size; /* context size. only valid if ctx has oob */
     ucp_ep_h                   *eps;
     ucc_tl_ucp_addr_storage_t  *addr_storage;
 } ucc_tl_ucp_context_t;
@@ -68,13 +71,15 @@ typedef struct ucc_tl_ucp_team {
               This optimization is only possible when user provides
               the necessary rank mappings team_rank->context_rank. */
     ucp_ep_h                  *eps;
-    int                        size;
-    int                        rank;
+    uint32_t                   size;
+    uint32_t                   rank;
     ucc_tl_ucp_addr_storage_t *addr_storage;
     uint32_t                   id;
     uint32_t                   scope;
     uint32_t                   scope_id;
     uint32_t                   seq_num;
+    ucc_ep_map_t               ep_map; /*< Maps team rank to context rank. Only used when
+                                         user provided CTX_EP, TEAM_EP, and EP_MAP */
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/ucp/tl_ucp_addr.c
+++ b/src/components/tl/ucp/tl_ucp_addr.c
@@ -13,7 +13,7 @@ enum {
 };
 
 ucc_status_t ucc_tl_ucp_addr_exchange_start(ucc_tl_ucp_context_t *ctx,
-                                            ucc_team_oob_coll_t oob,
+                                            ucc_oob_coll_t oob,
                                             ucc_tl_ucp_addr_storage_t **storage)
 {
     ucc_tl_ucp_addr_storage_t *st =
@@ -63,12 +63,11 @@ cleanup_st:
 
 ucc_status_t ucc_tl_ucp_addr_exchange_test(ucc_tl_ucp_addr_storage_t *storage)
 {
-    ucc_team_oob_coll_t *oob     = &storage->oob;
-    int                  n_polls = 0;
-    ucc_status_t         status;
-    void                *my_addr;
-    int                  i;
-
+    ucc_oob_coll_t *oob     = &storage->oob;
+    int             n_polls = 0;
+    ucc_status_t    status;
+    void           *my_addr;
+    int             i;
     if (storage->state == UCC_TL_UCP_ADDR_EXCHANGE_COMPLETE) {
         return UCC_OK;
     }

--- a/src/components/tl/ucp/tl_ucp_addr.h
+++ b/src/components/tl/ucp/tl_ucp_addr.h
@@ -16,12 +16,12 @@ typedef struct ucc_tl_ucp_addr_storage {
     int                   is_ctx;
     size_t               *addrlens;
     void                 *addresses;
-    ucc_team_oob_coll_t   oob;
+    ucc_oob_coll_t        oob;
     ucc_tl_ucp_context_t *ctx;
 } ucc_tl_ucp_addr_storage_t;
 
 ucc_status_t ucc_tl_ucp_addr_exchange_start(ucc_tl_ucp_context_t *ctx,
-                                            ucc_team_oob_coll_t oob,
+                                            ucc_oob_coll_t oob,
                                             ucc_tl_ucp_addr_storage_t **storage);
 
 ucc_status_t ucc_tl_ucp_addr_exchange_test(ucc_tl_ucp_addr_storage_t *storage);

--- a/src/components/tl/ucp/tl_ucp_ep.c
+++ b/src/components/tl/ucp/tl_ucp_ep.c
@@ -37,8 +37,8 @@ ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t *team, int team_rank)
 {
     ucc_tl_ucp_context_t *ctx = UCC_TL_UCP_TEAM_CTX(team);
     if (team->context_ep_storage) {
-        int ctx_rank = -1; //TODO map to ctx rank
-        ucc_assert(0);
+        ucc_assert(team->ep_map.type > 0);
+        uint32_t ctx_rank = ucc_ep_map_eval(team->ep_map, team_rank);
         return ucc_tl_ucp_connect_ctx_ep(ctx, ctx_rank);
     }
     return ucc_tl_ucp_connect_ep(ctx, &team->eps[team_rank],

--- a/src/components/tl/ucp/tl_ucp_ep.h
+++ b/src/components/tl/ucp/tl_ucp_ep.h
@@ -10,6 +10,7 @@
 #include "ucc/api/ucc.h"
 #include <ucp/api/ucp.h>
 #include "tl_ucp.h"
+#include "utils/ucc_math.h"
 typedef struct ucc_tl_ucp_context ucc_tl_ucp_context_t;
 typedef struct ucc_tl_ucp_team    ucc_tl_ucp_team_t;
 ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t *team, int team_rank);
@@ -39,8 +40,7 @@ static inline ucc_status_t ucc_tl_ucp_get_ep(ucc_tl_ucp_team_t *team, int rank,
     } else {
         ctx = UCC_TL_UCP_TEAM_CTX(team);
         ucc_assert(ctx->eps);
-        int ctx_rank = -1; //TODO map to ctx rank
-        ucc_assert(0);
+        uint32_t ctx_rank = ucc_ep_map_eval(team->ep_map, rank);
         if (NULL == ctx->eps[ctx_rank]) {
             /* Not connected yet */
             status = ucc_tl_ucp_connect_ctx_ep(ctx, ctx_rank);

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -203,8 +203,8 @@ static inline void ucc_copy_context_params(ucc_context_params_t *dst,
 {
     dst->mask = src->mask;
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_TYPE, ctx_type);
-    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_COLL_OOB, oob);
-    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_ID, ctx_id);
+    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_OOB, oob);
+    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_EP, ep);
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_COLL_SYNC_TYPE,
                             sync_type);
 }

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -12,4 +12,26 @@
 #define ucc_min(_a, _b) ucs_min((_a), (_b))
 #define ucc_max(_a, _b) ucs_max((_a), (_b))
 
+static inline uint32_t ucc_ep_map_eval(ucc_ep_map_t map, uint32_t rank)
+{
+    uint32_t r;
+    switch(map.type) {
+    case UCC_EP_MAP_FULL:
+        r = rank;
+        break;
+    case UCC_EP_MAP_STRIDED:
+        r = map.strided.start + rank*map.strided.stride;
+        break;
+    case UCC_EP_MAP_ARRAY:
+        r = *((uint32_t*)((ptrdiff_t)map.array.map + rank*map.array.elem_size));
+        break;
+    case UCC_EP_MAP_CB:
+        r = (uint32_t)map.cb.cb(rank, map.cb.cb_ctx);
+        break;
+    default:
+        r = -1;
+    }
+    return r;
+}
+
 #endif


### PR DESCRIPTION
## What
Adds context eps storage and team->ctx ranks mappers

## Why ?
Resource usage optimization (used mostly in MPI env) which is available when user provides a set of additional input for ucc context creation

## How ?
The context level storage of endpoints can be used when: (1) User passes a "context_ep" (aka world_rank or context rank) of a process when creating ctx, (2) user passes an OOB for context creation, (3) user passes a flag UCC_CONTEXT_FLAG_TEAM_EP_MAP to ctx creation , the flag says that ep_map field will be provided by user as part of ucc_team_params_t for ucc_team_create_post (this is the API change).
