### PR TITLE
TEST: gtest extended collectives tests

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -78,6 +78,10 @@ gtest_SOURCES =                     \
 	core/test_barrier.cc            \
 	core/test_alltoall.cc           \
 	core/test_alltoallv.cc          \
+	core/test_allgather.cc          \
+	core/test_allgatherv.cc         \
+	core/test_bcast.cc              \
+	core/test_allreduce.cc          \
 	utils/test_string.cc            \
 	coll_score/test_score.cc        \
 	coll_score/test_score_str.cc    \

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <string>
 
-#define UCC_CHECK(_call)    EXPECT_EQ(UCC_OK, (_call))
+#define UCC_CHECK(_call)    ASSERT_EQ(UCC_OK, (_call))
 
 namespace ucc {
 

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -25,6 +25,8 @@
 #include <vector>
 #include <string>
 
+#define UCC_CHECK(_call)    EXPECT_EQ(UCC_OK, (_call))
+
 namespace ucc {
 
 /**

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -319,13 +319,14 @@ err:
     reqs.clear();
 }
 
-UccReq::UccReq(UccTeam_h _team, UccCollArgsVec args) :
+UccReq::UccReq(UccTeam_h _team, UccCollCtxVec args) :
         team(_team)
 {
     EXPECT_EQ(team->procs.size(), args.size());
     ucc_coll_req_h req;
     for (auto i = 0; i < team->procs.size(); i++) {
-        if (UCC_OK != ucc_collective_init(args[i], &req, team->procs[i].team)) {
+        if (UCC_OK != ucc_collective_init(args[i]->args, &req,
+                                          team->procs[i].team)) {
             goto err;
         }
         reqs.push_back(req);
@@ -396,4 +397,14 @@ void UccReq::startall(std::vector<UccReq> &reqs)
     for (auto &r : reqs) {
         r.start();
     }
+}
+
+void UccCollArgs::set_mem_type(ucc_memory_type_t _mt)
+{
+    mem_type = _mt;
+}
+
+void UccCollArgs::set_inplace(gtest_ucc_inplace_t _inplace)
+{
+    inplace = _inplace;
 }

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -319,13 +319,13 @@ err:
     reqs.clear();
 }
 
-UccReq::UccReq(UccTeam_h _team, UccCollCtxVec args) :
+UccReq::UccReq(UccTeam_h _team, UccCollCtxVec ctxs) :
         team(_team)
 {
-    EXPECT_EQ(team->procs.size(), args.size());
+    EXPECT_EQ(team->procs.size(), ctxs.size());
     ucc_coll_req_h req;
     for (auto i = 0; i < team->procs.size(); i++) {
-        if (UCC_OK != ucc_collective_init(args[i]->args, &req,
+        if (UCC_OK != ucc_collective_init(ctxs[i]->args, &req,
                                           team->procs[i].team)) {
             goto err;
         }
@@ -401,6 +401,10 @@ void UccReq::startall(std::vector<UccReq> &reqs)
 
 void UccCollArgs::set_mem_type(ucc_memory_type_t _mt)
 {
+    if (UCC_OK != ucc_mc_available(_mt)) {
+        UCC_TEST_SKIP_R(ucc::to_string(ucc_memory_type_names[_mt]) +
+                        " memory type not available");
+    }
     mem_type = _mt;
 }
 

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -7,7 +7,9 @@
 #define TEST_UCC_H
 #include "test.h"
 #include "ucc/api/ucc.h"
+extern "C" {
 #include "core/ucc_mc.h"
+}
 #include <vector>
 #include <tuple>
 #include <memory>
@@ -56,8 +58,8 @@ public:
         inplace = TEST_NO_INPLACE;
     }
     virtual ~UccCollArgs() {}
-    virtual UccCollCtxVec data_init(int nprocs, ucc_datatype_t dtype,
-                                     size_t count) = 0;
+    virtual void data_init(int nprocs, ucc_datatype_t dtype,
+                           size_t count, UccCollCtxVec &args) = 0;
     virtual void data_fini(UccCollCtxVec args) = 0;
     virtual void data_validate(UccCollCtxVec args) = 0;
     void set_mem_type(ucc_memory_type_t _mt);

--- a/test/gtest/core/test_allgather.cc
+++ b/test/gtest/core/test_allgather.cc
@@ -10,6 +10,7 @@ extern "C" {
 #include "utils/ucc_math.h"
 
 using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_1 = std::tuple<int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
 
 class test_allgather : public UccCollArgs, public ucc::test
 {
@@ -136,10 +137,55 @@ UCC_TEST_P(test_allgather_0, single_host)
 }
 
 INSTANTIATE_TEST_CASE_P(
-    ,
-    test_allgather_0,
+    , test_allgather_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1, 4), // dtype
+#ifdef HAVE_CUDA
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
+#else
+        ::testing::Values(UCC_MEMORY_TYPE_HOST),
+#endif
+        ::testing::Values(1,3,8192), // count
+        ::testing::Values(TEST_INPLACE, TEST_NO_INPLACE)));  // inplace
+
+
+class test_allgather_1 : public test_allgather,
+        public ::testing::WithParamInterface<Param_1> {};
+
+UCC_TEST_P(test_allgather_1, multiple_host)
+{
+    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_memory_type_t   mem_type = std::get<1>(GetParam());
+    const int                 count    = std::get<2>(GetParam());
+    const gtest_ucc_inplace_t inplace  = std::get<3>(GetParam());
+    std::vector<UccReq>        reqs;
+    std::vector<UccCollCtxVec> ctxs;
+
+    for (int tid = 0; tid < UccJob::nStaticTeams; tid++) {
+        UccTeam_h       team = UccJob::getStaticTeams()[tid];
+        int             size = team->procs.size();
+        UccCollCtxVec   ctx;
+
+        this->set_inplace(inplace);
+        this->set_mem_type(mem_type);
+
+        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        reqs.push_back(UccReq(team, ctx));
+        ctxs.push_back(ctx);
+    }
+    UccReq::startall(reqs);
+    UccReq::waitall(reqs);
+
+    for (auto ctx : ctxs) {
+        data_validate(ctx);
+        data_fini(ctx);
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    , test_allgather_1,
+    ::testing::Combine(
         ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1, 4), // dtype
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type

--- a/test/gtest/core/test_allgather.cc
+++ b/test/gtest/core/test_allgather.cc
@@ -9,24 +9,24 @@ extern "C" {
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
+using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
 
-class test_alltoall : public UccCollArgs, public ucc::test
+class test_allgather : public UccCollArgs, public ucc::test
 {
 public:
     UccCollCtxVec data_init(int nprocs, ucc_datatype_t dtype,
                                      size_t count)
     {
         UccCollCtxVec ctxs(nprocs);
-        for (auto i = 0; i < nprocs; i++) {
+        for (auto r = 0; r < nprocs; r++) {
             ucc_coll_args_t *coll = (ucc_coll_args_t*)
                     calloc(1, sizeof(ucc_coll_args_t));
-
-            ctxs[i] = (gtest_ucc_coll_ctx_t*)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
-            ctxs[i]->args = coll;
+            ctxs[r] = (gtest_ucc_coll_ctx_t*)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
+            ctxs[r]->args = coll;
 
             coll->mask = 0;
-            coll->coll_type = UCC_COLL_TYPE_ALLTOALL;
+            coll->flags = 0;
+            coll->coll_type = UCC_COLL_TYPE_ALLGATHER;
             coll->src.info.mem_type = mem_type;
             coll->src.info.count   = (ucc_count_t)count;
             coll->src.info.datatype = dtype;
@@ -34,29 +34,29 @@ public:
             coll->dst.info.count   = (ucc_count_t)count;
             coll->dst.info.datatype = dtype;
 
-            UCC_CHECK(ucc_mc_alloc(&ctxs[i]->init_buf,
-                                   ucc_dt_size(dtype) * count * nprocs,
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf,
+                                   ucc_dt_size(dtype) * count,
                                    UCC_MEMORY_TYPE_HOST));
-            for (int r = 0; r < nprocs; r++) {
-                size_t rank_size = ucc_dt_size(dtype) * count;
-                alltoallx_init_buf(r, i,
-                                   (uint8_t*)ctxs[i]->init_buf + r * rank_size,
-                                   rank_size);
+            for (int i = 0; i < ucc_dt_size(dtype) * count; i++) {
+                uint8_t *sbuf = (uint8_t*)ctxs[r]->init_buf;
+                sbuf[i] = r;
             }
 
-            UCC_CHECK(ucc_mc_alloc(&coll->dst.info.buffer,
-                      ucc_dt_size(dtype) * count * nprocs, mem_type));
+            ctxs[r]->rbuf_size = ucc_dt_size(dtype) * count * nprocs;
+            UCC_CHECK(ucc_mc_alloc(&coll->dst.info.buffer, ctxs[r]->rbuf_size,
+                      mem_type));
             if (TEST_INPLACE == inplace) {
                 coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
                 coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
-                ucc_mc_memcpy(coll->dst.info.buffer, ctxs[i]->init_buf,
-                              ucc_dt_size(dtype) * count, mem_type,
-                              UCC_MEMORY_TYPE_HOST);
+                ucc_mc_memcpy((void*)((ptrdiff_t)coll->dst.info.buffer +
+                                      r * count * ucc_dt_size(dtype)),
+                              ctxs[r]->init_buf, ucc_dt_size(dtype) * count,
+                              mem_type, UCC_MEMORY_TYPE_HOST);
             } else {
                 UCC_CHECK(ucc_mc_alloc(&coll->src.info.buffer,
-                          ucc_dt_size(dtype) * count * nprocs, mem_type));
-                ucc_mc_memcpy(coll->src.info.buffer, ctxs[i]->init_buf,
-                              ucc_dt_size(dtype) * count * nprocs, mem_type,
+                          ucc_dt_size(dtype) * count, mem_type));
+                ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
+                              ucc_dt_size(dtype) * count, mem_type,
                               UCC_MEMORY_TYPE_HOST);
             }
         }
@@ -82,29 +82,24 @@ public:
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
-                size_t buf_size =
-                        ucc_dt_size(ctxs[r]->args->dst.info.datatype) *
-                        (size_t)ctxs[r]->args->dst.info.count * ctxs.size();
-                UCC_CHECK(ucc_mc_alloc((void**)&dsts[r], buf_size,
+                UCC_CHECK(ucc_mc_alloc((void**)&dsts[r], ctxs[r]->rbuf_size,
                                        UCC_MEMORY_TYPE_HOST));
                 ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info.buffer,
-                              buf_size, UCC_MEMORY_TYPE_HOST, mem_type);
+                              ctxs[r]->rbuf_size, UCC_MEMORY_TYPE_HOST, mem_type);
             }
         } else {
             for (int r = 0; r < ctxs.size(); r++) {
                 dsts[r] = (uint8_t *)(ctxs[r]->args->dst.info.buffer);
             }
         }
-        for (int r = 0; r < ctxs.size(); r++) {
-            ucc_coll_args_t* coll = ctxs[r]->args;
-
-            for (int i = 0; i < ctxs.size(); i++) {
-                size_t rank_size = ucc_dt_size(coll->dst.info.datatype) *
-                        (size_t)coll->dst.info.count;
-                ASSERT_EQ(0,
-                          alltoallx_validate_buf(i, r,
-                          (uint8_t*)coll->dst.info.buffer + rank_size * i,
-                          rank_size));
+        for (int i = 0; i < ctxs.size(); i++) {
+            uint8_t *rbuf = dsts[i];
+            for (int r = 0; r < ctxs.size(); r++) {
+                size_t rank_size = ucc_dt_size((ctxs[r])->args->src.info.datatype) *
+                        (ctxs[r])->args->src.info.count;
+                for (int i = 0; i < rank_size; i++) {
+                    EXPECT_EQ(r, rbuf[r*rank_size + i]);
+                }
             }
         }
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
@@ -112,27 +107,26 @@ public:
                 ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST);
             }
         }
-        return;
     }
 };
 
-class test_alltoall_0 : public test_alltoall,
+class test_allgather_0 : public test_allgather,
         public ::testing::WithParamInterface<Param_0> {};
 
-UCC_TEST_P(test_alltoall_0, single)
+UCC_TEST_P(test_allgather_0, single_host)
 {
-    const int            team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t dtype    = (ucc_datatype_t)std::get<1>(GetParam());
-    ucc_memory_type_t    mem_type = std::get<2>(GetParam());
-    gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
-    const int            count    = std::get<4>(GetParam());
-    UccTeam_h            team     = UccJob::getStaticTeams()[team_id];
-    int                  size     = team->procs.size();
+    const int                 team_id  = std::get<0>(GetParam());
+    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
+    const int                 count    = std::get<3>(GetParam());
+    const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
+    UccTeam_h                 team     = UccJob::getStaticTeams()[team_id];
+    int                       size     = team->procs.size();
 
-    this->set_inplace(inplace);
-    this->set_mem_type(mem_type);
+    set_inplace(inplace);
+    set_mem_type(mem_type);
 
-    UccCollCtxVec args = data_init(size, (ucc_datatype_t)dtype, count);
+    UccCollCtxVec args = data_init(size, dtype, count);
     UccReq    req(team, args);
     req.start();
     req.wait();
@@ -141,7 +135,8 @@ UCC_TEST_P(test_alltoall_0, single)
 }
 
 INSTANTIATE_TEST_CASE_P(
-    , test_alltoall_0,
+    ,
+    test_allgather_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
         ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1), // dtype
@@ -150,7 +145,5 @@ INSTANTIATE_TEST_CASE_P(
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
-        ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
-        ::testing::Values(1,3))); // count
-
-/* TODO: enable parallel teams once it is supported */
+        ::testing::Values(1,3), // count
+        ::testing::Values(TEST_INPLACE, TEST_NO_INPLACE)));  // inplace

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include <core/ucc_mc.h>
+}
+#include "common/test_ucc.h"
+#include "utils/ucc_math.h"
+
+using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+
+class test_allgatherv : public UccCollArgs, public ucc::test
+{
+public:
+    UccCollCtxVec data_init(int nprocs, ucc_datatype_t dtype, size_t count) {
+        UccCollCtxVec ctxs(nprocs);
+        for (auto r = 0; r < nprocs; r++) {
+            int *counts;
+            int *displs;
+            size_t my_count = (nprocs - r) * count;
+            size_t all_counts = 0;
+            ucc_coll_args_t *coll = (ucc_coll_args_t*)calloc(1, sizeof(ucc_coll_args_t));
+
+            ctxs[r] = (gtest_ucc_coll_ctx_t*)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
+            ctxs[r]->args = coll;
+
+            counts = (int*)malloc(sizeof(int) * nprocs);
+            displs = (int*)malloc(sizeof(int) * nprocs);
+
+            for (int i = 0; i < nprocs; i++) {
+                counts[i] = (nprocs - i) * count;
+                displs[i] = all_counts;
+                all_counts += counts[i];
+            }
+            coll->mask = 0;
+            coll->coll_type = UCC_COLL_TYPE_ALLGATHERV;
+
+            coll->src.info.mem_type = mem_type;
+            coll->src.info.count = my_count;
+            coll->src.info.datatype = dtype;
+
+            coll->dst.info_v.mem_type = mem_type;
+            coll->dst.info_v.counts   = (ucc_count_t*)counts;
+            coll->dst.info_v.displacements = (ucc_aint_t*)displs;
+            coll->dst.info_v.datatype = dtype;
+
+
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf,
+                                   ucc_dt_size(dtype) * my_count,
+                                   UCC_MEMORY_TYPE_HOST));
+            for (int i = 0; i < (ucc_dt_size(dtype) * my_count); i++) {
+                uint8_t *sbuf = (uint8_t*)ctxs[r]->init_buf;
+                sbuf[i] = r;
+            }
+
+            ctxs[r]->rbuf_size = ucc_dt_size(dtype) * all_counts;
+            UCC_CHECK(ucc_mc_alloc(&coll->dst.info_v.buffer, ctxs[r]->rbuf_size,
+                      mem_type));
+            if (TEST_INPLACE == inplace) {
+                coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
+                coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+                ucc_mc_memcpy((void*)((ptrdiff_t)coll->dst.info_v.buffer +
+                                      displs[r] * ucc_dt_size(dtype)
+                                      /*r * my_count * ucc_dt_size(dtype)*/),
+                              ctxs[r]->init_buf, ucc_dt_size(dtype) * my_count,
+                              mem_type, UCC_MEMORY_TYPE_HOST);
+            } else {
+                UCC_CHECK(ucc_mc_alloc(&coll->src.info.buffer,
+                          ucc_dt_size(dtype) * my_count, mem_type));
+                ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
+                              ucc_dt_size(dtype) * my_count, mem_type,
+                              UCC_MEMORY_TYPE_HOST);
+            }
+
+        }
+        return ctxs;
+    }
+    void data_fini(UccCollCtxVec ctxs)
+    {
+        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+            ucc_coll_args_t* coll = ctx->args;
+            if (coll->src.info.buffer) { /* no inplace */
+                UCC_CHECK(ucc_mc_free(coll->src.info.buffer, mem_type));
+            }
+            UCC_CHECK(ucc_mc_free(coll->dst.info.buffer, mem_type));
+            free(coll->dst.info_v.displacements);
+            free(coll->dst.info_v.counts);
+            UCC_CHECK(ucc_mc_free(ctx->init_buf, UCC_MEMORY_TYPE_HOST));
+            free(coll);
+            free(ctx);
+        }
+        ctxs.clear();
+    }
+    void data_validate(UccCollCtxVec ctxs)
+    {
+        std::vector<uint8_t *> dsts(ctxs.size());
+
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                UCC_CHECK(ucc_mc_alloc((void**)&dsts[r], ctxs[r]->rbuf_size,
+                                       UCC_MEMORY_TYPE_HOST));
+                ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info_v.buffer,
+                              ctxs[r]->rbuf_size, UCC_MEMORY_TYPE_HOST, mem_type);
+            }
+        } else {
+            for (int r = 0; r < ctxs.size(); r++) {
+                dsts[r] = (uint8_t *)(ctxs[r]->args->dst.info_v.buffer);
+            }
+        }
+
+        for (int i = 0; i < ctxs.size(); i++) {
+            size_t rank_size = 0;
+            uint8_t *rbuf = dsts[i];
+            for (int r = 0; r < ctxs.size(); r++) {
+                rbuf += rank_size;
+                rank_size = ucc_dt_size((ctxs[r])->args->src.info.datatype) *
+                        (ctxs[r])->args->src.info.count;
+                for (int i = 0; i < rank_size; i++) {
+                    EXPECT_EQ(r, rbuf[i]);
+                }
+            }
+        }
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST);
+            }
+        }
+    }
+};
+
+class test_allgatherv_0 : public test_allgatherv,
+        public ::testing::WithParamInterface<Param_0> {};
+
+UCC_TEST_P(test_allgatherv_0, single_host)
+{
+    const int                 team_id  = std::get<0>(GetParam());
+    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
+    const int                 count    = std::get<3>(GetParam());
+    const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
+    UccTeam_h                 team     = UccJob::getStaticTeams()[team_id];
+    int                       size     = team->procs.size();
+
+    set_inplace(inplace);
+    set_mem_type(mem_type);
+
+    UccCollCtxVec args = data_init(size, (ucc_datatype_t)dtype, count);
+    UccReq    req(team, args);
+    req.start();
+    req.wait();
+    data_validate(args);
+    data_fini(args);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ,
+    test_allgatherv_0,
+    ::testing::Combine(
+        ::testing::Range(1, UccJob::nStaticTeams), // team_ids
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1), // dtype
+#ifdef HAVE_CUDA
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
+#else
+        ::testing::Values(UCC_MEMORY_TYPE_HOST),
+#endif
+        ::testing::Values(1,3), // count
+        ::testing::Values(TEST_INPLACE, TEST_NO_INPLACE)));  // inplace
+

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -10,6 +10,7 @@ extern "C" {
 #include "utils/ucc_math.h"
 
 using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_1 = std::tuple<int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
 
 class test_allgatherv : public UccCollArgs, public ucc::test
 {
@@ -155,11 +156,10 @@ UCC_TEST_P(test_allgatherv_0, single_host)
 }
 
 INSTANTIATE_TEST_CASE_P(
-    ,
-    test_allgatherv_0,
+    , test_allgatherv_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1, 4), // dtype
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_INT64 + 1), // dtype
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
@@ -168,3 +168,47 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Values(1,3,8192), // count
         ::testing::Values(TEST_INPLACE, TEST_NO_INPLACE)));  // inplace
 
+class test_allgatherv_1 : public test_allgatherv,
+        public ::testing::WithParamInterface<Param_1> {};
+
+UCC_TEST_P(test_allgatherv_1, multiple)
+{
+    const ucc_datatype_t       dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_memory_type_t    mem_type = std::get<1>(GetParam());
+    const int                  count    = std::get<2>(GetParam());
+    const gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
+    std::vector<UccReq>        reqs;
+    std::vector<UccCollCtxVec> ctxs;
+
+    for (int tid = 0; tid < UccJob::nStaticTeams; tid++) {
+        UccTeam_h       team = UccJob::getStaticTeams()[tid];
+        int             size = team->procs.size();
+        UccCollCtxVec   ctx;
+
+        this->set_inplace(inplace);
+        this->set_mem_type(mem_type);
+
+        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        reqs.push_back(UccReq(team, ctx));
+        ctxs.push_back(ctx);
+    }
+    UccReq::startall(reqs);
+    UccReq::waitall(reqs);
+
+    for (auto ctx : ctxs) {
+        data_validate(ctx);
+        data_fini(ctx);
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    , test_allgatherv_1,
+    ::testing::Combine(
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_INT64 + 1), // dtype
+#ifdef HAVE_CUDA
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
+#else
+        ::testing::Values(UCC_MEMORY_TYPE_HOST),
+#endif
+        ::testing::Values(1,3,8192), // count
+        ::testing::Values(TEST_INPLACE, TEST_NO_INPLACE)));  // inplace

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -14,8 +14,9 @@ using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, gtest_ucc_inplace_t
 class test_allgatherv : public UccCollArgs, public ucc::test
 {
 public:
-    UccCollCtxVec data_init(int nprocs, ucc_datatype_t dtype, size_t count) {
-        UccCollCtxVec ctxs(nprocs);
+    void  data_init(int nprocs, ucc_datatype_t dtype, size_t count,
+                    UccCollCtxVec &ctxs) {
+        ctxs.resize(nprocs);
         for (auto r = 0; r < nprocs; r++) {
             int *counts;
             int *displs;
@@ -46,7 +47,6 @@ public:
             coll->dst.info_v.displacements = (ucc_aint_t*)displs;
             coll->dst.info_v.datatype = dtype;
 
-
             UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf,
                                    ucc_dt_size(dtype) * my_count,
                                    UCC_MEMORY_TYPE_HOST));
@@ -61,21 +61,19 @@ public:
             if (TEST_INPLACE == inplace) {
                 coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
                 coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
-                ucc_mc_memcpy((void*)((ptrdiff_t)coll->dst.info_v.buffer +
-                                      displs[r] * ucc_dt_size(dtype)
-                                      /*r * my_count * ucc_dt_size(dtype)*/),
-                              ctxs[r]->init_buf, ucc_dt_size(dtype) * my_count,
-                              mem_type, UCC_MEMORY_TYPE_HOST);
+                UCC_CHECK(ucc_mc_memcpy((void*)((ptrdiff_t)coll->dst.info_v.buffer +
+                                        displs[r] * ucc_dt_size(dtype)),
+                                        ctxs[r]->init_buf, ucc_dt_size(dtype) * my_count,
+                                        mem_type, UCC_MEMORY_TYPE_HOST));
             } else {
                 UCC_CHECK(ucc_mc_alloc(&coll->src.info.buffer,
                           ucc_dt_size(dtype) * my_count, mem_type));
-                ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
-                              ucc_dt_size(dtype) * my_count, mem_type,
-                              UCC_MEMORY_TYPE_HOST);
+                UCC_CHECK(ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
+                                        ucc_dt_size(dtype) * my_count, mem_type,
+                                        UCC_MEMORY_TYPE_HOST));
             }
 
         }
-        return ctxs;
     }
     void data_fini(UccCollCtxVec ctxs)
     {
@@ -101,8 +99,9 @@ public:
             for (int r = 0; r < ctxs.size(); r++) {
                 UCC_CHECK(ucc_mc_alloc((void**)&dsts[r], ctxs[r]->rbuf_size,
                                        UCC_MEMORY_TYPE_HOST));
-                ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info_v.buffer,
-                              ctxs[r]->rbuf_size, UCC_MEMORY_TYPE_HOST, mem_type);
+                UCC_CHECK(ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info_v.buffer,
+                                        ctxs[r]->rbuf_size, UCC_MEMORY_TYPE_HOST,
+                                        mem_type));
             }
         } else {
             for (int r = 0; r < ctxs.size(); r++) {
@@ -124,7 +123,7 @@ public:
         }
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
-                ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST);
+                UCC_CHECK(ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST));
             }
         }
     }
@@ -142,16 +141,17 @@ UCC_TEST_P(test_allgatherv_0, single_host)
     const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
     UccTeam_h                 team     = UccJob::getStaticTeams()[team_id];
     int                       size     = team->procs.size();
+    UccCollCtxVec             ctxs;
 
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    UccCollCtxVec args = data_init(size, (ucc_datatype_t)dtype, count);
-    UccReq    req(team, args);
+    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    UccReq    req(team, ctxs);
     req.start();
     req.wait();
-    data_validate(args);
-    data_fini(args);
+    data_validate(ctxs);
+    data_fini(ctxs);
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -159,12 +159,12 @@ INSTANTIATE_TEST_CASE_P(
     test_allgatherv_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1), // dtype
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1, 4), // dtype
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
-        ::testing::Values(1,3), // count
+        ::testing::Values(1,3,8192), // count
         ::testing::Values(TEST_INPLACE, TEST_NO_INPLACE)));  // inplace
 

--- a/test/gtest/core/test_allreduce.cc
+++ b/test/gtest/core/test_allreduce.cc
@@ -1,0 +1,180 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include <core/ucc_mc.h>
+}
+#include "test_mc_reduce.h"
+#include "common/test_ucc.h"
+#include "utils/ucc_math.h"
+
+#include <array>
+
+template<typename T>
+class test_allreduce : public UccCollArgs, public testing::Test {
+  public:
+    UccCollCtxVec data_init(int nprocs, ucc_datatype_t dt, size_t count) {
+        UccCollCtxVec ctxs(nprocs);
+        for (int r = 0; r < nprocs; r++) {
+            ucc_coll_args_t *coll = (ucc_coll_args_t*)
+                    calloc(1, sizeof(ucc_coll_args_t));
+
+            ctxs[r] = (gtest_ucc_coll_ctx_t*)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
+            ctxs[r]->args = coll;
+
+            coll->mask = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
+            coll->coll_type = UCC_COLL_TYPE_ALLREDUCE;
+            coll->reduce.predefined_op = T::redop;
+
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf, ucc_dt_size(dt) * count,
+                                   UCC_MEMORY_TYPE_HOST));
+            for (int i = 0; i < count; i++) {
+                typename T::type * ptr;
+                ptr = (typename T::type *)ctxs[r]->init_buf;
+                ptr[i] = (typename T::type)(2 * i + r + 1);
+            }
+
+            UCC_CHECK(ucc_mc_alloc(&coll->dst.info.buffer,
+                      ucc_dt_size(dt) * count, mem_type));
+            if (TEST_INPLACE == inplace) {
+                coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
+                coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+                ucc_mc_memcpy(coll->dst.info.buffer, ctxs[r]->init_buf,
+                              ucc_dt_size(dt) * count, mem_type,
+                              UCC_MEMORY_TYPE_HOST);
+            } else {
+                UCC_CHECK(ucc_mc_alloc(&coll->src.info.buffer,
+                          ucc_dt_size(dt) * count, mem_type));
+                ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
+                              ucc_dt_size(dt) * count, mem_type,
+                              UCC_MEMORY_TYPE_HOST);
+            }
+            coll->src.info.mem_type = mem_type;
+            coll->src.info.count   = (ucc_count_t)count;
+            coll->src.info.datatype = dt;
+
+            coll->dst.info.mem_type = mem_type;
+            coll->dst.info.count   = (ucc_count_t)count;
+            coll->dst.info.datatype = dt;
+        }
+        return ctxs;
+    }
+    void data_fini(UccCollCtxVec ctxs) {
+        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+            ucc_coll_args_t* coll = ctx->args;
+            if (coll->src.info.buffer) { /* no inplace */
+                UCC_CHECK(ucc_mc_free(coll->src.info.buffer, mem_type));
+            }
+            UCC_CHECK(ucc_mc_free(coll->dst.info.buffer, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->init_buf, UCC_MEMORY_TYPE_HOST));
+            free(coll);
+            free(ctx);
+        }
+        ctxs.clear();
+    }
+    void data_validate(UccCollCtxVec ctxs)
+    {
+        size_t count = (ctxs[0])->args->src.info.count;
+        std::vector<typename T::type *> dsts(ctxs.size());
+
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                UCC_CHECK(ucc_mc_alloc((void**)&dsts[r],
+                                       count * sizeof(typename T::type),
+                                       UCC_MEMORY_TYPE_HOST));
+                ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info.buffer,
+                              count * sizeof(typename T::type), UCC_MEMORY_TYPE_HOST,
+                              mem_type);
+            }
+        } else {
+            for (int r = 0; r < ctxs.size(); r++) {
+                dsts[r] = (typename T::type *)(ctxs[r]->args->dst.info.buffer);
+            }
+        }
+        for (int i = 0; i < count; i++) {
+            typename T::type res =
+                    ((typename T::type *)((ctxs[0])->init_buf))[i];
+            for (int r = 1; r < ctxs.size(); r++) {
+                res = T::do_op(res, ((typename T::type *)((ctxs[r])->init_buf))[i]);
+            }
+            for (int r = 0; r < ctxs.size(); r++) {
+                T::assert_equal(res, dsts[r][i]);
+            }
+        }
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST);
+            }
+        }
+        return;
+    }
+};
+
+TYPED_TEST_CASE(test_allreduce, ReductionTypesOps);
+
+#define TEST_DECLARE(_mem_type, _inplace)                                      \
+{                                                                              \
+    std::array<int,3> counts {1,2,4};                                          \
+    for (int tid = 0; tid < UccJob::nStaticTeams; tid++) {                     \
+        for (int count : counts) {                                             \
+            UccTeam_h team = UccJob::getStaticTeams()[tid];                    \
+            int       size = team->procs.size();                               \
+            this->set_mem_type(_mem_type);                                     \
+            this->set_inplace(_inplace);                                       \
+            UccCollCtxVec ctxs = this->data_init(size, TypeParam::dt, count);  \
+            UccReq    req(team, ctxs);                                         \
+            req.start();                                                       \
+            req.wait();                                                        \
+            this->data_validate(ctxs);                                         \
+            this->data_fini(ctxs);                                             \
+        }                                                                      \
+    }                                                                          \
+}
+
+TYPED_TEST(test_allreduce, single_host) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_NO_INPLACE);
+}
+
+TYPED_TEST(test_allreduce, single_host_inplace) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_INPLACE);
+}
+
+#ifdef HAVE_CUDA
+TYPED_TEST(test_allreduce, single_cuda) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_NO_INPLACE);
+}
+
+TYPED_TEST(test_allreduce, single_cuda_inplace) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE);
+}
+#endif
+
+/* TODO: enable parallel teams once it is supported */
+/*
+TYPED_TEST(test_allreduce, multi) {
+    const int count = 2;
+
+    std::vector<UccReq> reqs;
+    std::vector<UccCollArgsVec> args;
+    for (auto &team : UccJob::getStaticTeams()) {
+        UccCollArgsVec arg = this->data_init(team->procs.size(),
+                                       TypeParam::dt, count);
+        args.push_back(arg);
+        reqs.push_back(UccReq(team, arg));
+    }
+    UccReq::startall(reqs);
+    UccReq::waitall(reqs);
+    for (auto arg : args) {
+        this->data_validate(arg);
+        this->data_fini(arg);
+    }
+}
+*/

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -3,10 +3,13 @@
  * See file LICENSE for terms.
  */
 
+extern "C" {
+#include <core/ucc_mc.h>
+}
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int>;
+using Param_0 = std::tuple<int, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
 
 template <class T>
 class test_alltoallv : public UccCollArgs, public ucc::test
@@ -16,25 +19,28 @@ public:
     uint64_t coll_flags;
 
     test_alltoallv() : coll_mask(0), coll_flags(0) {}
-    UccCollArgsVec data_init(int nprocs, ucc_datatype_t dtype,
+    UccCollCtxVec data_init(int nprocs, ucc_datatype_t dtype,
                              size_t count) {
         int buf_count;
-        UccCollArgsVec args(nprocs);
+        UccCollCtxVec ctxs(nprocs);
 
         for (auto r = 0; r < nprocs; r++) {
             ucc_coll_args_t *coll = (ucc_coll_args_t*)
                     calloc(1, sizeof(ucc_coll_args_t));
-            coll->coll_type = UCC_COLL_TYPE_ALLTOALLV;
 
+            ctxs[r] = (gtest_ucc_coll_ctx_t*)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
+            ctxs[r]->args = coll;
+
+            coll->coll_type = UCC_COLL_TYPE_ALLTOALLV;
             coll->mask = coll_mask;
             coll->flags = coll_flags;
 
-            coll->src.info_v.mem_type = UCC_MEMORY_TYPE_HOST;
+            coll->src.info_v.mem_type = mem_type;
             coll->src.info_v.counts = (ucc_count_t*)malloc(sizeof(T) * nprocs);
             coll->src.info_v.datatype = dtype;
             coll->src.info_v.displacements = (ucc_aint_t*)malloc(sizeof(T) * nprocs);
 
-            coll->dst.info_v.mem_type = UCC_MEMORY_TYPE_HOST;
+            coll->dst.info_v.mem_type = mem_type;
             coll->dst.info_v.counts = (ucc_count_t*)malloc(sizeof(T) * nprocs);
             coll->dst.info_v.datatype = dtype;
             coll->dst.info_v.displacements = (ucc_aint_t*)malloc(sizeof(T) * nprocs);
@@ -47,12 +53,23 @@ public:
                 buf_count += rank_count;
             }
 
-            coll->src.info_v.buffer = malloc(buf_count * ucc_dt_size(dtype));
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf,
+                                   buf_count * ucc_dt_size(dtype),
+                                   UCC_MEMORY_TYPE_HOST));
             for (int i = 0; i < nprocs; i++) {
-                alltoallx_init_buf(r, i, (uint8_t*)coll->src.info_v.buffer +
+                alltoallx_init_buf(r, i, (uint8_t*)ctxs[r]->init_buf +
                                ((T*)coll->src.info_v.displacements)[i] * ucc_dt_size(dtype),
                                ((T*)coll->src.info_v.counts)[i] * ucc_dt_size(dtype));
             }
+            UCC_CHECK(ucc_mc_alloc(&coll->src.info_v.buffer,
+                                   buf_count * ucc_dt_size(dtype),
+                                   mem_type));
+            ucc_mc_memcpy(coll->src.info_v.buffer, ctxs[r]->init_buf,
+                          buf_count * ucc_dt_size(dtype), mem_type,
+                          UCC_MEMORY_TYPE_HOST);
+
+            /* TODO: inplace support */
+
             buf_count = 0;
             for (int i = 0; i < nprocs; i++) {
                 int rank_count = (nprocs - r + i) * count;
@@ -60,39 +77,63 @@ public:
                 ((T*)coll->dst.info_v.displacements)[i] = buf_count;
                 buf_count += rank_count;
             }
-            coll->dst.info_v.buffer = malloc(buf_count * ucc_dt_size(dtype));
-            args[r] = coll;
+            ctxs[r]->rbuf_size = buf_count * ucc_dt_size(dtype);
+            UCC_CHECK(ucc_mc_alloc(&coll->dst.info_v.buffer,
+                                   buf_count * ucc_dt_size(dtype),
+                                   mem_type));
         }
-        return args;
+        return ctxs;
     }
-    void data_validate(UccCollArgsVec args)
+    void data_validate(UccCollCtxVec ctxs)
     {
-        for (int r = 0; r < args.size(); r++) {
-            ucc_coll_args_t* coll = args[r];
-            for (int i = 0; i < args.size(); i++) {
+        std::vector<uint8_t *> dsts(ctxs.size());
+
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                UCC_CHECK(ucc_mc_alloc((void**)&dsts[r], ctxs[r]->rbuf_size,
+                                       UCC_MEMORY_TYPE_HOST));
+                ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info_v.buffer,
+                              ctxs[r]->rbuf_size, UCC_MEMORY_TYPE_HOST, mem_type);
+            }
+        } else {
+            for (int r = 0; r < ctxs.size(); r++) {
+                dsts[r] = (uint8_t *)(ctxs[r]->args->dst.info.buffer);
+            }
+        }
+        for (int r = 0; r < ctxs.size(); r++) {
+            ucc_coll_args_t* coll = ctxs[r]->args;
+            for (int i = 0; i < ctxs.size(); i++) {
                 size_t rank_size = ucc_dt_size(coll->dst.info_v.datatype) *
                         (size_t)((T*)coll->dst.info_v.counts)[i];
                 size_t rank_offs = ucc_dt_size(coll->dst.info_v.datatype) *
                         (size_t)((T*)coll->dst.info_v.displacements)[i];
                 EXPECT_EQ(0,
                           alltoallx_validate_buf(r, i,
-                          (uint8_t*)coll->dst.info_v.buffer + rank_offs,
+                          (uint8_t*)dsts[r] + rank_offs,
                           rank_size));
             }
         }
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST);
+            }
+        }
     }
-    void data_fini(UccCollArgsVec args)
+    void data_fini(UccCollCtxVec ctxs)
     {
-        for (ucc_coll_args_t* coll : args) {
-            free(coll->src.info_v.buffer);
+        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+            ucc_coll_args_t* coll = ctx->args;
+            UCC_CHECK(ucc_mc_free(coll->src.info_v.buffer, mem_type));
             free(coll->src.info_v.counts);
             free(coll->src.info_v.displacements);
-            free(coll->dst.info_v.buffer);
+            UCC_CHECK(ucc_mc_free(coll->dst.info_v.buffer, mem_type));
             free(coll->dst.info_v.counts);
             free(coll->dst.info_v.displacements);
+            UCC_CHECK(ucc_mc_free(ctx->init_buf, UCC_MEMORY_TYPE_HOST));
             free(coll);
+            free(ctx);
         }
-        args.clear();
+        ctxs.clear();
     }
 };
 
@@ -102,16 +143,19 @@ class test_alltoallv_0 : public test_alltoallv <uint64_t>,
 UCC_TEST_P(test_alltoallv_0, single)
 {
     const int            team_id = std::get<0>(GetParam());
-    const ucc_datatype_t dtype   = (ucc_datatype_t)std::get<1>(GetParam());
+    ucc_memory_type_t    mem_type = std::get<1>(GetParam());
+    gtest_ucc_inplace_t  inplace = std::get<2>(GetParam());
+    const ucc_datatype_t dtype   = (ucc_datatype_t)std::get<3>(GetParam());
     UccTeam_h            team    = UccJob::getStaticTeams()[team_id];
     int                  size    = team->procs.size();
 
     coll_mask = UCC_COLL_ARGS_FIELD_FLAGS;
     coll_flags = UCC_COLL_ARGS_FLAG_COUNT_64BIT |
                  UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+    set_inplace(inplace);
+    set_mem_type(mem_type);
 
-    UccCollArgsVec args = data_init(size, (ucc_datatype_t)dtype, 1);
-
+    UccCollCtxVec        args    = data_init(size, (ucc_datatype_t)dtype, 1);
     UccReq    req(team, args);
     req.start();
     req.wait();
@@ -127,13 +171,20 @@ class test_alltoallv_1 : public test_alltoallv <uint32_t>,
 UCC_TEST_P(test_alltoallv_1, single)
 {
     const int            team_id = std::get<0>(GetParam());
-    const ucc_datatype_t dtype   = (ucc_datatype_t)std::get<1>(GetParam());
+    ucc_memory_type_t    mem_type = std::get<1>(GetParam());
+    gtest_ucc_inplace_t  inplace = std::get<2>(GetParam());
+    const ucc_datatype_t dtype   = (ucc_datatype_t)std::get<3>(GetParam());
     UccTeam_h            team    = UccJob::getStaticTeams()[team_id];
     int                  size    = team->procs.size();
-    UccCollArgsVec       args    = data_init(size, (ucc_datatype_t)dtype, 1);
+
+    set_inplace(inplace);
+    set_mem_type(mem_type);
+
+    UccCollCtxVec args    = data_init(size, (ucc_datatype_t)dtype, 1);
     UccReq    req(team, args);
     req.start();
     req.wait();
+
     data_validate(args);
     data_fini(args);
 }
@@ -142,73 +193,23 @@ INSTANTIATE_TEST_CASE_P(
         64, test_alltoallv_0,
         ::testing::Combine(
             ::testing::Range(1, UccJob::nStaticTeams), // team_ids
+#ifdef HAVE_CUDA
+            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
+#else
+            ::testing::Values(UCC_MEMORY_TYPE_HOST),
+#endif
+            ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
             ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+
 
 INSTANTIATE_TEST_CASE_P(
         32, test_alltoallv_1,
         ::testing::Combine(
             ::testing::Range(1, UccJob::nStaticTeams), // team_ids
+#ifdef HAVE_CUDA
+            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
+#else
+            ::testing::Values(UCC_MEMORY_TYPE_HOST),
+#endif
+            ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
             ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
-
-class test_alltoallv_2 : public test_alltoallv<uint64_t>,
-        public ::testing::WithParamInterface<int> {};
-
-class test_alltoallv_3 : public test_alltoallv<uint32_t>,
-        public ::testing::WithParamInterface<int> {};
-
-UCC_TEST_P(test_alltoallv_2, multiple)
-{
-    const ucc_datatype_t dtype = (ucc_datatype_t)(GetParam());
-    std::vector<UccReq> reqs;
-    std::vector<UccCollArgsVec> args;
-
-    coll_mask = UCC_COLL_ARGS_FIELD_FLAGS;
-    coll_flags = UCC_COLL_ARGS_FLAG_COUNT_64BIT |
-                 UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
-
-    for (auto &team : UccJob::getStaticTeams()) {
-        UccCollArgsVec arg = data_init(team->procs.size(),
-                                       dtype, 1);
-        args.push_back(arg);
-        reqs.push_back(UccReq(team, arg));
-    }
-    UccReq::startall(reqs);
-    UccReq::waitall(reqs);
-
-    for (auto arg : args) {
-        data_validate(arg);
-        data_fini(arg);
-    }
-}
-
-
-UCC_TEST_P(test_alltoallv_3, multiple)
-{
-    const ucc_datatype_t dtype = (ucc_datatype_t)(GetParam());
-    std::vector<UccReq> reqs;
-    std::vector<UccCollArgsVec> args;
-
-    for (auto &team : UccJob::getStaticTeams()) {
-        UccCollArgsVec arg = data_init(team->procs.size(),
-                                       dtype, 1);
-        args.push_back(arg);
-        reqs.push_back(UccReq(team, arg));
-    }
-    UccReq::startall(reqs);
-    UccReq::waitall(reqs);
-
-    for (auto arg : args) {
-        data_validate(arg);
-        data_fini(arg);
-    }
-}
-
-INSTANTIATE_TEST_CASE_P(
-        64,
-        test_alltoallv_2,
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1)); // dtype
-
-INSTANTIATE_TEST_CASE_P(
-        32,
-        test_alltoallv_3,
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1)); // dtype

--- a/test/gtest/core/test_bcast.cc
+++ b/test/gtest/core/test_bcast.cc
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include <core/ucc_mc.h>
+}
+#include "common/test_ucc.h"
+#include "utils/ucc_math.h"
+
+using Param = std::tuple<int, int, ucc_memory_type_t, int, int>;
+
+class test_bcast : public UccCollArgs, public ucc::test
+{
+private:
+    int root;
+public:
+    UccCollCtxVec data_init(int nprocs, ucc_datatype_t dtype, size_t count)
+    {
+        UccCollCtxVec ctxs(nprocs);
+        for (auto r = 0; r < nprocs; r++) {
+            ucc_coll_args_t *coll = (ucc_coll_args_t*)
+                    calloc(1, sizeof(ucc_coll_args_t));
+
+            ctxs[r] = (gtest_ucc_coll_ctx_t*)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
+            ctxs[r]->args = coll;
+
+            coll->mask = 0;
+            coll->coll_type = UCC_COLL_TYPE_BCAST;
+            coll->src.info.mem_type = mem_type;
+            coll->src.info.count   = (ucc_count_t)count;
+            coll->src.info.datatype = dtype;
+            coll->root = root;
+
+            ctxs[r]->rbuf_size = ucc_dt_size(dtype) * count;
+
+            UCC_CHECK(ucc_mc_alloc(&coll->src.info.buffer, ctxs[r]->rbuf_size,
+                                   mem_type));
+            if (r == root) {
+                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf, ctxs[r]->rbuf_size,
+                                       UCC_MEMORY_TYPE_HOST));
+                for (int i = 0; i < ctxs[r]->rbuf_size; i++) {
+                    uint8_t *sbuf = (uint8_t*)ctxs[r]->init_buf;
+                    sbuf[i] = i;
+                }
+                ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
+                              ctxs[r]->rbuf_size, mem_type,
+                              UCC_MEMORY_TYPE_HOST);
+            }
+        }
+        return ctxs;
+    }
+    void data_fini(UccCollCtxVec ctxs)
+    {
+        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+            ucc_coll_args_t* coll = ctx->args;
+            UCC_CHECK(ucc_mc_free(coll->src.info.buffer, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->init_buf, UCC_MEMORY_TYPE_HOST));
+            free(coll);
+            free(ctx);
+        }
+        ctxs.clear();
+    }
+    void data_validate(UccCollCtxVec ctxs)
+    {
+        int root = ctxs[0]->args->root;
+        uint8_t *dsts;
+
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+                UCC_CHECK(ucc_mc_alloc((void**)&dsts, ctxs[root]->rbuf_size,
+                                       UCC_MEMORY_TYPE_HOST));
+                ucc_mc_memcpy(dsts, ctxs[root]->args->src.info.buffer,
+                              ctxs[root]->rbuf_size, UCC_MEMORY_TYPE_HOST, mem_type);
+        } else {
+            dsts = (uint8_t*)ctxs[root]->args->src.info.buffer;
+        }
+        for (int r = 0; r < ctxs.size(); r++) {
+            ucc_coll_args_t* coll = ctxs[r]->args;
+            if (coll->root == r) {
+                continue;
+            }
+            for (int i = 0; i < ctxs[r]->rbuf_size; i++) {
+                EXPECT_EQ(i, dsts[i]);
+            }
+        }
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            ucc_mc_free((void*)dsts, UCC_MEMORY_TYPE_HOST);
+        }
+        return;
+    }
+    void set_root(int _root)
+    {
+        root = _root;
+    }
+};
+
+class test_bcast_0 : public test_bcast,
+        public ::testing::WithParamInterface<Param> {};
+
+UCC_TEST_P(test_bcast_0, single_host)
+{
+    const int                 team_id  = std::get<0>(GetParam());
+    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
+    const int                 count    = std::get<3>(GetParam());
+    const int                 root     = std::get<4>(GetParam());
+    UccTeam_h                 team     = UccJob::getStaticTeams()[team_id];
+    int                       size     = team->procs.size();
+
+    set_mem_type(mem_type);
+    set_root(root);
+
+    UccCollCtxVec args = data_init(size, (ucc_datatype_t)dtype, count);
+    UccReq    req(team, args);
+    req.start();
+    req.wait();
+    data_validate(args);
+    data_fini(args);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ,
+    test_bcast_0,
+    ::testing::Combine(
+        ::testing::Range(1, UccJob::nStaticTeams), // team_ids
+        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_UINT32 + 1), // dtype
+#ifdef HAVE_CUDA
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
+#else
+        ::testing::Values(UCC_MEMORY_TYPE_HOST),
+#endif
+        ::testing::Values(1,3), // count
+        ::testing::Values(0,1))); // root


### PR DESCRIPTION
- Added collectives:
  - allgather
  - allgatherv
  - allreduce (will be available after merge https://github.com/openucx/ucc/pull/95, due to common code)
  - bcast
- Added CUDA for all collectives
- Added `inplace` option support

