### PR TITLE
TL/NCCL: add control path and alltoall

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -36,7 +36,7 @@ jobs:
               return 1
             fi
           fi
-          if ! echo $msg | grep -qP '^Merge |^((CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC)|(CL/|TL/|MC/|UCP|UCG|BASIC|CUDA|CPU))+: \w'
+          if ! echo $msg | grep -qP '^Merge |^((CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC)|(CL/|TL/|MC/|UCP|UCG|NCCL|BASIC|CUDA|CPU))+: \w'
           then
             echo "Wrong header"
             return 1

--- a/config/m4/nccl.m4
+++ b/config/m4/nccl.m4
@@ -1,0 +1,95 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+AC_DEFUN([CHECK_NCCL],[
+AS_IF([test "x$nccl_checked" != "xyes"],[
+    nccl_happy="no"
+
+    AC_ARG_WITH([nccl],
+            [AS_HELP_STRING([--with-nccl=(DIR)], [Enable the use of NCCL (default is guess).])],
+            [], [with_nccl=guess])
+
+    AS_IF([test "x$with_nccl" != "xno"],
+    [
+        save_CPPFLAGS="$CPPFLAGS"
+        save_CFLAGS="$CFLAGS"
+        save_LDFLAGS="$LDFLAGS"
+
+        AS_IF([test ! -z "$with_nccl" -a "x$with_nccl" != "xyes" -a "x$with_nccl" != "xguess"],
+        [
+            AS_IF([test ! -d $with_nccl],
+                  [AC_MSG_ERROR([Provided "--with-nccl=${with_nccl}" location does not exist])], [])
+            check_nccl_dir="$with_nccl"
+            check_nccl_libdir="$with_nccl/lib"
+            CPPFLAGS="-I$with_nccl/include $save_CPPFLAGS"
+            LDFLAGS="-L$check_nccl_libdir $save_LDFLAGS"
+        ])
+
+        AS_IF([test ! -z "$with_nccl_libdir" -a "x$with_nccl_libdir" != "xyes"],
+        [
+            check_nccl_libdir="$with_nccl_libdir"
+            LDFLAGS="-L$check_nccl_libdir $save_LDFLAGS"
+        ])
+
+        AS_IF([test "x$cuda_happy" = "xyes"],
+        [
+            CPPFLAGS="$CUDA_CPPFLAGS $CPPFLAGS"
+            LDFLAGS="$CUDA_LDFLAGS $LDFLAGS"
+            AC_CHECK_HEADERS([nccl.h],
+            [
+                AC_CHECK_LIB([nccl], [ncclCommInitRank],
+                [
+                    nccl_happy="yes"
+                ],
+                [
+                    nccl_happy="no"
+                ], [-lcuda])
+            ],
+            [
+                nccl_happy="no"
+            ])
+        ],
+        [
+            nccl_happy="no"
+        ])
+
+        AS_IF([test "x$nccl_happy" = "xyes"],
+        [
+            AS_IF([test "x$check_nccl_dir" != "x"],
+            [
+                AC_MSG_RESULT([NCCL dir: $check_nccl_dir])
+                AC_SUBST(NCCL_CPPFLAGS, "-I$check_nccl_dir/include/")
+            ])
+
+            AS_IF([test "x$check_nccl_libdir" != "x"],
+            [
+                AC_SUBST(NCCL_LDFLAGS, "-L$check_nccl_libdir")
+            ])
+
+            AC_SUBST(NCCL_LIBADD, "-lnccl")
+        ],
+        [
+            AS_IF([test "x$with_nccl" != "xguess"],
+            [
+                AC_MSG_ERROR([NCCL support is requested but NCCL packages cannot be found $CPPFLAGS $LDFLAGS])
+            ],
+            [
+                AC_MSG_WARN([NCCL not found])
+            ])
+        ])
+
+        CFLAGS="$save_CFLAGS"
+        CPPFLAGS="$save_CPPFLAGS"
+        LDFLAGS="$save_LDFLAGS"
+
+    ],
+    [
+        AC_MSG_WARN([NCCL was explicitly disabled])
+    ])
+
+    nccl_checked=yes
+    AM_CONDITIONAL([HAVE_NCCL], [test "x$nccl_happy" != xno])
+])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_AARCH64_HI1620], [false])
      AM_CONDITIONAL([HAVE_UCX], [false])
      AM_CONDITIONAL([HAVE_CUDA], [false])
+     AM_CONDITIONAL([HAVE_NCCL], [false])
     ],
     [
      AM_CONDITIONAL([DOCS_ONLY], [false])
@@ -148,6 +149,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/sysdep.m4])
      m4_include([config/m4/ucx.m4])
      m4_include([config/m4/cuda.m4])
+     m4_include([config/m4/nccl.m4])
      m4_include([test/gtest/configure.m4])
 
      AC_ARG_ENABLE([debug],
@@ -174,6 +176,8 @@ AS_IF([test "x$with_docs_only" = xyes],
      CHECK_CUDA
      AC_MSG_RESULT([CUDA support: $cuda_happy; $CUDA_CPPFLAGS $CUDA_LDFLAGS])
 
+     CHECK_NCCL
+     AC_MSG_RESULT([NCCL support: $nccl_happy])
     ]) # Docs only
 
 
@@ -192,6 +196,7 @@ AC_CONFIG_FILES([
                  src/core/ucc_version.c
                  src/components/cl/basic/Makefile
                  src/components/tl/ucp/Makefile
+                 src/components/tl/nccl/Makefile
                  src/components/mc/cpu/Makefile
                  src/components/mc/cuda/Makefile
                  src/components/mc/cuda/kernel/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,6 +14,10 @@ if HAVE_CUDA
 mc_dirs += components/mc/cuda
 endif
 
+if HAVE_NCCL
+tl_dirs += components/tl/nccl
+endif
+
 SUBDIRS = . $(cl_dirs) $(tl_dirs) $(mc_dirs)
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =

--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -11,6 +11,7 @@
 #include "components/tl/ucc_tl.h"
 
 #define UCC_CL_BASIC_DEFAULT_PRIORITY 10
+#define UCC_CL_BASIC_NUM_TLS 2
 
 typedef struct ucc_cl_basic_iface {
     ucc_cl_iface_t super;

--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -42,10 +42,10 @@ UCC_CLASS_DECLARE(ucc_cl_basic_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
 
 typedef struct ucc_cl_basic_team {
-    ucc_cl_team_t           super;
-    ucc_base_team_params_t  b_params;
-    ucc_tl_team_t          *tl_ucp_team;
-    ucc_tl_team_t          *tl_nccl_team;
+    ucc_cl_team_t                   super;
+    ucc_team_create_multiple_req_t *team_create_req;
+    ucc_tl_team_t                  *tl_ucp_team;
+    ucc_tl_team_t                  *tl_nccl_team;
 } ucc_cl_basic_team_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -36,13 +36,16 @@ UCC_CLASS_DECLARE(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *,
 typedef struct ucc_cl_basic_context {
     ucc_cl_context_t super;
     ucc_tl_context_t *tl_ucp_ctx;
+    ucc_tl_context_t *tl_nccl_ctx;
 } ucc_cl_basic_context_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
 
 typedef struct ucc_cl_basic_team {
-    ucc_cl_team_t super;
-    ucc_tl_team_t *tl_ucp_team;
+    ucc_cl_team_t           super;
+    ucc_base_team_params_t  b_params;
+    ucc_tl_team_t          *tl_ucp_team;
+    ucc_tl_team_t          *tl_nccl_team;
 } ucc_cl_basic_team_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/cl/basic/cl_basic_coll.c
+++ b/src/components/cl/basic/cl_basic_coll.c
@@ -6,6 +6,11 @@
 
 #include "cl_basic.h"
 
+static inline int ucc_is_inplace(ucc_coll_args_t *args) {
+    return (args->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
+           (args->flags & UCC_COLL_ARGS_FLAG_IN_PLACE);
+}
+
 ucc_status_t ucc_cl_basic_select_tl(ucc_base_coll_args_t *args,
                                     ucc_cl_basic_team_t *cl_basic_team,
                                     ucc_tl_team_t **tl_team)
@@ -16,8 +21,7 @@ ucc_status_t ucc_cl_basic_select_tl(ucc_base_coll_args_t *args,
         switch (args->args.coll_type) {
         case UCC_COLL_TYPE_ALLTOALL:
             if ((args->args.src.info.mem_type == UCC_MEMORY_TYPE_CUDA) &&
-                (((args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
-                  (args->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) ||
+                (ucc_is_inplace(&args->args) ||
                  (args->args.dst.info.mem_type == UCC_MEMORY_TYPE_CUDA))) {
                 *tl_team = cl_basic_team->tl_nccl_team;
                 return UCC_OK;
@@ -25,8 +29,7 @@ ucc_status_t ucc_cl_basic_select_tl(ucc_base_coll_args_t *args,
             break;
         case UCC_COLL_TYPE_ALLTOALLV:
             if ((args->args.src.info_v.mem_type == UCC_MEMORY_TYPE_CUDA) &&
-                (((args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
-                  (args->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) ||
+                (ucc_is_inplace(&args->args) ||
                  (args->args.dst.info_v.mem_type == UCC_MEMORY_TYPE_CUDA))) {
                 *tl_team = cl_basic_team->tl_nccl_team;
                 return UCC_OK;

--- a/src/components/cl/basic/cl_basic_coll.c
+++ b/src/components/cl/basic/cl_basic_coll.c
@@ -5,11 +5,7 @@
  */
 
 #include "cl_basic.h"
-
-static inline int ucc_is_inplace(ucc_coll_args_t *args) {
-    return (args->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
-           (args->flags & UCC_COLL_ARGS_FLAG_IN_PLACE);
-}
+#include "utils/ucc_coll_utils.h"
 
 ucc_status_t ucc_cl_basic_select_tl(ucc_base_coll_args_t *args,
                                     ucc_cl_basic_team_t *cl_basic_team,
@@ -20,17 +16,17 @@ ucc_status_t ucc_cl_basic_select_tl(ucc_base_coll_args_t *args,
     if (cl_basic_team->tl_nccl_team != NULL) {
         switch (args->args.coll_type) {
         case UCC_COLL_TYPE_ALLTOALL:
-            if ((args->args.src.info.mem_type == UCC_MEMORY_TYPE_CUDA) &&
-                (ucc_is_inplace(&args->args) ||
-                 (args->args.dst.info.mem_type == UCC_MEMORY_TYPE_CUDA))) {
+            if ((args->args.dst.info.mem_type == UCC_MEMORY_TYPE_CUDA) &&
+                (UCC_IS_INPLACE(args->args) ||
+                 (args->args.src.info.mem_type == UCC_MEMORY_TYPE_CUDA))) {
                 *tl_team = cl_basic_team->tl_nccl_team;
                 return UCC_OK;
             }
             break;
         case UCC_COLL_TYPE_ALLTOALLV:
-            if ((args->args.src.info_v.mem_type == UCC_MEMORY_TYPE_CUDA) &&
-                (ucc_is_inplace(&args->args) ||
-                 (args->args.dst.info_v.mem_type == UCC_MEMORY_TYPE_CUDA))) {
+            if ((args->args.dst.info_v.mem_type == UCC_MEMORY_TYPE_CUDA) &&
+                (UCC_IS_INPLACE(args->args) ||
+                 (args->args.src.info_v.mem_type == UCC_MEMORY_TYPE_CUDA))) {
                 *tl_team = cl_basic_team->tl_nccl_team;
                 return UCC_OK;
             }

--- a/src/components/cl/basic/cl_basic_coll.c
+++ b/src/components/cl/basic/cl_basic_coll.c
@@ -13,13 +13,12 @@ ucc_status_t ucc_cl_basic_select_tl(ucc_base_coll_args_t *args,
     /* If NCCL TL is available and both src and dst buffers are CUDA then
        choose NCCL TL for alltoall and alltoallv otherwise use UCP TL*/
     if (cl_basic_team->tl_nccl_team != NULL) {
-        switch (args->args.coll_type)
-        {
+        switch (args->args.coll_type) {
         case UCC_COLL_TYPE_ALLTOALL:
             if ((args->args.src.info.mem_type == UCC_MEMORY_TYPE_CUDA) &&
                 (((args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
-                (args->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) ||
-                (args->args.dst.info.mem_type == UCC_MEMORY_TYPE_CUDA))) {
+                  (args->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) ||
+                 (args->args.dst.info.mem_type == UCC_MEMORY_TYPE_CUDA))) {
                 *tl_team = cl_basic_team->tl_nccl_team;
                 return UCC_OK;
             }
@@ -27,8 +26,8 @@ ucc_status_t ucc_cl_basic_select_tl(ucc_base_coll_args_t *args,
         case UCC_COLL_TYPE_ALLTOALLV:
             if ((args->args.src.info_v.mem_type == UCC_MEMORY_TYPE_CUDA) &&
                 (((args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
-                (args->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) ||
-                (args->args.dst.info_v.mem_type == UCC_MEMORY_TYPE_CUDA))) {
+                  (args->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) ||
+                 (args->args.dst.info_v.mem_type == UCC_MEMORY_TYPE_CUDA))) {
                 *tl_team = cl_basic_team->tl_nccl_team;
                 return UCC_OK;
             }
@@ -50,6 +49,6 @@ ucc_status_t ucc_cl_basic_coll_init(ucc_base_coll_args_t *coll_args,
     ucc_tl_team_t *tl_team;
 
     ucc_cl_basic_select_tl(coll_args, cl_team, &tl_team);
-    return UCC_TL_TEAM_IFACE(tl_team)
-        ->coll.init(coll_args, &tl_team->super, task);
+    return UCC_TL_TEAM_IFACE(tl_team)->coll.init(coll_args, &tl_team->super,
+                                                 task);
 }

--- a/src/components/cl/basic/cl_basic_coll.c
+++ b/src/components/cl/basic/cl_basic_coll.c
@@ -6,11 +6,50 @@
 
 #include "cl_basic.h"
 
+ucc_status_t ucc_cl_basic_select_tl(ucc_base_coll_args_t *args,
+                                    ucc_cl_basic_team_t *cl_basic_team,
+                                    ucc_tl_team_t **tl_team)
+{
+    /* If NCCL TL is available and both src and dst buffers are CUDA then
+       choose NCCL TL for alltoall and alltoallv otherwise use UCP TL*/
+    if (cl_basic_team->tl_nccl_team != NULL) {
+        switch (args->args.coll_type)
+        {
+        case UCC_COLL_TYPE_ALLTOALL:
+            if ((args->args.src.info.mem_type == UCC_MEMORY_TYPE_CUDA) &&
+                (((args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
+                (args->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) ||
+                (args->args.dst.info.mem_type == UCC_MEMORY_TYPE_CUDA))) {
+                *tl_team = cl_basic_team->tl_nccl_team;
+                return UCC_OK;
+            }
+            break;
+        case UCC_COLL_TYPE_ALLTOALLV:
+            if ((args->args.src.info_v.mem_type == UCC_MEMORY_TYPE_CUDA) &&
+                (((args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
+                (args->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) ||
+                (args->args.dst.info_v.mem_type == UCC_MEMORY_TYPE_CUDA))) {
+                *tl_team = cl_basic_team->tl_nccl_team;
+                return UCC_OK;
+            }
+            break;
+        default:
+            *tl_team = cl_basic_team->tl_ucp_team;
+            return UCC_OK;
+        }
+    }
+    *tl_team = cl_basic_team->tl_ucp_team;
+    return UCC_OK;
+}
+
 ucc_status_t ucc_cl_basic_coll_init(ucc_base_coll_args_t *coll_args,
                                     ucc_base_team_t *team,
                                     ucc_coll_task_t **task)
 {
     ucc_cl_basic_team_t *cl_team = ucc_derived_of(team, ucc_cl_basic_team_t);
-    return UCC_TL_TEAM_IFACE(cl_team->tl_ucp_team)
-        ->coll.init(coll_args, &cl_team->tl_ucp_team->super, task);
+    ucc_tl_team_t *tl_team;
+
+    ucc_cl_basic_select_tl(coll_args, cl_team, &tl_team);
+    return UCC_TL_TEAM_IFACE(tl_team)
+        ->coll.init(coll_args, &tl_team->super, task);
 }

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -19,9 +19,18 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
     status = ucc_tl_context_get(params->context, UCC_TL_UCP,
                                 &self->tl_ucp_ctx);
     if (UCC_OK != status) {
-        cl_warn(cl_config->cl_lib, "TL UCP context is not available, CL BASIC can't proceed");
+        cl_warn(cl_config->cl_lib,
+                "TL UCP context is not available, CL BASIC can't proceed");
         return UCC_ERR_NOT_FOUND;
     }
+    status = ucc_tl_context_get(params->context, UCC_TL_NCCL,
+                                &self->tl_nccl_ctx);
+    if (UCC_OK != status) {
+        cl_info(cl_config->cl_lib,
+                "TL NCCL context is not available, skipping");
+        self->tl_nccl_ctx = NULL;
+    }
+
     cl_info(cl_config->cl_lib, "initialized cl context: %p", self);
     return UCC_OK;
 }
@@ -30,6 +39,9 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_context_t)
 {
     cl_info(self->super.super.lib, "finalizing cl context: %p", self);
     ucc_tl_context_put(self->tl_ucp_ctx);
+    if (self->tl_nccl_ctx) {
+        ucc_tl_context_put(self->tl_nccl_ctx);
+    }
 }
 
 UCC_CLASS_DEFINE(ucc_cl_basic_context_t, ucc_cl_context_t);

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -32,6 +32,6 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
                                        ucc_base_attr_t *base_attr)
 {
     ucc_cl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
-    attr->tls = UCC_TL_UCP;
+    attr->tls = UCC_TL_UCP | UCC_TL_NCCL;
     return UCC_OK;
 }

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -32,6 +32,6 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
                                        ucc_base_attr_t *base_attr)
 {
     ucc_cl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
-    attr->tls = UCC_TL_UCP | UCC_TL_NCCL;
+    attr->tls               = UCC_TL_UCP | UCC_TL_NCCL;
     return UCC_OK;
 }

--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -14,38 +14,31 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_team_t, ucc_base_context_t *cl_context,
         ucc_derived_of(cl_context, ucc_cl_basic_context_t);
     int                     nteams = 0;
     ucc_status_t            status;
-    ucc_base_team_params_t *b_params;
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_team_t, &ctx->super);
-    b_params = ucc_malloc(sizeof(*b_params), "base team params");
-    if (!b_params) {
-        cl_error(cl_context->lib, "failed to allocate %zd bytes for params",
-                 sizeof(*b_params));
-        return UCC_ERR_NO_MEMORY;
-    }
-    memcpy(b_params, params, sizeof(ucc_base_team_params_t));
-    b_params->scope    = UCC_CL_BASIC;
-    b_params->scope_id = 0;
     self->tl_ucp_team  = NULL;
     self->tl_nccl_team = NULL;
-
+    ucc_assert(ctx->tl_ucp_ctx != NULL);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_team_t, &ctx->super);
     status = ucc_team_create_multiple_req_alloc(&self->team_create_req,
                                                 UCC_CL_BASIC_NUM_TLS);
     if (UCC_OK != status) {
-        ucc_free(b_params);
+        cl_error(cl_context->lib, "failed to allocate team req multiple");
         return status;
     }
-    ucc_assert(ctx->tl_ucp_ctx != NULL);
-    self->team_create_req->contexts[nteams] = ctx->tl_ucp_ctx;
-    self->team_create_req->params[nteams]   = b_params;
+    self->team_create_req->descs[nteams].ctx = ctx->tl_ucp_ctx;
+    memcpy(&self->team_create_req->descs[nteams].param, params,
+           sizeof(ucc_base_team_params_t));
+    self->team_create_req->descs[nteams].param.scope    = UCC_CL_BASIC;
+    self->team_create_req->descs[nteams].param.scope_id = 0;
     nteams += 1;
     if (ctx->tl_nccl_ctx != NULL) {
-        self->team_create_req->contexts[nteams] = ctx->tl_nccl_ctx;
-        self->team_create_req->params[nteams]   = b_params;
+        self->team_create_req->descs[nteams].ctx = ctx->tl_nccl_ctx;
+        memcpy(&self->team_create_req->descs[nteams].param,
+               &self->team_create_req->descs[nteams-1].param,
+               sizeof(ucc_base_team_params_t));
         nteams += 1;
     }
     self->team_create_req->n_teams = nteams;
-
     status = ucc_tl_team_create_multiple(self->team_create_req);
     if (status < 0) {
         cl_error(cl_context->lib, "failed to post tl team create (%d)",
@@ -106,11 +99,11 @@ ucc_status_t ucc_cl_basic_team_create_test(ucc_base_team_t *cl_team)
         team->tl_ucp_team = NULL;
         team->tl_nccl_team = NULL;
         if ((ctx->tl_nccl_ctx != NULL) &&
-            (team->team_create_req->teams_status[1] == UCC_OK)) {
-            team->tl_nccl_team = team->team_create_req->teams[1];
+            (team->team_create_req->descs[1].status == UCC_OK)) {
+            team->tl_nccl_team = team->team_create_req->descs[1].team;
             cl_info(ctx->super.super.lib, "initialized nccl team");
         }
-        if (team->team_create_req->teams_status[0] != UCC_OK) {
+        if (team->team_create_req->descs[0].status != UCC_OK) {
             if (team->tl_nccl_team) {
                 UCC_TL_CTX_IFACE(ctx->tl_nccl_ctx)
                     ->team.destroy(&team->tl_nccl_team->super);
@@ -118,9 +111,8 @@ ucc_status_t ucc_cl_basic_team_create_test(ucc_base_team_t *cl_team)
             }
             cl_error(ctx->super.super.lib, "failed to create tl ucp team");
         }
-        team->tl_ucp_team = team->team_create_req->teams[0];
-        status            = team->team_create_req->teams_status[0];
-        ucc_free(team->team_create_req->params[0]);
+        team->tl_ucp_team = team->team_create_req->descs[0].team;
+        status            = team->team_create_req->descs[0].status;
         ucc_team_create_multiple_req_free(team->team_create_req);
     }
     return status;

--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -12,23 +12,40 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_team_t, ucc_base_context_t *cl_context,
 {
     ucc_cl_basic_context_t *ctx =
         ucc_derived_of(cl_context, ucc_cl_basic_context_t);
-    ucc_status_t     status;
-    ucc_base_team_t *b_team;
+    ucc_status_t status;
+    ucc_base_team_params_t *b_params;
+    int nteams = 0;
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_cl_team_t, &ctx->super);
-    memcpy(&self->b_params, params, sizeof(ucc_base_team_params_t));
-    self->b_params.scope    = UCC_CL_BASIC;
-    self->b_params.scope_id = 0;
-    status = UCC_TL_CTX_IFACE(ctx->tl_ucp_ctx)
-                ->team.create_post(&ctx->tl_ucp_ctx->super, &self->b_params,
-                                   &b_team);
+    b_params = ucc_malloc(sizeof(*b_params), "base team params");
+    if (!b_params) {
+        cl_error(cl_context->lib, "failed to allocate %zd bytes for params",
+                 sizeof(*b_params));
+        return UCC_ERR_NO_MEMORY;
+    }
+    memcpy(b_params, params, sizeof(ucc_base_team_params_t));
+    b_params->scope    = UCC_CL_BASIC;
+    b_params->scope_id = 0;
+    self->tl_ucp_team  = NULL;
+    self->tl_nccl_team = NULL;
+
+    status = ucc_team_create_multiple_req_alloc(&self->team_create_req, 2);
     if (UCC_OK != status) {
-        self->tl_ucp_team = NULL;
-        cl_error(cl_context->lib, "tl ucp team create post failed");
+        ucc_free(b_params);
         return status;
     }
-    self->tl_ucp_team = ucc_derived_of(b_team, ucc_tl_team_t);
-    self->tl_nccl_team = NULL;
+    ucc_assert(ctx->tl_ucp_ctx != NULL);
+    self->team_create_req->contexts[nteams] = ctx->tl_ucp_ctx;
+    self->team_create_req->params[nteams] = b_params;
+    nteams += 1;
+    if (ctx->tl_nccl_ctx != NULL) {
+        self->team_create_req->contexts[nteams] = ctx->tl_nccl_ctx;
+        self->team_create_req->params[nteams] = b_params;
+        nteams += 1;
+    }
+    self->team_create_req->n_teams = nteams;
+
+    status = ucc_tl_team_create_multiple(self->team_create_req);
     cl_info(cl_context->lib, "posted cl team: %p", self);
     return UCC_OK;
 }
@@ -71,41 +88,27 @@ ucc_status_t ucc_cl_basic_team_create_test(ucc_base_team_t *cl_team)
     ucc_cl_basic_team_t    *team = ucc_derived_of(cl_team, ucc_cl_basic_team_t);
     ucc_cl_basic_context_t *ctx  = UCC_CL_BASIC_TEAM_CTX(team);
     ucc_status_t            status;
-    ucc_base_team_t        *b_team;
 
-    status = UCC_TL_CTX_IFACE(ctx->tl_ucp_ctx)
-                 ->team.create_test(&team->tl_ucp_team->super);
-    if (UCC_OK == status) {
-        if (ctx->tl_nccl_ctx != NULL) {
-            if (team->tl_nccl_team == NULL) {
-                status = UCC_TL_CTX_IFACE(ctx->tl_nccl_ctx)
-                            ->team.create_post(&ctx->tl_nccl_ctx->super,
-                                            &team->b_params, &b_team);
-                if (UCC_OK != status) {
-                    team->tl_nccl_team = NULL;
-                    cl_info(ctx->super.super.lib,
-                            "tl nccl team create post failed");
-                    status = UCC_OK;
-                } else {
-                    team->tl_nccl_team = ucc_derived_of(b_team, ucc_tl_team_t);
-                    status = UCC_INPROGRESS;
-                }
-            } else {
-                status = UCC_TL_CTX_IFACE(ctx->tl_nccl_ctx)
-                            ->team.create_test(&team->tl_nccl_team->super);
-                if (status < 0) {
-                    team->tl_nccl_team = NULL;
-                    cl_info(ctx->super.super.lib,
-                            "tl nccl team create test failed");
-                    status = UCC_OK;
-                }
-            }
+    status = ucc_tl_team_create_multiple(team->team_create_req);
+    if (status == UCC_OK) {
+        if ((ctx->tl_nccl_ctx != NULL) &&
+            (team->team_create_req->teams_status[1] == UCC_OK)) {
+            team->tl_nccl_team = team->team_create_req->teams[1];
+            cl_info(ctx->super.super.lib, "initialized nccl team");
         }
-    }
-    if (UCC_OK == status) {
-        cl_info(ctx->super.super.lib, "initialized cl team: %p", team);
-    } else if (UCC_INPROGRESS != status) {
-        cl_error(ctx->super.super.lib, "failed to create tl ucp team");
+        if (team->team_create_req->teams_status[0] != UCC_OK)  {
+            if (team->tl_nccl_team) {
+                UCC_TL_CTX_IFACE(ctx->tl_nccl_ctx)
+                                ->team.destroy(&team->tl_nccl_team->super);
+                team->tl_nccl_team = NULL;
+            }
+            team->tl_ucp_team = NULL;
+            cl_error(ctx->super.super.lib, "failed to create tl ucp team");
+        }
+        team->tl_ucp_team = team->team_create_req->teams[0];
+        status = team->team_create_req->teams_status[0];
+        ucc_free(team->team_create_req->params[0]);
+        ucc_team_create_multiple_req_free(team->team_create_req);
     }
     return status;
 }

--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -12,9 +12,9 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_team_t, ucc_base_context_t *cl_context,
 {
     ucc_cl_basic_context_t *ctx =
         ucc_derived_of(cl_context, ucc_cl_basic_context_t);
-    ucc_status_t status;
+    int                     nteams = 0;
+    ucc_status_t            status;
     ucc_base_team_params_t *b_params;
-    int nteams = 0;
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_cl_team_t, &ctx->super);
     b_params = ucc_malloc(sizeof(*b_params), "base team params");
@@ -36,16 +36,19 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_team_t, ucc_base_context_t *cl_context,
     }
     ucc_assert(ctx->tl_ucp_ctx != NULL);
     self->team_create_req->contexts[nteams] = ctx->tl_ucp_ctx;
-    self->team_create_req->params[nteams] = b_params;
+    self->team_create_req->params[nteams]   = b_params;
     nteams += 1;
     if (ctx->tl_nccl_ctx != NULL) {
         self->team_create_req->contexts[nteams] = ctx->tl_nccl_ctx;
-        self->team_create_req->params[nteams] = b_params;
+        self->team_create_req->params[nteams]   = b_params;
         nteams += 1;
     }
     self->team_create_req->n_teams = nteams;
 
     status = ucc_tl_team_create_multiple(self->team_create_req);
+    if (status < 0) {
+        return status;
+    }
     cl_info(cl_context->lib, "posted cl team: %p", self);
     return UCC_OK;
 }
@@ -91,22 +94,23 @@ ucc_status_t ucc_cl_basic_team_create_test(ucc_base_team_t *cl_team)
 
     status = ucc_tl_team_create_multiple(team->team_create_req);
     if (status == UCC_OK) {
+        team->tl_ucp_team = NULL;
+        team->tl_nccl_team = NULL;
         if ((ctx->tl_nccl_ctx != NULL) &&
             (team->team_create_req->teams_status[1] == UCC_OK)) {
             team->tl_nccl_team = team->team_create_req->teams[1];
             cl_info(ctx->super.super.lib, "initialized nccl team");
         }
-        if (team->team_create_req->teams_status[0] != UCC_OK)  {
+        if (team->team_create_req->teams_status[0] != UCC_OK) {
             if (team->tl_nccl_team) {
                 UCC_TL_CTX_IFACE(ctx->tl_nccl_ctx)
-                                ->team.destroy(&team->tl_nccl_team->super);
+                    ->team.destroy(&team->tl_nccl_team->super);
                 team->tl_nccl_team = NULL;
             }
-            team->tl_ucp_team = NULL;
             cl_error(ctx->super.super.lib, "failed to create tl ucp team");
         }
         team->tl_ucp_team = team->team_create_req->teams[0];
-        status = team->team_create_req->teams_status[0];
+        status            = team->team_create_req->teams_status[0];
         ucc_free(team->team_create_req->params[0]);
         ucc_team_create_multiple_req_free(team->team_create_req);
     }

--- a/src/components/tl/nccl/Makefile.am
+++ b/src/components/tl/nccl/Makefile.am
@@ -8,8 +8,8 @@ sources =             \
 	tl_nccl_lib.c     \
 	tl_nccl_context.c \
 	tl_nccl_team.c    \
-    tl_nccl_coll.h    \
-    tl_nccl_coll.c
+	tl_nccl_coll.h    \
+	tl_nccl_coll.c
 
 module_LTLIBRARIES = libucc_tl_nccl.la
 libucc_tl_nccl_la_SOURCES  = $(sources)

--- a/src/components/tl/nccl/Makefile.am
+++ b/src/components/tl/nccl/Makefile.am
@@ -1,0 +1,20 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+
+sources =             \
+	tl_nccl.h         \
+	tl_nccl.c         \
+	tl_nccl_lib.c     \
+	tl_nccl_context.c \
+	tl_nccl_team.c    \
+    tl_nccl_coll.h    \
+    tl_nccl_coll.c
+
+module_LTLIBRARIES = libucc_tl_nccl.la
+libucc_tl_nccl_la_SOURCES  = $(sources)
+libucc_tl_nccl_la_CPPFLAGS = $(AM_CPPFLAGS) $(NCCL_CPPFLAGS)
+libucc_tl_nccl_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(NCCL_LDFLAGS)
+libucc_tl_nccl_la_LIBADD   = $(NCCL_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
+
+include $(top_srcdir)/config/module.am

--- a/src/components/tl/nccl/Makefile.am
+++ b/src/components/tl/nccl/Makefile.am
@@ -13,8 +13,8 @@ sources =             \
 
 module_LTLIBRARIES = libucc_tl_nccl.la
 libucc_tl_nccl_la_SOURCES  = $(sources)
-libucc_tl_nccl_la_CPPFLAGS = $(AM_CPPFLAGS) $(NCCL_CPPFLAGS)
-libucc_tl_nccl_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(NCCL_LDFLAGS)
-libucc_tl_nccl_la_LIBADD   = $(NCCL_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
+libucc_tl_nccl_la_CPPFLAGS = $(AM_CPPFLAGS) $(CUDA_CPPFLAGS) $(NCCL_CPPFLAGS)
+libucc_tl_nccl_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLAGS) $(NCCL_LDFLAGS)
+libucc_tl_nccl_la_LIBADD   = $(CUDA_LIBS) $(NCCL_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 include $(top_srcdir)/config/module.am

--- a/src/components/tl/nccl/tl_nccl.c
+++ b/src/components/tl/nccl/tl_nccl.c
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_nccl.h"
+#include "components/mc/base/ucc_mc_base.h"
+
+ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib,
+                                      ucc_base_attr_t *base_attr);
+
+ucc_status_t ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context,
+                                          ucc_base_attr_t *base_attr);
+
+static ucc_config_field_t ucc_tl_nccl_lib_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_tl_nccl_lib_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)},
+
+    {NULL}
+};
+
+static ucs_config_field_t ucc_tl_nccl_context_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_tl_nccl_context_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_tl_context_config_table)},
+
+    {NULL}
+};
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_nccl_lib_t, ucc_base_lib_t,
+                          const ucc_base_lib_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_nccl_lib_t, ucc_base_lib_t);
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_nccl_context_t, ucc_base_context_t,
+                          const ucc_base_context_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_nccl_context_t, ucc_base_context_t);
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_nccl_team_t, ucc_base_team_t,
+                          ucc_base_context_t *, const ucc_base_team_params_t *);
+
+ucc_status_t ucc_tl_nccl_team_create_test(ucc_base_team_t *tl_team);
+ucc_status_t ucc_tl_nccl_team_destroy(ucc_base_team_t *tl_team);
+ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_op_args_t *coll_args,
+                                   ucc_base_team_t *team,
+                                   ucc_coll_task_t **task);
+
+UCC_TL_IFACE_DECLARE(nccl, NCCL);

--- a/src/components/tl/nccl/tl_nccl.c
+++ b/src/components/tl/nccl/tl_nccl.c
@@ -17,15 +17,13 @@ static ucc_config_field_t ucc_tl_nccl_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_nccl_lib_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)},
 
-    {NULL}
-};
+    {NULL}};
 
 static ucs_config_field_t ucc_tl_nccl_context_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_nccl_context_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_tl_context_config_table)},
 
-    {NULL}
-};
+    {NULL}};
 
 UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_nccl_lib_t, ucc_base_lib_t,
                           const ucc_base_lib_params_t *,

--- a/src/components/tl/nccl/tl_nccl.c
+++ b/src/components/tl/nccl/tl_nccl.c
@@ -44,7 +44,7 @@ UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_nccl_team_t, ucc_base_team_t,
 
 ucc_status_t ucc_tl_nccl_team_create_test(ucc_base_team_t *tl_team);
 ucc_status_t ucc_tl_nccl_team_destroy(ucc_base_team_t *tl_team);
-ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_op_args_t *coll_args,
+ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t *team,
                                    ucc_coll_task_t **task);
 

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -63,4 +63,22 @@ typedef struct ucc_tl_nccl_task {
 UCC_CLASS_DECLARE(ucc_tl_nccl_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
 
+#define NCCLCHECK_GOTO(_cmd, _label, _status, _lib) do {                       \
+  ncclResult_t e = _cmd;                                                       \
+  if(ncclSuccess != e) {                                                       \
+    tl_error(_lib, "NCCL error %d %s", e, ncclGetErrorString(e));              \
+    _status = UCC_ERR_NO_MESSAGE;                                              \
+    goto _label;                                                               \
+  }                                                                            \
+} while(0)
+
+#define CUDACHECK_GOTO(_cmd, _label, _status, _lib) do {                       \
+  cudaError_t e = _cmd;                                                        \
+  if(cudaSuccess != e) {                                                       \
+    tl_error(_lib, "CUDA error %d %s", e, cudaGetErrorName(e));                \
+    _status = UCC_ERR_NO_MESSAGE;                                              \
+    goto _label;                                                               \
+  }                                                                            \
+} while(0)
+
 #endif

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -63,22 +63,24 @@ typedef struct ucc_tl_nccl_task {
 UCC_CLASS_DECLARE(ucc_tl_nccl_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
 
-#define NCCLCHECK_GOTO(_cmd, _label, _status, _lib) do {                       \
-  ncclResult_t e = _cmd;                                                       \
-  if(ncclSuccess != e) {                                                       \
-    tl_error(_lib, "NCCL error %d %s", e, ncclGetErrorString(e));              \
-    _status = UCC_ERR_NO_MESSAGE;                                              \
-    goto _label;                                                               \
-  }                                                                            \
-} while(0)
+#define NCCLCHECK_GOTO(_cmd, _label, _status, _lib)                            \
+    do {                                                                       \
+        ncclResult_t e = _cmd;                                                 \
+        if (ncclSuccess != e) {                                                \
+            tl_error(_lib, "NCCL error %d %s", e, ncclGetErrorString(e));      \
+            _status = UCC_ERR_NO_MESSAGE;                                      \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
 
-#define CUDACHECK_GOTO(_cmd, _label, _status, _lib) do {                       \
-  cudaError_t e = _cmd;                                                        \
-  if(cudaSuccess != e) {                                                       \
-    tl_error(_lib, "CUDA error %d %s", e, cudaGetErrorName(e));                \
-    _status = UCC_ERR_NO_MESSAGE;                                              \
-    goto _label;                                                               \
-  }                                                                            \
-} while(0)
+#define CUDACHECK_GOTO(_cmd, _label, _status, _lib)                            \
+    do {                                                                       \
+        cudaError_t e = _cmd;                                                  \
+        if (cudaSuccess != e) {                                                \
+            tl_error(_lib, "CUDA error %d %s", e, cudaGetErrorName(e));        \
+            _status = UCC_ERR_NO_MESSAGE;                                      \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
 
 #endif

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_NCCL_H_
+#define UCC_TL_NCCL_H_
+
+#include "components/tl/ucc_tl.h"
+#include "components/tl/ucc_tl_log.h"
+#include "utils/ucc_mpool.h"
+
+#include <nccl.h>
+#include <cuda.h>
+
+typedef struct ucc_tl_nccl_iface {
+    ucc_tl_iface_t super;
+} ucc_tl_nccl_iface_t;
+
+extern ucc_tl_nccl_iface_t ucc_tl_nccl;
+
+typedef struct ucc_tl_nccl_lib_config {
+    ucc_tl_lib_config_t super;
+} ucc_tl_nccl_lib_config_t;
+
+typedef struct ucc_tl_nccl_context_config {
+    ucc_tl_context_config_t super;
+} ucc_tl_nccl_context_config_t;
+
+typedef struct ucc_tl_nccl_lib {
+    ucc_tl_lib_t super;
+} ucc_tl_nccl_lib_t;
+UCC_CLASS_DECLARE(ucc_tl_nccl_lib_t, const ucc_base_lib_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_nccl_context {
+    ucc_tl_context_t             super;
+    ucc_tl_nccl_context_config_t cfg;
+    ucc_mpool_t                  req_mp;
+} ucc_tl_nccl_context_t;
+UCC_CLASS_DECLARE(ucc_tl_nccl_context_t, const ucc_base_context_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_nccl_team {
+    ucc_tl_team_t        super;
+    ncclUniqueId        *unique_id;
+    void                *oob_req;
+    ucc_team_oob_coll_t  oob;
+    ncclComm_t           nccl_comm;
+    uint32_t             rank;
+    uint32_t             size;
+    cudaStream_t         stream;
+} ucc_tl_nccl_team_t;
+
+typedef struct ucc_tl_nccl_task {
+    ucc_coll_task_t     super;
+    ucc_tl_nccl_team_t *team;
+    ucc_coll_op_args_t  args;
+    cudaEvent_t         completed;
+} ucc_tl_nccl_task_t;
+
+UCC_CLASS_DECLARE(ucc_tl_nccl_team_t, ucc_base_context_t *,
+                  const ucc_base_team_params_t *);
+
+#endif

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -56,7 +56,7 @@ typedef struct ucc_tl_nccl_team {
 typedef struct ucc_tl_nccl_task {
     ucc_coll_task_t     super;
     ucc_tl_nccl_team_t *team;
-    ucc_coll_op_args_t  args;
+    ucc_coll_args_t     args;
     cudaEvent_t         completed;
 } ucc_tl_nccl_task_t;
 

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -48,8 +48,8 @@ typedef struct ucc_tl_nccl_team {
     void                *oob_req;
     ucc_team_oob_coll_t  oob;
     ncclComm_t           nccl_comm;
-    uint32_t             rank;
-    uint32_t             size;
+    ucc_rank_t           rank;
+    ucc_rank_t           size;
     cudaStream_t         stream;
 } ucc_tl_nccl_team_t;
 

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -46,11 +46,11 @@ ncclRedOp_t ucc_to_nccl_reduce_op[] = {
 
 ucc_status_t ucc_nccl_collective_progress(ucc_coll_task_t *coll_task)
 {
-    cudaError_t cuda_st;
     ucc_tl_nccl_task_t *task = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    cudaError_t cuda_st;
 
     cuda_st = cudaEventQuery(task->completed);
-    switch(cuda_st) {
+    switch (cuda_st) {
     case cudaSuccess:
         coll_task->super.status = UCC_OK;
         return UCC_OK;
@@ -78,12 +78,12 @@ ucc_status_t ucc_nccl_alltoall_start(ucc_coll_task_t *coll_task)
                 ucc_dt_size(task->args.src.info.datatype);
     NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
     for (peer = 0; peer < gsize; peer++) {
-        NCCLCHECK_GOTO(ncclSend((void*)(sbuf + peer*data_size), data_size,
+        NCCLCHECK_GOTO(ncclSend((void *)(sbuf + peer * data_size), data_size,
                                 ncclChar, peer, team->nccl_comm, stream),
                        exit_coll, status, UCC_TL_TEAM_LIB(team));
-        NCCLCHECK_GOTO(ncclRecv((void*)(rbuf + peer*data_size), data_size,
+        NCCLCHECK_GOTO(ncclRecv((void *)(rbuf + peer * data_size), data_size,
                                 ncclChar, peer, team->nccl_comm, stream),
-                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
     }
     NCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
 
@@ -104,7 +104,7 @@ ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task)
                  "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    task->super.post = ucc_nccl_alltoall_start;
+    task->super.post     = ucc_nccl_alltoall_start;
     task->super.progress = ucc_nccl_collective_progress;
     return UCC_OK;
 }
@@ -142,23 +142,25 @@ ucc_status_t ucc_nccl_alltoallv_start(ucc_coll_task_t *coll_task)
 
     task->super.super.status = UCC_INPROGRESS;
     sdt_size = ucc_dt_size(task->args.src.info_v.datatype);
-    rdt_size = ucc_dt_size(task->args.dst.info_v.datatype);
+    rdt_size                   = ucc_dt_size(task->args.dst.info_v.datatype);
     NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
     for (peer = 0; peer < team->size; peer++) {
-        data_size  = get_count(task->args.src.info_v.counts, peer, task) *
-                               sdt_size;
-        data_displ = get_displacement(task->args.src.info_v.displacements,
-                                      peer, task) * sdt_size;
-        NCCLCHECK_GOTO(ncclSend((void*)(sbuf + data_displ), data_size,
+        data_size  =
+            get_count(task->args.src.info_v.counts, peer, task) * sdt_size;
+        data_displ =
+            get_displacement(task->args.src.info_v.displacements,peer, task) *
+            sdt_size;
+        NCCLCHECK_GOTO(ncclSend((void *)(sbuf + data_displ), data_size,
                                 ncclChar, peer, team->nccl_comm, stream),
                        exit_coll, status, UCC_TL_TEAM_LIB(team));
-        data_size  = get_count(task->args.dst.info_v.counts, peer, task) *
-                               rdt_size;
-        data_displ = get_displacement(task->args.dst.info_v.displacements,
-                                      peer, task) * rdt_size;
-        NCCLCHECK_GOTO(ncclRecv((void*)(rbuf + data_displ), data_size,
+        data_size  =
+            get_count(task->args.dst.info_v.counts, peer, task) * rdt_size;
+        data_displ =
+            get_displacement(task->args.dst.info_v.displacements, peer, task) *
+            rdt_size;
+        NCCLCHECK_GOTO(ncclRecv((void *)(rbuf + data_displ), data_size,
                                 ncclChar, peer, team->nccl_comm, stream),
-                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
     }
     NCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
 
@@ -173,13 +175,13 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_alltoallv_init(ucc_tl_nccl_task_t *task)
 {
-    if ((task->args.src.info.datatype == UCC_DT_USERDEFINED) ||
-        (task->args.dst.info.datatype == UCC_DT_USERDEFINED)) {
+    if ((task->args.src.info_v.datatype == UCC_DT_USERDEFINED) ||
+        (task->args.dst.info_v.datatype == UCC_DT_USERDEFINED)) {
         tl_error(UCC_TL_TEAM_LIB(task->team),
                  "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    task->super.post = ucc_nccl_alltoallv_start;
+    task->super.post     = ucc_nccl_alltoallv_start;
     task->super.progress = ucc_nccl_collective_progress;
     return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -5,7 +5,44 @@
  */
 
 #include "tl_nccl_coll.h"
+#include "utils/ucc_math.h"
 
+#define ncclOpUnsupported (ncclNumOps + 1)
+#define ncclDataTypeUnsupported (ncclNumTypes + 1)
+
+ncclDataType_t ucc_to_nccl_dtype[] = {
+    [UCC_DT_INT8]        = ncclInt8,
+    [UCC_DT_INT16]       = ncclDataTypeUnsupported,
+    [UCC_DT_INT32]       = ncclInt32,
+    [UCC_DT_INT64]       = ncclInt64,
+    [UCC_DT_INT128]      = ncclDataTypeUnsupported,
+    [UCC_DT_UINT8]       = ncclUint8,
+    [UCC_DT_UINT16]      = ncclDataTypeUnsupported,
+    [UCC_DT_UINT32]      = ncclUint32,
+    [UCC_DT_UINT64]      = ncclUint64,
+    [UCC_DT_UINT128]     = ncclDataTypeUnsupported,
+    [UCC_DT_FLOAT16]     = ncclFloat16,
+    [UCC_DT_FLOAT32]     = ncclFloat32,
+    [UCC_DT_FLOAT64]     = ncclFloat64,
+    [UCC_DT_USERDEFINED] = ncclDataTypeUnsupported,
+    [UCC_DT_OPAQUE]      = ncclDataTypeUnsupported,
+};
+
+ncclRedOp_t ucc_to_nccl_reduce_op[] = {
+    [UCC_OP_USERDEFINED] = ncclOpUnsupported,
+    [UCC_OP_SUM]         = ncclSum,
+    [UCC_OP_PROD]        = ncclProd,
+    [UCC_OP_MAX]         = ncclMax,
+    [UCC_OP_MIN]         = ncclMin,
+    [UCC_OP_LAND]        = ncclOpUnsupported,
+    [UCC_OP_LOR]         = ncclOpUnsupported,
+    [UCC_OP_LXOR]        = ncclOpUnsupported,
+    [UCC_OP_BAND]        = ncclOpUnsupported,
+    [UCC_OP_BOR]         = ncclOpUnsupported,
+    [UCC_OP_BXOR]        = ncclOpUnsupported,
+    [UCC_OP_MAXLOC]      = ncclOpUnsupported,
+    [UCC_OP_MINLOC]      = ncclOpUnsupported,
+};
 
 ucc_status_t ucc_nccl_collective_progress(ucc_coll_task_t *coll_task)
 {
@@ -25,38 +62,47 @@ ucc_status_t ucc_nccl_collective_progress(ucc_coll_task_t *coll_task)
 }
 ucc_status_t ucc_nccl_alltoall_start(ucc_coll_task_t *coll_task)
 {
-    // ptrdiff_t    sbuf, rbuf;
-    // size_t       data_size;
-    // int          group_size;
-    // int          peer;
-    // cudaStream_t *stream;
+    ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_tl_nccl_team_t *team   = task->team;
+    cudaStream_t        stream = team->stream;
+    ucc_rank_t          gsize  = team->size;
+    ucc_status_t        status = UCC_OK;
+    ptrdiff_t           sbuf   = (ptrdiff_t)task->args.src.info.buffer;
+    ptrdiff_t           rbuf   = (ptrdiff_t)task->args.dst.info.buffer;
+    size_t data_size;
+    ucc_rank_t peer;
 
-    // stream = (cudaStream_t*)args->stream.stream;
-    // NCCLCHECK(ncclCommCount(req->team->nccl_comm, &group_size));
-    // sbuf      = (ptrdiff_t)args->buffer_info.src_buffer;
-    // rbuf      = (ptrdiff_t)args->buffer_info.dst_buffer;
-    // data_size = args->buffer_info.len;
+    task->super.super.status = UCC_INPROGRESS;
+    data_size = (size_t)task->args.src.info.count *
+                ucc_dt_size(task->args.src.info.datatype);
+    NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    for (peer = 0; peer < gsize; peer++) {
+        NCCLCHECK_GOTO(ncclSend((void*)(sbuf + peer*data_size), data_size,
+                                ncclChar, peer, team->nccl_comm, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
+        NCCLCHECK_GOTO(ncclRecv((void*)(rbuf + peer*data_size), data_size,
+                                ncclChar, peer, team->nccl_comm, stream),
+                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+    }
+    NCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
 
-    // NCCLCHECK(ncclGroupStart());
-    // for (peer = 0; peer < group_size; peer++) {
-    //     NCCLCHECK(ncclSend((void*)(sbuf + peer*data_size),
-    //                        data_size, ncclChar, peer,
-    //                        req->team->nccl_comm,
-    //                        *stream));
-    //     NCCLCHECK(ncclRecv((void*)(rbuf + peer*data_size),
-    //                        data_size, ncclChar, peer,
-    //                        req->team->nccl_comm,
-    //                        *stream));
-
-    // }
-    // NCCLCHECK(ncclGroupEnd());
-
-    return UCC_ERR_NOT_IMPLEMENTED;
+exit_coll:
+    if (status == UCC_OK) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+    } else if (status < 0) {
+        task->super.super.status = status;
+    }
+    return status;
 }
 
 ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task)
 {
-    task->super.super.status = UCC_INPROGRESS;
+    if ((task->args.src.info.datatype == UCC_DT_USERDEFINED) ||
+        (task->args.dst.info.datatype == UCC_DT_USERDEFINED)) {
+        tl_error(UCC_TL_TEAM_LIB(task->team),
+                 "user defined datatype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
     task->super.post = ucc_nccl_alltoall_start;
     task->super.progress = ucc_nccl_collective_progress;
     return UCC_OK;

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -15,6 +15,7 @@ ucc_status_t ucc_nccl_collective_progress(ucc_coll_task_t *coll_task)
     cuda_st = cudaEventQuery(task->completed);
     switch(cuda_st) {
     case cudaSuccess:
+        coll_task->super.status = UCC_OK;
         return UCC_OK;
     case cudaErrorNotReady:
         return UCC_INPROGRESS;
@@ -55,6 +56,7 @@ ucc_status_t ucc_nccl_alltoall_start(ucc_coll_task_t *coll_task)
 
 ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task)
 {
+    task->super.super.status = UCC_INPROGRESS;
     task->super.post = ucc_nccl_alltoall_start;
     task->super.progress = ucc_nccl_collective_progress;
     return UCC_OK;

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -60,6 +60,7 @@ ucc_status_t ucc_nccl_collective_progress(ucc_coll_task_t *coll_task)
         return UCC_ERR_NO_MESSAGE;
     }
 }
+
 ucc_status_t ucc_nccl_alltoall_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
@@ -104,6 +105,81 @@ ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task)
         return UCC_ERR_NOT_SUPPORTED;
     }
     task->super.post = ucc_nccl_alltoall_start;
+    task->super.progress = ucc_nccl_collective_progress;
+    return UCC_OK;
+}
+
+static inline size_t get_count(ucc_count_t *counts, ucc_rank_t idx,
+                               ucc_tl_nccl_task_t *task)
+{
+    if ((task->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
+        (task->args.flags & UCC_COLL_ARGS_FLAG_COUNT_64BIT)) {
+        return ((uint64_t *)counts)[idx];
+    }
+    return ((uint32_t *)counts)[idx];
+}
+
+static inline size_t get_displacement(ucc_aint_t *displacements, ucc_rank_t idx,
+                                      ucc_tl_nccl_task_t *task)
+{
+    if ((task->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
+        (task->args.flags & UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT)) {
+        return ((uint64_t *)displacements)[idx];
+    }
+    return ((uint32_t *)displacements)[idx];
+}
+
+ucc_status_t ucc_nccl_alltoallv_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_tl_nccl_team_t *team   = task->team;
+    cudaStream_t        stream = team->stream;
+    ucc_status_t        status = UCC_OK;
+    ptrdiff_t           sbuf   = (ptrdiff_t)task->args.src.info.buffer;
+    ptrdiff_t           rbuf   = (ptrdiff_t)task->args.dst.info.buffer;
+    size_t data_size, data_displ, sdt_size, rdt_size;
+    ucc_rank_t peer;
+
+    task->super.super.status = UCC_INPROGRESS;
+    sdt_size = ucc_dt_size(task->args.src.info_v.datatype);
+    rdt_size = ucc_dt_size(task->args.dst.info_v.datatype);
+    NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    for (peer = 0; peer < team->size; peer++) {
+        data_size  = get_count(task->args.src.info_v.counts, peer, task) *
+                               sdt_size;
+        data_displ = get_displacement(task->args.src.info_v.displacements,
+                                      peer, task) * sdt_size;
+        NCCLCHECK_GOTO(ncclSend((void*)(sbuf + data_displ), data_size,
+                                ncclChar, peer, team->nccl_comm, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
+        data_size  = get_count(task->args.dst.info_v.counts, peer, task) *
+                               rdt_size;
+        data_displ = get_displacement(task->args.dst.info_v.displacements,
+                                      peer, task) * rdt_size;
+        NCCLCHECK_GOTO(ncclRecv((void*)(rbuf + data_displ), data_size,
+                                ncclChar, peer, team->nccl_comm, stream),
+                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+    }
+    NCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+
+exit_coll:
+    if (status == UCC_OK) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+    } else if (status < 0) {
+        task->super.super.status = status;
+    }
+    return status;
+}
+
+ucc_status_t ucc_tl_nccl_alltoallv_init(ucc_tl_nccl_task_t *task)
+{
+    if ((task->args.src.info.datatype == UCC_DT_USERDEFINED) ||
+        (task->args.dst.info.datatype == UCC_DT_USERDEFINED)) {
+        tl_error(UCC_TL_TEAM_LIB(task->team),
+                 "user defined datatype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    task->super.post = ucc_nccl_alltoallv_start;
     task->super.progress = ucc_nccl_collective_progress;
     return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_nccl_coll.h"
+
+
+ucc_status_t ucc_nccl_collective_progress(ucc_coll_task_t *coll_task)
+{
+    cudaError_t cuda_st;
+    ucc_tl_nccl_task_t *task = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+
+    cuda_st = cudaEventQuery(task->completed);
+    switch(cuda_st) {
+    case cudaSuccess:
+        return UCC_OK;
+    case cudaErrorNotReady:
+        return UCC_INPROGRESS;
+    default:
+        return UCC_ERR_NO_MESSAGE;
+    }
+}
+ucc_status_t ucc_nccl_alltoall_start(ucc_coll_task_t *coll_task)
+{
+    // ptrdiff_t    sbuf, rbuf;
+    // size_t       data_size;
+    // int          group_size;
+    // int          peer;
+    // cudaStream_t *stream;
+
+    // stream = (cudaStream_t*)args->stream.stream;
+    // NCCLCHECK(ncclCommCount(req->team->nccl_comm, &group_size));
+    // sbuf      = (ptrdiff_t)args->buffer_info.src_buffer;
+    // rbuf      = (ptrdiff_t)args->buffer_info.dst_buffer;
+    // data_size = args->buffer_info.len;
+
+    // NCCLCHECK(ncclGroupStart());
+    // for (peer = 0; peer < group_size; peer++) {
+    //     NCCLCHECK(ncclSend((void*)(sbuf + peer*data_size),
+    //                        data_size, ncclChar, peer,
+    //                        req->team->nccl_comm,
+    //                        *stream));
+    //     NCCLCHECK(ncclRecv((void*)(rbuf + peer*data_size),
+    //                        data_size, ncclChar, peer,
+    //                        req->team->nccl_comm,
+    //                        *stream));
+
+    // }
+    // NCCLCHECK(ncclGroupEnd());
+
+    return UCC_ERR_NOT_IMPLEMENTED;
+}
+
+ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task)
+{
+    task->super.post = ucc_nccl_alltoall_start;
+    task->super.progress = ucc_nccl_collective_progress;
+    return UCC_OK;
+}

--- a/src/components/tl/nccl/tl_nccl_coll.h
+++ b/src/components/tl/nccl/tl_nccl_coll.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_NCCL_COLL_H_
+#define UCC_TL_NCCL_COLL_H_
+
+#include "tl_nccl.h"
+
+ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task);
+
+#endif

--- a/src/components/tl/nccl/tl_nccl_coll.h
+++ b/src/components/tl/nccl/tl_nccl_coll.h
@@ -11,4 +11,6 @@
 
 ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task);
 
+ucc_status_t ucc_tl_nccl_alltoallv_init(ucc_tl_nccl_task_t *task);
+
 #endif

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_nccl.h"
+
+UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
+                    const ucc_base_context_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    ucc_tl_nccl_context_config_t *tl_nccl_config =
+        ucc_derived_of(config, ucc_tl_nccl_context_config_t);
+    ucc_status_t status;
+
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_nccl_config->super.tl_lib,
+                              params->context);
+    memcpy(&self->cfg, tl_nccl_config, sizeof(*tl_nccl_config));
+    status = ucc_mpool_init(&self->req_mp, sizeof(ucc_tl_nccl_task_t),
+                            UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL, NULL,
+                            "tl_nccl_req_mp");
+    if (status != UCC_OK) {
+        tl_error(self->super.super.lib,
+                 "failed to initialize tl_nccl_req mpool");
+        return status;
+    }
+    tl_info(self->super.super.lib, "initialized tl context: %p", self);
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_context_t)
+{
+    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    ucc_mpool_cleanup(&self->req_mp, 1);
+}
+
+UCC_CLASS_DEFINE(ucc_tl_nccl_context_t, ucc_tl_context_t);
+
+ucc_status_t ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
+                                          ucc_base_attr_t *attr) /* NOLINT */
+{
+    /* TODO */
+    return UCC_ERR_NOT_IMPLEMENTED;
+}

--- a/src/components/tl/nccl/tl_nccl_lib.c
+++ b/src/components/tl/nccl/tl_nccl_lib.c
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_nccl.h"
+
+/* NOLINTNEXTLINE  params is not used*/
+UCC_CLASS_INIT_FUNC(ucc_tl_nccl_lib_t, const ucc_base_lib_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    const ucc_tl_lib_config_t *tl_config =
+        ucc_derived_of(config, ucc_tl_lib_config_t);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_nccl.super, tl_config);
+    tl_info(&self->super, "initialized lib object: %p", self);
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_lib_t)
+{
+    tl_info(&self->super, "finalizing lib object: %p", self);
+}
+
+UCC_CLASS_DEFINE(ucc_tl_nccl_lib_t, ucc_tl_lib_t);
+
+ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
+                                     ucc_base_attr_t *attr)     /* NOLINT */
+{
+    //TODO
+    return UCC_ERR_NOT_IMPLEMENTED;
+}

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -1,0 +1,174 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_nccl.h"
+#include "tl_nccl_coll.h"
+
+#define NCCLCHECK_GOTO(_cmd, _label, _status, _lib) do {                       \
+  ncclResult_t e = _cmd;                                                       \
+  if(ncclSuccess != e) {                                                       \
+    tl_error(_lib, "NCCL error %d %s", e, ncclGetErrorString(e));              \
+    _status = UCC_ERR_NO_MESSAGE;                                              \
+    goto _label;                                                               \
+  }                                                                            \
+} while(0)
+
+#define CUDACHECK_GOTO(_cmd, _label, _status, _lib) do {                       \
+  cudaError_t e = _cmd;                                                        \
+  if(cudaSuccess != e) {                                                       \
+    tl_error(_lib, "CUDA error %d %s", e, cudaGetErrorName(e));                \
+    _status = UCC_ERR_NO_MESSAGE;                                              \
+    goto _label;                                                               \
+  }                                                                            \
+} while(0)
+
+
+UCC_CLASS_INIT_FUNC(ucc_tl_nccl_team_t, ucc_base_context_t *tl_context,
+                    const ucc_base_team_params_t *params)
+{
+    ucc_tl_nccl_context_t *ctx    =
+        ucc_derived_of(tl_context, ucc_tl_nccl_context_t);
+    ucc_status_t status;
+
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super);
+    self->oob       = params->params.oob;
+    self->size      = self->oob.participants;
+    self->rank      = params->rank;
+    self->unique_id = ucc_malloc(sizeof(ncclUniqueId) * (self->size + 1),
+                                 "tl_nccl_unique_id");
+    if (!self->unique_id) {
+        tl_error(ctx->super.super.lib,
+                 "failed to allocate %zd bytes for unique_id array",
+                 sizeof(ncclUniqueId) * (self->size + 1));
+        return UCC_ERR_NO_MEMORY;
+    }
+    if (self->rank == 0) {
+        NCCLCHECK_GOTO(ncclGetUniqueId(&self->unique_id[self->size]),
+                       free_unique_id, status, ctx->super.super.lib);
+    }
+    status = self->oob.allgather(&self->unique_id[self->size], self->unique_id,
+                                 sizeof(ncclUniqueId), self->oob.coll_info,
+                                 &self->oob_req);
+    if (status != UCC_OK) {
+        tl_error(ctx->super.super.lib, "failed to start oob allgather");
+        goto free_unique_id;
+    }
+    return UCC_OK;
+
+free_unique_id:
+    ucc_free(self->unique_id);
+    return status;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_team_t)
+{
+    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    if (self->nccl_comm) {
+        ncclCommDestroy(self->nccl_comm);
+        cudaStreamDestroy(self->stream);
+    }
+}
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_nccl_team_t, ucc_base_team_t);
+UCC_CLASS_DEFINE(ucc_tl_nccl_team_t, ucc_tl_team_t);
+
+ucc_status_t ucc_tl_nccl_team_destroy(ucc_base_team_t *tl_team)
+{
+    // ucc_tl_nccl_team_t *team = ucc_derived_of(tl_team, ucc_tl_nccl_team_t);
+    UCC_CLASS_DELETE_FUNC_NAME(ucc_tl_nccl_team_t)(tl_team);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_nccl_team_create_test(ucc_base_team_t *tl_team)
+{
+    ucc_tl_nccl_team_t *team = ucc_derived_of(tl_team, ucc_tl_nccl_team_t);
+    ucc_status_t status;
+    ncclResult_t nccl_status;
+
+    status = team->oob.req_test(team->oob_req);
+    if (status < 0) {
+        team->oob.req_free(team->oob_req);
+        tl_error(team->super.super.context->lib, "oob req test failed");
+        goto free_unique_id;
+    }
+    if (status == UCC_INPROGRESS) {
+        return UCC_INPROGRESS;
+    }
+    status = team->oob.req_free(team->oob_req);
+    if (status != UCC_OK) {
+        tl_error(team->super.super.context->lib, "oob req free failed");
+        goto free_unique_id;
+    }
+    CUDACHECK_GOTO(cudaStreamCreateWithFlags(&team->stream,
+                   cudaStreamNonBlocking), free_unique_id, status,
+                   team->super.super.context->lib);
+    nccl_status = ncclCommInitRank(&team->nccl_comm,team->size,
+                                   team->unique_id[0], team->rank);
+    if (nccl_status != ncclSuccess) {
+        tl_info(team->super.super.context->lib, "NCCL error %d %s",
+                nccl_status, ncclGetErrorString(nccl_status));
+        status = UCC_ERR_NO_MESSAGE;
+        goto free_stream;
+    }
+
+    ucc_free(team->unique_id);
+    return UCC_OK;
+
+free_stream:
+    cudaStreamDestroy(team->stream);
+free_unique_id:
+    ucc_free(team->unique_id);
+    return status;
+}
+
+static ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    tl_info(task->team->super.super.context->lib, "finalizing coll task %p",
+            task);
+    cudaEventDestroy(task->completed);
+    ucc_mpool_put(task);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_op_args_t *coll_args,
+                                   ucc_base_team_t *team,
+                                   ucc_coll_task_t **task_h)
+{
+    ucc_tl_nccl_team_t    *nccl_team = ucc_derived_of(team, ucc_tl_nccl_team_t);
+    ucc_tl_nccl_context_t *nccl_ctx  = ucc_derived_of(team->context,
+                                                      ucc_tl_nccl_context_t);
+    ucc_tl_nccl_task_t    *task;
+    ucc_status_t status;
+
+    task = ucc_mpool_get(&nccl_ctx->req_mp);
+    ucc_coll_task_init(&task->super);
+    memcpy(&task->args, &coll_args->args, sizeof(ucc_coll_op_args_t));
+    task->team = nccl_team;
+    task->super.finalize = ucc_tl_nccl_coll_finalize;
+    CUDACHECK_GOTO(cudaEventCreateWithFlags(&task->completed,
+                   cudaEventDisableTiming), free_task, status,
+                   team->context->lib);
+    switch (coll_args->args.coll_type)
+    {
+    case UCC_COLL_TYPE_ALLTOALL:
+        status = ucc_tl_nccl_alltoall_init(task);
+        break;
+    default:
+        status = UCC_ERR_NOT_SUPPORTED;
+    }
+    if (status != UCC_OK) {
+        goto free_event;
+    }
+    *task_h = &task->super;
+    return status;
+
+free_event:
+    cudaEventDestroy(task->completed);
+free_task:
+    ucc_mpool_put(task);
+    return status;
+}

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -134,7 +134,7 @@ static ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_op_args_t *coll_args,
+ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t *team,
                                    ucc_coll_task_t **task_h)
 {
@@ -146,7 +146,7 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_op_args_t *coll_args,
 
     task = ucc_mpool_get(&nccl_ctx->req_mp);
     ucc_coll_task_init(&task->super);
-    memcpy(&task->args, &coll_args->args, sizeof(ucc_coll_op_args_t));
+    memcpy(&task->args, &coll_args->args, sizeof(ucc_coll_args_t));
     task->team = nccl_team;
     task->super.finalize = ucc_tl_nccl_coll_finalize;
     CUDACHECK_GOTO(cudaEventCreateWithFlags(&task->completed,

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -7,25 +7,6 @@
 #include "tl_nccl.h"
 #include "tl_nccl_coll.h"
 
-#define NCCLCHECK_GOTO(_cmd, _label, _status, _lib) do {                       \
-  ncclResult_t e = _cmd;                                                       \
-  if(ncclSuccess != e) {                                                       \
-    tl_error(_lib, "NCCL error %d %s", e, ncclGetErrorString(e));              \
-    _status = UCC_ERR_NO_MESSAGE;                                              \
-    goto _label;                                                               \
-  }                                                                            \
-} while(0)
-
-#define CUDACHECK_GOTO(_cmd, _label, _status, _lib) do {                       \
-  cudaError_t e = _cmd;                                                        \
-  if(cudaSuccess != e) {                                                       \
-    tl_error(_lib, "CUDA error %d %s", e, cudaGetErrorName(e));                \
-    _status = UCC_ERR_NO_MESSAGE;                                              \
-    goto _label;                                                               \
-  }                                                                            \
-} while(0)
-
-
 UCC_CLASS_INIT_FUNC(ucc_tl_nccl_team_t, ucc_base_context_t *tl_context,
                     const ucc_base_team_params_t *params)
 {

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -96,13 +96,14 @@ ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context)
     return UCC_OK;
 }
 
-ucc_status_t ucc_team_create_multiple_req_alloc(ucc_team_create_multiple_req_t **req,
-                                        int n_teams)
+ucc_status_t
+ucc_team_create_multiple_req_alloc(ucc_team_create_multiple_req_t **req,
+                                   int n_teams)
 {
     ucc_team_create_multiple_req_t *r;
 
     r = ucc_malloc(sizeof(ucc_team_create_multiple_req_t),
-                          "team create multiple req alloc");
+                   "team create multiple req alloc");
     if (!r) {
         goto exit_err;
     }
@@ -127,8 +128,8 @@ ucc_status_t ucc_team_create_multiple_req_alloc(ucc_team_create_multiple_req_t *
         goto free_teams;
     }
     r->last_created = -1;
-    r->n_teams = n_teams;
-    *req = r;
+    r->n_teams      = n_teams;
+    *req            = r;
     return UCC_OK;
 free_teams:
     ucc_free(r->teams);
@@ -154,9 +155,9 @@ void ucc_team_create_multiple_req_free(ucc_team_create_multiple_req_t *req)
 
 ucc_status_t ucc_tl_team_create_multiple(ucc_team_create_multiple_req_t *req)
 {
+    int *id = &req->last_created;
     ucc_base_team_t *b_team;
     ucc_status_t     status;
-    int *id = &req->last_created;
 
     if (*id == req->n_teams) {
         return UCC_OK;
@@ -167,20 +168,20 @@ ucc_status_t ucc_tl_team_create_multiple(ucc_team_create_multiple_req_t *req)
         if (*id == req->n_teams) {
             return UCC_OK;
         }
-        status = UCC_TL_CTX_IFACE(req->contexts[*id])->team.create_post(
-                    &((req->contexts[*id])->super),
-                    req->params[*id],
-                    &b_team);
+        status = UCC_TL_CTX_IFACE(req->contexts[*id])
+                     ->team.create_post(&((req->contexts[*id])->super),
+                                        req->params[*id], &b_team);
         if (UCC_OK != status) {
             req->teams_status[*id] = status;
-            req->teams[*id] = NULL;
+            req->teams[*id]        = NULL;
         } else {
             req->teams_status[*id] = UCC_INPROGRESS;
-            req->teams[*id] = ucc_derived_of(b_team, ucc_tl_team_t);
+            req->teams[*id]        = ucc_derived_of(b_team, ucc_tl_team_t);
         }
         return UCC_INPROGRESS;
     }
-    req->teams_status[*id] = UCC_TL_CTX_IFACE(req->contexts[*id])->team.create_test(&req->teams[*id]->super);
+    req->teams_status[*id] = UCC_TL_CTX_IFACE(req->contexts[*id])
+                                 ->team.create_test(&req->teams[*id]->super);
     return UCC_INPROGRESS;
 }
 

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -96,6 +96,94 @@ ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context)
     return UCC_OK;
 }
 
+ucc_status_t ucc_team_create_multiple_req_alloc(ucc_team_create_multiple_req_t **req,
+                                        int n_teams)
+{
+    ucc_team_create_multiple_req_t *r;
+
+    r = ucc_malloc(sizeof(ucc_team_create_multiple_req_t),
+                          "team create multiple req alloc");
+    if (!r) {
+        goto exit_err;
+    }
+    r->contexts = ucc_malloc(n_teams * sizeof(ucc_tl_context_t*),
+                             "team create multiple req alloc");
+    if (!r->contexts) {
+        goto free_req;
+    }
+    r->params = ucc_malloc(n_teams * sizeof(ucc_base_team_params_t*),
+                           "team create multiple req alloc");
+    if (!r->params) {
+        goto free_contexts;
+    }
+    r->teams = ucc_malloc(n_teams * sizeof(ucc_tl_team_t*),
+                          "team create multiple req alloc");
+    if (!r->teams) {
+        goto free_params;
+    }
+    r->teams_status = ucc_malloc(n_teams * sizeof(ucc_status_t),
+                                 "team create multiple req alloc");
+    if (!r->teams_status) {
+        goto free_teams;
+    }
+    r->last_created = -1;
+    r->n_teams = n_teams;
+    *req = r;
+    return UCC_OK;
+free_teams:
+    ucc_free(r->teams);
+free_params:
+    ucc_free(r->params);
+free_contexts:
+    ucc_free(r->contexts);
+free_req:
+    ucc_free(r);
+exit_err:
+    *req = NULL;
+    return UCC_ERR_NO_MEMORY;
+}
+
+void ucc_team_create_multiple_req_free(ucc_team_create_multiple_req_t *req)
+{
+    ucc_free(req->contexts);
+    ucc_free(req->params);
+    ucc_free(req->teams);
+    ucc_free(req->teams_status);
+    ucc_free(req);
+}
+
+ucc_status_t ucc_tl_team_create_multiple(ucc_team_create_multiple_req_t *req)
+{
+    ucc_base_team_t *b_team;
+    ucc_status_t     status;
+    int *id = &req->last_created;
+
+    if (*id == req->n_teams) {
+        return UCC_OK;
+    }
+    if ((*id == -1) || (req->teams_status[*id] != UCC_INPROGRESS)) {
+        /* post next team */
+        *id += 1;
+        if (*id == req->n_teams) {
+            return UCC_OK;
+        }
+        status = UCC_TL_CTX_IFACE(req->contexts[*id])->team.create_post(
+                    &((req->contexts[*id])->super),
+                    req->params[*id],
+                    &b_team);
+        if (UCC_OK != status) {
+            req->teams_status[*id] = status;
+            req->teams[*id] = NULL;
+        } else {
+            req->teams_status[*id] = UCC_INPROGRESS;
+            req->teams[*id] = ucc_derived_of(b_team, ucc_tl_team_t);
+        }
+        return UCC_INPROGRESS;
+    }
+    req->teams_status[*id] = UCC_TL_CTX_IFACE(req->contexts[*id])->team.create_test(&req->teams[*id]->super);
+    return UCC_INPROGRESS;
+}
+
 UCC_CLASS_INIT_FUNC(ucc_tl_team_t, ucc_tl_context_t *tl_context)
 {
     UCC_CLASS_CALL_BASE_INIT();

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -85,6 +85,22 @@ ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, ucc_tl_type_t type,
                                 ucc_tl_context_t **tl_context);
 ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context);
 
+typedef struct ucc_team_create_multiple_req {
+    ucc_tl_context_t       **contexts;
+    ucc_base_team_params_t **params;
+    ucc_tl_team_t          **teams;
+    ucc_status_t            *teams_status;
+    int                      last_created;
+    int                      n_teams;
+} ucc_team_create_multiple_req_t;
+
+ucc_status_t ucc_team_create_multiple_req_alloc(ucc_team_create_multiple_req_t **req,
+                                                int n_teams);
+
+ucc_status_t ucc_tl_team_create_multiple(ucc_team_create_multiple_req_t *req);
+
+void ucc_team_create_multiple_req_free(ucc_team_create_multiple_req_t *req);
+
 #define UCC_TL_CTX_IFACE(_tl_ctx)                                              \
     (ucc_derived_of((_tl_ctx)->super.lib, ucc_tl_lib_t))->iface
 

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -86,12 +86,14 @@ ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, ucc_tl_type_t type,
 ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context);
 
 typedef struct ucc_team_create_multiple_req {
-    ucc_tl_context_t       **contexts;
-    ucc_base_team_params_t **params;
-    ucc_tl_team_t          **teams;
-    ucc_status_t            *teams_status;
-    int                      last_created;
-    int                      n_teams;
+    int                          n_teams;
+    int                          last_created;
+    struct ucc_team_team_desc {
+        ucc_tl_context_t        *ctx;
+        ucc_tl_team_t           *team;
+        ucc_base_team_params_t   param;
+        ucc_status_t             status;
+    } descs[1];
 } ucc_team_create_multiple_req_t;
 
 ucc_status_t

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -94,8 +94,9 @@ typedef struct ucc_team_create_multiple_req {
     int                      n_teams;
 } ucc_team_create_multiple_req_t;
 
-ucc_status_t ucc_team_create_multiple_req_alloc(ucc_team_create_multiple_req_t **req,
-                                                int n_teams);
+ucc_status_t
+ucc_team_create_multiple_req_alloc(ucc_team_create_multiple_req_t **req,
+                                   int n_teams);
 
 ucc_status_t ucc_tl_team_create_multiple(ucc_team_create_multiple_req_t *req);
 
@@ -109,7 +110,6 @@ void ucc_team_create_multiple_req_free(ucc_team_create_multiple_req_t *req);
 
 #define UCC_TL_TEAM_LIB(_tl_team) (_tl_team)->super.super.context->lib
 
-#define UCC_TL_CORE_CTX(_tl_team)                                              \
-    ((_tl_team)->super.super.context->ucc_context)
+#define UCC_TL_CORE_CTX(_tl_team) ((_tl_team)->super.super.context->ucc_context)
 
 #endif

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -26,7 +26,8 @@ typedef struct ucc_tl_context ucc_tl_context_t;
 typedef struct ucc_tl_team    ucc_tl_team_t;
 
 typedef enum ucc_tl_type {
-    UCC_TL_UCP = UCC_BIT(0),
+    UCC_TL_UCP  = UCC_BIT(0),
+    UCC_TL_NCCL = UCC_BIT(1),
 } ucc_tl_type_t;
 
 typedef struct ucc_tl_lib_config {

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -108,4 +108,8 @@ void ucc_team_create_multiple_req_free(ucc_team_create_multiple_req_t *req);
     (ucc_derived_of((_tl_team)->super.context->lib, ucc_tl_lib_t))->iface
 
 #define UCC_TL_TEAM_LIB(_tl_team) (_tl_team)->super.super.context->lib
+
+#define UCC_TL_CORE_CTX(_tl_team)                                              \
+    ((_tl_team)->super.super.context->ucc_context)
+
 #endif

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -25,3 +25,8 @@ CXX=mpicxx
 CXXFLAGS+=-I${top_builddir}/src -std=gnu++11
 
 LDFLAGS=-L${top_builddir}/src/.libs -lucc
+
+if HAVE_CUDA
+CFLAGS += $(CUDA_CFLAGS) -DUCC_TEST_WITH_CUDA
+LDFLAGS+= $(CUDA_LDFLAGS) -lcudart
+endif


### PR DESCRIPTION
## What
Adding TL NCCL

## Why ?
TL NCCL can be used for GPU collectives

## How ?
New TL has been added, it's available only if CUDA and NCCL libs are there. NCCL comm is mapped to UCC team, so each new team creates new NCCL comm. CL Basis tries to initialize NCCL TL but if it can't it simply ignores it and proceed.
