### PR TITLE
TL/UCP: bcast knomial

### DIFF
--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -17,6 +17,11 @@ alltoallv =                        \
 	alltoallv/alltoallv.c          \
 	alltoallv/alltoallv_pairwise.c
 
+bcast =                   \
+	bcast/bcast.h         \
+	bcast/bcast.c         \
+	bcast/bcast_knomial.c
+
 allreduce =                       \
 	allreduce/allreduce.h         \
 	allreduce/allreduce.c         \
@@ -47,7 +52,8 @@ sources =            \
 	$(alltoallv)     \
 	$(allreduce)     \
 	$(allgather)     \
-	$(allgatherv)
+	$(allgatherv)    \
+	$(bcast)
 
 module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)

--- a/src/components/tl/ucp/bcast/bcast.c
+++ b/src/components/tl/ucp/bcast/bcast.c
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#include "config.h"
+#include "tl_ucp.h"
+#include "bcast.h"
+
+ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *task);
+ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_ucp_bcast_init(ucc_tl_ucp_task_t *task)
+{
+    task->super.post     = ucc_tl_ucp_bcast_knomial_start;
+    task->super.progress = ucc_tl_ucp_bcast_knomial_progress;
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/bcast/bcast.h
+++ b/src/components/tl/ucp/bcast/bcast.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#ifndef BCAST_H_
+#define BCAST_H_
+#include "../tl_ucp.h"
+#include "../tl_ucp_coll.h"
+
+ucc_status_t ucc_tl_ucp_bcast_init(ucc_tl_ucp_task_t *task);
+
+#endif

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "tl_ucp.h"
+#include "bcast.h"
+#include "core/ucc_progress_queue.h"
+#include "tl_ucp_sendrecv.h"
+#include "utils/ucc_math.h"
+
+#define CALC_DIST(_size, _radix, _dist)                                        \
+    do {                                                                       \
+        _dist = 1;                                                             \
+        while (_dist * _radix < _size) {                                       \
+            _dist *= _radix;                                                   \
+        }                                                                      \
+    } while (0)
+
+ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team      = task->team;
+    ucc_rank_t         myrank    = team->rank;
+    ucc_rank_t         team_size = team->size;
+    ucc_rank_t         root      = (uint32_t)task->args.root;
+    uint32_t           radix     = task->bcast_kn.radix;
+    ucc_rank_t         vrank     = (myrank - root + team_size) % team_size;
+    ucc_rank_t         dist      = task->bcast_kn.dist;
+    void              *buffer    = task->args.src.info.buffer;
+    ucc_memory_type_t  mtype     = task->args.src.info.mem_type;
+    size_t data_size =
+        task->args.src.info.count * ucc_dt_size(task->args.src.info.datatype);
+    ucc_rank_t vpeer, peer, vroot_at_level, root_at_level, pos;
+    uint32_t i;
+
+    if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+        return task->super.super.status;
+    }
+    while (dist >= 1) {
+        if (vrank % dist == 0) {
+            pos = (vrank / dist) % radix;
+            if (pos == 0) {
+                for (i = radix - 1; i >= 1; i--) {
+                    vpeer = vrank + i * dist;
+                    if (vpeer < team_size) {
+                        peer = (vpeer + root) % team_size;
+                        ucc_tl_ucp_send_nb(buffer, data_size, mtype, peer, team,
+                                           task);
+                    }
+                }
+            } else {
+                vroot_at_level = vrank - pos * dist;
+                root_at_level  = (vroot_at_level + root) % team_size;
+                ucc_tl_ucp_recv_nb(buffer, data_size, mtype, root_at_level,
+                                   team, task);
+                ucc_assert(task->send_posted == 0 && task->recv_posted == 1);
+            }
+        }
+        dist /= radix;
+        if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+            task->bcast_kn.dist = dist;
+            return task->super.super.status;
+        }
+    }
+
+    ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
+    task->super.super.status = UCC_OK;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team = task->team;
+    ucc_status_t       status;
+    task->bcast_kn.radix =
+        ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.bcast_kn_radix, team->size);
+    CALC_DIST(team->size, task->bcast_kn.radix, task->bcast_kn.dist);
+    task->super.super.status = UCC_INPROGRESS;
+    status                   = ucc_tl_ucp_bcast_knomial_progress(&task->super);
+    if (UCC_INPROGRESS == status) {
+        ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
+    } else if (status < 0) {
+        return status;
+    }
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -37,6 +37,11 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
+    {"BCAST_KN_RADIX", "4",
+     "Radix of the recursive-knomial bcast algorithm",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, bcast_kn_radix),
+     UCC_CONFIG_TYPE_UINT},
+
     {NULL}};
 
 static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -23,6 +23,7 @@ typedef struct ucc_tl_ucp_lib_config {
     ucc_tl_lib_config_t super;
     uint32_t            barrier_kn_radix;
     uint32_t            allreduce_kn_radix;
+    uint32_t            bcast_kn_radix;
     uint32_t            alltoall_pairwise_num_posts;
     uint32_t            alltoallv_pairwise_num_posts;
 } ucc_tl_ucp_lib_config_t;

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -13,6 +13,7 @@
 #include "allreduce/allreduce.h"
 #include "allgather/allgather.h"
 #include "allgatherv/allgatherv.h"
+#include "bcast/bcast.h"
 
 void ucc_tl_ucp_send_completion_cb(void *request, ucs_status_t status,
                                    void *user_data)
@@ -82,6 +83,9 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_args_t *coll_args,
         break;
     case UCC_COLL_TYPE_ALLGATHERV:
         status = ucc_tl_ucp_allgatherv_init(task);
+        break;
+    case UCC_COLL_TYPE_BCAST:
+        status = ucc_tl_ucp_bcast_init(task);
         break;
     default:
         status = UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -31,6 +31,10 @@ typedef struct ucc_tl_ucp_task {
             ucc_knomial_pattern_t p;
             void                 *scratch;
         } allreduce_kn;
+        struct {
+            ucc_rank_t            dist;
+            uint32_t              radix;
+        } bcast_kn;
     };
 } ucc_tl_ucp_task_t;
 

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -18,7 +18,8 @@ ucc_test_mpi_SOURCES = \
 	test_barrier.cc    \
 	test_allreduce.cc  \
 	test_allgather.cc  \
-	test_allgatherv.cc
+	test_allgatherv.cc \
+	test_bcast.cc
 
 CXX=mpicxx
 CXXFLAGS+=-I${top_builddir}/src -std=gnu++11

--- a/test/mpi/buffer.cc
+++ b/test/mpi/buffer.cc
@@ -17,9 +17,8 @@ template<typename T>
 void init_buffer_host(void *buf, size_t count, int _value)
 {
     T *ptr = (T *)buf;
-    T value = (T)_value;
     for (int i = 0; i < count; i++) {
-        ptr[i] = value;
+        ptr[i] = (T)((_value + i + 1) % 128);
     }
 }
 

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -83,6 +83,8 @@ static ucc_coll_type_t coll_str_to_type(std::string coll)
         return UCC_COLL_TYPE_ALLGATHER;
     } else if (coll == "allgatherv") {
         return UCC_COLL_TYPE_ALLGATHERV;
+    } else if (coll == "bcast") {
+        return UCC_COLL_TYPE_BCAST;
     } else {
         std::cerr << "incorrect coll type: " << coll << std::endl;
         PrintHelp();

--- a/test/mpi/test_bcast.cc
+++ b/test/mpi/test_bcast.cc
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "test_mpi.h"
+#include "mpi_util.h"
+
+#define TEST_DT UCC_DT_UINT32
+
+TestBcast::TestBcast(size_t _msgsize, ucc_memory_type_t _mt,
+                     int _root, ucc_test_team_t &_team) :
+    TestCaseNoInplace(_team, _mt, _msgsize)
+{
+    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t count = _msgsize/dt_size;
+    int rank, size;
+    MPI_Comm_rank(team.comm, &rank);
+    MPI_Comm_size(team.comm, &size);
+    root = _root;
+
+    UCC_CHECK(ucc_mc_alloc(&check_buf, _msgsize*size, _mt));
+    UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize, _mt));
+    if (rank == root) {
+        init_buffer(sbuf, count, TEST_DT, _mt, rank);
+    }
+
+    args.coll_type            = UCC_COLL_TYPE_BCAST;
+    args.src.info.buffer      = sbuf;
+    args.src.info.count       = count;
+    args.src.info.datatype    = TEST_DT;
+    args.src.info.mem_type    = _mt;
+    args.root                 = root;
+    UCC_CHECK(ucc_collective_init(&args, &req, team.team));
+}
+
+ucc_status_t TestBcast::check()
+{
+    size_t       count = args.src.info.count;
+    MPI_Datatype dt    = ucc_dt_to_mpi(TEST_DT);
+    int          rank;
+    MPI_Comm_rank(team.comm, &rank);
+    MPI_Bcast((rank == root) ? sbuf : check_buf, count, dt, root, team.comm);
+    return (rank == root) ? UCC_OK :
+        compare_buffers(sbuf, check_buf, count, TEST_DT, mem_type);
+}

--- a/test/mpi/test_bcast.cc
+++ b/test/mpi/test_bcast.cc
@@ -11,7 +11,7 @@
 
 TestBcast::TestBcast(size_t _msgsize, ucc_memory_type_t _mt,
                      int _root, ucc_test_team_t &_team) :
-    TestCaseNoInplace(_team, _mt, _msgsize)
+    TestCase(_team, _mt, _msgsize)
 {
     size_t dt_size = ucc_dt_size(TEST_DT);
     size_t count = _msgsize/dt_size;

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -24,6 +24,8 @@ std::shared_ptr<TestCase> TestCase::init(ucc_coll_type_t _type,
         return std::make_shared<TestAllgather>(msgsize, inplace, mt, _team);
     case UCC_COLL_TYPE_ALLGATHERV:
         return std::make_shared<TestAllgatherv>(msgsize, inplace, mt, _team);
+    case UCC_COLL_TYPE_BCAST:
+        return std::make_shared<TestBcast>(msgsize, mt, 0, _team);
     default:
         break;
     }

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -8,6 +8,7 @@
 
 std::shared_ptr<TestCase> TestCase::init(ucc_coll_type_t _type,
                                          ucc_test_team_t &_team,
+                                         int root,
                                          size_t msgsize,
                                          ucc_test_mpi_inplace_t inplace,
                                          ucc_memory_type_t mt,
@@ -25,7 +26,7 @@ std::shared_ptr<TestCase> TestCase::init(ucc_coll_type_t _type,
     case UCC_COLL_TYPE_ALLGATHERV:
         return std::make_shared<TestAllgatherv>(msgsize, inplace, mt, _team);
     case UCC_COLL_TYPE_BCAST:
-        return std::make_shared<TestBcast>(msgsize, mt, 0, _team);
+        return std::make_shared<TestBcast>(msgsize, mt, root, _team);
     default:
         break;
     }
@@ -56,9 +57,15 @@ void TestCase::wait()
 }
 
 std::string TestCase::str() {
-    return std::string("tc=")+std::string(ucc_coll_type_str(args.coll_type)) +
-        std::string(" team=") + std::string(team_str(team.type)) + " msgsize="
-        + std::to_string(msgsize);
+    std::string _str = std::string("tc=") + ucc_coll_type_str(args.coll_type) +
+        " team=" + team_str(team.type) + " msgsize=" + std::to_string(msgsize);
+    if (ucc_coll_inplace_supported(args.coll_type)) {
+        _str += std::string(" inplace=") + (inplace == TEST_INPLACE ? "1" : "0");
+    }
+    if (ucc_coll_is_rooted(args.coll_type)) {
+        _str += std::string(" root=") + std::to_string(root);
+    }
+    return _str;
 }
 
 ucc_status_t TestCase::exec()

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -10,7 +10,7 @@ BEGIN_C_DECLS
 #include "utils/ucc_math.h"
 END_C_DECLS
 #include <algorithm>
-
+#include <assert.h>
 UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t tm,
                        std::vector<ucc_test_mpi_team_t> &test_teams,
                        const char *cls)
@@ -220,9 +220,7 @@ ucc_status_t UccTestMpi::run_all()
             for (auto r : roots) {
                 if (c == UCC_COLL_TYPE_BARRIER) {
                     auto tc = TestCase::init(c, t);
-                    if (UCC_OK != tc.get()->exec()) {
-                        status = UCC_ERR_NO_MESSAGE;
-                    }
+                    results.push_back(tc.get()->exec());
                 } else {
                     for (auto mt : mtypes) {
                         for (auto m : msgsizes) {
@@ -232,9 +230,7 @@ ucc_status_t UccTestMpi::run_all()
                                     for (auto op : ops) {
                                         auto tc = TestCase::init(c, t, r, m,
                                                                  inplace, mt, dt, op);
-                                        if (UCC_OK != tc.get()->exec()) {
-                                            status = UCC_ERR_NO_MESSAGE;
-                                        }
+                                        results.push_back(tc.get()->exec());
                                     }
                                 }
                             } else {
@@ -243,9 +239,7 @@ ucc_status_t UccTestMpi::run_all()
                                     ucc_coll_inplace_supported(c)) {
                                     continue;
                                 }
-                                if (UCC_OK != tc.get()->exec()) {
-                                    status = UCC_ERR_NO_MESSAGE;
-                                }
+                                results.push_back(tc.get()->exec());
                             }
                         }
                     }

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -89,6 +89,7 @@ class UccTestMpi {
     std::vector<ucc_coll_type_t> colls;
     std::vector<int> gen_roots(ucc_test_team_t &team);
 public:
+    std::vector<ucc_status_t> results;
     UccTestMpi(int argc, char *argv[], ucc_thread_mode_t tm,
                std::vector<ucc_test_mpi_team_t> &test_teams,
                const char* cls = NULL);


### PR DESCRIPTION
## What
Knomial tree bcast algorithm in  TL/UCP
TEST/MPI/bcast

OSU Bcast (max lat), n8ppn28
msgsize | ucc | xccl | tuned
-- | -- | -- | --
1 | 4.9 | 5.27 | 6.64
2 | 4.79 | 5.16 | 8.13
4 | 4.77 | 5.09 | 8.42
8 | 4.68 | 5.23 | 8.16
16 | 4.99 | 5.16 | 8.23
32 | 4.94 | 5.02 | 8.84
64 | 5.28 | 5.56 | 9.29
128 | 6.42 | 6.79 | 10.87
256 | 7.82 | 8.43 | 13.24
512 | 8.42 | 8.9 | 14.37
1024 | 10.93 | 10.04 | 16.21
2048 | 12.05 | 12.29 | 21.16
4096 | 17.1 | 17.08 | 36.56
8192 | 24.8 | 25.75 | 55.14
16384 | 50.45 | 33.77 | 213.19
32768 | 82.18 | 55.01 | 142.74
65536 | 109.38 | 102.13 | 104.63
131072 | 190.1 | 192.68 | 205.2
262144 | 345.93 | 370.24 | 412.62
524288 | 659.53 | 725.5 | 819.11
1048576 | 1274.36 | 1250.17 | 1463.39

