### PR TITLE
CORE: fixes CL libs filtering

### DIFF
--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -28,7 +28,7 @@ typedef struct ucc_base_config {
 } ucc_base_config_t;
 
 typedef struct ucc_base_attr_t {
-    ucc_thread_mode_t thread_mode;
+    ucc_lib_attr_t attr;
 } ucc_base_attr_t;
 
 typedef struct ucc_base_lib_params {

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -31,7 +31,10 @@ UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
 ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
                                        ucc_base_attr_t *base_attr)
 {
-    ucc_cl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
-    attr->tls               = UCC_TL_UCP | UCC_TL_NCCL;
+    ucc_cl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
+    attr->tls                    = UCC_TL_UCP | UCC_TL_NCCL;
+    attr->super.attr.thread_mode = UCC_THREAD_SINGLE;
+    /* TODO: fill coll_types, reduction_types, sync_mode.
+       Correctly fill thead_mode multiple when possible. */
     return UCC_OK;
 }

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -59,7 +59,6 @@ ucc_status_t ucc_cl_lib_config_read(ucc_cl_iface_t *iface,
 typedef struct ucc_cl_iface {
     ucc_component_iface_t          super;
     ucc_cl_type_t                  type;
-    ucc_lib_attr_t                 attr;
     ucc_config_global_list_entry_t cl_lib_config;
     ucc_config_global_list_entry_t cl_context_config;
     ucc_base_lib_iface_t           lib;

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -67,9 +67,11 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
 {
     int                   n_cls = ucc_global_config.cl_framework.n_components;
     uint64_t              supported_coll_types = 0;
-    ucc_thread_mode_t     supported_tm         = UCC_THREAD_MULTIPLE;
+    ucc_thread_mode_t     highest_tm           = UCC_THREAD_SINGLE;
+    ucc_thread_mode_t     lowest_tm            = UCC_THREAD_MULTIPLE;
     ucc_lib_params_t      params               = *user_params;
     ucc_cl_lib_config_t  *cl_config            = NULL;
+    ucc_cl_lib_attr_t     attrs[UCC_CL_LAST];
     ucc_cl_iface_t       *cl_iface;
     ucc_base_lib_t *      b_lib;
     ucc_base_lib_params_t b_params;
@@ -102,17 +104,6 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
             (0 == ucc_cl_requested(config, cl_iface->type))) {
             continue;
         }
-        if (params.thread_mode > cl_iface->attr.thread_mode) {
-            /* Requested THREAD_MODE is not supported by the CL:
-               1. If cls == "all" - just skip this CL
-               2. If specific CLs are requested: continue and user will
-                  have to query result attributes and check thread mode*/
-            if (!lib->specific_cls_requested) {
-                ucc_info("requested thread_mode is not supported by the CL: %s",
-                         cl_iface->super.name);
-                continue;
-            }
-        }
         status = ucc_cl_lib_config_read(cl_iface, lib->full_prefix, &cl_config);
         if (UCC_OK != status) {
             ucc_error("failed to read CL \"%s\" lib configuration",
@@ -135,20 +126,58 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
         ucc_base_config_release(&cl_config->super);
         cl_lib                          = ucc_derived_of(b_lib, ucc_cl_lib_t);
         lib->cl_libs[lib->n_cl_libs_opened++] = cl_lib;
-        supported_coll_types |= cl_iface->attr.coll_types;
-        if (cl_iface->attr.thread_mode < supported_tm) {
-            supported_tm = cl_iface->attr.thread_mode;
+        status = cl_iface->lib.get_attr(&cl_lib->super, &attrs[i].super);
+        if (UCC_OK != status) {
+            ucc_error("failed to query cl lib %s attr", cl_lib->iface->super.name);
+            return status;
         }
         ucc_info("lib_prefix \"%s\": initialized component \"%s\" priority %d",
                  config->full_prefix, cl_iface->super.name, cl_lib->priority);
+        if (attrs[i].super.attr.thread_mode > highest_tm) {
+            highest_tm = attrs[i].super.attr.thread_mode;
+        }
+        if (attrs[i].super.attr.thread_mode < lowest_tm) {
+            lowest_tm = attrs[i].super.attr.thread_mode;
+        }
     }
 
     if (lib->n_cl_libs_opened == 0) {
-        ucc_error("lib_init failed: no CLs left after filtering");
+        ucc_error("lib_init failed: no CL libs were opened");
         status = UCC_ERR_NO_MESSAGE;
         goto error;
     }
 
+    if (highest_tm < params.thread_mode) {
+        /* No CL can provide the thread_mode that user required.
+           Leave all the selected components and set library thread_mode
+           to lowest_tm */
+        ucc_info("selected set of CLs does not provide the requested "
+                 "thread_mode");
+        lib->attr.thread_mode = lowest_tm;
+    } else if (lowest_tm < highest_tm) {
+        /* Some CLs can support the required thread_mode but some can't.
+           Lets try to satisfy user request and remove all the CLs with
+           thread_mode < required */
+        int n_cl_libs_filtered = 0;
+        lib->attr.thread_mode  = params.thread_mode;
+        for (i = 0; i < lib->n_cl_libs_opened; i++) {
+            if (attrs[i].super.attr.thread_mode >= params.thread_mode) {
+                lib->cl_libs[n_cl_libs_filtered] = lib->cl_libs[i];
+                attrs[n_cl_libs_filtered]        = attrs[i];
+                n_cl_libs_filtered++;
+            }
+        }
+        lib->n_cl_libs_opened = n_cl_libs_filtered;
+        ucc_assert(n_cl_libs_filtered > 0);
+    } else {
+        /* All opened CLs can support required thread mode:
+           leave them all*/
+        lib->attr.thread_mode = params.thread_mode;
+    }
+
+    for (i = 0; i < lib->n_cl_libs_opened; i++) {
+        supported_coll_types |= attrs[i].super.attr.coll_types;
+    }
     /* Check if the combination of the selected CLs provides all the
        requested coll_types: not an error, just print a message if not
        all the colls are supproted */
@@ -157,12 +186,7 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
         ucc_debug("selected set of CLs does not provide all the requested "
                   "coll_types");
     }
-    if (params.thread_mode > supported_tm) {
-        ucc_debug("selected set of CLs does not provide the requested "
-                  "thread_mode");
-    }
     lib->attr.coll_types  = supported_coll_types;
-    lib->attr.thread_mode = ucc_min(supported_tm, params.thread_mode);
     return UCC_OK;
 
 error_cl_init:


### PR DESCRIPTION
## What
Makes proper CL libs filtering based on user thread mode requirement: params.thread_mode

## Why ?
Currently filtering is not correct and uses uninitialized cl_iface.attr.thread_mode. Works only because all our tests use THREAD_SINGLE.

## How ?
cl_iface.attr is not initialized/used - removed it.
thread_mode is queried from cl lib objects.
The highest and lowest supported thread_mode is detected among all the available CL libs. Next, we first try to satisfy user requirement: ie, if at least some CL supports required thread_mode (highest_tm >= params.thread_mode) then we keep it as active thread_mode and filter out those CLs that might have lower supported tm (lowest_tm < highest_tm). If NO CL libs can support user requirement (highest_tm < params.thread_mode) then we set active thread_mode of ucc_lib to lowest_tm and keep all the opened CLs - it is still user responsibility  to query provided thread_mode; lastly if all CLs have tm >=params.thread_mode then we just keep them all.
