### PR TITLE
CORE: check memtype in collective init

### DIFF
--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -6,6 +6,7 @@
 #include "config.h"
 #include "ucc_team.h"
 #include "ucc_context.h"
+#include "ucc_mc.h"
 #include "components/cl/ucc_cl.h"
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_log.h"
@@ -21,13 +22,108 @@ static ucc_cl_team_t *ucc_select_cl_team(ucc_coll_args_t *coll_args,
     return team->cl_teams[0];
 }
 
+#define UCC_BUFFER_INFO_CHECK_MEM_TYPE(_info) do {                             \
+    if ((_info).mem_type == UCC_MEMORY_TYPE_UNKNOWN) {                         \
+        ucc_status_t st = ucc_mc_type((_info).buffer, &((_info).mem_type));    \
+        if (st != UCC_OK) {                                                    \
+            return st;                                                         \
+        }                                                                      \
+    }                                                                          \
+} while(0)
+
+#define UCC_IS_ROOT(_args, _myrank) ((_args).root == (_myrank))
+
+static ucc_status_t ucc_coll_args_check_mem_type(ucc_coll_args_t *coll_args,
+                                                 ucc_rank_t rank)
+{
+    switch (coll_args->coll_type) {
+    case UCC_COLL_TYPE_BARRIER:
+    case UCC_COLL_TYPE_FANIN:
+    case UCC_COLL_TYPE_FANOUT:
+        return UCC_OK;
+    case UCC_COLL_TYPE_BCAST:
+        UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info);
+        return UCC_OK;
+    case UCC_COLL_TYPE_ALLREDUCE:
+        UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info);
+        if (!UCC_IS_INPLACE(*coll_args)) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info);
+        } else {
+            coll_args->src.info.mem_type = coll_args->dst.info.mem_type;
+        }
+        return UCC_OK;
+    case UCC_COLL_TYPE_ALLGATHER:
+    case UCC_COLL_TYPE_ALLTOALL:
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info);
+        if (!UCC_IS_INPLACE(*coll_args)) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info);
+        }
+        return UCC_OK;
+    case UCC_COLL_TYPE_ALLGATHERV:
+    case UCC_COLL_TYPE_REDUCE_SCATTERV:
+        UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info_v);
+        if (!UCC_IS_INPLACE(*coll_args)) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info);
+        }
+        return UCC_OK;
+    case UCC_COLL_TYPE_ALLTOALLV:
+        UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info_v);
+        if (!UCC_IS_INPLACE(*coll_args)) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info_v);
+        }
+        return UCC_OK;
+    case UCC_COLL_TYPE_GATHER:
+    case UCC_COLL_TYPE_REDUCE:
+        if (UCC_IS_ROOT(*coll_args, rank)) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info);
+        }
+        if (!(UCC_IS_INPLACE(*coll_args) && UCC_IS_ROOT(*coll_args, rank))) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info);
+        }
+        return UCC_OK;
+    case UCC_COLL_TYPE_GATHERV:
+        if (UCC_IS_ROOT(*coll_args, rank)) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info_v);
+        }
+        if (!(UCC_IS_INPLACE(*coll_args) && UCC_IS_ROOT(*coll_args, rank))) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info);
+        }
+        return UCC_OK;
+    case UCC_COLL_TYPE_SCATTER:
+        if (UCC_IS_ROOT(*coll_args, rank)) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info);
+        }
+        if (!(UCC_IS_INPLACE(*coll_args) && UCC_IS_ROOT(*coll_args, rank))) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info);
+        }
+        return UCC_OK;
+    case UCC_COLL_TYPE_SCATTERV:
+        if (UCC_IS_ROOT(*coll_args, rank)) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info_v);
+        }
+        if (!(UCC_IS_INPLACE(*coll_args) && UCC_IS_ROOT(*coll_args, rank))) {
+            UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info);
+        }
+        return UCC_OK;
+    default:
+        ucc_error("unknown collective type");
+        return UCC_ERR_INVALID_PARAM;
+    };
+}
+
 ucc_status_t ucc_collective_init(ucc_coll_args_t *coll_args,
                                  ucc_coll_req_h *request, ucc_team_h team)
 {
-    ucc_cl_team_t          *cl_team;
-    ucc_base_coll_args_t    op_args;
-    ucc_status_t            status;
-    ucc_coll_task_t        *task;
+    ucc_cl_team_t         *cl_team;
+    ucc_coll_task_t       *task;
+    ucc_base_coll_args_t   op_args;
+    ucc_status_t           status;
+    status = ucc_coll_args_check_mem_type(coll_args, team->rank);
+    if (status != UCC_OK) {
+        ucc_error("memory type detection failed");
+        return status;
+    }
     /* TO discuss: maybe we want to pass around user pointer ? */
     memcpy(&op_args.args, coll_args, sizeof(ucc_coll_args_t));
     cl_team = ucc_select_cl_team(coll_args, team);

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -7,6 +7,7 @@
 #define UCC_TEAM_H_
 
 #include "ucc/api/ucc.h"
+#include "utils/ucc_datastruct.h"
 
 typedef struct ucc_context ucc_context_t;
 typedef struct ucc_cl_team ucc_cl_team_t;
@@ -20,7 +21,7 @@ typedef struct ucc_team {
     int               n_cl_teams;
     int               last_team_create_posted;
     uint16_t          id; /*< context-uniq team identifier */
-    uint32_t          rank;
+    ucc_rank_t        rank;
 } ucc_team_t;
 
 void ucc_copy_team_params(ucc_team_params_t *dst, const ucc_team_params_t *src);


### PR DESCRIPTION
## What
Do memory type detection if UCC_MEMORY_TYPE_UNKNOWN is set in coll_args.

## Why ?
We want to know memory type as earlier as possible to do CL, TL or algorithm selection. If user doesn't specify memory type then UCC will try to detect it in collective init.

## How ?
Following collective args description in [doc](https://github.com/openucx/ucc/blob/master/docs/images/ucc_coll_args_table1.pdf)
ucc_coll_args_check_mem_type function checks if memory type is unknown and in that case uses mc detect to get memory type.
Questions:
1. The large switch can be collapsed if we move mem_type and data_type from info/info_v to src and dst in coll_args, but it requires changes in ucc_coll_args_t again.
2. For allreduce specification says that in case of inplace src.info.buffer is ignored, but src.info.mem_type and src.info.datatype should be set. It doesn't make sense to set buffer memory type if buffer is ignored, should we change comment to "src.info.buffer, src.info.mem_type, src.info.datatype are ignored"?