### PR TITLE
CORE: ctx progress queue multi thread

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,6 +62,7 @@ libucc_la_SOURCES =                  \
 	core/ucc_coll.c                  \
 	core/ucc_progress_queue.c        \
 	core/ucc_progress_queue_st.c     \
+	core/ucc_progress_queue_mt.c     \
 	schedule/ucc_schedule.c          \
 	utils/ucc_component.c            \
 	utils/ucc_status.c               \

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -275,7 +275,7 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
         goto error;
     }
     ctx->lib                     = lib;
-    ucc_list_head_init(&ctx->progress_list);
+    ucc_list_head_init(&ctx->progress_list); // todo shouldn't the struct be also MT in case of UCC_THREAD_MULTIPLE?
     ucc_copy_context_params(&ctx->params, params);
     ucc_copy_context_params(&b_params.params, params);
     b_params.context           = ctx;

--- a/src/core/ucc_progress_queue.c
+++ b/src/core/ucc_progress_queue.c
@@ -7,12 +7,16 @@
 #include "ucc_progress_queue.h"
 
 ucc_status_t ucc_pq_st_init(ucc_progress_queue_t **pq);
+ucc_status_t ucc_pq_mt_init(ucc_progress_queue_t **pq);
 
 ucc_status_t ucc_progress_queue_init(ucc_progress_queue_t **pq,
-                                     ucc_thread_mode_t      tm)      /* NOLINT */
+                                     ucc_thread_mode_t      tm)
 {
-    // TODO add branch if tm == THREAD_MULTIPLE return pq_mt_init and remove NOLINT
-    return ucc_pq_st_init(pq);
+    if(tm == UCC_THREAD_SINGLE){
+        return ucc_pq_st_init(pq);
+    } else { // todo - also for UCC_THREAD_FUNNELED ?
+        return ucc_pq_mt_init(pq);
+    }
 }
 
 void ucc_progress_queue_finalize(ucc_progress_queue_t *pq)

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "ucc_progress_queue.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_log.h"
+#include "utils/ucc_spinlock.h"
+#include "utils/ucc_atomic.h"
+
+typedef struct ucc_pq_mt {
+    ucc_progress_queue_t super;
+    ucc_spinlock_t       locked_queue_lock;
+    ucc_coll_task_t***   tasks;
+    uint8_t              which_pool;
+    ucc_list_link_t      locked_queue;
+    uint32_t             tasks_countrs[2];
+} ucc_pq_mt_t; //todo the struct isn't a queue because not maintaining order, maybe another name
+
+#define LINE_SIZE 8
+#define NUM_POOLS 2
+
+static void ucc_pq_mt_enqueue(ucc_progress_queue_t *pq, ucc_coll_task_t *task) {
+    ucc_pq_mt_t *pq_mt = ucc_derived_of(pq, ucc_pq_mt_t);
+    int i;
+    int which_pool = task->was_progressed ^(pq_mt->which_pool & 1);
+    for (i = 0; i < LINE_SIZE; i++) {
+        if (ucc_atomic_bool_cswap64((uint64_t *) &(pq_mt->tasks[which_pool][i]), 0, (uint64_t) task)) {
+            ucc_atomic_add32(&pq_mt->tasks_countrs[which_pool], 1);
+            return;
+        }
+    }
+    ucc_spin_lock(&pq_mt->locked_queue_lock);
+    ucc_list_add_tail(&pq_mt->locked_queue, &task->list_elem);
+    ucc_spin_unlock(&pq_mt->locked_queue_lock);
+}
+
+static void ucc_pq_mt_dequeue(ucc_pq_mt_t *pq_mt, ucc_coll_task_t **popped_task_ptr, int is_first_call) {
+    int i, curr_which_pool, which_pool;
+    curr_which_pool = pq_mt->which_pool; // extract value in the beginning of the function
+    which_pool = curr_which_pool & 1; // turn from even/odd -> bool
+    ucc_coll_task_t *popped_task = NULL;
+    if (pq_mt->tasks_countrs[which_pool]) {
+        for (i = 0; i < LINE_SIZE; i++) {
+            popped_task = pq_mt->tasks[which_pool][i];
+            if (popped_task) {
+                if (ucc_atomic_bool_cswap64((uint64_t *) &(pq_mt->tasks[which_pool][i]), (uint64_t) popped_task, 0)) {
+                    ucc_atomic_sub32(&pq_mt->tasks_countrs[which_pool], 1);
+                    *popped_task_ptr = popped_task;
+                    popped_task->was_progressed = 1;
+                    return;
+                } else {
+                    i = -1;
+                    //break statement - was here on XCCL, seems like a mistake - we want the pop to give at least 1 task if exist
+                }
+            }
+        }
+    }
+    if (is_first_call) {
+        ucc_atomic_cswap8(&pq_mt->which_pool, curr_which_pool, curr_which_pool + 1);
+        ucc_pq_mt_dequeue(pq_mt, popped_task_ptr, 0);
+        return;
+    }
+    popped_task = NULL;
+    ucc_spin_lock(&pq_mt->locked_queue_lock);
+    if (!ucc_list_is_empty(&pq_mt->locked_queue)) {
+        popped_task = ucc_list_extract_head(&pq_mt->locked_queue, ucc_coll_task_t, list_elem);
+    }
+    ucc_spin_unlock(&pq_mt->locked_queue_lock);
+    if (popped_task) {
+        popped_task->was_progressed = 1;
+    }
+    *popped_task_ptr = popped_task;
+}
+
+ucc_status_t ucc_pq_mt_progress(ucc_progress_queue_t *pq) {
+    ucc_pq_mt_t     *pq_mt        = ucc_derived_of(pq, ucc_pq_mt_t);
+    ucc_coll_task_t *task;
+    ucc_status_t     status;
+    ucc_pq_mt_dequeue(pq_mt, &task, 1);
+    if (task) {
+        if (task->progress) {
+            status = task->progress(task);
+            if (status != UCC_OK) { //todo in st its status < 0
+                return status;
+            }
+        }
+        if (UCC_OK == task->super.status) {
+            return ucc_event_manager_notify(&task->em, UCC_EVENT_COMPLETED);
+        } else {
+            ucc_pq_mt_enqueue(pq, task);
+        }
+    }
+    return UCC_OK;
+}
+
+static void ucc_pq_mt_finalize(ucc_progress_queue_t *pq) {
+    ucc_pq_mt_t *pq_mt = ucc_derived_of(pq, ucc_pq_mt_t);
+    int i;
+    for (i = 0; i < NUM_POOLS; i++) {
+        ucc_free(pq_mt->tasks[i]);
+    }
+    ucc_free(pq_mt->tasks);
+    ucc_spinlock_destroy(&pq_mt->locked_queue_lock);
+    ucc_free(pq_mt);
+}
+
+ucc_status_t ucc_pq_mt_init(ucc_progress_queue_t **pq) {
+    ucc_pq_mt_t *pq_mt = ucc_malloc(sizeof(*pq_mt), "pq_mt");
+    if (!pq_mt) {
+        ucc_error("failed to allocate %zd bytes for pq_mt", sizeof(*pq_mt));
+        return UCC_ERR_NO_MEMORY;
+    }
+    pq_mt->tasks = (ucc_coll_task_t ***) ucc_calloc(NUM_POOLS, sizeof(ucc_coll_task_t **));
+    if (!pq_mt->tasks) {
+        ucc_error("failed to allocate %zd bytes for pq_mt->tasks", NUM_POOLS * sizeof(ucc_coll_task_t **));
+        return UCC_ERR_NO_MEMORY;
+    }
+    pq_mt->tasks[0] = (ucc_coll_task_t **) ucc_calloc(LINE_SIZE, sizeof(ucc_coll_task_t *));
+    if (!pq_mt->tasks[0]) {
+        ucc_error("failed to allocate %zd bytes for pq_mt->tasks[0]", LINE_SIZE * sizeof(ucc_coll_task_t *));
+        return UCC_ERR_NO_MEMORY;
+    }
+    pq_mt->tasks[1] = (ucc_coll_task_t **) ucc_calloc(LINE_SIZE, sizeof(ucc_coll_task_t *));
+    if (!pq_mt->tasks[1]) {
+        ucc_error("failed to allocate %zd bytes for pq_mt->tasks[1]", LINE_SIZE * sizeof(ucc_coll_task_t *));
+        return UCC_ERR_NO_MEMORY;
+    }
+    ucc_spinlock_init(&pq_mt->locked_queue_lock, 0);
+    ucc_list_head_init(&pq_mt->locked_queue);
+    pq_mt->which_pool = 0;
+    pq_mt->tasks_countrs[0] = 0;
+    pq_mt->tasks_countrs[1] = 0;
+    pq_mt->super.enqueue  = ucc_pq_mt_enqueue;
+    pq_mt->super.progress = ucc_pq_mt_progress;
+    pq_mt->super.finalize = ucc_pq_mt_finalize;
+    *pq                   = &pq_mt->super;
+    return UCC_OK;
+}

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -36,6 +36,7 @@ typedef struct ucc_coll_task {
     struct ucc_schedule       *schedule;
     /* used for progress queue */
     ucc_list_link_t            list_elem;
+    uint8_t                    was_progressed;
 } ucc_coll_task_t;
 
 typedef struct ucc_context ucc_context_t;

--- a/src/utils/ucc_atomic.h
+++ b/src/utils/ucc_atomic.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_ATOMIC_H_
+#define UCC_ATOMIC_H_
+
+#include "config.h"
+#include <ucs/arch/atomic.h>
+
+#define ucc_atomic_add32          ucs_atomic_add32
+#define ucc_atomic_sub32          ucs_atomic_sub32
+#define ucc_atomic_cswap8         ucs_atomic_cswap8
+#define ucc_atomic_bool_cswap64   ucs_atomic_bool_cswap64
+#endif

--- a/src/utils/ucc_datastruct.h
+++ b/src/utils/ucc_datastruct.h
@@ -9,7 +9,7 @@
 #include <ucs/datastruct/list.h>
 
 #define UCC_LIST_HEAD UCS_LIST_HEAD
-#define ucc_list_link_t ucs_list_link_t
+#define ucc_list_link_t ucs_list_link_t //todo defined twice also at ucc_list.h
 typedef uint32_t ucc_rank_t;
 
 #endif

--- a/src/utils/ucc_list.h
+++ b/src/utils/ucc_list.h
@@ -15,4 +15,6 @@
 #define ucc_list_del           ucs_list_del
 #define ucc_list_for_each_safe ucs_list_for_each_safe
 #define ucc_list_for_each      ucs_list_for_each
+#define ucc_list_is_empty      ucs_list_is_empty
+#define ucc_list_extract_head  ucs_list_extract_head
 #endif

--- a/src/utils/ucc_spinlock.h
+++ b/src/utils/ucc_spinlock.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_SPINLOCK_H_
+#define UCC_SPINLOCK_H_
+
+#include "config.h"
+#include <ucs/type/spinlock.h>
+
+#define ucc_spinlock_t         ucs_spinlock_t
+#define ucc_spinlock_init      ucs_spinlock_init
+#define ucc_spinlock_destroy   ucs_spinlock_destroy
+#define ucc_spin_lock          ucs_spin_lock
+#define ucc_spin_unlock        ucs_spin_unlock
+#endif

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -19,6 +19,6 @@ ucc_test_mpi_SOURCES = \
 	test_allreduce.cc
 
 CXX=mpicxx
-CXXFLAGS+=-I${top_builddir}/src -std=gnu++11
+CXXFLAGS+=-I${top_builddir}/src -std=gnu++11 -pthread
 
 LDFLAGS=-L${top_builddir}/src/.libs -lucc

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -68,10 +68,10 @@ class UccTestMpi {
     ucc_context_h ctx;
     ucc_lib_h     lib;
     ucc_test_mpi_inplace_t inplace;
-    void create_team(ucc_test_mpi_team_t t);
+    void create_team(ucc_test_mpi_team_t t, int thread_index);
     void destroy_team(ucc_test_team_t &team);
     ucc_team_h create_ucc_team(MPI_Comm comm);    
-    std::vector<ucc_test_team_t> teams;
+    std::vector<std::vector<ucc_test_team_t>> threads_teams;
     std::vector<size_t> msgsizes;
     std::vector<ucc_memory_type_t> mtypes;
     std::vector<ucc_datatype_t> dtypes;
@@ -79,7 +79,6 @@ class UccTestMpi {
     std::vector<ucc_coll_type_t> colls;
 public:
     UccTestMpi(int argc, char *argv[], ucc_thread_mode_t tm,
-               std::vector<ucc_test_mpi_team_t> &test_teams,
                const char* cls = NULL);
     ~UccTestMpi();
     void set_msgsizes(size_t min, size_t max, size_t power);
@@ -90,7 +89,8 @@ public:
     void set_inplace(ucc_test_mpi_inplace_t _inplace) {
         inplace = _inplace;
     }
-    ucc_status_t run_all();
+    void run_all(ucc_status_t* status, int thread_index, std::vector<ucc_test_mpi_inplace_t> &inplace_args, int iterations);
+    void create_teams(int num_of_threads, std::vector<ucc_test_mpi_team_t> &test_teams);
 };
 
 class TestCase {


### PR DESCRIPTION
## What
Implements MT ucc_context_progress

## Why ?
core api

## How ?
In a multi-threaded environment, where we have multiple threads inserting and progressing collective requests to the progress_queue, we need a thread safe data structure.
Here we use double array structure where all new tasks inserted to the primary array and old tasks to the secondary. tasks are being extracted only from the primary array. when primary is empty, they switch roles. All insertions & deletions are performed with atomic operations.
