### PR TITLE
TEST: gtest: use static teams

### DIFF
--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -113,11 +113,12 @@ typedef std::vector<ucc_env_var_t> ucc_job_env_t;
 /* UccJob - environent that has n_procs processes.
    Multiple UccTeams can be created from UccJob */
 class UccJob {
-    static const int staticUccJobSize = 16;
-    static constexpr int staticTeamSizes[] = {2, 7, 8};
     static UccJob* staticUccJob;
     static std::vector<UccTeam_h> staticTeams;
 public:
+    static const int nStaticTeams     = 3;
+    static const int staticUccJobSize = 16;
+    static constexpr int staticTeamSizes[nStaticTeams] = {2, 11, 16};
     static void cleanup();
     static UccJob* getStaticJob();
     static const std::vector<UccTeam_h> &getStaticTeams();

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -125,15 +125,14 @@ class test_alltoallv_1 : public test_alltoallv <uint32_t>,
 
 UCC_TEST_P(test_alltoallv_1, single)
 {
-    const int size = std::get<0>(GetParam());
-    const ucc_datatype_t dtype = (ucc_datatype_t)std::get<1>(GetParam());
-    UccTeam_h team = UccJob::getStaticJob()->create_team(size);
-    UccCollArgsVec args = data_init(size, (ucc_datatype_t)dtype, 1);
-
+    const int            team_id = std::get<0>(GetParam());
+    const ucc_datatype_t dtype   = (ucc_datatype_t)std::get<1>(GetParam());
+    UccTeam_h            team    = UccJob::getStaticTeams()[team_id];
+    int                  size    = team->procs.size();
+    UccCollArgsVec       args    = data_init(size, (ucc_datatype_t)dtype, 1);
     UccReq    req(team, args);
     req.start();
     req.wait();
-
     data_validate(args);
     data_fini(args);
 }
@@ -143,14 +142,14 @@ INSTANTIATE_TEST_CASE_P(
         64,
         test_alltoallv_0,
         ::testing::Combine(
-            ::testing::Values(1,3,16), // nprocs
+            ::testing::Range(1, UccJob::nStaticTeams), // team_ids
             ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
 
 INSTANTIATE_TEST_CASE_P(
         32,
         test_alltoallv_1,
         ::testing::Combine(
-            ::testing::Values(1,3,16), // nprocs
+            ::testing::Range(1, UccJob::nStaticTeams), // team_ids
             ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
 
 
@@ -160,6 +159,7 @@ class test_alltoallv_2 : public test_alltoallv<uint64_t>,
 class test_alltoallv_3 : public test_alltoallv<uint32_t>,
         public ::testing::WithParamInterface<int> {};
 
+# if 0
 UCC_TEST_P(test_alltoallv_2, multiple)
 {
     const ucc_datatype_t dtype = (ucc_datatype_t)(GetParam());
@@ -216,3 +216,4 @@ INSTANTIATE_TEST_CASE_P(
         32,
         test_alltoallv_3,
         ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1)); // dtype
+#endif

--- a/test/gtest/core/test_barrier.cc
+++ b/test/gtest/core/test_barrier.cc
@@ -25,8 +25,7 @@ UCC_TEST_F(test_barrier, single_2proc)
 
 UCC_TEST_F(test_barrier, single_max_procs)
 {
-    int team_size = UccJob::getStaticJob()->n_procs;
-    UccTeam_h team = UccJob::getStaticJob()->create_team(team_size);
+    UccTeam_h team = UccJob::getStaticTeams().back();
     UccReq    req(team, &coll);
     req.start();
     req.wait();


### PR DESCRIPTION
    - Collective tests (currently barrier, alltoall, alltoallv) should
    be using UccJob::getStaticTeams() instead of creating/destroying
    new team for each TestFixture. Otherwise known UCX (ucp) cleanup
    issue may happen which leads to memory leak.
    - Disable alltoall(v) "mutliple" tests. Right now UCC (over UCP tl)
    does not support this yet. Will be re-enabled once team-id
    allocation feature is merged to  UCC master.

