### PR TITLE
CL/BASIC: destroy tl team multiple

### DIFF
--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -43,10 +43,10 @@ UCC_CLASS_DECLARE(ucc_cl_basic_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
 
 typedef struct ucc_cl_basic_team {
-    ucc_cl_team_t                   super;
-    ucc_team_create_multiple_req_t *team_create_req;
-    ucc_tl_team_t                  *tl_ucp_team;
-    ucc_tl_team_t                  *tl_nccl_team;
+    ucc_cl_team_t            super;
+    ucc_team_multiple_req_t *team_create_req;
+    ucc_tl_team_t           *tl_ucp_team;
+    ucc_tl_team_t           *tl_nccl_team;
 } ucc_cl_basic_team_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -85,24 +85,25 @@ ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, ucc_tl_type_t type,
                                 ucc_tl_context_t **tl_context);
 ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context);
 
-typedef struct ucc_team_create_multiple_req {
+typedef struct ucc_team_multiple_req {
     int                          n_teams;
-    int                          last_created;
+    int                          last;
     struct ucc_team_team_desc {
         ucc_tl_context_t        *ctx;
         ucc_tl_team_t           *team;
         ucc_base_team_params_t   param;
         ucc_status_t             status;
     } descs[1];
-} ucc_team_create_multiple_req_t;
+} ucc_team_multiple_req_t;
 
 ucc_status_t
-ucc_team_create_multiple_req_alloc(ucc_team_create_multiple_req_t **req,
+ucc_team_multiple_req_alloc(ucc_team_multiple_req_t **req,
                                    int n_teams);
 
-ucc_status_t ucc_tl_team_create_multiple(ucc_team_create_multiple_req_t *req);
+ucc_status_t ucc_tl_team_create_multiple(ucc_team_multiple_req_t *req);
+ucc_status_t ucc_tl_team_destroy_multiple(ucc_team_multiple_req_t *req);
 
-void ucc_team_create_multiple_req_free(ucc_team_create_multiple_req_t *req);
+void ucc_team_multiple_req_free(ucc_team_multiple_req_t *req);
 
 #define UCC_TL_CTX_IFACE(_tl_ctx)                                              \
     (ucc_derived_of((_tl_ctx)->super.lib, ucc_tl_lib_t))->iface


### PR DESCRIPTION
## What
TL interface to destroy multiple teams in a non-blocking way 

## Why ?
We defined internal team destruction interface to be non-blocking (at least if TL/CL supports it)
