### PR TITLE
TEST: use specific clang version

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -7,13 +7,14 @@ env:
   OPEN_UCX_BRANCH: master
 jobs:
   clang-tidy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common
-        sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
+        sudo apt-add-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
         sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-11 bear
     - name: Get UCX
       run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx

--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -6,14 +6,16 @@ env:
   GIT_CF: https://raw.githubusercontent.com/llvm/llvm-project/release/11.x/clang/tools/clang-format/git-clang-format
 jobs:
   check-codestyle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Check code style
     steps:
     - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common
-        sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
+        sudo apt-add-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
+        sudo apt-get install -y --no-install-recommends clang-format-11
         curl -OL $GIT_CF && chmod +x ./git-clang-format && sudo mv ./git-clang-format /usr/bin/git-clang-format
     - name: Checking out repository
       uses: actions/checkout@v2
@@ -67,7 +69,7 @@ jobs:
       run: |
         set -eE
         echo "Commit ${{ github.event.pull_request.base.sha }}"
-        diff=`git clang-format --style=file --diff ${{ github.event.pull_request.base.sha }}`
+        diff=`git clang-format --binary=clang-format-11 --style=file --diff ${{ github.event.pull_request.base.sha }}`
         if [ "$diff" = "no modified files to format" ] || [ "$diff" = "clang-format did not modify any files" ]
         then
           echo "Format check PASS"


### PR DESCRIPTION
## What
Use specific clang version for tests

## Why ?
In gh actions we use latest available clang, clang-format and clang-tidy. It's not reliable because clang upstream changes might cause fails in ucc ci scripts. In this PR clang version is set to latest stable clang-11
