### PR TITLE
MC/CUDA: reduce multi implementation

### DIFF
--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -70,9 +70,12 @@ typedef struct ucc_mc_ops {
                               ucc_mem_attr_t *mem_attr);
     ucc_status_t (*mem_alloc)(void **ptr, size_t size);
     ucc_status_t (*mem_free)(void *ptr);
-    ucc_status_t (*reduce)(const void *src1, const void *src2,
-                           void *dst, size_t count, ucc_datatype_t dt,
+    ucc_status_t (*reduce)(const void *src1, const void *src2, void *dst,
+                           size_t count, ucc_datatype_t dt,
                            ucc_reduction_op_t op);
+    ucc_status_t (*reduce_multi)(const void *src1, const void *src2, void *dst,
+                                 size_t count, size_t size, size_t stride,
+                                 ucc_datatype_t dt, ucc_reduction_op_t op);
     ucc_status_t (*memcpy)(void *dst, const void *src, size_t len,
                            ucc_memory_type_t dst_mem,
                            ucc_memory_type_t src_mem);

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -64,6 +64,27 @@ static ucc_status_t ucc_mc_cpu_reduce(const void *src1, const void *src2,
     return 0;
 }
 
+static ucc_status_t ucc_mc_cpu_reduce_multi(const void *src1, const void *src2,
+                                            void *dst, size_t size,
+                                            size_t count, size_t stride,
+                                            ucc_datatype_t dt,
+                                            ucc_reduction_op_t op)
+{
+    int i;
+    ucc_status_t st;
+
+    //TODO implemente efficient reduce_multi
+    st = ucc_mc_cpu_reduce(src1, src2, dst, count, dt, op);
+    for (i = 1; i < size; i++) {
+        if (st != UCC_OK) {
+            return st;
+        }
+        st = ucc_mc_cpu_reduce((void *)((ptrdiff_t)src2 + stride * i), dst, dst,
+                               count, dt, op);
+    }
+    return st;
+}
+
 static ucc_status_t ucc_mc_cpu_mem_free(void *ptr)
 {
     ucc_free(ptr);
@@ -95,23 +116,24 @@ static ucc_status_t ucc_mc_cpu_mem_query(const void *ptr, size_t length,
 
 
 ucc_mc_cpu_t ucc_mc_cpu = {
-    .super.super.name = "cpu mc",
-    .super.ref_cnt    = 0,
-    .super.type       = UCC_MEMORY_TYPE_HOST,
-    .super.config_table =
+    .super.super.name       = "cpu mc",
+    .super.ref_cnt          = 0,
+    .super.type             = UCC_MEMORY_TYPE_HOST,
+    .super.init             = ucc_mc_cpu_init,
+    .super.finalize         = ucc_mc_cpu_finalize,
+    .super.ops.mem_query    = ucc_mc_cpu_mem_query,
+    .super.ops.mem_alloc    = ucc_mc_cpu_mem_alloc,
+    .super.ops.mem_free     = ucc_mc_cpu_mem_free,
+    .super.ops.reduce       = ucc_mc_cpu_reduce,
+    .super.ops.reduce_multi = ucc_mc_cpu_reduce_multi,
+    .super.ops.memcpy       = ucc_mc_cpu_memcpy,
+    .super.config_table     =
         {
             .name   = "CPU memory component",
             .prefix = "MC_CPU_",
             .table  = ucc_mc_cpu_config_table,
             .size   = sizeof(ucc_mc_cpu_config_t),
         },
-    .super.init          = ucc_mc_cpu_init,
-    .super.finalize      = ucc_mc_cpu_finalize,
-    .super.ops.mem_query = ucc_mc_cpu_mem_query,
-    .super.ops.mem_alloc = ucc_mc_cpu_mem_alloc,
-    .super.ops.mem_free  = ucc_mc_cpu_mem_free,
-    .super.ops.reduce    = ucc_mc_cpu_reduce,
-    .super.ops.memcpy    = ucc_mc_cpu_memcpy
 };
 
 UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_mc_cpu.super.config_table,

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -73,7 +73,7 @@ static ucc_status_t ucc_mc_cpu_reduce_multi(const void *src1, const void *src2,
     int i;
     ucc_status_t st;
 
-    //TODO implemente efficient reduce_multi
+    //TODO implement efficient reduce_multi
     st = ucc_mc_cpu_reduce(src1, src2, dst, count, dt, op);
     for (i = 1; i < size; i++) {
         if (st != UCC_OK) {

--- a/src/components/mc/cpu/mc_cpu_reduce.h
+++ b/src/components/mc/cpu/mc_cpu_reduce.h
@@ -7,16 +7,7 @@
 #ifndef UCC_MC_CPU_REDUCE_H_
 #define UCC_MC_CPU_REDUCE_H_
 
-#define  DO_OP_MAX(_v1, _v2) (_v1 > _v2 ? _v1 : _v2)
-#define  DO_OP_MIN(_v1, _v2) (_v1 < _v2 ? _v1 : _v2)
-#define  DO_OP_SUM(_v1, _v2) (_v1 + _v2)
-#define DO_OP_PROD(_v1, _v2) (_v1 * _v2)
-#define DO_OP_LAND(_v1, _v2) (_v1 && _v2)
-#define DO_OP_BAND(_v1, _v2) (_v1 & _v2)
-#define  DO_OP_LOR(_v1, _v2) (_v1 || _v2)
-#define  DO_OP_BOR(_v1, _v2) (_v1 | _v2)
-#define DO_OP_LXOR(_v1, _v2) ((!_v1) != (!_v2))
-#define DO_OP_BXOR(_v1, _v2) (_v1 ^ _v2)
+#include "utils/ucc_math.h"
 
 #define DO_DT_REDUCE_WITH_OP(s1, s2, d, count, OP) do {                        \
         size_t i;                                                              \

--- a/src/components/mc/cuda/kernel/Makefile.am
+++ b/src/components/mc/cuda/kernel/Makefile.am
@@ -15,7 +15,8 @@ LINK = $(LIBTOOL) --mode=link $(CC) -o $@
 
 comp_noinst = libucc_mc_cuda_kernels.la
 
-libucc_mc_cuda_kernels_la_SOURCES  = mc_cuda_reduce.cu
+libucc_mc_cuda_kernels_la_SOURCES  = mc_cuda_reduce.cu \
+                                     mc_cuda_reduce_multi.cu
 libucc_mc_cuda_kernels_la_CPPFLAGS =
 
 noinst_LTLIBRARIES = $(comp_noinst)

--- a/src/components/mc/cuda/kernel/mc_cuda_reduce.cu
+++ b/src/components/mc/cuda/kernel/mc_cuda_reduce.cu
@@ -17,17 +17,6 @@ extern "C" {
 #include <assert.h>
 #include <stdio.h>
 
-#define  DO_OP_MAX(_v1, _v2) (_v1 > _v2 ? _v1 : _v2)
-#define  DO_OP_MIN(_v1, _v2) (_v1 < _v2 ? _v1 : _v2)
-#define  DO_OP_SUM(_v1, _v2) (_v1 + _v2)
-#define DO_OP_PROD(_v1, _v2) (_v1 * _v2)
-#define DO_OP_LAND(_v1, _v2) (_v1 && _v2)
-#define DO_OP_BAND(_v1, _v2) (_v1 & _v2)
-#define  DO_OP_LOR(_v1, _v2) (_v1 || _v2)
-#define  DO_OP_BOR(_v1, _v2) (_v1 | _v2)
-#define DO_OP_LXOR(_v1, _v2) ((!_v1) != (!_v2))
-#define DO_OP_BXOR(_v1, _v2) (_v1 ^ _v2)
-
 #define CUDA_REDUCE_WITH_OP(NAME, OP)                                          \
 template <typename T>                                                          \
 __global__ void UCC_REDUCE_CUDA_ ## NAME (const T *s1, const T *s2, T *d,      \
@@ -129,13 +118,10 @@ ucc_status_t ucc_mc_cuda_reduce(const void *src1, const void *src2, void *dst,
                                 size_t count, ucc_datatype_t dt,
                                 ucc_reduction_op_t op)
 {
-    int th;
-    unsigned long bk;
-    cudaStream_t stream;
+    cudaStream_t  stream = ucc_mc_cuda.stream;
+    int           th     = MC_CUDA_CONFIG->reduce_num_threads;;
+    unsigned long bk     = (count + th - 1)/th;;
 
-    stream = ucc_mc_cuda.stream;
-    th = MC_CUDA_CONFIG->reduce_num_threads;
-    bk = (count + th - 1)/th;
     if (MC_CUDA_CONFIG->reduce_num_blocks != UCC_ULUNITS_AUTO) {
         bk = ucc_min(bk, MC_CUDA_CONFIG->reduce_num_blocks);
     }

--- a/src/components/mc/cuda/kernel/mc_cuda_reduce_multi.cu
+++ b/src/components/mc/cuda/kernel/mc_cuda_reduce_multi.cu
@@ -1,0 +1,198 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "../mc_cuda.h"
+#include "utils/ucc_math.h"
+#ifdef __cplusplus
+}
+#endif
+
+#include <assert.h>
+#include <stdio.h>
+
+#define  DO_OP_MAX(_v1, _v2) (_v1 > _v2 ? _v1 : _v2)
+#define  DO_OP_MIN(_v1, _v2) (_v1 < _v2 ? _v1 : _v2)
+#define  DO_OP_SUM(_v1, _v2) (_v1 + _v2)
+#define DO_OP_PROD(_v1, _v2) (_v1 * _v2)
+#define DO_OP_LAND(_v1, _v2) (_v1 && _v2)
+#define DO_OP_BAND(_v1, _v2) (_v1 & _v2)
+#define  DO_OP_LOR(_v1, _v2) (_v1 || _v2)
+#define  DO_OP_BOR(_v1, _v2) (_v1 | _v2)
+#define DO_OP_LXOR(_v1, _v2) ((!_v1) != (!_v2))
+#define DO_OP_BXOR(_v1, _v2) (_v1 ^ _v2)
+
+#define CUDA_REDUCE_WITH_OP(NAME, OP)                                          \
+template <typename T>                                                          \
+__global__ void UCC_REDUCE_CUDA_ ## NAME (const T *s1, const T *s2, T *d,      \
+                                          size_t size, size_t count,           \
+                                          size_t ld)                           \
+{                                                                              \
+        size_t start = blockIdx.x * blockDim.x + threadIdx.x;                  \
+        size_t step  = blockDim.x * gridDim.x;                                 \
+        for (size_t i = start; i < count; i+=step) {                           \
+            d[i] = OP(s1[i], s2[i]);                                           \
+            for (size_t j = 1; j < size; j++) {                                \
+                d[i] = OP(d[i], s2[i + j * ld]);                               \
+            }                                                                  \
+        }                                                                      \
+}                                                                              \
+
+CUDA_REDUCE_WITH_OP(MAX,  DO_OP_MAX)
+CUDA_REDUCE_WITH_OP(MIN,  DO_OP_MIN)
+CUDA_REDUCE_WITH_OP(SUM,  DO_OP_SUM)
+CUDA_REDUCE_WITH_OP(PROD, DO_OP_PROD)
+CUDA_REDUCE_WITH_OP(LAND, DO_OP_LAND)
+CUDA_REDUCE_WITH_OP(BAND, DO_OP_BAND)
+CUDA_REDUCE_WITH_OP(LOR,  DO_OP_LOR)
+CUDA_REDUCE_WITH_OP(BOR,  DO_OP_BOR)
+CUDA_REDUCE_WITH_OP(LXOR, DO_OP_LXOR)
+CUDA_REDUCE_WITH_OP(BXOR, DO_OP_BXOR)
+
+#define LAUNCH_KERNEL(NAME, type, src1, src2, dest, size, count, ld, s, b, t)  \
+        UCC_REDUCE_CUDA_ ## NAME<type> <<<b, t, 0, s>>>(src1, src2, dest,      \
+                                                        size, count, ld)
+
+#define DT_REDUCE_INT(type, op, src1_p, src2_p, dest_p, size, count, ld, s,    \
+                      b, t) do {                                               \
+        const type *sbuf1 = (type *)src1_p;                                    \
+        const type *sbuf2= (type *)src2_p;                                     \
+        type *dest = (type *)dest_p;                                           \
+        switch(op) {                                                           \
+        case UCC_OP_MAX:                                                       \
+            LAUNCH_KERNEL(MAX, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_MIN:                                                       \
+            LAUNCH_KERNEL(MIN, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_SUM:                                                       \
+            LAUNCH_KERNEL(SUM, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_PROD:                                                      \
+            LAUNCH_KERNEL(PROD, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_LAND:                                                      \
+            LAUNCH_KERNEL(LAND, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_BAND:                                                      \
+            LAUNCH_KERNEL(BAND, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_LOR:                                                       \
+            LAUNCH_KERNEL(LOR, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+        case UCC_OP_BOR:                                                       \
+            LAUNCH_KERNEL(BOR, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_LXOR:                                                      \
+            LAUNCH_KERNEL(LXOR, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_BXOR:                                                      \
+            LAUNCH_KERNEL(BXOR, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        default:                                                               \
+            mc_error(&ucc_mc_cuda.super, "int dtype does not support "         \
+                                         "requested reduce op: %d", op);       \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
+    } while(0)
+
+#define DT_REDUCE_FLOAT(type, op, src1_p, src2_p, dest_p, size, count, ld, s,  \
+                        b, t) do {                                             \
+        const type *sbuf1 = (const type *)src1_p;                              \
+        const type *sbuf2 = (const type *)src2_p;                              \
+        type *dest = (type *)dest_p;                                           \
+        switch(op) {                                                           \
+        case UCC_OP_MAX:                                                       \
+            LAUNCH_KERNEL(MAX, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_MIN:                                                       \
+            LAUNCH_KERNEL(MIN, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_SUM:                                                       \
+            LAUNCH_KERNEL(SUM, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_PROD:                                                      \
+            LAUNCH_KERNEL(PROD, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        default:                                                               \
+            mc_error(&ucc_mc_cuda.super, "float dtype does not support "       \
+                                         "requested reduce op: %d", op);       \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
+    } while(0)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ucc_status_t ucc_mc_cuda_reduce_multi(const void *src1, const void *src2,
+                                      void *dst, size_t size, size_t count,
+                                      size_t stride, ucc_datatype_t dt,
+                                      ucc_reduction_op_t op)
+{
+    size_t ld = stride / ucc_dt_size(dt);
+    int th;
+    unsigned long bk;
+    cudaStream_t stream;
+
+    stream = ucc_mc_cuda.stream;
+    th = MC_CUDA_CONFIG->reduce_num_threads;
+    bk = (count + th - 1)/th;
+    if (MC_CUDA_CONFIG->reduce_num_blocks != UCC_ULUNITS_AUTO) {
+        bk = ucc_min(bk, MC_CUDA_CONFIG->reduce_num_blocks);
+    }
+    switch (dt)
+    {
+        case UCC_DT_INT16:
+            DT_REDUCE_INT(int16_t, op, src1, src2, dst, size, count, ld, stream,
+                          bk, th);
+            break;
+        case UCC_DT_INT32:
+            DT_REDUCE_INT(int32_t, op, src1, src2, dst, size, count, ld, stream,
+                          bk, th);
+            break;
+        case UCC_DT_INT64:
+            DT_REDUCE_INT(int64_t, op, src1, src2, dst, size, count, ld, stream,
+                         bk, th);
+            break;
+        case UCC_DT_FLOAT32:
+            ucc_assert(4 == sizeof(float));
+            DT_REDUCE_FLOAT(float, op, src1, src2, dst, size, count, ld, stream,
+                            bk, th);
+            break;
+        case UCC_DT_FLOAT64:
+            ucc_assert(8 == sizeof(double));
+            DT_REDUCE_FLOAT(double, op, src1, src2, dst, size, count, ld,
+                            stream, bk, th);
+            break;
+        default:
+            mc_error(&ucc_mc_cuda.super, "unsupported reduction type (%d)", dt);
+            return UCC_ERR_NOT_SUPPORTED;
+    }
+    CUDACHECK(cudaStreamSynchronize(stream));
+    return UCC_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -184,9 +184,17 @@ static ucc_status_t ucc_mc_cuda_mem_query(const void *ptr,
 }
 
 ucc_mc_cuda_t ucc_mc_cuda = {
-    .super.super.name = "cuda mc",
-    .super.ref_cnt    = 0,
-    .super.type       = UCC_MEMORY_TYPE_CUDA,
+    .super.super.name       = "cuda mc",
+    .super.ref_cnt          = 0,
+    .super.type             = UCC_MEMORY_TYPE_CUDA,
+    .super.init             = ucc_mc_cuda_init,
+    .super.finalize         = ucc_mc_cuda_finalize,
+    .super.ops.mem_query    = ucc_mc_cuda_mem_query,
+    .super.ops.mem_alloc    = ucc_mc_cuda_mem_alloc,
+    .super.ops.mem_free     = ucc_mc_cuda_mem_free,
+    .super.ops.reduce       = ucc_mc_cuda_reduce,
+    .super.ops.reduce_multi = ucc_mc_cuda_reduce_multi,
+    .super.ops.memcpy       = ucc_mc_cuda_memcpy,
     .super.config_table =
         {
             .name   = "CUDA memory component",
@@ -194,13 +202,6 @@ ucc_mc_cuda_t ucc_mc_cuda = {
             .table  = ucc_mc_cuda_config_table,
             .size   = sizeof(ucc_mc_cuda_config_t),
         },
-    .super.init          = ucc_mc_cuda_init,
-    .super.finalize      = ucc_mc_cuda_finalize,
-    .super.ops.mem_query = ucc_mc_cuda_mem_query,
-    .super.ops.mem_alloc = ucc_mc_cuda_mem_alloc,
-    .super.ops.mem_free  = ucc_mc_cuda_mem_free,
-    .super.ops.reduce    = ucc_mc_cuda_reduce,
-    .super.ops.memcpy    = ucc_mc_cuda_memcpy
 };
 
 UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_mc_cuda.super.config_table,

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -27,6 +27,11 @@ ucc_status_t ucc_mc_cuda_reduce(const void *src1, const void *src2,
                                 void *dst, size_t count, ucc_datatype_t dt,
                                 ucc_reduction_op_t op);
 
+ucc_status_t ucc_mc_cuda_reduce_multi(const void *src1, const void *src2,
+                                      void *dst, size_t size, size_t count,
+                                      size_t stride, ucc_datatype_t dt,
+                                      ucc_reduction_op_t op);
+
 extern ucc_mc_cuda_t ucc_mc_cuda;
 #define CUDACHECK(cmd) do {                                                    \
         cudaError_t e = cmd;                                                   \

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -15,7 +15,8 @@ ucc_status_t ucc_mc_available(ucc_memory_type_t mem_type);
 
 ucc_status_t ucc_mc_type(const void *ptr, ucc_memory_type_t *mem_type);
 
-ucc_status_t ucc_mc_query(const void *ptr, size_t length, ucc_mem_attr_t *mem_attr);
+ucc_status_t ucc_mc_query(const void *ptr, size_t length,
+                          ucc_mem_attr_t *mem_attr);
 
 ucc_status_t ucc_mc_alloc(void **ptr, size_t len, ucc_memory_type_t mem_type);
 
@@ -50,16 +51,17 @@ static inline ucc_status_t ucc_dt_reduce(const void *src1, const void *src2,
     }
 }
 
-static inline ucc_status_t ucc_dt_reduce_multi(void *src1, void *src2, void *dst,
-                                               size_t count, size_t size,
-                                               size_t stride, ucc_datatype_t dt,
+static inline ucc_status_t ucc_dt_reduce_multi(void *src1, void *src2,
+                                               void *dst, size_t size,
+                                               size_t count, size_t stride,
+                                               ucc_datatype_t dt,
                                                ucc_memory_type_t mem_type,
                                                ucc_coll_args_t *args)
 {
     if (args->mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) {
         return UCC_ERR_NOT_SUPPORTED; //TODO
     } else {
-        return ucc_mc_reduce_multi(src1, src2, dst, count, size, stride,
+        return ucc_mc_reduce_multi(src1, src2, dst, size, count, stride,
                                    dt, args->reduce.predefined_op, mem_type);
     }
 }

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -13,6 +13,17 @@
 #define ucc_min(_a, _b) ucs_min((_a), (_b))
 #define ucc_max(_a, _b) ucs_max((_a), (_b))
 
+#define DO_OP_MAX(_v1, _v2) (_v1 > _v2 ? _v1 : _v2)
+#define DO_OP_MIN(_v1, _v2) (_v1 < _v2 ? _v1 : _v2)
+#define DO_OP_SUM(_v1, _v2) (_v1 + _v2)
+#define DO_OP_PROD(_v1, _v2) (_v1 * _v2)
+#define DO_OP_LAND(_v1, _v2) (_v1 && _v2)
+#define DO_OP_BAND(_v1, _v2) (_v1 & _v2)
+#define DO_OP_LOR(_v1, _v2) (_v1 || _v2)
+#define DO_OP_BOR(_v1, _v2) (_v1 | _v2)
+#define DO_OP_LXOR(_v1, _v2) ((!_v1) != (!_v2))
+#define DO_OP_BXOR(_v1, _v2) (_v1 ^ _v2)
+
 extern size_t ucc_dt_sizes[UCC_DT_USERDEFINED];
 static inline size_t ucc_dt_size(ucc_datatype_t dt)
 {


### PR DESCRIPTION
## What
Implementation of reduce multi for cuda memory component

## Why ?
Reduce multi allows to do a reduction for multiple vectors in one call hence only one kernel launch is needed. This is useful for allreduce/reduce collectives with radix greater than 2.

## How ?
Reduce multi is added to base memory component interface. In CPU MC reduce multi is implemented as N calls to normal reduce.