### PR TITLE
Topic/context estimated eps ppn

### DIFF
--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -37,6 +37,8 @@ typedef struct ucc_context_config {
     ucc_lib_info_t           *lib;
     ucc_cl_context_config_t **configs;
     int                       n_cl_cfg;
+    uint32_t                  estimated_num_eps;
+    uint32_t                  estimated_num_ppn;
 } ucc_context_config_t;
 
 /* Any internal UCC component (TL, CL, etc) may register its own

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -770,10 +770,10 @@ void ucc_context_config_print(const ucc_context_config_h config, FILE *stream,
  *  @ingroup UCC_CONTEXT
  *
  *  @brief The @ref ucc_context_config_modify routine modifies the runtime configuration
- *                  of UCC context (for a given CLS)
+ *                  of UCC context (optionally for a given CLS)
  *
  *  @param [in] config   Pointer to the configuration descriptor to be modified
- *  @param [in] cls      Comma separated list of CLS
+ *  @param [in] cls      Comma separated list of CLS or NULL. If NULL then core context config is modified.
  *  @param [in] name     Configuration variable to be modified
  *  @param [in] value    Configuration value to set
  *

--- a/test/gtest/core/test_context_config.cc
+++ b/test/gtest/core/test_context_config.cc
@@ -73,3 +73,27 @@ UCC_TEST_F(test_context_config, modify)
 
     ucc_context_config_release(ctx_config);
 }
+
+UCC_TEST_F(test_context_config, modify_core)
+{
+    ucc_context_config_h ctx_config;
+    unsigned             flags;
+    std::string          output;
+    flags = UCC_CONFIG_PRINT_CONFIG;
+    EXPECT_EQ(UCC_OK, ucc_context_config_read(lib_h, NULL, &ctx_config));
+
+    /* modify known field to expected value */
+    EXPECT_EQ(UCC_OK, ucc_context_config_modify(ctx_config, NULL, "ESTIMATED_NUM_EPS", "12345"));
+    testing::internal::CaptureStdout();
+    ucc_context_config_print(ctx_config, stdout, "", (ucc_config_print_flags_t)flags);
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_NE(std::string::npos, output.find("UCC_ESTIMATED_NUM_EPS=12345"));
+
+    /* modify uknown field */
+    testing::internal::CaptureStdout();
+    EXPECT_NE(UCC_OK,
+              ucc_context_config_modify(ctx_config, NULL, "_UNKNOWN_FIELD", "_unknown_value"));
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_NE(std::string::npos, output.find("failed to modify"));
+    ucc_context_config_release(ctx_config);
+}


### PR DESCRIPTION
## What
Adds ucc context configuration for estimated_num_eps/ppn.


## Why ?
Estimated num eps/ppn are optimization hints provided by the user. estimated_num_eps: estimated number of endpoints that will be connected for the given context; estimated_num_ppn  - the same but for eps on a single node. Both values exactly match the same configuration parameters for UCP. Internally they are passed to TL/UCP where they will affect transport selection (and hence better TL/UCP perf).

## How ?
Context config used to have only configs from CLs. Now we added 2 more fields on the ucc_context_config structure itself. ucc_context_config_modify is changed. ITs 3rd parameter "cls" (comma separated string of CLs to modify config) now can be NULL. In that case the main core ucc_context_config parameters are modified. ucc_context_config_print is also modified accordingly. gtest is expanded.
