### PR TITLE
Topic/tl ucp ep close sync

### DIFF
--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -91,6 +91,11 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
 
 #define UCC_TL_UCP_WORKER(_team) UCC_TL_UCP_TEAM_CTX(_team)->ucp_worker
 
+#define UCC_TL_CTX_HAS_OOB(_ctx) ((_ctx)->super.super.ucc_context->params.mask & \
+                                  UCC_CONTEXT_PARAM_FIELD_OOB)
+
+#define UCC_TL_CTX_OOB(_ctx) ((_ctx)->super.super.ucc_context->params.oob)
+
 void ucc_tl_ucp_pre_register_mem(ucc_tl_ucp_team_t *team, void *addr,
                                  size_t length, ucc_memory_type_t mem_type);
 #endif

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -39,7 +39,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
 
     ucp_params.field_mask =
         UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_TAG_SENDER_MASK;
-    ucp_params.features        = UCP_FEATURE_TAG | UCP_FEATURE_RMA;
+    ucp_params.features        = UCP_FEATURE_TAG;
     ucp_params.tag_sender_mask = UCC_TL_UCP_TAG_SENDER_MASK;
 
     if (params->estimated_num_ppn > 0) {

--- a/src/components/tl/ucp/tl_ucp_ep.c
+++ b/src/components/tl/ucp/tl_ucp_ep.c
@@ -2,6 +2,12 @@
 #include "tl_ucp_ep.h"
 #include "tl_ucp_addr.h"
 
+static void ucc_tl_ucp_err_handler(void *arg, ucp_ep_h ep, ucs_status_t status)
+{
+    /* Dummy fn - we don't expect errors in disconnect flow */
+    ;
+}
+
 static inline ucc_status_t ucc_tl_ucp_connect_ep(ucc_tl_ucp_context_t *ctx,
                                                  ucp_ep_h *ep, char *addr_array,
                                                  size_t max_addrlen, ucc_rank_t rank)
@@ -17,6 +23,13 @@ static inline ucc_status_t ucc_tl_ucp_connect_ep(ucc_tl_ucp_context_t *ctx,
     ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
     ep_params.address    = (ucp_address_t*)address->addr;
 
+    if (!UCC_TL_CTX_HAS_OOB(ctx)) {
+        ep_params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
+        ep_params.err_handler.cb  = ucc_tl_ucp_err_handler;
+        ep_params.err_handler.arg = NULL;
+        ep_params.field_mask     |= UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
+                                    UCP_EP_PARAM_FIELD_ERR_HANDLER;
+    }
     status = ucp_ep_create(ctx->ucp_worker, &ep_params, ep);
 
     if (UCS_OK != status) {

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -244,10 +244,10 @@ static inline void ucc_copy_context_params(ucc_context_params_t *dst,
                                            const ucc_context_params_t *src)
 {
     dst->mask = src->mask;
-    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_TYPE, ctx_type);
-    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_COLL_OOB, oob);
+    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_TYPE, type);
+    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_OOB, oob);
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_ID, ctx_id);
-    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_COLL_SYNC_TYPE,
+    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_SYNC_TYPE,
                             sync_type);
 }
 
@@ -371,7 +371,7 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
     /* Initialize ctx thread mode:
        if context is EXCLUSIVE then thread_mode is always SINGLE,
        otherwise it is  inherited from lib */
-    ctx->thread_mode = ((params->ctx_type == UCC_CONTEXT_EXCLUSIVE) &&
+    ctx->thread_mode = ((params->type == UCC_CONTEXT_EXCLUSIVE) &&
                         (params->mask & UCC_CONTEXT_PARAM_FIELD_TYPE))
                            ? UCC_THREAD_SINGLE
                            : lib->attr.thread_mode;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -612,10 +612,10 @@ typedef enum {
  *  @ingroup UCC_CONTEXT_DT
  */
 enum ucc_context_params_field {
-    UCC_CONTEXT_PARAM_FIELD_TYPE                   = UCC_BIT(0),
-    UCC_CONTEXT_PARAM_FIELD_COLL_SYNC_TYPE         = UCC_BIT(1),
-    UCC_CONTEXT_PARAM_FIELD_COLL_OOB               = UCC_BIT(2),
-    UCC_CONTEXT_PARAM_FIELD_ID                     = UCC_BIT(3)
+    UCC_CONTEXT_PARAM_FIELD_TYPE              = UCC_BIT(0),
+    UCC_CONTEXT_PARAM_FIELD_SYNC_TYPE         = UCC_BIT(1),
+    UCC_CONTEXT_PARAM_FIELD_OOB               = UCC_BIT(2),
+    UCC_CONTEXT_PARAM_FIELD_ID                = UCC_BIT(3)
 };
 
 /**
@@ -623,10 +623,10 @@ enum ucc_context_params_field {
  *  @ingroup UCC_CONTEXT_DT
  */
 enum ucc_context_attr_field {
-    UCC_CONTEXT_ATTR_FIELD_TYPE                   = UCC_BIT(0),
-    UCC_CONTEXT_ATTR_FIELD_COLL_SYNC_TYPE         = UCC_BIT(1),
-    UCC_CONTEXT_ATTR_FIELD_CONTEXT_ADDR           = UCC_BIT(2),
-    UCC_CONTEXT_ATTR_FIELD_CONTEXT_ADDR_LEN       = UCC_BIT(3)
+    UCC_CONTEXT_ATTR_FIELD_TYPE               = UCC_BIT(0),
+    UCC_CONTEXT_ATTR_FIELD_SYNC_TYPE          = UCC_BIT(1),
+    UCC_CONTEXT_ATTR_FIELD_CTX_ADDR           = UCC_BIT(2),
+    UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN       = UCC_BIT(3)
 };
 
 /**
@@ -635,7 +635,7 @@ enum ucc_context_attr_field {
  * @brief OOB collective operation for creating the context
  */
 typedef struct ucc_context_oob_coll {
-    int             (*allgather)(void *src_buf, void *recv_buf, size_t size,
+    ucc_status_t    (*allgather)(void *src_buf, void *recv_buf, size_t size,
                                  void *allgather_info,  void **request);
     ucc_status_t    (*req_test)(void *request);
     ucc_status_t    (*req_free)(void *request);
@@ -667,7 +667,7 @@ typedef struct ucc_context_oob_coll {
  */
 typedef struct ucc_context_params {
     uint64_t                mask;
-    ucc_context_type_t      ctx_type;
+    ucc_context_type_t      type;
     ucc_coll_sync_type_t    sync_type;
     ucc_context_oob_coll_t  oob;
     uint64_t                ctx_id;
@@ -694,7 +694,7 @@ typedef struct ucc_context_params {
  */
 typedef struct ucc_context_attr {
     uint64_t                mask;
-    ucc_context_type_t      ctx_type;
+    ucc_context_type_t      type;
     ucc_coll_sync_type_t    sync_type;
     ucc_context_addr_t      ctx_addr;
     ucc_context_addr_len_t  ctx_addr_len;

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -56,7 +56,7 @@ public:
     };
     static constexpr ucc_context_params_t default_ctx_params = {
         .mask = UCC_CONTEXT_PARAM_FIELD_TYPE,
-        .ctx_type = UCC_CONTEXT_EXCLUSIVE
+        .type = UCC_CONTEXT_EXCLUSIVE
     };
     ucc_lib_h            lib_h;
     ucc_context_h        ctx_h;

--- a/test/gtest/core/test_alltoall.cc
+++ b/test/gtest/core/test_alltoall.cc
@@ -54,7 +54,7 @@ public:
             for (int i = 0; i < args.size(); i++) {
                 size_t rank_size = ucc_dt_size(coll->dst.info.datatype) *
                         (size_t)coll->dst.info.count;
-                EXPECT_EQ(0,
+                ASSERT_EQ(0,
                           alltoallx_validate_buf(i, r,
                           (uint8_t*)coll->dst.info.buffer + rank_size * i,
                           rank_size));

--- a/test/gtest/core/test_context.cc
+++ b/test/gtest/core/test_context.cc
@@ -22,7 +22,7 @@ UCC_TEST_F(test_context, create_destroy)
     ucc_context_params_t ctx_params;
     ucc_context_h        ctx_h;
     ctx_params.mask = UCC_CONTEXT_PARAM_FIELD_TYPE;
-    ctx_params.ctx_type = UCC_CONTEXT_EXCLUSIVE;
+    ctx_params.type = UCC_CONTEXT_EXCLUSIVE;
     EXPECT_EQ(UCC_OK, ucc_context_create(lib_h, &ctx_params, ctx_config, &ctx_h));
     EXPECT_EQ(UCC_OK, ucc_context_destroy(ctx_h));
 }
@@ -34,7 +34,7 @@ UCC_TEST_F(test_context, init_multiple)
     ucc_context_h              ctx_h;
     std::vector<ucc_context_h> ctxs;
     ctx_params.mask = UCC_CONTEXT_PARAM_FIELD_TYPE;
-    ctx_params.ctx_type = UCC_CONTEXT_EXCLUSIVE;
+    ctx_params.type = UCC_CONTEXT_EXCLUSIVE;
     for (int i = 0; i < n_ctxs; i++) {
         EXPECT_EQ(UCC_OK, ucc_context_create(lib_h, &ctx_params, ctx_config, &ctx_h));
         ctxs.push_back(ctx_h);

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -389,7 +389,7 @@ int main(int argc, char *argv[])
         std::chrono::steady_clock::now();
     int rank;
     int failed = 0;
-    UccTestMpi test(argc, argv, UCC_THREAD_SINGLE);
+    UccTestMpi test(argc, argv, UCC_THREAD_SINGLE, 0);
     ProcessArgs(argc, argv);
     test.create_teams(teams);
     test.set_colls(colls);

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -129,7 +129,7 @@ class UccTestMpi {
     size_t test_max_size;
 public:
     std::vector<ucc_status_t> results;
-    UccTestMpi(int argc, char *argv[], ucc_thread_mode_t tm);
+    UccTestMpi(int argc, char *argv[], ucc_thread_mode_t tm, int is_local);
     ~UccTestMpi();
     void set_msgsizes(size_t min, size_t max, size_t power);
     void set_dtypes(std::vector<ucc_datatype_t> &_dtypes);


### PR DESCRIPTION
## What
If OOB is provided for UCC context then we should launch a barrier after endpoints have been closed. Otherwise, we have to create ucp ep endpoints with ERR_HANDLER (to avoid segv during ep_flush). This may results in worse perf do to suboptimal ucp ep lanes selection.

## Why ?
W/o the fix segv is likely to happen in ucc_tl_ucp_context_destroy

