### PR TITLE
COMPONENTS: Fix Thread Mode Query

### DIFF
--- a/config/m4/ucx.m4
+++ b/config/m4/ucx.m4
@@ -5,7 +5,7 @@
 
 AC_DEFUN([CHECK_UCX],[
 UCX_MIN_REQUIRED_MAJOR=1
-UCX_MIN_REQUIRED_MINOR=10
+UCX_MIN_REQUIRED_MINOR=11
 AS_IF([test "x$ucx_checked" != "xyes"],[
     ucx_happy="no"
 

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -7,6 +7,8 @@
 #include "cl_basic.h"
 #include "utils/ucc_malloc.h"
 #include "components/tl/ucc_tl.h"
+#include "core/ucc_global_opts.h"
+#include "utils/ucc_math.h"
 
 /* NOLINTNEXTLINE  TODO params is not used*/
 UCC_CLASS_INIT_FUNC(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *params,
@@ -31,10 +33,37 @@ UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
 ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
                                        ucc_base_attr_t *base_attr)
 {
-    ucc_cl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
-    attr->tls                    = UCC_TL_UCP | UCC_TL_NCCL;
-    attr->super.attr.thread_mode = UCC_THREAD_SINGLE;
-    /* TODO: fill coll_types, reduction_types, sync_mode.
-       Correctly fill thead_mode multiple when possible. */
+    ucc_cl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
+    attr->tls               = UCC_TL_UCP | UCC_TL_NCCL;
+    ucc_status_t           status;
+    ucc_tl_lib_attr_t      ucp_tl_attr, nccl_tl_attr;
+    ucc_component_iface_t *ucp_iface, *nccl_iface;
+    ucc_tl_iface_t        *tl_ucp_iface, *tl_nccl_iface;
+    ucp_iface = ucc_get_component(&ucc_global_config.tl_framework, "ucp");
+    if (!ucp_iface) {
+    	cl_error(lib, "failed to get UCP component");
+    	return UCC_ERR_NO_RESOURCE;
+    }
+    tl_ucp_iface = ucc_derived_of(ucp_iface, ucc_tl_iface_t);
+    memset(&ucp_tl_attr, 0, sizeof(ucc_tl_lib_attr_t));
+    status = tl_ucp_iface->lib.get_attr(NULL, &ucp_tl_attr.super);
+    if (UCC_OK != status) {
+        cl_error(lib, "failed to query cl lib attributes");
+        return status;
+    }
+    attr->super.attr.thread_mode = ucp_tl_attr.super.attr.thread_mode;
+    nccl_iface = ucc_get_component(&ucc_global_config.tl_framework, "nccl");
+    if (nccl_iface) {
+        tl_nccl_iface = ucc_derived_of(nccl_iface, ucc_tl_iface_t);
+        memset(&nccl_tl_attr, 0, sizeof(ucc_tl_lib_attr_t));
+        status = tl_nccl_iface->lib.get_attr(NULL, &nccl_tl_attr.super);
+        if (UCC_OK != status) {
+            cl_error(lib, "failed to query cl lib attributes");
+            return status;
+        }
+        attr->super.attr.thread_mode = ucc_min(attr->super.attr.thread_mode,
+    			nccl_tl_attr.super.attr.thread_mode);
+    }
+    /* TODO: fill coll_types, reduction_types, sync_mode.*/
     return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl_lib.c
+++ b/src/components/tl/nccl/tl_nccl_lib.c
@@ -25,8 +25,9 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_lib_t)
 UCC_CLASS_DEFINE(ucc_tl_nccl_lib_t, ucc_tl_lib_t);
 
 ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
-                                     ucc_base_attr_t *attr)     /* NOLINT */
+                                     ucc_base_attr_t *attr)
 {
-    //TODO
-    return UCC_ERR_NOT_IMPLEMENTED;
+    ucc_tl_lib_attr_t *attr      = ucc_derived_of(attr, ucc_tl_lib_attr_t);
+    attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
+    return UCC_OK;
 }

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -121,6 +121,10 @@ ucc_status_t ucc_tl_team_destroy_multiple(ucc_team_multiple_req_t *req);
 
 void ucc_team_multiple_req_free(ucc_team_multiple_req_t *req);
 
+typedef struct ucc_tl_lib_attr {
+    ucc_base_attr_t super;
+} ucc_tl_lib_attr_t;
+
 #define UCC_TL_CTX_IFACE(_tl_ctx)                                              \
     (ucc_derived_of((_tl_ctx)->super.lib, ucc_tl_lib_t))->iface
 


### PR DESCRIPTION
## What
This PR Fixes the setting of ucc_lib_attr.thread_mode of CL.

## Why ?
Currently thread_mode is not correct and uses uninitialized cl_iface.attr.thread_mode. Works only because all our tests use THREAD_SINGLE.

## How ?
CL thread mode is decided according to the min thread support of all of its TLs. Each TL has its own get_lib_attributes method, which include thread_mode.
