### PR TITLE
Test mpi fixes

### DIFF
--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -2,6 +2,7 @@
 #include <sstream>
 #include "test_mpi.h"
 #include <chrono>
+#include "mpi_util.h"
 
 static std::vector<ucc_coll_type_t> colls = {UCC_COLL_TYPE_BARRIER,
                                              UCC_COLL_TYPE_ALLREDUCE,
@@ -334,5 +335,6 @@ int main(int argc, char *argv[])
             std::chrono::duration_cast<std::chrono::seconds>(end - begin).count()
                   << "s" << std::endl;
     }
+    mpi_progress_cleanup();
     return 0;
 }

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -7,7 +7,8 @@
 static std::vector<ucc_coll_type_t> colls = {UCC_COLL_TYPE_BARRIER,
                                              UCC_COLL_TYPE_ALLREDUCE,
                                              UCC_COLL_TYPE_ALLGATHER,
-                                             UCC_COLL_TYPE_ALLGATHERV};
+                                             UCC_COLL_TYPE_ALLGATHERV,
+                                             UCC_COLL_TYPE_BCAST};
 static std::vector<ucc_memory_type_t> mtypes = {UCC_MEMORY_TYPE_HOST};
 static std::vector<ucc_datatype_t> dtypes = {UCC_DT_INT32, UCC_DT_INT64,
                                              UCC_DT_FLOAT32, UCC_DT_FLOAT64};
@@ -16,7 +17,7 @@ static std::vector<ucc_test_mpi_team_t> teams = {TEAM_WORLD, TEAM_REVERSE,
                                                  TEAM_SPLIT_HALF, TEAM_SPLIT_ODD_EVEN};
 static size_t msgrange[3] = {8, (1ULL << 21), 8};
 static char *cls = NULL;
-static std::vector<ucc_test_mpi_inplace_t> inplace = {TEST_NO_INPLACE};
+static std::vector<ucc_test_mpi_inplace_t> inplace = {TEST_NO_INPLACE, TEST_INPLACE};
 static ucc_test_mpi_root_t root_type = ROOT_RANDOM;
 static int root_value = 10;
 static std::vector<std::string> str_split(const char *value, const char *delimiter)

--- a/test/mpi/mpi_util.cc
+++ b/test/mpi/mpi_util.cc
@@ -54,3 +54,23 @@ MPI_Comm create_mpi_comm(ucc_test_mpi_team_t t)
     }
     return MPI_COMM_NULL;
 }
+static MPI_Request progress_request = NULL;
+void mpi_progress()
+{
+    int completed;
+    if (!progress_request) {
+        int rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Isend(NULL, 0, MPI_BYTE, rank, 456, MPI_COMM_WORLD, &progress_request);
+    }
+    MPI_Test(&progress_request, &completed, MPI_STATUS_IGNORE);
+}
+
+void mpi_progress_cleanup() {
+    int rank;
+    if (progress_request) {
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Recv(NULL, 0, MPI_BYTE, rank, 456, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        MPI_Wait(&progress_request, MPI_STATUS_IGNORE);
+    }
+}

--- a/test/mpi/mpi_util.h
+++ b/test/mpi/mpi_util.h
@@ -76,4 +76,6 @@ static inline MPI_Op ucc_op_to_mpi(ucc_reduction_op_t op)
 }
 
 MPI_Comm create_mpi_comm(ucc_test_mpi_team_t t);
+void mpi_progress();
+void mpi_progress_cleanup();
 #endif

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -5,7 +5,7 @@
  */
 
 #include "test_mpi.h"
-
+#include "mpi_util.h"
 std::shared_ptr<TestCase> TestCase::init(ucc_coll_type_t _type,
                                          ucc_test_team_t &_team,
                                          int root,
@@ -53,6 +53,7 @@ void TestCase::wait()
             MPI_Abort(MPI_COMM_WORLD, -1);
         }
         ucc_context_progress(team.ctx);
+        mpi_progress();
     } while (UCC_OK != status);
 }
 

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -255,14 +255,20 @@ std::vector<int> UccTestMpi::gen_roots(ucc_test_team_t &team)
 {
     int size;
     std::vector<int> _roots;
+    std::default_random_engine eng;
+    eng.seed(123);
     MPI_Comm_size(team.comm, &size);
+    std::uniform_int_distribution<int> urd(0, size-1);
+
     switch(root_type) {
     case ROOT_SINGLE:
         _roots = std::vector<int>({ucc_min(root_value, size-1)});
         break;
     case ROOT_RANDOM:
         _roots.resize(root_value);
-        std::generate(_roots.begin(), _roots.end(), [=](){ return rand() % size;});
+        for (unsigned i = 0; i < _roots.size(); i++) {
+            _roots[i] = urd(eng);
+        }
         break;
     case ROOT_ALL:
         _roots.resize(size);

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -200,6 +200,7 @@ int ucc_coll_is_rooted(ucc_coll_type_t c)
     switch(c) {
     case UCC_COLL_TYPE_ALLREDUCE:
     case UCC_COLL_TYPE_ALLGATHER:
+    case UCC_COLL_TYPE_ALLGATHERV:
     case UCC_COLL_TYPE_ALLTOALL:
     case UCC_COLL_TYPE_BARRIER:
         return 0;


### PR DESCRIPTION
## What
TEST/MPI:
- Fixes random root generation (use local random engine instead of rand())
- Fixes hang due to lack of MPI progress (need to move MPI runtime when waiting for ucc collective)
- Adds broadcast to the test list
- Enables INPLACE + NO_INPLACE


