### PR TITLE
BUILD: add libucc dependency for cl,tl,mc

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,7 @@ if HAVE_CUDA
 mc_dirs += components/mc/cuda
 endif
 
-SUBDIRS = $(cl_dirs) $(tl_dirs) $(mc_dirs)
+SUBDIRS = . $(cl_dirs) $(tl_dirs) $(mc_dirs)
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =
 

--- a/src/components/cl/basic/Makefile.am
+++ b/src/components/cl/basic/Makefile.am
@@ -14,5 +14,6 @@ module_LTLIBRARIES          = libucc_cl_basic.la
 libucc_cl_basic_la_SOURCES  = $(sources)
 libucc_cl_basic_la_CPPFLAGS = $(AM_CPPFLAGS)
 libucc_cl_basic_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
+libucc_cl_basic_la_LIBADD   = $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 include $(top_srcdir)/config/module.am

--- a/src/components/mc/cpu/Makefile.am
+++ b/src/components/mc/cpu/Makefile.am
@@ -11,5 +11,6 @@ module_LTLIBRARIES        = libucc_mc_cpu.la
 libucc_mc_cpu_la_SOURCES  = $(sources)
 libucc_mc_cpu_la_CPPFLAGS = $(AM_CPPFLAGS)
 libucc_mc_cpu_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
+libucc_mc_cpu_la_LIBADD   = $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 include $(top_srcdir)/config/module.am

--- a/src/components/mc/cuda/Makefile.am
+++ b/src/components/mc/cuda/Makefile.am
@@ -13,7 +13,9 @@ module_LTLIBRARIES         = libucc_mc_cuda.la
 libucc_mc_cuda_la_SOURCES  = $(sources)
 libucc_mc_cuda_la_CPPFLAGS = $(AM_CPPFLAGS) $(CUDA_CPPFLAGS)
 libucc_mc_cuda_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLAGS)
-libucc_mc_cuda_la_LIBADD   = $(CUDA_LIBS) kernel/libucc_mc_cuda_kernels.la
+libucc_mc_cuda_la_LIBADD   = $(CUDA_LIBS)                      \
+                             $(UCC_TOP_BUILDDIR)/src/libucc.la \
+                             kernel/libucc_mc_cuda_kernels.la
 
 include $(top_srcdir)/config/module.am
 endif

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -24,6 +24,6 @@ module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)
 libucc_tl_ucp_la_CPPFLAGS = $(AM_CPPFLAGS) $(UCX_CPPFLAGS)
 libucc_tl_ucp_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(UCX_LDFLAGS)
-libucc_tl_ucp_la_LIBADD   = $(UCX_LIBADD)
+libucc_tl_ucp_la_LIBADD   = $(UCX_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 include $(top_srcdir)/config/module.am


### PR DESCRIPTION
## What
Adding explicit dependency for each cl, tl and mc on libucc

## Why ?
UCC component depends on some symbols from libucc e.g. ucc_global_config. Thus in some environments ld fails to find such symbols if there is no dependency.

## How ?
Build libucc first, add libadd=libucc.la in each component.
