### PR TITLE
TL/UCP: endpoints hash

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,6 +50,7 @@ noinst_HEADERS =                     \
 	utils/ucc_list.h				 \
 	utils/ucc_queue.h				 \
 	utils/ucc_proc_info.h            \
+	utils/khash.h                    \
 	components/base/ucc_base_iface.h \
 	components/cl/ucc_cl.h           \
 	components/cl/ucc_cl_log.h       \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,8 +74,8 @@ libucc_la_SOURCES =                  \
 	schedule/ucc_schedule.c          \
 	utils/ucc_component.c            \
 	utils/ucc_status.c               \
-    utils/ucc_math.c                 \
-    utils/ucc_proc_info.c            \
+	utils/ucc_math.c                 \
+	utils/ucc_proc_info.c            \
 	components/base/ucc_base_iface.c \
 	components/cl/ucc_cl.c           \
 	components/tl/ucc_tl.c           \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,6 +49,7 @@ noinst_HEADERS =                     \
 	utils/ucc_coll_utils.h           \
 	utils/ucc_list.h				 \
 	utils/ucc_queue.h				 \
+	utils/ucc_proc_info.h            \
 	components/base/ucc_base_iface.h \
 	components/cl/ucc_cl.h           \
 	components/cl/ucc_cl_log.h       \
@@ -73,6 +74,7 @@ libucc_la_SOURCES =                  \
 	utils/ucc_component.c            \
 	utils/ucc_status.c               \
     utils/ucc_math.c                 \
+    utils/ucc_proc_info.c            \
 	components/base/ucc_base_iface.c \
 	components/cl/ucc_cl.c           \
 	components/tl/ucc_tl.c           \

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -9,7 +9,7 @@
 #include "components/tl/ucc_tl.h"
 #include "components/tl/ucc_tl_log.h"
 #include "utils/ucc_mpool.h"
-
+#include "tl_ucp_ep_hash.h"
 #include <ucp/api/ucp.h>
 #include <ucs/memory/memory_type.h>
 
@@ -57,10 +57,11 @@ typedef struct ucc_tl_ucp_context {
     ucp_worker_h                ucp_worker;
     size_t                      ucp_addrlen;
     ucp_address_t              *worker_address;
+    ucp_ep_h                   *eps;
     ucc_tl_ucp_ep_close_state_t ep_close_state;
     ucc_mpool_t                 req_mp;
-    ucp_ep_h                   *eps;
     ucc_tl_ucp_addr_storage_t  *addr_storage;
+    tl_ucp_ep_hash_t           *ep_hash;
 } ucc_tl_ucp_context_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
@@ -69,15 +70,10 @@ typedef struct ucc_tl_ucp_task ucc_tl_ucp_task_t;
 typedef struct ucc_tl_ucp_team {
     ucc_tl_team_t              super;
     ucc_status_t               status;
-    int                        context_ep_storage; /*< The flag
-              indicates whether ucp endpoints are stored on the
-              ucc_tl_ucp_context or are they created per-team.
-              This optimization is only possible when user provides
-              the necessary rank mappings team_rank->context_rank. */
-    ucp_ep_h                  *eps;
     ucc_rank_t                 size;
     ucc_rank_t                 rank;
     ucc_tl_ucp_addr_storage_t *addr_storage;
+    int                        ctx_addr_exchange;
     uint32_t                   id;
     uint32_t                   scope;
     uint32_t                   scope_id;

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -46,7 +46,6 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *,
 typedef struct ucc_tl_ucp_addr_storage ucc_tl_ucp_addr_storage_t;
 
 typedef struct ucc_tl_ucp_ep_close_state {
-    ucc_rank_t ep;
     void      *close_req;
 } ucc_tl_ucp_ep_close_state_t;
 
@@ -57,10 +56,8 @@ typedef struct ucc_tl_ucp_context {
     ucp_worker_h                ucp_worker;
     size_t                      ucp_addrlen;
     ucp_address_t              *worker_address;
-    ucp_ep_h                   *eps;
     ucc_tl_ucp_ep_close_state_t ep_close_state;
     ucc_mpool_t                 req_mp;
-    ucc_tl_ucp_addr_storage_t  *addr_storage;
     tl_ucp_ep_hash_t           *ep_hash;
 } ucc_tl_ucp_context_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
@@ -73,7 +70,6 @@ typedef struct ucc_tl_ucp_team {
     ucc_rank_t                 size;
     ucc_rank_t                 rank;
     ucc_tl_ucp_addr_storage_t *addr_storage;
-    int                        ctx_addr_exchange;
     uint32_t                   id;
     uint32_t                   scope;
     uint32_t                   scope_id;

--- a/src/components/tl/ucp/tl_ucp_addr.h
+++ b/src/components/tl/ucp/tl_ucp_addr.h
@@ -8,14 +8,25 @@
 #define UCC_TL_UCP_ADDR_H_
 #include "components/tl/ucc_tl.h"
 
+enum {
+    UCC_TL_UCP_ADDR_EXCHANGE_MAX_ADDRLEN,
+    UCC_TL_UCP_ADDR_EXCHANGE_GATHER,
+    UCC_TL_UCP_ADDR_EXCHANGE_COMPLETE,
+};
+
 typedef struct ucc_tl_ucp_context ucc_tl_ucp_context_t;
+typedef struct ucc_tl_ucp_addr {
+    ucc_context_id_t id;
+    char             addr[1];
+} ucc_tl_ucp_addr_t;
+
 typedef struct ucc_tl_ucp_addr_storage {
     void                 *oob_req;
     size_t                max_addrlen;
     int                   state;
     int                   is_ctx;
     size_t               *addrlens;
-    void                 *addresses;
+    ucc_tl_ucp_addr_t    *addresses;
     ucc_team_oob_coll_t   oob;
     ucc_tl_ucp_context_t *ctx;
 } ucc_tl_ucp_addr_storage_t;

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -7,6 +7,7 @@
 #include "tl_ucp.h"
 #include "tl_ucp_tag.h"
 #include "tl_ucp_coll.h"
+#include "tl_ucp_ep.h"
 #include <limits.h>
 
 UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
@@ -29,6 +30,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     memcpy(&self->cfg, tl_ucp_config, sizeof(*tl_ucp_config));
     self->ep_close_state.close_req = NULL;
     self->ep_close_state.ep        = 0;
+    self->eps                      = NULL;
     status = ucp_config_read(params->prefix, NULL, &ucp_config);
     if (UCS_OK != status) {
         tl_error(self->super.super.lib, "failed to read ucp configuration, %s",
@@ -113,6 +115,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
         tl_error(self->super.super.lib, "failed to register progress function");
         goto err_thread_mode;
     }
+    self->ep_hash = kh_init(tl_ucp_ep_hash);
     tl_info(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 
@@ -126,7 +129,12 @@ err_cfg:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_context_t)
 {
+    ucc_status_t status;
     tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    while (UCC_OK != (status = ucc_tl_ucp_close_eps(self))) {
+        ; //TODO can we hang the runtime this way ?
+    }
+	kh_destroy(tl_ucp_ep_hash, self->ep_hash);
     ucc_context_progress_deregister(
         self->super.super.ucc_context,
         (ucc_context_progress_fn_t)ucp_worker_progress, self->ucp_worker);

--- a/src/components/tl/ucp/tl_ucp_ep.c
+++ b/src/components/tl/ucp/tl_ucp_ep.c
@@ -6,7 +6,8 @@ static inline ucc_status_t ucc_tl_ucp_connect_ep(ucc_tl_ucp_context_t *ctx,
                                                  ucp_ep_h *ep, char *addr_array,
                                                  size_t max_addrlen, ucc_rank_t rank)
 {
-    ucp_address_t  *address = (ucp_address_t *)(addr_array + max_addrlen * rank);
+    ucc_tl_ucp_addr_t  *address = (ucc_tl_ucp_addr_t *)(addr_array +
+                                                        max_addrlen * rank);
     ucp_ep_params_t ep_params;
     ucs_status_t    status;
     if (*ep) {
@@ -14,7 +15,7 @@ static inline ucc_status_t ucc_tl_ucp_connect_ep(ucc_tl_ucp_context_t *ctx,
         return UCC_OK;
     }
     ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-    ep_params.address    = address;
+    ep_params.address    = (ucp_address_t*)address->addr;
 
     status = ucp_ep_create(ctx->ucp_worker, &ep_params, ep);
 
@@ -29,28 +30,36 @@ static inline ucc_status_t ucc_tl_ucp_connect_ep(ucc_tl_ucp_context_t *ctx,
 ucc_status_t ucc_tl_ucp_connect_ctx_ep(ucc_tl_ucp_context_t *ctx, ucc_rank_t ctx_rank)
 {
     return ucc_tl_ucp_connect_ep(ctx, &ctx->eps[ctx_rank],
-                                 ctx->addr_storage->addresses,
+                                 (char*)ctx->addr_storage->addresses,
                                  ctx->addr_storage->max_addrlen, ctx_rank);
 }
 
-ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t *team, ucc_rank_t team_rank)
+ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t *team, ucc_rank_t team_rank,
+                                        ucc_context_id_t key, ucp_ep_h *ep)
 {
     ucc_tl_ucp_context_t *ctx = UCC_TL_UCP_TEAM_CTX(team);
-    if (team->context_ep_storage) {
+    ucc_status_t status;
+    if (ctx->eps) {
         int ctx_rank = -1; //TODO map to ctx rank
         ucc_assert(0);
-        return ucc_tl_ucp_connect_ctx_ep(ctx, ctx_rank);
+        status = ucc_tl_ucp_connect_ctx_ep(ctx, ctx_rank);
+        *ep = ctx->eps[0]; //TODO map
+        return status;
     }
-    return ucc_tl_ucp_connect_ep(ctx, &team->eps[team_rank],
-                                 team->addr_storage->addresses,
-                                 team->addr_storage->max_addrlen, team_rank);
+    status = ucc_tl_ucp_connect_ep(ctx, ep,
+                                   (char*)team->addr_storage->addresses,
+                                   team->addr_storage->max_addrlen, team_rank);
+    if (UCC_OK == status) {
+        tl_ucp_hash_put(ctx->ep_hash, key, *ep);
+    }
+    return status;
 }
 
-ucc_status_t ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx, ucp_ep_h *eps,
-                                  ucc_rank_t n_eps)
+ucc_status_t ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx)
 {
     ucc_tl_ucp_ep_close_state_t *state = &ctx->ep_close_state;
-    ucs_status_t status;
+    ucp_ep_h                     ep;
+    ucs_status_t                 status;
     if (state->close_req) {
         ucp_worker_progress(ctx->ucp_worker);
         status = ucp_request_check_status(state->close_req);
@@ -58,18 +67,17 @@ ucc_status_t ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx, ucp_ep_h *eps,
             return UCC_INPROGRESS;
         }
         ucp_request_free(state->close_req);
-        eps[state->ep++] = NULL;
     }
-
-    for (; state->ep < n_eps; state->ep++) {
-        if (!eps[state->ep]) {
-            continue;
+    while (1) {
+        ep = tl_ucp_hash_pop(ctx->ep_hash);
+        if (NULL == ep) {
+            break;
         }
         state->close_req =
-            ucp_ep_close_nb(eps[state->ep], UCP_EP_CLOSE_MODE_FLUSH);
+            ucp_ep_close_nb(ep, UCP_EP_CLOSE_MODE_FLUSH);
         if (UCS_PTR_IS_ERR(state->close_req)) {
             tl_error(ctx->super.super.lib, "failed to start ep close, ep %p",
-                     eps[state->ep]);
+                     ep);
         }
         status = UCS_PTR_STATUS(state->close_req);
         /* try progress once */
@@ -81,11 +89,7 @@ ucc_status_t ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx, ucp_ep_h *eps,
             }
             ucp_request_free(state->close_req);
         }
-        if (status == UCS_OK) {
-            eps[state->ep] = NULL;
-        }
     }
     state->close_req = NULL;
-    state->ep        = 0;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_ep.h
+++ b/src/components/tl/ucp/tl_ucp_ep.h
@@ -24,8 +24,12 @@ ucc_status_t ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx);
 static inline ucc_context_id_t
 ucc_tl_ucp_get_rank_key(ucc_tl_ucp_team_t *team, ucc_rank_t rank)
 {
-    size_t max_addrlen = team->addr_storage->max_addrlen;
-    char *addresses = (char*)team->addr_storage->addresses;
+    ucc_assert(team->addr_storage);
+    /* Currently team always has addr_storage by this moment.
+       At some point we might add the logic when addressing stored on a context
+       or even outside of UCC */
+    size_t max_addrlen = team->addr_storage->max_addrlen; /* NOLINT */
+    char *addresses    = (char*)team->addr_storage->addresses;
     ucc_tl_ucp_addr_t  *address = (ucc_tl_ucp_addr_t *)(addresses +
                                                         max_addrlen * rank);
     return address->id;
@@ -35,34 +39,18 @@ static inline ucc_status_t ucc_tl_ucp_get_ep(ucc_tl_ucp_team_t *team, ucc_rank_t
                                              ucp_ep_h *ep)
 {
     ucc_tl_ucp_context_t *ctx = UCC_TL_UCP_TEAM_CTX(team);
+    ucc_context_id_t      key = ucc_tl_ucp_get_rank_key(team, rank);
     ucc_status_t          status;
-    if (!ctx->eps) {
-        ucc_context_id_t key = ucc_tl_ucp_get_rank_key(team, rank);
-        *ep = tl_ucp_hash_get(ctx->ep_hash, key);
-        if (NULL == (*ep)) {
-            /* Not connected yet */
-            status = ucc_tl_ucp_connect_team_ep(team, rank, key, ep);
-            if (UCC_OK != status) {
-                tl_error(UCC_TL_TEAM_LIB(team), "failed to connect team ep");
-                *ep = NULL;
-                return status;
-            }
+
+    *ep = tl_ucp_hash_get(ctx->ep_hash, key);
+    if (NULL == (*ep)) {
+        /* Not connected yet */
+        status = ucc_tl_ucp_connect_team_ep(team, rank, key, ep);
+        if (UCC_OK != status) {
+            tl_error(UCC_TL_TEAM_LIB(team), "failed to connect team ep");
+            *ep = NULL;
+            return status;
         }
-    } else {
-        ucc_assert(ctx->eps);
-        ucc_rank_t ctx_rank = -1; //TODO map to ctx rank
-        ucc_assert(0);
-        if (NULL == ctx->eps[ctx_rank]) {
-            /* Not connected yet */
-            status = ucc_tl_ucp_connect_ctx_ep(ctx, ctx_rank);
-            if (UCC_OK != status) {
-                tl_error(UCC_TL_TEAM_LIB(team), "failed to connect ctx ep");
-                *ep = NULL;
-                return status;
-            }
-        }
-        ucc_assert(ctx->eps[ctx_rank]);
-        *ep = ctx->eps[ctx_rank];
     }
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_ep.h
+++ b/src/components/tl/ucp/tl_ucp_ep.h
@@ -10,34 +10,45 @@
 #include "ucc/api/ucc.h"
 #include <ucp/api/ucp.h>
 #include "tl_ucp.h"
+#include "tl_ucp_addr.h"
 typedef struct ucc_tl_ucp_context ucc_tl_ucp_context_t;
 typedef struct ucc_tl_ucp_team    ucc_tl_ucp_team_t;
-ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t *team, ucc_rank_t team_rank);
+
+
+ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t *team, ucc_rank_t team_rank,
+                                        ucc_context_id_t key, ucp_ep_h *ep);
 ucc_status_t ucc_tl_ucp_connect_ctx_ep(ucc_tl_ucp_context_t *ctx, ucc_rank_t ctx_rank);
 
-ucc_status_t ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx, ucp_ep_h *eps,
-                                  ucc_rank_t n_eps);
+ucc_status_t ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx);
+
+static inline ucc_context_id_t
+ucc_tl_ucp_get_rank_key(ucc_tl_ucp_team_t *team, ucc_rank_t rank)
+{
+    size_t max_addrlen = team->addr_storage->max_addrlen;
+    char *addresses = (char*)team->addr_storage->addresses;
+    ucc_tl_ucp_addr_t  *address = (ucc_tl_ucp_addr_t *)(addresses +
+                                                        max_addrlen * rank);
+    return address->id;
+}
 
 static inline ucc_status_t ucc_tl_ucp_get_ep(ucc_tl_ucp_team_t *team, ucc_rank_t rank,
                                              ucp_ep_h *ep)
 {
+    ucc_tl_ucp_context_t *ctx = UCC_TL_UCP_TEAM_CTX(team);
     ucc_status_t          status;
-    ucc_tl_ucp_context_t *ctx;
-    if (!team->context_ep_storage) {
-        ucc_assert(team->eps);
-        if (NULL == team->eps[rank]) {
+    if (!ctx->eps) {
+        ucc_context_id_t key = ucc_tl_ucp_get_rank_key(team, rank);
+        *ep = tl_ucp_hash_get(ctx->ep_hash, key);
+        if (NULL == (*ep)) {
             /* Not connected yet */
-            status = ucc_tl_ucp_connect_team_ep(team, rank);
+            status = ucc_tl_ucp_connect_team_ep(team, rank, key, ep);
             if (UCC_OK != status) {
                 tl_error(UCC_TL_TEAM_LIB(team), "failed to connect team ep");
                 *ep = NULL;
                 return status;
             }
         }
-        ucc_assert(team->eps[rank]);
-        *ep = team->eps[rank];
     } else {
-        ctx = UCC_TL_UCP_TEAM_CTX(team);
         ucc_assert(ctx->eps);
         ucc_rank_t ctx_rank = -1; //TODO map to ctx rank
         ucc_assert(0);

--- a/src/components/tl/ucp/tl_ucp_ep_hash.h
+++ b/src/components/tl/ucp/tl_ucp_ep_hash.h
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_UCP_EP_HASH_H_
+#define UCC_TL_UCP_EP_HASH_H_
+#include "config.h"
+#include "core/ucc_context.h"
+#include "utils/khash.h"
+#include <stdint.h>
+
+static inline uint32_t tl_ucp_ctx_id_hash_fn_impl(uint32_t h, uint32_t k)
+{
+    uint32_t H = h & 0xf8000000;
+    h = h << 5;
+    h = h ^ ( H >> 27 );
+    h = h ^ k;
+    return h;
+}
+
+static inline khint32_t tl_ucp_ctx_id_hash_fn(ucc_context_id_t k)
+{
+    uint32_t h = 0;
+    h = tl_ucp_ctx_id_hash_fn_impl(h, k.host_id);
+    h = tl_ucp_ctx_id_hash_fn_impl(h, k.pid);
+    h = tl_ucp_ctx_id_hash_fn_impl(h, k.seq_num);
+    return (khint32_t)h;
+}
+
+#define tl_ucp_ctx_id_equal_fn(_a, _b) (((_a).host_id == (_b).host_id) && \
+                                        ((_a).pid == (_b).pid) &&       \
+                                        ((_a).seq_num == (_b).seq_num))
+
+
+KHASH_INIT(tl_ucp_ep_hash, ucc_context_id_t, void*, 1, \
+           tl_ucp_ctx_id_hash_fn, tl_ucp_ctx_id_equal_fn);
+
+#define tl_ucp_ep_hash_t khash_t(tl_ucp_ep_hash)
+
+static inline void* tl_ucp_hash_get(tl_ucp_ep_hash_t *h, ucc_context_id_t key)
+{
+    khiter_t k;
+    void    *value;
+    k = kh_get(tl_ucp_ep_hash, h , key);
+    if (k == kh_end(h)) {
+        return NULL;
+    }
+    value = kh_value(h, k);
+    return value;
+}
+
+static inline void tl_ucp_hash_put(tl_ucp_ep_hash_t *h, ucc_context_id_t key,
+                                   void *value)
+{
+    int ret;
+    khiter_t k;
+    k = kh_put(tl_ucp_ep_hash, h, key, &ret);
+    kh_value(h, k) = value;
+}
+
+static inline void* tl_ucp_hash_pop(tl_ucp_ep_hash_t *h)
+{
+    void    *ep = NULL;
+    khiter_t k;
+    k = kh_begin(h);
+    while (k != kh_end(h)) {
+        if (kh_exist(h, k)) {
+            ep = kh_value(h, k);
+            break;
+        }
+        k++;
+    }
+    if (ep) {
+        kh_del(tl_ucp_ep_hash, h, k);
+    }
+    return ep;
+}
+#endif

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -20,9 +20,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super);
     /* TODO: init based on ctx settings and on params: need to check
              if all the necessary ranks mappings are provided */
-    self->context_ep_storage = 0;
+    self->ctx_addr_exchange  = 0;
     self->addr_storage       = NULL;
-    self->eps                = NULL;
     self->preconnect_task    = NULL;
     self->size               = params->params.oob.participants;
     self->scope              = params->scope;
@@ -30,7 +29,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     self->rank               = params->rank;
     self->id                 = params->id;
     self->seq_num            = 0;
-    if (self->context_ep_storage) {
+
+    if (self->ctx_addr_exchange) {
         self->status = UCC_OK;
     } else {
         self->status = UCC_INPROGRESS;
@@ -58,20 +58,6 @@ UCC_CLASS_DEFINE(ucc_tl_ucp_team_t, ucc_tl_team_t);
 
 ucc_status_t ucc_tl_ucp_team_destroy(ucc_base_team_t *tl_team)
 {
-    ucc_tl_ucp_team_t    *team = ucc_derived_of(tl_team, ucc_tl_ucp_team_t);
-    ucc_tl_ucp_context_t *ctx  = UCC_TL_UCP_TEAM_CTX(team);
-    ucc_status_t          status;
-    if (team->eps) {
-        status = ucc_tl_ucp_close_eps(ctx, team->eps, team->size);
-        if (UCC_INPROGRESS == status) {
-            return status;
-        } else if (UCC_OK != status) {
-            tl_error(team->super.super.context->lib,
-                     "failed to close team eps");
-            return status;
-        }
-        ucc_free(team->eps);
-    }
     UCC_CLASS_DELETE_FUNC_NAME(ucc_tl_ucp_team_t)(tl_team);
     return UCC_OK;
 }
@@ -120,19 +106,13 @@ ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team)
     if (team->status == UCC_OK) {
         return UCC_OK;
     }
-    if (team->addr_storage && (!team->eps)) {
+    if (team->addr_storage &&
+        (team->addr_storage->state != UCC_TL_UCP_ADDR_EXCHANGE_COMPLETE)) {
         status = ucc_tl_ucp_addr_exchange_test(team->addr_storage);
         if (UCC_INPROGRESS == status) {
             return UCC_INPROGRESS;
         } else if (UCC_OK != status) {
             return status;
-        }
-        team->eps = ucc_calloc(sizeof(ucp_ep_h), team->size, "team_eps");
-        if (!team->eps) {
-            tl_error(tl_team->context->lib,
-                     "failed to allocate %zd bytes for team eps",
-                     sizeof(ucp_ep_h) * team->size);
-            return UCC_ERR_NO_MEMORY;
         }
     }
     if (team->size <= ctx->cfg.preconnect) {
@@ -149,6 +129,5 @@ ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team)
     return UCC_OK;
 
 err_preconnect:
-    ucc_free(team->eps);
     return status;
 }

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -20,7 +20,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super);
     /* TODO: init based on ctx settings and on params: need to check
              if all the necessary ranks mappings are provided */
-    self->ctx_addr_exchange  = 0;
     self->addr_storage       = NULL;
     self->preconnect_task    = NULL;
     self->size               = params->params.oob.participants;
@@ -29,17 +28,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     self->rank               = params->rank;
     self->id                 = params->id;
     self->seq_num            = 0;
-
-    if (self->ctx_addr_exchange) {
-        self->status = UCC_OK;
-    } else {
-        self->status = UCC_INPROGRESS;
-        status       = ucc_tl_ucp_addr_exchange_start(ctx, params->params.oob,
-                                                      &self->addr_storage);
-        if (status == UCC_INPROGRESS) {
-            /* exchange started but not complete return UCC_OK from post */
-            status = UCC_OK;
-        }
+    self->status             = UCC_INPROGRESS;
+    status                   = ucc_tl_ucp_addr_exchange_start(ctx,
+                                                   params->params.oob,
+                                                  &self->addr_storage);
+    if (status == UCC_INPROGRESS) {
+        /* exchange started but not complete return UCC_OK from post */
+        status = UCC_OK;
     }
     tl_info(tl_context->lib, "posted tl team: %p", self);
     return status;

--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -8,7 +8,7 @@
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_component.h"
 #include "utils/ucc_log.h"
-
+#include "utils/ucc_proc_info.h"
 #include <link.h>
 #include <dlfcn.h>
 
@@ -89,9 +89,13 @@ ucc_status_t ucc_constructor(void)
         }
         status = ucc_components_load("mc", &ucc_global_config.mc_framework);
         if (UCC_OK != status) {
-            ucc_debug("no memory components were found in the "
+            ucc_error("no memory components were found in the "
                       "UCC_COMPONENT_PATH: %s",
                       ucc_global_config.component_path);
+            return status;
+        }
+        if (UCC_OK != ucc_local_proc_info_init()) {
+            ucc_error("failed to initialize local proc info");
             return status;
         }
     }

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -12,6 +12,7 @@
 #include "utils/ucc_list.h"
 #include "ucc_progress_queue.h"
 
+static uint32_t ucc_context_seq_num = 0;
 static ucc_config_field_t ucc_context_config_table[] = {
     {"ESTIMATED_NUM_EPS", "0",
      "An optimization hint of how many endpoints will be created on this context",
@@ -379,6 +380,9 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
         ucc_error("failed to init progress queue for context %p", ctx);
         goto error_ctx_create;
     }
+    ctx->id.host_id = ucc_local_proc.host_id;
+    ctx->id.pid     = getpid();
+    ctx->id.seq_num = ucc_context_seq_num++;
     ucc_info("created ucc context %p for lib %s", ctx, lib->full_prefix);
     *context = ctx;
     return UCC_OK;

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -423,8 +423,8 @@ ucc_status_t ucc_context_destroy(ucc_context_t *context)
     }
     ucc_progress_queue_finalize(context->pq);
     ucc_free(context->tl_ctx);
-    ucc_free(context);
     ucc_free(context->ids.pool);
+    ucc_free(context);
     return UCC_OK;
 }
 

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -9,6 +9,8 @@
 #include "ucc/api/ucc.h"
 #include "ucc_progress_queue.h"
 #include "utils/ucc_list.h"
+#include "utils/ucc_proc_info.h"
+
 typedef struct ucc_lib_info          ucc_lib_info_t;
 typedef struct ucc_cl_context        ucc_cl_context_t;
 typedef struct ucc_tl_context        ucc_tl_context_t;
@@ -25,6 +27,12 @@ typedef struct ucc_team_id_pool {
     uint32_t  pool_size;
 } ucc_team_id_pool_t;
 
+typedef struct ucc_context_id {
+    ucc_host_id_t host_id;
+    pid_t         pid;
+    uint32_t      seq_num;
+} ucc_context_id_t;
+
 typedef struct ucc_context {
     ucc_lib_info_t         *lib;
     ucc_context_params_t    params;
@@ -38,6 +46,7 @@ typedef struct ucc_context {
     ucc_list_link_t         progress_list;
     ucc_progress_queue_t   *pq;
     ucc_team_id_pool_t      ids;
+    ucc_context_id_t        id;
 } ucc_context_t;
 
 typedef struct ucc_context_config {

--- a/src/utils/khash.h
+++ b/src/utils/khash.h
@@ -1,0 +1,700 @@
+/* The MIT License
+
+   Copyright (c) 2008, 2009, 2011 by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/*
+  An example:
+
+#include "khash.h"
+KHASH_MAP_INIT_INT(32, char)
+int main() {
+	int ret, is_missing;
+	khiter_t k;
+	khash_t(32) *h = kh_init(32);
+	k = kh_put(32, h, 5, &ret);
+	kh_value(h, k) = 10;
+	k = kh_get(32, h, 10);
+	is_missing = (k == kh_end(h));
+	k = kh_get(32, h, 5);
+	kh_del(32, h, k);
+	for (k = kh_begin(h); k != kh_end(h); ++k)
+		if (kh_exist(h, k)) kh_value(h, k) = 1;
+	kh_destroy(32, h);
+	return 0;
+}
+*/
+
+/*
+  2013-05-02 (0.2.8):
+
+	* Use quadratic probing. When the capacity is power of 2, stepping function
+	  i*(i+1)/2 guarantees to traverse each bucket. It is better than double
+	  hashing on cache performance and is more robust than linear probing.
+
+	  In theory, double hashing should be more robust than quadratic probing.
+	  However, my implementation is probably not for large hash tables, because
+	  the second hash function is closely tied to the first hash function,
+	  which reduce the effectiveness of double hashing.
+
+	Reference: http://research.cs.vt.edu/AVresearch/hashing/quadratic.php
+
+  2011-12-29 (0.2.7):
+
+    * Minor code clean up; no actual effect.
+
+  2011-09-16 (0.2.6):
+
+	* The capacity is a power of 2. This seems to dramatically improve the
+	  speed for simple keys. Thank Zilong Tan for the suggestion. Reference:
+
+	   - http://code.google.com/p/ulib/
+	   - http://nothings.org/computer/judy/
+
+	* Allow to optionally use linear probing which usually has better
+	  performance for random input. Double hashing is still the default as it
+	  is more robust to certain non-random input.
+
+	* Added Wang's integer hash function (not used by default). This hash
+	  function is more robust to certain non-random input.
+
+  2011-02-14 (0.2.5):
+
+    * Allow to declare global functions.
+
+  2009-09-26 (0.2.4):
+
+    * Improve portability
+
+  2008-09-19 (0.2.3):
+
+	* Corrected the example
+	* Improved interfaces
+
+  2008-09-11 (0.2.2):
+
+	* Improved speed a little in kh_put()
+
+  2008-09-10 (0.2.1):
+
+	* Added kh_clear()
+	* Fixed a compiling error
+
+  2008-09-02 (0.2.0):
+
+	* Changed to token concatenation which increases flexibility.
+
+  2008-08-31 (0.1.2):
+
+	* Fixed a bug in kh_get(), which has not been tested previously.
+
+  2008-08-31 (0.1.1):
+
+	* Added destructor
+*/
+
+
+#ifndef __AC_KHASH_H
+#define __AC_KHASH_H
+
+/*!
+  @header
+
+  Generic hash table library.
+ */
+
+#define AC_VERSION_KHASH_H "0.2.8"
+
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+/* Clang analyzer thinks that `h->flags` can be NULL, but this is
+ * the wrong assumption - add `kassert()` to suppress the warning */
+#ifdef __clang_analyzer__
+#include <assert.h>
+#define kassert(...)              assert(__VA_ARGS__)
+#define kmemset_analyzer(P, Z, N) kmemset(P, Z, N)
+#else
+#define kassert(...)
+#define kmemset_analyzer(P, Z, N)
+#endif
+
+/* compiler specific configuration */
+
+#if UINT_MAX == 0xffffffffu
+typedef unsigned int khint32_t;
+#elif ULONG_MAX == 0xffffffffu
+typedef unsigned long khint32_t;
+#endif
+
+#if ULONG_MAX == ULLONG_MAX
+typedef unsigned long khint64_t;
+#else
+typedef unsigned long long khint64_t;
+#endif
+
+#ifndef kh_inline
+#ifdef _MSC_VER
+#define kh_inline __inline
+#else
+#define kh_inline inline
+#endif
+#endif /* kh_inline */
+
+#ifndef klib_unused
+#if (defined __clang__ && __clang_major__ >= 3) || (defined __GNUC__ && __GNUC__ >= 3)
+#define klib_unused __attribute__ ((__unused__))
+#else
+#define klib_unused
+#endif
+#endif /* klib_unused */
+
+typedef khint32_t khint_t;
+typedef khint_t khiter_t;
+
+#define __ac_isempty(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&2)
+#define __ac_isdel(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&1)
+#define __ac_iseither(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&3)
+#define __ac_set_isdel_false(flag, i) (flag[i>>4]&=~(1ul<<((i&0xfU)<<1)))
+#define __ac_set_isempty_false(flag, i) (flag[i>>4]&=~(2ul<<((i&0xfU)<<1)))
+#define __ac_set_isboth_false(flag, i) (flag[i>>4]&=~(3ul<<((i&0xfU)<<1)))
+#define __ac_set_isdel_true(flag, i) (flag[i>>4]|=1ul<<((i&0xfU)<<1))
+
+#define __ac_fsize(m) ((m) < 16? 1 : (m)>>4)
+
+#ifndef kroundup32
+#define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+#endif
+
+#ifndef kcalloc
+#define kcalloc(N,Z) calloc(N,Z)
+#endif
+#ifndef kmalloc
+#define kmalloc(Z) malloc(Z)
+#endif
+#ifndef krealloc
+#define krealloc(P,Z) realloc(P,Z)
+#endif
+#ifndef kfree
+#define kfree(P) free(P)
+#endif
+#ifndef kmemset
+#define kmemset(P,Z,N) memset(P,Z,N)
+#endif
+
+static const double __ac_HASH_UPPER = 0.77;
+
+#define __KHASH_TYPE(name, khkey_t, khval_t) \
+	typedef struct kh_##name##_s { \
+		khint_t n_buckets, size, n_occupied, upper_bound; \
+		khint32_t *flags; \
+		khkey_t *keys; \
+		khval_t *vals; \
+	} kh_##name##_t;
+
+#define __KHASH_PROTOTYPES(name, khkey_t, khval_t)	 					\
+	extern kh_##name##_t *kh_init_##name(void);							\
+    extern kh_##name##_t *kh_init_##name##_inplace(kh_##name##_t *h);   \
+	extern void kh_destroy_##name(kh_##name##_t *h);					\
+    extern void kh_destroy_##name##_inplace(kh_##name##_t *h);          \
+	extern void kh_clear_##name(kh_##name##_t *h);						\
+	extern khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key); 	\
+	extern int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets); \
+	extern khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret); \
+	extern void kh_del_##name(kh_##name##_t *h, khint_t x);
+
+#define __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	SCOPE kh_##name##_t *kh_init_##name(void) {							\
+		return (kh_##name##_t*)kcalloc(1, sizeof(kh_##name##_t));		\
+	}																	\
+    SCOPE kh_##name##_t *kh_init_##name##_inplace(kh_##name##_t *h) {   \
+        return (kh_##name##_t*)kmemset(h, 0, sizeof(kh_##name##_t));    \
+    }                                                                   \
+	SCOPE void kh_destroy_##name(kh_##name##_t *h)						\
+	{																	\
+		if (h) {														\
+			kfree((void *)h->keys); kfree(h->flags);					\
+			kfree((void *)h->vals);										\
+			kfree(h);													\
+		}																\
+	}																	\
+    SCOPE void kh_destroy_##name##_inplace(kh_##name##_t *h)            \
+    {                                                                   \
+        kfree((void *)h->keys);                                         \
+        kfree((void *)h->flags);                                        \
+        kfree((void *)h->vals);                                         \
+    }                                                                   \
+	SCOPE void kh_clear_##name(kh_##name##_t *h)						\
+	{																	\
+		if (h && h->flags) {											\
+			memset(h->flags, 0xaa, __ac_fsize(h->n_buckets) * sizeof(khint32_t)); \
+			h->size = h->n_occupied = 0;								\
+		}																\
+	}																	\
+	SCOPE khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key) 	\
+	{																	\
+		if (h->n_buckets) {												\
+			khint_t k, i, last, mask, step = 0; \
+			mask = h->n_buckets - 1;									\
+			\
+			kassert(h->flags != NULL); \
+			\
+			k = __hash_func(key); i = k & mask;							\
+			last = i; \
+			while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) { \
+				i = (i + (++step)) & mask; \
+				if (i == last) return h->n_buckets;						\
+			}															\
+			return __ac_iseither(h->flags, i)? h->n_buckets : i;		\
+		} else return 0;												\
+	}																	\
+	SCOPE int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets) \
+	{ /* This function uses 0.25*n_buckets bytes of working space instead of [sizeof(key_t+val_t)+.25]*n_buckets. */ \
+		khint32_t *new_flags = 0;										\
+		khint_t j = 1;													\
+		{																\
+			kroundup32(new_n_buckets); 									\
+			if (new_n_buckets < 4) new_n_buckets = 4;					\
+			if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5)) j = 0;	/* requested size is too small */ \
+			else { /* hash table size to be changed (shrink or expand); rehash */ \
+				new_flags = (khint32_t*)kmalloc(__ac_fsize(new_n_buckets) * sizeof(khint32_t));	\
+				if (!new_flags) return -1;								\
+				memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t)); \
+				if (h->n_buckets < new_n_buckets) {	/* expand */		\
+					khkey_t *new_keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
+					if (!new_keys) { kfree(new_flags); return -1; }		\
+					h->keys = new_keys;									\
+					kmemset_analyzer(h->keys + (h->n_buckets * sizeof(khkey_t)), 0, \
+							 (new_n_buckets - h->n_buckets) * sizeof(khkey_t)); \
+					if (kh_is_map) {									\
+						khval_t *new_vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
+						if (!new_vals) { kfree(new_flags); return -1; }	\
+						h->vals = new_vals;								\
+					}													\
+				} /* otherwise shrink */								\
+			}															\
+		}																\
+		if (j) { /* rehashing is needed */								\
+			for (j = 0; j != h->n_buckets; ++j) {						\
+				if (__ac_iseither(h->flags, j) == 0) {					\
+					khkey_t key = h->keys[j];							\
+					khval_t val;										\
+					khint_t new_mask;									\
+					new_mask = new_n_buckets - 1; 						\
+					if (kh_is_map) val = h->vals[j];					\
+					__ac_set_isdel_true(h->flags, j);					\
+					while (1) { /* kick-out process; sort of like in Cuckoo hashing */ \
+						khint_t k, i, step = 0; \
+						k = __hash_func(key);							\
+						i = k & new_mask;								\
+						while (!__ac_isempty(new_flags, i)) i = (i + (++step)) & new_mask; \
+						__ac_set_isempty_false(new_flags, i);			\
+						if (i < h->n_buckets && __ac_iseither(h->flags, i) == 0) { /* kick out the existing element */ \
+							{ khkey_t tmp = h->keys[i]; h->keys[i] = key; key = tmp; } \
+							if (kh_is_map) { khval_t tmp = h->vals[i]; h->vals[i] = val; val = tmp; } \
+							__ac_set_isdel_true(h->flags, i); /* mark it as deleted in the old hash table */ \
+						} else { /* write the element and jump out of the loop */ \
+							h->keys[i] = key;							\
+							if (kh_is_map) h->vals[i] = val;			\
+							break;										\
+						}												\
+					}													\
+				}														\
+			}															\
+			if (h->n_buckets > new_n_buckets) { /* shrink the hash table */ \
+				h->keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
+				if (kh_is_map) h->vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
+			}															\
+			kfree(h->flags); /* free the working space */				\
+			h->flags = new_flags;										\
+			h->n_buckets = new_n_buckets;								\
+			h->n_occupied = h->size;									\
+			h->upper_bound = (khint_t)(h->n_buckets * __ac_HASH_UPPER + 0.5); \
+		}																\
+		return 0;														\
+	}																	\
+	SCOPE khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret) \
+	{																	\
+		khint_t x;														\
+		if (h->n_occupied >= h->upper_bound) { /* update the hash table */ \
+			if (h->n_buckets > (h->size<<1)) {							\
+				if (kh_resize_##name(h, h->n_buckets - 1) < 0) { /* clear "deleted" elements */ \
+					*ret = -1; return h->n_buckets;						\
+				}														\
+			} else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
+				*ret = -1; return h->n_buckets;							\
+			}															\
+		} /* TODO: to implement automatically shrinking; resize() already support shrinking */ \
+		\
+		kassert(h->flags != NULL); \
+		\
+		{																\
+			khint_t k, i, site, last, mask = h->n_buckets - 1, step = 0; \
+			x = site = h->n_buckets; k = __hash_func(key); i = k & mask; \
+			if (__ac_isempty(h->flags, i)) x = i; /* for speed up */	\
+			else {														\
+				last = i; \
+				while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) { \
+					if (__ac_isdel(h->flags, i)) site = i;				\
+					i = (i + (++step)) & mask; \
+					if (i == last) { x = site; break; }					\
+				}														\
+				if (x == h->n_buckets) {								\
+					if (__ac_isempty(h->flags, i) && site != h->n_buckets) x = site; \
+					else x = i;											\
+				}														\
+			}															\
+		}																\
+		if (__ac_isempty(h->flags, x)) { /* not present at all */		\
+			h->keys[x] = key;											\
+			__ac_set_isboth_false(h->flags, x);							\
+			++h->size; ++h->n_occupied;									\
+			*ret = 1;													\
+		} else if (__ac_isdel(h->flags, x)) { /* deleted */				\
+			h->keys[x] = key;											\
+			__ac_set_isboth_false(h->flags, x);							\
+			++h->size;													\
+			*ret = 2;													\
+		} else *ret = 0; /* Don't touch h->keys[x] if present and not deleted */ \
+		return x;														\
+	}																	\
+	SCOPE void kh_del_##name(kh_##name##_t *h, khint_t x)				\
+	{																	\
+		if (x != h->n_buckets && !__ac_iseither(h->flags, x)) {			\
+			__ac_set_isdel_true(h->flags, x);							\
+			--h->size;													\
+		}																\
+	}
+
+#define KHASH_DECLARE(name, khkey_t, khval_t)		 					\
+	__KHASH_TYPE(name, khkey_t, khval_t) 								\
+	__KHASH_PROTOTYPES(name, khkey_t, khval_t)
+
+#define KHASH_INIT2(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	__KHASH_TYPE(name, khkey_t, khval_t) 								\
+	__KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+
+#define KHASH_INIT(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+
+#define KHASH_TYPE(name, khkey_t, khval_t) \
+	__KHASH_TYPE(name, khkey_t, khval_t)
+
+#define KHASH_IMPL(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	__KHASH_IMPL(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+
+/* --- BEGIN OF HASH FUNCTIONS --- */
+
+/*! @function
+  @abstract     Integer hash function
+  @param  key   The integer [khint32_t]
+  @return       The hash value [khint_t]
+ */
+#define kh_int_hash_func(key) (khint32_t)(key)
+/*! @function
+  @abstract     Integer comparison function
+ */
+#define kh_int_hash_equal(a, b) ((a) == (b))
+/*! @function
+  @abstract     64-bit integer hash function
+  @param  key   The integer [khint64_t]
+  @return       The hash value [khint_t]
+ */
+#define kh_int64_hash_func(key) (khint32_t)((key)>>33^(key)^(key)<<11)
+/*! @function
+  @abstract     64-bit integer comparison function
+ */
+#define kh_int64_hash_equal(a, b) ((a) == (b))
+/*! @function
+  @abstract     const char* hash function
+  @param  s     Pointer to a null terminated string
+  @return       The hash value
+ */
+static kh_inline khint_t __ac_X31_hash_string(const char *s)
+{
+	khint_t h = (khint_t)*s;
+	if (h) for (++s ; *s; ++s) h = (h << 5) - h + (khint_t)*s;
+	return h;
+}
+/*! @function
+  @abstract     Another interface to const char* hash function
+  @param  key   Pointer to a null terminated string [const char*]
+  @return       The hash value [khint_t]
+ */
+#define kh_str_hash_func(key) __ac_X31_hash_string(key)
+/*! @function
+  @abstract     Const char* comparison function
+ */
+#define kh_str_hash_equal(a, b) (strcmp(a, b) == 0)
+
+static kh_inline khint_t __ac_Wang_hash(khint_t key)
+{
+    key += ~(key << 15);
+    key ^=  (key >> 10);
+    key +=  (key << 3);
+    key ^=  (key >> 6);
+    key += ~(key << 11);
+    key ^=  (key >> 16);
+    return key;
+}
+#define kh_int_hash_func2(key) __ac_Wang_hash((khint_t)key)
+
+/* --- END OF HASH FUNCTIONS --- */
+
+/* Other convenient macros... */
+
+/*!
+  @abstract Type of the hash table.
+  @param  name  Name of the hash table [symbol]
+ */
+#define khash_t(name) kh_##name##_t
+
+/*! @function
+  @abstract     Initiate a hash table.
+  @param  name  Name of the hash table [symbol]
+  @return       Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_init(name) kh_init_##name()
+
+/*! @function
+  @abstract     Initiate a hash table if the in-place case.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_init_inplace(name, h) kh_init_##name##_inplace(h)
+
+/*! @function
+  @abstract     Destroy a hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_destroy(name, h) kh_destroy_##name(h)
+
+/*! @function
+  @abstract     Destroy a hash table if the in-place case.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_destroy_inplace(name, h) kh_destroy_##name##_inplace(h)
+
+/*! @function
+  @abstract     Reset a hash table without deallocating memory.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_clear(name, h) kh_clear_##name(h)
+
+/*! @function
+  @abstract     Resize a hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  s     New size [khint_t]
+ */
+#define kh_resize(name, h, s) kh_resize_##name(h, s)
+
+/*! @function
+  @abstract     Insert a key to the hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  k     Key [type of keys]
+  @param  r     Extra return code: -1 if the operation failed;
+                0 if the key is present in the hash table;
+                1 if the bucket is empty (never used); 2 if the element in
+				the bucket has been deleted [int*]
+  @return       Iterator to the inserted element [khint_t]
+ */
+#define kh_put(name, h, k, r) kh_put_##name(h, k, r)
+
+typedef enum ucs_kh_put {
+    UCS_KH_PUT_FAILED       = -1,
+    UCS_KH_PUT_KEY_PRESENT  = 0,
+    UCS_KH_PUT_BUCKET_EMPTY = 1,
+    UCS_KH_PUT_BUCKET_CLEAR = 2
+} ucs_kh_put_t;
+
+/*! @function
+  @abstract     Retrieve a key from the hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  k     Key [type of keys]
+  @return       Iterator to the found element, or kh_end(h) if the element is absent [khint_t]
+ */
+#define kh_get(name, h, k) kh_get_##name(h, k)
+
+/*! @function
+  @abstract     Remove a key from the hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  k     Iterator to the element to be deleted [khint_t]
+ */
+#define kh_del(name, h, k) kh_del_##name(h, k)
+
+/*! @function
+  @abstract     Test whether a bucket contains data.
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  x     Iterator to the bucket [khint_t]
+  @return       1 if containing data; 0 otherwise [int]
+ */
+#define kh_exist(h, x) (!__ac_iseither((h)->flags, (x)))
+
+/*! @function
+  @abstract     Get key given an iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  x     Iterator to the bucket [khint_t]
+  @return       Key [type of keys]
+ */
+#define kh_key(h, x) ((h)->keys[x])
+
+/*! @function
+  @abstract     Get value given an iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  x     Iterator to the bucket [khint_t]
+  @return       Value [type of values]
+  @discussion   For hash sets, calling this results in segfault.
+ */
+#define kh_val(h, x) ((h)->vals[x])
+
+/*! @function
+  @abstract     Alias of kh_val()
+ */
+#define kh_value(h, x) ((h)->vals[x])
+
+/*! @function
+  @abstract     Get the start iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       The start iterator [khint_t]
+ */
+#define kh_begin(h) (khint_t)(0)
+
+/*! @function
+  @abstract     Get the end iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       The end iterator [khint_t]
+ */
+#define kh_end(h) ((h)->n_buckets)
+
+/*! @function
+  @abstract     Get the number of elements in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       Number of elements in the hash table [khint_t]
+ */
+#define kh_size(h) ((h)->size)
+
+/*! @function
+  @abstract     Get the number of buckets in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       Number of buckets in the hash table [khint_t]
+ */
+#define kh_n_buckets(h) ((h)->n_buckets)
+
+/*! @function
+  @abstract     Iterate over the entries in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  kvar  Variable to which key will be assigned
+  @param  vvar  Variable to which value will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach(h, kvar, vvar, code) { khint_t __i;		\
+	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		if (!kh_exist(h,__i)) continue;						\
+		(kvar) = kh_key(h,__i);								\
+		(vvar) = kh_val(h,__i);								\
+		code;												\
+	} }
+
+/*! @function
+  @abstract     Iterate over the keys in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  kvar  Variable to which key will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach_key(h, kvar, code) { khint_t __i;        \
+    for (__i = kh_begin(h); __i != kh_end(h); ++__i) {      \
+        if (!kh_exist(h,__i)) continue;                     \
+        (kvar) = kh_key(h,__i);                             \
+        code;                                               \
+    } }
+
+/*! @function
+  @abstract     Iterate over the values in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  vvar  Variable to which value will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach_value(h, vvar, code) { khint_t __i;		\
+	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		if (!kh_exist(h,__i)) continue;						\
+		(vvar) = kh_val(h,__i);								\
+		code;												\
+	} }
+
+/* More conenient interfaces */
+
+/*! @function
+  @abstract     Instantiate a hash set containing integer keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_INT(name)										\
+	KHASH_INIT(name, khint32_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing integer keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_INT(name, khval_t)								\
+	KHASH_INIT(name, khint32_t, khval_t, 1, kh_int_hash_func, kh_int_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing 64-bit integer keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_INT64(name)										\
+	KHASH_INIT(name, khint64_t, char, 0, kh_int64_hash_func, kh_int64_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing 64-bit integer keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_INT64(name, khval_t)								\
+	KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
+
+typedef const char *kh_cstr_t;
+/*! @function
+  @abstract     Instantiate a hash map containing const char* keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_STR(name)										\
+	KHASH_INIT(name, kh_cstr_t, char, 0, kh_str_hash_func, kh_str_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing const char* keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_STR(name, khval_t)								\
+	KHASH_INIT(name, kh_cstr_t, khval_t, 1, kh_str_hash_func, kh_str_hash_equal)
+
+#endif /* __AC_KHASH_H */

--- a/src/utils/ucc_proc_info.c
+++ b/src/utils/ucc_proc_info.c
@@ -1,0 +1,12 @@
+#include "ucc_proc_info.h"
+ucc_proc_info_t ucc_local_proc;
+char ucc_local_hostname[128];
+
+ucc_status_t ucc_local_proc_info_init()
+{
+    ucc_local_proc.host_id = gethostid();
+    if (gethostname(ucc_local_hostname, sizeof(ucc_local_hostname))) {
+        ucc_local_hostname[0] = '\0';
+    }
+    return UCC_OK;
+}

--- a/src/utils/ucc_proc_info.h
+++ b/src/utils/ucc_proc_info.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PROC_INFO_H_
+#define UCC_PROC_INFO_H_
+
+#include "config.h"
+#include "ucc/api/ucc.h"
+#include <unistd.h>
+#include <stdint.h>
+typedef uint32_t ucc_host_id_t;
+typedef uint32_t ucc_socket_id_t;
+
+typedef struct ucc_proc_info {
+    ucc_host_id_t   host_id;
+    ucc_socket_id_t socket_id;
+} ucc_proc_info_t;
+
+extern ucc_proc_info_t ucc_local_proc;
+extern char ucc_local_hostname[128];
+
+ucc_status_t ucc_local_proc_info_init();
+
+static inline const char*  ucc_hostname() {
+    return ucc_local_hostname;
+}
+#endif


### PR DESCRIPTION
## What
Changes the way ucp ep are stored in TL. Now we use a hash table located on ucc_tl_ucp_contet_t. The hash implementation is a "khash" - opensource free license MIT implementation also used by UCX. 

## Why ?
Storing eps on team results in huge memory leak (#108) and team create overhead doe to connect-disconnect

## How ?
The key to the hash table is ucc_context_id_t structure which consists of a triplet: host_id, pid, and ucc context sequence number.
TL/UCP exchanges ucp_worker addresses + the keys during team creation (exchange during ctx create or PMIx-like iface is not yet implemented). The ep is then created only once and put into hash based on the key.

OVerheads:
1. i've measured the cost of the hash itself (implemented a simple benchmark):
    1.1 for the size of the hash ~1000 the overhead to find the ep in the has is ~0.02 us (<2% compared to network p2p cost)
     1.2 for the size of the hash ~10000 it is ~0.03 us.
     1.3 for the size of the hash ~1000000 it is ~0.08 us.
2. Eval on the Collectives (see xls attached 
[ep_hash_eval.xlsx](https://github.com/openucx/ucc/files/6171030/ep_hash_eval.xlsx). Shortly, for the allreduce, the difference ~5% is observed on 1 node, ~3% on 2 nodes, and nearly 0 difference on 8 nodes. And of course it can only be observed on small messages.

All this makes the approach feasible imho. THe overheads are minimal. Moreover, we can optimize smallest colls (barrier, and small msg ar) by pre-allocating the alg data structure with EPs (doing hash access once during team create) - this will be made in another PR.

