### PR TITLE
TEST: introduced alltoall[v] gtest

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -74,7 +74,9 @@ gtest_SOURCES =                 \
 	core/test_context.cc        \
 	core/test_mc.cc             \
 	core/test_team.cc           \
-	core/test_barrier.cc
+	core/test_barrier.cc        \
+	core/test_alltoall.cc       \
+	core/test_alltoallv.cc
 
 if HAVE_CUDA
 gtest_SOURCES += \

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -9,6 +9,8 @@
 #ifndef UCC_TEST_HELPERS_H
 #define UCC_TEST_HELPERS_H
 
+#include "src/ucc/api/ucc.h"
+#include "src/utils/ucc_math.h"
 #include "gtest.h"
 
 #ifndef UINT16_MAX
@@ -156,8 +158,6 @@ T from_string(const std::string& str) {
 }
 
 namespace detail {
-
-#define ucc_max(_a, _b) ((_a > _b) ? _a : _b) // TODO: remove after ucc_max is merged upstream correctly
 
 class message_stream {
 public:

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -311,7 +311,7 @@ UccReq::UccReq(UccTeam_h _team, ucc_coll_args_t *args) :
     }
 }
 
-UccReq::UccReq(UccTeam_h _team, std::vector<ucc_coll_args_t*> args) :
+UccReq::UccReq(UccTeam_h _team, UccCollArgsVec args) :
         team(_team)
 {
     EXPECT_EQ(team->procs.size(), args.size());

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -311,6 +311,17 @@ UccReq::UccReq(UccTeam_h _team, ucc_coll_args_t *args) :
     }
 }
 
+UccReq::UccReq(UccTeam_h _team, std::vector<ucc_coll_args_t*> args) :
+        team(_team)
+{
+    EXPECT_EQ(team->procs.size(), args.size());
+    ucc_coll_req_h req;
+    for (auto i = 0; i < team->procs.size(); i++) {
+        EXPECT_EQ(UCC_OK, ucc_collective_init(args[i], &req, team->procs[i].team));
+        reqs.push_back(req);
+    }
+}
+
 UccReq::~UccReq()
 {
     for (auto r : reqs) {

--- a/test/gtest/core/test_alltoall.cc
+++ b/test/gtest/core/test_alltoall.cc
@@ -17,25 +17,6 @@ using Param_1 = std::tuple<int, int>;
 
 class test_alltoall : public UccCollArgs, public ucc::test
 {
-private:
-    void init_proc_buf(int nprocs, int rank, uint8_t *buf, size_t len)
-    {
-        for (auto i = 0; i < len * nprocs; i++) {
-            buf[i] = (uint8_t)rank;
-        }
-    }
-    int validate_buf(int nprocs, uint8_t *buf, size_t len)
-    {
-        for (auto p = 0; p < nprocs; p++) {
-            for (auto i = 0; i < len; i++) {
-                EXPECT_EQ(buf[len*p + i], (uint8_t)p);
-                if (buf[len*p + i] != (uint8_t)p) {
-                    return 1;
-                }
-            }
-        }
-        return 0;
-    }
 public:
     UccCollArgsVec data_init(int nprocs, ucc_datatype_t dtype,
                                      size_t count) {
@@ -44,16 +25,21 @@ public:
             ucc_coll_args_t *coll = (ucc_coll_args_t*)
                     calloc(1, sizeof(ucc_coll_args_t));
             coll->coll_type = UCC_COLL_TYPE_ALLTOALL;
+            coll->src.info.mem_type = UCC_MEMORY_TYPE_HOST;
             coll->src.info.count   = (ucc_count_t)count;
             coll->src.info.datatype = dtype;
+            coll->dst.info.mem_type = UCC_MEMORY_TYPE_HOST;
             coll->dst.info.count   = (ucc_count_t)count;
             coll->dst.info.datatype = dtype;
 
             coll->src.info.buffer = malloc(ucc_dt_size(dtype) * count * nprocs);
             coll->dst.info.buffer = malloc(ucc_dt_size(dtype) * count * nprocs);
 
-            init_proc_buf(nprocs, i, (uint8_t*)coll->src.info.buffer,
-                          ucc_dt_size(dtype) * count);
+            for (int r = 0; r < nprocs; r++) {
+                size_t rank_size = ucc_dt_size(dtype) * count;
+                alltoallx_init_buf(r, i, (uint8_t*)coll->src.info.buffer +
+                              r * rank_size, rank_size);
+            }
             args.push_back(coll);
         }
         return args;
@@ -68,12 +54,16 @@ public:
     }
     void data_validate(UccCollArgsVec args)
     {
-        for (ucc_coll_args_t* coll : args) {
-            EXPECT_EQ(0,
-                      validate_buf(args.size(),
-                                   (uint8_t*)coll->dst.info.buffer,
-                                   ucc_dt_size(coll->dst.info.datatype) *
-                                   (size_t)coll->dst.info.count));
+        for (int r = 0; r < args.size(); r++) {
+            ucc_coll_args_t* coll = args[r];
+            for (int i = 0; i < args.size(); i++) {
+                size_t rank_size = ucc_dt_size(coll->dst.info.datatype) *
+                        (size_t)coll->dst.info.count;
+                EXPECT_EQ(0,
+                          alltoallx_validate_buf(i, r,
+                          (uint8_t*)coll->dst.info.buffer + rank_size * i,
+                          rank_size));
+            }
         }
     }
 };

--- a/test/gtest/core/test_alltoall.cc
+++ b/test/gtest/core/test_alltoall.cc
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "common/test_ucc.h"
+
+// tmp
+#ifdef ucc_max
+#undef ucc_max
+#endif
+
+#include "src/utils/ucc_math.h"
+
+using Param_0 = std::tuple<int, int, int>;
+using Param_1 = std::tuple<int, int>;
+
+class test_alltoall : public UccCollArgs, public ucc::test
+{
+private:
+    void init_proc_buf(int nprocs, int rank, uint8_t *buf, size_t len)
+    {
+        for (auto i = 0; i < len * nprocs; i++) {
+            buf[i] = (uint8_t)rank;
+        }
+    }
+    int validate_buf(int nprocs, uint8_t *buf, size_t len)
+    {
+        for (auto p = 0; p < nprocs; p++) {
+            for (auto i = 0; i < len; i++) {
+                EXPECT_EQ(buf[len*p + i], (uint8_t)p);
+                if (buf[len*p + i] != (uint8_t)p) {
+                    return 1;
+                }
+            }
+        }
+        return 0;
+    }
+public:
+    UccCollArgsVec data_init(int nprocs, ucc_datatype_t dtype,
+                                     size_t count) {
+        UccCollArgsVec args;
+        for (auto i = 0; i < nprocs; i++) {
+            ucc_coll_args_t *coll = (ucc_coll_args_t*)
+                    calloc(1, sizeof(ucc_coll_args_t));
+            coll->coll_type = UCC_COLL_TYPE_ALLTOALL;
+            coll->src.info.count   = (ucc_count_t)count;
+            coll->src.info.datatype = dtype;
+            coll->dst.info.count   = (ucc_count_t)count;
+            coll->dst.info.datatype = dtype;
+
+            coll->src.info.buffer = malloc(ucc_dt_size(dtype) * count * nprocs);
+            coll->dst.info.buffer = malloc(ucc_dt_size(dtype) * count * nprocs);
+
+            init_proc_buf(nprocs, i, (uint8_t*)coll->src.info.buffer,
+                          ucc_dt_size(dtype) * count);
+            args.push_back(coll);
+        }
+        return args;
+    }
+    void data_fini(UccCollArgsVec args) {
+        for (ucc_coll_args_t* coll : args) {
+            free(coll->src.info.buffer);
+            free(coll->dst.info.buffer);
+            free(coll);
+        }
+        args.clear();
+    }
+    void data_validate(UccCollArgsVec args)
+    {
+        for (ucc_coll_args_t* coll : args) {
+            EXPECT_EQ(0,
+                      validate_buf(args.size(),
+                                   (uint8_t*)coll->dst.info.buffer,
+                                   ucc_dt_size(coll->dst.info.datatype) *
+                                   (size_t)coll->dst.info.count));
+        }
+    }
+};
+
+class test_alltoall_0 : public test_alltoall,
+        public ::testing::WithParamInterface<Param_0> {};
+
+UCC_TEST_P(test_alltoall_0, single)
+{
+    const int size = std::get<0>(GetParam());
+    const ucc_datatype_t dtype = (ucc_datatype_t)std::get<1>(GetParam());
+    const int count = std::get<2>(GetParam());
+
+    UccTeam_h team = UccJob::getStaticJob()->create_team(size);
+    UccCollArgsVec args = data_init(size, (ucc_datatype_t)dtype, count);
+    UccReq    req(team, args);
+    req.start();
+    req.wait();
+    data_validate(args);
+    data_fini(args);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ,
+    test_alltoall_0,
+    ::testing::Combine(
+        ::testing::Values(1,3,16), // nprocs
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1), // dtype
+        ::testing::Values(1,3,8))); // count
+
+class test_alltoall_1 : public test_alltoall,
+        public ::testing::WithParamInterface<Param_1> {};
+
+UCC_TEST_P(test_alltoall_1, multiple)
+{
+    const ucc_datatype_t dtype = (ucc_datatype_t)std::get<0>(GetParam());
+    const int count = std::get<1>(GetParam());
+
+    std::vector<UccReq> reqs;
+    std::vector<UccCollArgsVec> args;
+    for (auto &team : UccJob::getStaticTeams()) {
+        UccCollArgsVec arg = data_init(team->procs.size(),
+                                       dtype, count);
+        args.push_back(arg);
+        reqs.push_back(UccReq(team, arg));
+    }
+    UccReq::startall(reqs);
+    UccReq::waitall(reqs);
+
+    for (auto arg : args) {
+        data_validate(arg);
+        data_fini(arg);
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ,
+    test_alltoall_1,
+    ::testing::Combine(
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1), // dtype
+        ::testing::Values(1,3,8))); // count

--- a/test/gtest/core/test_alltoall.cc
+++ b/test/gtest/core/test_alltoall.cc
@@ -4,12 +4,6 @@
  */
 
 #include "common/test_ucc.h"
-
-// tmp
-#ifdef ucc_max
-#undef ucc_max
-#endif
-
 #include "src/utils/ucc_math.h"
 
 using Param_0 = std::tuple<int, int, int>;
@@ -20,10 +14,11 @@ class test_alltoall : public UccCollArgs, public ucc::test
 public:
     UccCollArgsVec data_init(int nprocs, ucc_datatype_t dtype,
                                      size_t count) {
-        UccCollArgsVec args;
+        UccCollArgsVec args(nprocs);
         for (auto i = 0; i < nprocs; i++) {
             ucc_coll_args_t *coll = (ucc_coll_args_t*)
                     calloc(1, sizeof(ucc_coll_args_t));
+            coll->mask = 0;
             coll->coll_type = UCC_COLL_TYPE_ALLTOALL;
             coll->src.info.mem_type = UCC_MEMORY_TYPE_HOST;
             coll->src.info.count   = (ucc_count_t)count;
@@ -40,7 +35,7 @@ public:
                 alltoallx_init_buf(r, i, (uint8_t*)coll->src.info.buffer +
                               r * rank_size, rank_size);
             }
-            args.push_back(coll);
+            args[i] = coll;
         }
         return args;
     }

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "common/test_ucc.h"
+
+// tmp
+#ifdef ucc_max
+#undef ucc_max
+#endif
+
+#include "src/utils/ucc_math.h"
+
+using Param_0 = std::tuple<int, int>;
+
+class test_alltoallv : public UccCollArgs, public ucc::test
+{
+private:
+    void init_proc_buf(int nprocs, int rank, uint8_t *buf, size_t len)
+    {
+        for (auto i = 0; i < len; i++) {
+            buf[i] = (uint8_t)rank;
+        }
+    }
+    int validate_buf(int proc, uint8_t *buf, size_t len)
+    {
+        int err = 0;
+        for (int i = 0; i < len; i ++) {
+            if (buf[i] != proc) {
+                err++;
+            }
+        }
+        return err;
+    }
+public:
+    UccCollArgsVec data_init(int nprocs, ucc_datatype_t dtype,
+                             size_t count) {
+        int buf_count;
+        UccCollArgsVec args;
+
+        for (auto r = 0; r < nprocs; r++) {
+            ucc_coll_args_t *coll = (ucc_coll_args_t*)
+                    calloc(1, sizeof(ucc_coll_args_t));
+            coll->coll_type = UCC_COLL_TYPE_ALLTOALLV;
+            coll->mask = UCC_COLL_ARGS_FIELD_FLAGS;
+            coll->flags = UCC_COLL_ARGS_FLAG_COUNT_64BIT | UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+            coll->src.info_v.counts = (ucc_count_t*)malloc(sizeof(ucc_count_t) * nprocs);
+            coll->src.info_v.datatype = dtype;
+            coll->src.info_v.displacements = (ucc_aint_t*)malloc(sizeof(ucc_aint_t) * nprocs);
+
+            coll->dst.info_v.counts = (ucc_count_t*)malloc(sizeof(ucc_count_t) * nprocs);
+            coll->dst.info_v.datatype = dtype;
+            coll->dst.info_v.displacements = (ucc_aint_t*)malloc(sizeof(ucc_aint_t) * nprocs);
+
+            buf_count = 0;
+            for (int i = 0; i < nprocs; i++) {
+                int rank_count = (nprocs + r - i) * count;
+
+                coll->src.info_v.counts[i] = rank_count;
+                coll->src.info_v.displacements[i] = buf_count;
+                buf_count += rank_count;
+            }
+
+            coll->src.info_v.buffer = malloc(buf_count * ucc_dt_size(dtype));
+            for (int i = 0; i < nprocs; i++) {
+                init_proc_buf(nprocs, i, (uint8_t*)coll->src.info_v.buffer +
+                              coll->src.info_v.displacements[i] * ucc_dt_size(dtype),
+                              coll->src.info_v.counts[i] * ucc_dt_size(dtype));
+            }
+
+            buf_count = 0;
+            for (int i = 0; i < nprocs; i++) {
+                int rank_count = (nprocs - r + i) * count;
+                coll->dst.info_v.counts[i] = rank_count;
+                coll->dst.info_v.displacements[i] = buf_count;
+                buf_count += rank_count;
+            }
+            coll->dst.info_v.buffer = malloc(buf_count * ucc_dt_size(dtype));
+            args.push_back(coll);
+        }
+        return args;
+    }
+    void data_validate(UccCollArgsVec args)
+    {
+        int proc = 0;
+        size_t dst_size = 0;
+        for (ucc_coll_args_t* coll : args) {
+            dst_size = 0;
+            for (int i = 0; i < args.size(); i++) {
+                dst_size += coll->dst.info_v.counts[i];
+            }
+            EXPECT_EQ(0, validate_buf(proc, (uint8_t*)coll->dst.info_v.buffer,
+                         dst_size * ucc_dt_size(coll->dst.info_v.datatype)));
+            proc++;
+        }
+    }
+    void data_fini(UccCollArgsVec args)
+    {
+        for (ucc_coll_args_t* coll : args) {
+            free(coll->src.info_v.counts);
+            free(coll->src.info_v.displacements);
+            free(coll->dst.info_v.counts);
+            free(coll->dst.info_v.displacements);
+            free(coll);
+        }
+        args.clear();
+    }
+};
+
+class test_alltoallv_0 : public test_alltoallv,
+        public ::testing::WithParamInterface<Param_0> {};
+
+UCC_TEST_P(test_alltoallv_0, single)
+{
+    const int size = std::get<0>(GetParam());
+    const ucc_datatype_t dtype = (ucc_datatype_t)std::get<1>(GetParam());
+
+    UccTeam_h team = UccJob::getStaticJob()->create_team(size);
+    UccCollArgsVec args = data_init(size, (ucc_datatype_t)dtype, 1);
+
+    UccReq    req(team, args);
+    req.start();
+    req.wait();
+
+    data_validate(args);
+    data_fini(args);
+}
+
+INSTANTIATE_TEST_CASE_P(
+        ,
+        test_alltoallv_0,
+        ::testing::Combine(
+            ::testing::Values(1,3,16), // nprocs
+            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+
+class test_alltoallv_1 : public test_alltoallv,
+        public ::testing::WithParamInterface<int> {};
+
+UCC_TEST_P(test_alltoallv_1, multiple)
+{
+    const ucc_datatype_t dtype = (ucc_datatype_t)(GetParam());
+    std::vector<UccReq> reqs;
+    std::vector<UccCollArgsVec> args;
+
+    for (auto &team : UccJob::getStaticTeams()) {
+        UccCollArgsVec arg = data_init(team->procs.size(),
+                                       dtype, 1);
+        args.push_back(arg);
+        reqs.push_back(UccReq(team, arg));
+    }
+    UccReq::startall(reqs);
+    UccReq::waitall(reqs);
+
+    for (auto arg : args) {
+        data_validate(arg);
+        data_fini(arg);
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(
+        ,
+        test_alltoallv_1,
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1)); // dtype

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -4,35 +4,12 @@
  */
 
 #include "common/test_ucc.h"
-
-// tmp
-#ifdef ucc_max
-#undef ucc_max
-#endif
-
 #include "src/utils/ucc_math.h"
 
 using Param_0 = std::tuple<int, int>;
 
 class test_alltoallv : public UccCollArgs, public ucc::test
 {
-private:
-    void init_proc_buf(int nprocs, int rank, uint8_t *buf, size_t len)
-    {
-        for (auto i = 0; i < len; i++) {
-            buf[i] = (uint8_t)rank;
-        }
-    }
-    int validate_buf(int proc, uint8_t *buf, size_t len)
-    {
-        int err = 0;
-        for (int i = 0; i < len; i ++) {
-            if (buf[i] != proc) {
-                err++;
-            }
-        }
-        return err;
-    }
 public:
     UccCollArgsVec data_init(int nprocs, ucc_datatype_t dtype,
                              size_t count) {
@@ -44,11 +21,15 @@ public:
                     calloc(1, sizeof(ucc_coll_args_t));
             coll->coll_type = UCC_COLL_TYPE_ALLTOALLV;
             coll->mask = UCC_COLL_ARGS_FIELD_FLAGS;
-            coll->flags = UCC_COLL_ARGS_FLAG_COUNT_64BIT | UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+            coll->flags = UCC_COLL_ARGS_FLAG_COUNT_64BIT |
+                          UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+
+            coll->src.info_v.mem_type = UCC_MEMORY_TYPE_HOST;
             coll->src.info_v.counts = (ucc_count_t*)malloc(sizeof(ucc_count_t) * nprocs);
             coll->src.info_v.datatype = dtype;
             coll->src.info_v.displacements = (ucc_aint_t*)malloc(sizeof(ucc_aint_t) * nprocs);
 
+            coll->dst.info_v.mem_type = UCC_MEMORY_TYPE_HOST;
             coll->dst.info_v.counts = (ucc_count_t*)malloc(sizeof(ucc_count_t) * nprocs);
             coll->dst.info_v.datatype = dtype;
             coll->dst.info_v.displacements = (ucc_aint_t*)malloc(sizeof(ucc_aint_t) * nprocs);
@@ -56,7 +37,6 @@ public:
             buf_count = 0;
             for (int i = 0; i < nprocs; i++) {
                 int rank_count = (nprocs + r - i) * count;
-
                 coll->src.info_v.counts[i] = rank_count;
                 coll->src.info_v.displacements[i] = buf_count;
                 buf_count += rank_count;
@@ -64,11 +44,10 @@ public:
 
             coll->src.info_v.buffer = malloc(buf_count * ucc_dt_size(dtype));
             for (int i = 0; i < nprocs; i++) {
-                init_proc_buf(nprocs, i, (uint8_t*)coll->src.info_v.buffer +
+                alltoallx_init_buf(r, i, (uint8_t*)coll->src.info_v.buffer +
                               coll->src.info_v.displacements[i] * ucc_dt_size(dtype),
                               coll->src.info_v.counts[i] * ucc_dt_size(dtype));
             }
-
             buf_count = 0;
             for (int i = 0; i < nprocs; i++) {
                 int rank_count = (nprocs - r + i) * count;
@@ -83,23 +62,27 @@ public:
     }
     void data_validate(UccCollArgsVec args)
     {
-        int proc = 0;
-        size_t dst_size = 0;
-        for (ucc_coll_args_t* coll : args) {
-            dst_size = 0;
+        for (int r = 0; r < args.size(); r++) {
+            ucc_coll_args_t* coll = args[r];
             for (int i = 0; i < args.size(); i++) {
-                dst_size += coll->dst.info_v.counts[i];
+                size_t rank_size = ucc_dt_size(coll->dst.info_v.datatype) *
+                        (size_t)coll->dst.info_v.counts[i];
+                size_t rank_offs = ucc_dt_size(coll->dst.info_v.datatype) *
+                        (size_t)coll->dst.info_v.displacements[i];
+                EXPECT_EQ(0,
+                          alltoallx_validate_buf(r, i,
+                          (uint8_t*)coll->dst.info_v.buffer + rank_offs,
+                          rank_size));
             }
-            EXPECT_EQ(0, validate_buf(proc, (uint8_t*)coll->dst.info_v.buffer,
-                         dst_size * ucc_dt_size(coll->dst.info_v.datatype)));
-            proc++;
         }
     }
     void data_fini(UccCollArgsVec args)
     {
         for (ucc_coll_args_t* coll : args) {
+            free(coll->src.info_v.buffer);
             free(coll->src.info_v.counts);
             free(coll->src.info_v.displacements);
+            free(coll->dst.info_v.buffer);
             free(coll->dst.info_v.counts);
             free(coll->dst.info_v.displacements);
             free(coll);

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -19,7 +19,7 @@ public:
     UccCollArgsVec data_init(int nprocs, ucc_datatype_t dtype,
                              size_t count) {
         int buf_count;
-        UccCollArgsVec args;
+        UccCollArgsVec args(nprocs);
 
         for (auto r = 0; r < nprocs; r++) {
             ucc_coll_args_t *coll = (ucc_coll_args_t*)
@@ -61,7 +61,7 @@ public:
                 buf_count += rank_count;
             }
             coll->dst.info_v.buffer = malloc(buf_count * ucc_dt_size(dtype));
-            args.push_back(coll);
+            args[r] = coll;
         }
         return args;
     }

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -8,9 +8,14 @@
 
 using Param_0 = std::tuple<int, int>;
 
+template <class T>
 class test_alltoallv : public UccCollArgs, public ucc::test
 {
 public:
+    uint64_t coll_mask;
+    uint64_t coll_flags;
+
+    test_alltoallv() : coll_mask(0), coll_flags(0) {}
     UccCollArgsVec data_init(int nprocs, ucc_datatype_t dtype,
                              size_t count) {
         int buf_count;
@@ -20,39 +25,39 @@ public:
             ucc_coll_args_t *coll = (ucc_coll_args_t*)
                     calloc(1, sizeof(ucc_coll_args_t));
             coll->coll_type = UCC_COLL_TYPE_ALLTOALLV;
-            coll->mask = UCC_COLL_ARGS_FIELD_FLAGS;
-            coll->flags = UCC_COLL_ARGS_FLAG_COUNT_64BIT |
-                          UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+
+            coll->mask = coll_mask;
+            coll->flags = coll_flags;
 
             coll->src.info_v.mem_type = UCC_MEMORY_TYPE_HOST;
-            coll->src.info_v.counts = (ucc_count_t*)malloc(sizeof(ucc_count_t) * nprocs);
+            coll->src.info_v.counts = (ucc_count_t*)malloc(sizeof(T) * nprocs);
             coll->src.info_v.datatype = dtype;
-            coll->src.info_v.displacements = (ucc_aint_t*)malloc(sizeof(ucc_aint_t) * nprocs);
+            coll->src.info_v.displacements = (ucc_aint_t*)malloc(sizeof(T) * nprocs);
 
             coll->dst.info_v.mem_type = UCC_MEMORY_TYPE_HOST;
-            coll->dst.info_v.counts = (ucc_count_t*)malloc(sizeof(ucc_count_t) * nprocs);
+            coll->dst.info_v.counts = (ucc_count_t*)malloc(sizeof(T) * nprocs);
             coll->dst.info_v.datatype = dtype;
-            coll->dst.info_v.displacements = (ucc_aint_t*)malloc(sizeof(ucc_aint_t) * nprocs);
+            coll->dst.info_v.displacements = (ucc_aint_t*)malloc(sizeof(T) * nprocs);
 
             buf_count = 0;
             for (int i = 0; i < nprocs; i++) {
                 int rank_count = (nprocs + r - i) * count;
-                coll->src.info_v.counts[i] = rank_count;
-                coll->src.info_v.displacements[i] = buf_count;
+                ((T*)coll->src.info_v.counts)[i] = rank_count;
+                ((T*)coll->src.info_v.displacements)[i] = buf_count;
                 buf_count += rank_count;
             }
 
             coll->src.info_v.buffer = malloc(buf_count * ucc_dt_size(dtype));
             for (int i = 0; i < nprocs; i++) {
                 alltoallx_init_buf(r, i, (uint8_t*)coll->src.info_v.buffer +
-                              coll->src.info_v.displacements[i] * ucc_dt_size(dtype),
-                              coll->src.info_v.counts[i] * ucc_dt_size(dtype));
+                               ((T*)coll->src.info_v.displacements)[i] * ucc_dt_size(dtype),
+                               ((T*)coll->src.info_v.counts)[i] * ucc_dt_size(dtype));
             }
             buf_count = 0;
             for (int i = 0; i < nprocs; i++) {
                 int rank_count = (nprocs - r + i) * count;
-                coll->dst.info_v.counts[i] = rank_count;
-                coll->dst.info_v.displacements[i] = buf_count;
+                ((T*)coll->dst.info_v.counts)[i] = rank_count;
+                ((T*)coll->dst.info_v.displacements)[i] = buf_count;
                 buf_count += rank_count;
             }
             coll->dst.info_v.buffer = malloc(buf_count * ucc_dt_size(dtype));
@@ -66,9 +71,9 @@ public:
             ucc_coll_args_t* coll = args[r];
             for (int i = 0; i < args.size(); i++) {
                 size_t rank_size = ucc_dt_size(coll->dst.info_v.datatype) *
-                        (size_t)coll->dst.info_v.counts[i];
+                        (size_t)((T*)coll->dst.info_v.counts)[i];
                 size_t rank_offs = ucc_dt_size(coll->dst.info_v.datatype) *
-                        (size_t)coll->dst.info_v.displacements[i];
+                        (size_t)((T*)coll->dst.info_v.displacements)[i];
                 EXPECT_EQ(0,
                           alltoallx_validate_buf(r, i,
                           (uint8_t*)coll->dst.info_v.buffer + rank_offs,
@@ -91,14 +96,37 @@ public:
     }
 };
 
-class test_alltoallv_0 : public test_alltoallv,
+class test_alltoallv_0 : public test_alltoallv <uint64_t>,
         public ::testing::WithParamInterface<Param_0> {};
 
 UCC_TEST_P(test_alltoallv_0, single)
 {
     const int size = std::get<0>(GetParam());
     const ucc_datatype_t dtype = (ucc_datatype_t)std::get<1>(GetParam());
+    UccTeam_h team = UccJob::getStaticJob()->create_team(size);
 
+    coll_mask = UCC_COLL_ARGS_FIELD_FLAGS;
+    coll_flags = UCC_COLL_ARGS_FLAG_COUNT_64BIT |
+                 UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+
+    UccCollArgsVec args = data_init(size, (ucc_datatype_t)dtype, 1);
+
+    UccReq    req(team, args);
+    req.start();
+    req.wait();
+
+    data_validate(args);
+    data_fini(args);
+}
+
+
+class test_alltoallv_1 : public test_alltoallv <uint32_t>,
+        public ::testing::WithParamInterface<Param_0> {};
+
+UCC_TEST_P(test_alltoallv_1, single)
+{
+    const int size = std::get<0>(GetParam());
+    const ucc_datatype_t dtype = (ucc_datatype_t)std::get<1>(GetParam());
     UccTeam_h team = UccJob::getStaticJob()->create_team(size);
     UccCollArgsVec args = data_init(size, (ucc_datatype_t)dtype, 1);
 
@@ -110,17 +138,55 @@ UCC_TEST_P(test_alltoallv_0, single)
     data_fini(args);
 }
 
+
 INSTANTIATE_TEST_CASE_P(
-        ,
+        64,
         test_alltoallv_0,
         ::testing::Combine(
             ::testing::Values(1,3,16), // nprocs
             ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
 
-class test_alltoallv_1 : public test_alltoallv,
+INSTANTIATE_TEST_CASE_P(
+        32,
+        test_alltoallv_1,
+        ::testing::Combine(
+            ::testing::Values(1,3,16), // nprocs
+            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+
+
+class test_alltoallv_2 : public test_alltoallv<uint64_t>,
         public ::testing::WithParamInterface<int> {};
 
-UCC_TEST_P(test_alltoallv_1, multiple)
+class test_alltoallv_3 : public test_alltoallv<uint32_t>,
+        public ::testing::WithParamInterface<int> {};
+
+UCC_TEST_P(test_alltoallv_2, multiple)
+{
+    const ucc_datatype_t dtype = (ucc_datatype_t)(GetParam());
+    std::vector<UccReq> reqs;
+    std::vector<UccCollArgsVec> args;
+
+    coll_mask = UCC_COLL_ARGS_FIELD_FLAGS;
+    coll_flags = UCC_COLL_ARGS_FLAG_COUNT_64BIT |
+                 UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+
+    for (auto &team : UccJob::getStaticTeams()) {
+        UccCollArgsVec arg = data_init(team->procs.size(),
+                                       dtype, 1);
+        args.push_back(arg);
+        reqs.push_back(UccReq(team, arg));
+    }
+    UccReq::startall(reqs);
+    UccReq::waitall(reqs);
+
+    for (auto arg : args) {
+        data_validate(arg);
+        data_fini(arg);
+    }
+}
+
+
+UCC_TEST_P(test_alltoallv_3, multiple)
 {
     const ucc_datatype_t dtype = (ucc_datatype_t)(GetParam());
     std::vector<UccReq> reqs;
@@ -142,6 +208,11 @@ UCC_TEST_P(test_alltoallv_1, multiple)
 }
 
 INSTANTIATE_TEST_CASE_P(
-        ,
-        test_alltoallv_1,
+        64,
+        test_alltoallv_2,
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1)); // dtype
+
+INSTANTIATE_TEST_CASE_P(
+        32,
+        test_alltoallv_3,
         ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1)); // dtype


### PR DESCRIPTION
## What
Added gtest alltoall & alltoallv:
- single/multiple UCC teams
- covering dtypes UCC_DT_INT8..UCC_DT_FLOAT64
- runs for proc numbers: 1,3,16
- alltoallv: generates a different amount of data counts for send/recv
