### PR TITLE
TL/UCP: allgather ring

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -36,7 +36,7 @@ jobs:
               return 1
             fi
           fi
-          if ! echo $msg | grep -qP '^Merge |^((CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD)|(CL/|TL/|UCP|UCG|BASIC))+: \w'
+          if ! echo $msg | grep -qP '^Merge |^((CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC)|(CL/|TL/|MC/|UCP|UCG|BASIC|CUDA|CPU))+: \w'
           then
             echo "Wrong header"
             return 1

--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -73,9 +73,9 @@ typedef struct ucc_mc_ops {
     ucc_status_t (*reduce)(const void *src1, const void *src2,
                            void *dst, size_t count, ucc_datatype_t dt,
                            ucc_reduction_op_t op);
-    ucc_status_t (*mem_copy)(void *dst, const void *src, size_t len,
-                             ucc_memory_type_t dst_mem,
-                             ucc_memory_type_t src_mem);
+    ucc_status_t (*memcpy)(void *dst, const void *src, size_t len,
+                           ucc_memory_type_t dst_mem,
+                           ucc_memory_type_t src_mem);
  } ucc_mc_ops_t;
 
 typedef struct ucc_mc_base {

--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -73,6 +73,9 @@ typedef struct ucc_mc_ops {
     ucc_status_t (*reduce)(const void *src1, const void *src2,
                            void *dst, size_t count, ucc_datatype_t dt,
                            ucc_reduction_op_t op);
+    ucc_status_t (*mem_copy)(void *dst, const void *src, size_t len,
+                             ucc_memory_type_t dst_mem,
+                             ucc_memory_type_t src_mem);
  } ucc_mc_ops_t;
 
 typedef struct ucc_mc_base {

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -70,10 +70,12 @@ static ucc_status_t ucc_mc_cpu_mem_free(void *ptr)
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_cpu_mem_copy(void *dst, const void *src, size_t len,
-                                        ucc_memory_type_t dst_mem, /* NOLINT */
-                                        ucc_memory_type_t src_mem) /* NOLINT */
+static ucc_status_t ucc_mc_cpu_memcpy(void *dst, const void *src, size_t len,
+                                      ucc_memory_type_t dst_mem,
+                                      ucc_memory_type_t src_mem)
 {
+    ucc_assert((dst_mem == UCC_MEMORY_TYPE_HOST) &&
+               (src_mem == UCC_MEMORY_TYPE_HOST));
     memcpy(dst, src, len);
     return UCC_OK;
 }
@@ -109,7 +111,7 @@ ucc_mc_cpu_t ucc_mc_cpu = {
     .super.ops.mem_alloc = ucc_mc_cpu_mem_alloc,
     .super.ops.mem_free  = ucc_mc_cpu_mem_free,
     .super.ops.reduce    = ucc_mc_cpu_reduce,
-    .super.ops.mem_copy  = ucc_mc_cpu_mem_copy
+    .super.ops.memcpy    = ucc_mc_cpu_memcpy
 };
 
 UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_mc_cpu.super.config_table,

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -70,6 +70,14 @@ static ucc_status_t ucc_mc_cpu_mem_free(void *ptr)
     return UCC_OK;
 }
 
+static ucc_status_t ucc_mc_cpu_mem_copy(void *dst, const void *src, size_t len,
+                                        ucc_memory_type_t dst_mem, /* NOLINT */
+                                        ucc_memory_type_t src_mem) /* NOLINT */
+{
+    memcpy(dst, src, len);
+    return UCC_OK;
+}
+
 static ucc_status_t ucc_mc_cpu_mem_query(const void *ptr, size_t length,
                                         ucc_mem_attr_t *mem_attr)
 {
@@ -101,6 +109,7 @@ ucc_mc_cpu_t ucc_mc_cpu = {
     .super.ops.mem_alloc = ucc_mc_cpu_mem_alloc,
     .super.ops.mem_free  = ucc_mc_cpu_mem_free,
     .super.ops.reduce    = ucc_mc_cpu_reduce,
+    .super.ops.mem_copy  = ucc_mc_cpu_mem_copy
 };
 
 UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_mc_cpu.super.config_table,

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -101,9 +101,9 @@ static inline ucc_status_t ucc_mc_cuda_memcpy_kind_map(ucc_memory_type_t dst_mem
     return status;
 }
 
-static ucc_status_t ucc_mc_cuda_mem_cpy(void *dst, const void *src, size_t len,
-                                        ucc_memory_type_t dst_mem,
-                                        ucc_memory_type_t src_mem)
+static ucc_status_t ucc_mc_cuda_memcpy(void *dst, const void *src, size_t len,
+                                       ucc_memory_type_t dst_mem,
+                                       ucc_memory_type_t src_mem)
 {
     cudaError_t    st;
     cudaMemcpyKind kind;
@@ -231,6 +231,7 @@ ucc_mc_cuda_t ucc_mc_cuda = {
     .super.ops.mem_alloc = ucc_mc_cuda_mem_alloc,
     .super.ops.mem_free  = ucc_mc_cuda_mem_free,
     .super.ops.reduce    = ucc_mc_cuda_reduce,
+    .super.ops.memcpy    = ucc_mc_cuda_memcpy
 };
 
 UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_mc_cuda.super.config_table,

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -78,6 +78,66 @@ static ucc_status_t ucc_mc_cuda_mem_free(void *ptr)
     return UCC_OK;
 }
 
+static inline ucc_status_t ucc_mc_cuda_memcpy_kind_map(ucc_memory_type_t dst_mem,
+                                                       ucc_memory_type_t src_mem,
+                                                       cudaMemcpyKind *kind)
+{
+    ucc_status_t status = UCC_OK;
+    switch (dst_mem) {
+    case UCC_MEMORY_TYPE_HOST:
+        ucc_assert(src_mem == UCC_MEMORY_TYPE_CUDA);
+        *kind = cudaMemcpyDeviceToHost;
+        break;
+    case UCC_MEMORY_TYPE_CUDA:
+        ucc_assert(src_mem == UCC_MEMORY_TYPE_CUDA ||
+                   src_mem == UCC_MEMORY_TYPE_HOST);
+        *kind = (src_mem == UCC_MEMORY_TYPE_HOST) ?
+            cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice;
+        break;
+    default:
+        status = UCC_ERR_INVALID_PARAM;
+        break;
+    }
+    return status;
+}
+
+static ucc_status_t ucc_mc_cuda_mem_cpy(void *dst, const void *src, size_t len,
+                                        ucc_memory_type_t dst_mem,
+                                        ucc_memory_type_t src_mem)
+{
+    cudaError_t    st;
+    cudaMemcpyKind kind;
+    ucc_status_t   status;
+    ucc_assert(dst_mem == UCC_MEMORY_TYPE_CUDA ||
+               src_mem == UCC_MEMORY_TYPE_CUDA);
+
+    if (UCC_OK != (status = ucc_mc_cuda_memcpy_kind_map(dst_mem, src_mem, &kind))) {
+        mc_error(&ucc_mc_cuda.super,
+                 "failed to derive cudaMemcpyKind, dst_mem_type %d, src_mem_type %d",
+                 dst_mem, src_mem);
+        return status;
+    }
+    st = cudaMemcpyAsync(dst, src, len, kind, &ucc_mc_cuda.stream);
+    if (st != cudaSuccess) {
+        cudaGetLastError();
+        mc_error(&ucc_mc_cuda.super,
+                 "failed to launch cudaMemcpyAsync,  dst %p, src %p, len %zd "
+                 "cuda error %d(%s)",
+                 dst, src, len, st, cudaGetErrorString(st));
+        return UCC_ERR_NO_MESSAGE;
+    }
+    st = cudaStreamSynchronize(&ucc_mc_cuda.stream);
+    if (st != cudaSuccess) {
+        cudaGetLastError();
+        mc_error(&ucc_mc_cuda.super,
+                 "failed to synchronize mc_cuda.stream "
+                 "cuda error %d(%s)",
+                 st, cudaGetErrorString(st));
+        return UCC_ERR_NO_MESSAGE;
+    }
+    return UCC_OK;
+}
+
 static ucc_status_t ucc_mc_cuda_mem_query(const void *ptr,
                                           size_t length,
                                           ucc_mem_attr_t *mem_attr)

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -31,7 +31,7 @@ extern ucc_mc_cuda_t ucc_mc_cuda;
 #define CUDACHECK(cmd) do {                                                    \
         cudaError_t e = cmd;                                                   \
         if(e != cudaSuccess) {                                                 \
-            mc_error(&ucc_mc_cuda.super, "cuda failed wtih ret:%d(%s)", e,     \
+            mc_error(&ucc_mc_cuda.super, "cuda failed with ret:%d(%s)", e,     \
                      cudaGetErrorString(e));                                   \
             return UCC_ERR_NO_MESSAGE;                                         \
         }                                                                      \

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -22,6 +22,11 @@ allreduce =                       \
 	allreduce/allreduce.c         \
 	allreduce/allreduce_knomial.c
 
+allgather =                       \
+	allgather/allgather.h         \
+	allgather/allgather.c         \
+	allgather/allgather_ring.c
+
 sources =            \
 	tl_ucp.h         \
 	tl_ucp.c         \
@@ -36,7 +41,8 @@ sources =            \
 	$(barrier)       \
 	$(alltoall)      \
 	$(alltoallv)     \
-	$(allreduce)
+	$(allreduce)     \
+	$(allgather)
 
 module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)

--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#include "config.h"
+#include "tl_ucp.h"
+#include "allgather.h"
+
+ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *task);
+ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
+{
+    task->super.post     = ucc_tl_ucp_allgather_ring_start;
+    task->super.progress = ucc_tl_ucp_allgather_ring_progress;
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -12,6 +12,12 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
 {
+    if ((task->args.src.info.datatype == UCC_DT_USERDEFINED) ||
+        (task->args.dst.info.datatype == UCC_DT_USERDEFINED)) {
+        tl_error(UCC_TL_TEAM_LIB(task->team),
+                 "user defined datatype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
     task->super.post     = ucc_tl_ucp_allgather_ring_start;
     task->super.progress = ucc_tl_ucp_allgather_ring_progress;
     return UCC_OK;

--- a/src/components/tl/ucp/allgather/allgather.h
+++ b/src/components/tl/ucp/allgather/allgather.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#ifndef ALLGATHER_H_
+#define ALLGATHER_H_
+#include "../tl_ucp.h"
+#include "../tl_ucp_coll.h"
+
+ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task);
+
+#endif

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -62,8 +62,11 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
 
     task->super.super.status     = UCC_INPROGRESS;
     if (!UCC_IS_INPLACE(task->args)) {
-        ucc_mc_memcpy((void*)((ptrdiff_t)rbuf + data_size * team->rank),
-                      sbuf, data_size, rmem, smem);
+        status = ucc_mc_memcpy((void*)((ptrdiff_t)rbuf + data_size * team->rank),
+                               sbuf, data_size, rmem, smem);
+        if (UCC_OK != status) {
+            return status;
+        }
     }
 
     status = ucc_tl_ucp_allgather_ring_progress(&task->super);

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "tl_ucp.h"
+#include "allgather.h"
+#include "core/ucc_progress_queue.h"
+#include "tl_ucp_sendrecv.h"
+#include "utils/ucc_math.h"
+#include "core/ucc_mc.h"
+
+ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team       = task->team;
+    ucc_rank_t         group_rank = team->rank;
+    ucc_rank_t         group_size = team->size;
+    void              *rbuf       = task->args.dst.info.buffer;
+    ucc_memory_type_t  rmem       = task->args.dst.info.mem_type;
+    size_t             count      = task->args.dst.info.count;
+    ucc_datatype_t     dt         = task->args.dst.info.datatype;
+    size_t             data_size  = count * ucc_dt_size(dt);
+    ucc_rank_t         sendto     = (group_rank + 1) % group_size;
+    ucc_rank_t         recvfrom   = (group_rank - 1 + group_size) % group_size;
+    int                step;
+    if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+        return task->super.super.status;
+    }
+
+    while (task->send_posted < group_size - 1) {
+        step = task->send_posted;
+        ucc_tl_ucp_send_nb((void*)((ptrdiff_t)rbuf +
+                           ((group_rank - step + group_size) % group_size)
+                            * data_size), data_size, rmem, sendto, team, task);
+        ucc_tl_ucp_recv_nb((void*)((ptrdiff_t)rbuf +
+                           ((group_rank - step - 1 + group_size) % group_size)
+                            * data_size), data_size, rmem, recvfrom, team, task);
+        if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+            return task->super.super.status;
+        }
+    }
+    ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
+    task->super.super.status = UCC_OK;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team      = task->team;
+    size_t             count     = task->args.dst.info.count;
+    void              *sbuf      = task->args.src.info.buffer;
+    void              *rbuf      = task->args.dst.info.buffer;
+    ucc_memory_type_t  smem      = task->args.src.info.mem_type;
+    ucc_memory_type_t  rmem      = task->args.dst.info.mem_type;
+    ucc_datatype_t     dt        = task->args.dst.info.datatype;
+    size_t             data_size = count * ucc_dt_size(dt);
+    ucc_status_t       status;
+
+    task->super.super.status     = UCC_INPROGRESS;
+    if (!UCC_IS_INPLACE(task->args)) {
+        ucc_mc_memcpy((void*)((ptrdiff_t)rbuf + data_size * team->rank),
+                      sbuf, data_size, rmem, smem);
+    }
+
+    status = ucc_tl_ucp_allgather_ring_progress(&task->super);
+    if (UCC_INPROGRESS == status) {
+        ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
+    } else if (status < 0) {
+        return status;
+    }
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -11,6 +11,7 @@
 #include "alltoall/alltoall.h"
 #include "alltoallv/alltoallv.h"
 #include "allreduce/allreduce.h"
+#include "allgather/allgather.h"
 
 void ucc_tl_ucp_send_completion_cb(void *request, ucs_status_t status,
                                    void *user_data)
@@ -73,6 +74,9 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_args_t *coll_args,
         break;
     case UCC_COLL_TYPE_ALLREDUCE:
         status = ucc_tl_ucp_allreduce_init(task);
+        break;
+    case UCC_COLL_TYPE_ALLGATHER:
+        status = ucc_tl_ucp_allgather_init(task);
         break;
     default:
         status = UCC_ERR_NOT_SUPPORTED;

--- a/src/core/ucc_mc.c
+++ b/src/core/ucc_mc.c
@@ -138,19 +138,21 @@ ucc_status_t ucc_mc_memcpy(void *dst, const void *src, size_t len,
                            ucc_memory_type_t dst_mem,
                            ucc_memory_type_t src_mem)
 {
-    if (src_mem == UCC_MEMORY_TYPE_HOST &&
-         dst_mem == UCC_MEMORY_TYPE_HOST) {
+    ucc_memory_type_t mt;
+    if (src_mem == UCC_MEMORY_TYPE_UNKNOWN ||
+        dst_mem == UCC_MEMORY_TYPE_UNKNOWN) {
+        return UCC_ERR_INVALID_PARAM;
+    } else if (src_mem == UCC_MEMORY_TYPE_HOST &&
+               dst_mem == UCC_MEMORY_TYPE_HOST) {
         UCC_CHECK_MC_AVAILABLE(UCC_MEMORY_TYPE_HOST);
-        return mc_ops[UCC_MEMORY_TYPE_HOST]->mem_copy(dst, src, len,
-                                                      UCC_MEMORY_TYPE_HOST,
-                                                      UCC_MEMORY_TYPE_HOST);
-    } else {
-        /* take any non host MC component */
-        ucc_memory_type_t mt = (dst_mem == UCC_MEMORY_TYPE_HOST) ?
-            src_mem : dst_mem;
-        UCC_CHECK_MC_AVAILABLE(mt);
-        return mc_ops[mt]->mem_copy(dst, src, len, dst_mem, src_mem);
+        return mc_ops[UCC_MEMORY_TYPE_HOST]->memcpy(dst, src, len,
+                                                    UCC_MEMORY_TYPE_HOST,
+                                                    UCC_MEMORY_TYPE_HOST);
     }
+    /* take any non host MC component */
+    mt = (dst_mem == UCC_MEMORY_TYPE_HOST) ? src_mem : dst_mem;
+    UCC_CHECK_MC_AVAILABLE(mt);
+    return mc_ops[mt]->memcpy(dst, src, len, dst_mem, src_mem);
 }
 
 ucc_status_t ucc_mc_finalize()

--- a/src/core/ucc_mc.c
+++ b/src/core/ucc_mc.c
@@ -134,6 +134,25 @@ ucc_status_t ucc_mc_free(void *ptr, ucc_memory_type_t mem_type)
     return mc_ops[mem_type]->mem_free(ptr);
 }
 
+ucc_status_t ucc_mc_memcpy(void *dst, const void *src, size_t len,
+                           ucc_memory_type_t dst_mem,
+                           ucc_memory_type_t src_mem)
+{
+    if (src_mem == UCC_MEMORY_TYPE_HOST &&
+         dst_mem == UCC_MEMORY_TYPE_HOST) {
+        UCC_CHECK_MC_AVAILABLE(UCC_MEMORY_TYPE_HOST);
+        return mc_ops[UCC_MEMORY_TYPE_HOST]->mem_copy(dst, src, len,
+                                                      UCC_MEMORY_TYPE_HOST,
+                                                      UCC_MEMORY_TYPE_HOST);
+    } else {
+        /* take any non host MC component */
+        ucc_memory_type_t mt = (dst_mem == UCC_MEMORY_TYPE_HOST) ?
+            src_mem : dst_mem;
+        UCC_CHECK_MC_AVAILABLE(mt);
+        return mc_ops[mt]->mem_copy(dst, src, len, dst_mem, src_mem);
+    }
+}
+
 ucc_status_t ucc_mc_finalize()
 {
    ucc_memory_type_t  mt;

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -27,6 +27,10 @@ ucc_status_t ucc_mc_reduce(const void *src1, const void *src2, void *dst,
                            size_t count, ucc_datatype_t dt,
                            ucc_reduction_op_t op, ucc_memory_type_t mem_type);
 
+ucc_status_t ucc_mc_memcpy(void *dst, const void *src, size_t len,
+                           ucc_memory_type_t dst_mem,
+                           ucc_memory_type_t src_mem);
+
 ucc_status_t ucc_mc_reduce_multi(void *src1, void *src2, void *dst,
                                  size_t count, size_t size, size_t stride,
                                  ucc_datatype_t dtype, ucc_reduction_op_t op,

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -16,7 +16,8 @@ ucc_test_mpi_SOURCES = \
 	mpi_util.cc        \
 	test_case.cc       \
 	test_barrier.cc    \
-	test_allreduce.cc
+	test_allreduce.cc  \
+	test_allgather.cc
 
 CXX=mpicxx
 CXXFLAGS+=-I${top_builddir}/src -std=gnu++11

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -3,7 +3,8 @@
 #include "test_mpi.h"
 
 static std::vector<ucc_coll_type_t> colls = {UCC_COLL_TYPE_BARRIER,
-                                             UCC_COLL_TYPE_ALLREDUCE};
+                                             UCC_COLL_TYPE_ALLREDUCE,
+                                             UCC_COLL_TYPE_ALLGATHER};
 static std::vector<ucc_memory_type_t> mtypes = {UCC_MEMORY_TYPE_HOST};
 static std::vector<ucc_datatype_t> dtypes = {UCC_DT_INT32, UCC_DT_INT64,
                                              UCC_DT_FLOAT32, UCC_DT_FLOAT64};
@@ -77,6 +78,8 @@ static ucc_coll_type_t coll_str_to_type(std::string coll)
         return UCC_COLL_TYPE_BARRIER;
     } else if (coll == "allreduce") {
         return UCC_COLL_TYPE_ALLREDUCE;
+    } else if (coll == "allgather") {
+        return UCC_COLL_TYPE_ALLGATHER;
     } else {
         std::cerr << "incorrect coll type: " << coll << std::endl;
         PrintHelp();

--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "test_mpi.h"
+#include "mpi_util.h"
+
+#define TEST_DT UCC_DT_UINT32
+
+TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
+                             ucc_memory_type_t _mt, ucc_test_team_t &_team) :
+    TestCase(_team, _mt, _msgsize, _inplace)
+{
+    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t count = _msgsize/dt_size;
+    int rank, size;
+    MPI_Comm_rank(team.comm, &rank);
+    MPI_Comm_size(team.comm, &size);
+
+    UCC_CHECK(ucc_mc_alloc(&rbuf, _msgsize*size, _mt));
+    UCC_CHECK(ucc_mc_alloc(&check_buf, _msgsize*size, _mt));
+    if (TEST_NO_INPLACE == inplace) {
+        UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize, _mt));
+        init_buffer(sbuf, count, TEST_DT, _mt, rank);
+    } else {
+        args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+        init_buffer((void*)((ptrdiff_t)rbuf + rank*count*dt_size),
+                    count, TEST_DT, _mt, rank);
+        init_buffer((void*)((ptrdiff_t)check_buf + rank*count*dt_size),
+                    count, TEST_DT, _mt, rank);
+    }
+
+    args.coll_type            = UCC_COLL_TYPE_ALLGATHER;
+
+    args.src.info.buffer      = sbuf;
+    args.src.info.count       = count;
+    args.src.info.datatype    = TEST_DT;
+    args.src.info.mem_type    = _mt;
+
+    args.dst.info.buffer      = rbuf;
+    args.dst.info.count       = count;
+    args.dst.info.datatype    = TEST_DT;
+    args.dst.info.mem_type    = _mt;
+    UCC_CHECK(ucc_collective_init(&args, &req, team.team));
+}
+
+ucc_status_t TestAllgather::check()
+{
+    size_t       count = args.dst.info.count;
+    MPI_Datatype dt    = ucc_dt_to_mpi(TEST_DT);
+    int          size;
+    MPI_Comm_size(team.comm, &size);
+    MPI_Allgather(inplace ? MPI_IN_PLACE : sbuf, count, dt,
+                  check_buf, count, dt, team.comm);
+    return compare_buffers(rbuf, check_buf, count*size, TEST_DT, mem_type);
+}

--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -33,17 +33,15 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                     count, TEST_DT, _mt, rank);
     }
 
-    args.coll_type            = UCC_COLL_TYPE_ALLGATHER;
-
-    args.src.info.buffer      = sbuf;
-    args.src.info.count       = count;
-    args.src.info.datatype    = TEST_DT;
-    args.src.info.mem_type    = _mt;
-
-    args.dst.info.buffer      = rbuf;
-    args.dst.info.count       = count;
-    args.dst.info.datatype    = TEST_DT;
-    args.dst.info.mem_type    = _mt;
+    args.coll_type         = UCC_COLL_TYPE_ALLGATHER;
+    args.src.info.buffer   = sbuf;
+    args.src.info.count    = count;
+    args.src.info.datatype = TEST_DT;
+    args.src.info.mem_type = _mt;
+    args.dst.info.buffer   = rbuf;
+    args.dst.info.count    = count;
+    args.dst.info.datatype = TEST_DT;
+    args.dst.info.mem_type = _mt;
     UCC_CHECK(ucc_collective_init(&args, &req, team.team));
 }
 

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -20,6 +20,8 @@ std::shared_ptr<TestCase> TestCase::init(ucc_coll_type_t _type,
     case UCC_COLL_TYPE_ALLREDUCE:
         return std::make_shared<TestAllreduce>(msgsize, inplace, dt,
                                                op, mt, _team);
+    case UCC_COLL_TYPE_ALLGATHER:
+        return std::make_shared<TestAllgather>(msgsize, inplace, mt, _team);
     default:
         break;
     }

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -145,6 +145,13 @@ public:
     std::string str();
 };
 
+class TestAllgather : public TestCase {
+public:
+    TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t inplace,
+                  ucc_memory_type_t _mt, ucc_test_team_t &team);
+    ucc_status_t check();
+};
+
 void init_buffer(void *buf, size_t count, ucc_datatype_t dt,
                  ucc_memory_type_t mt, int value);
 


### PR DESCRIPTION
## What
Adds ring allgather algorithm into TL/UCP + test_mpi::allgather
Also adds ucc_mc_memcpy interface which is used by the allgather and potentially will be used in other algs/tls/cls.
