### PR TITLE
CORE: Add Multi-threaded context progress queue

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,6 +53,7 @@ noinst_HEADERS =                     \
 	utils/ucc_proc_info.h            \
 	utils/khash.h                    \
 	utils/ucc_spinlock.h             \
+	utils/ucc_mpool.h                \
 	components/base/ucc_base_iface.h \
 	components/cl/ucc_cl.h           \
 	components/cl/ucc_cl_log.h       \
@@ -78,6 +79,7 @@ libucc_la_SOURCES =                  \
 	schedule/ucc_schedule.c          \
 	utils/ucc_component.c            \
 	utils/ucc_status.c               \
+	utils/ucc_mpool.c                \
 	utils/ucc_math.c                 \
 	utils/ucc_proc_info.c            \
 	components/base/ucc_base_iface.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,6 +74,7 @@ libucc_la_SOURCES =                  \
 	core/ucc_coll.c                  \
 	core/ucc_progress_queue.c        \
 	core/ucc_progress_queue_st.c     \
+	core/ucc_progress_queue_mt.c     \
 	schedule/ucc_schedule.c          \
 	utils/ucc_component.c            \
 	utils/ucc_status.c               \

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -47,24 +47,23 @@ static ucc_config_field_t ucc_mc_cuda_config_table[] = {
     {NULL}
 };
 
-static ucs_status_t
-ucc_mc_cuda_stream_req_mpool_chunk_malloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
+static ucc_status_t ucc_mc_cuda_stream_req_mpool_chunk_malloc(ucc_mpool_t *mp,
+                                                              size_t *size_p,
+                                                              void ** chunk_p)
 {
     ucc_status_t status;
 
     status = CUDA_FUNC(cudaHostAlloc((void**)chunk_p, *size_p, cudaHostAllocMapped));
-    if(status != UCC_OK)  {
-        return UCS_ERR_NO_MEMORY;
-    }
-    return UCS_OK;
+    return status;
 }
 
-static void ucc_mc_cuda_stream_req_mpool_chunk_free(ucs_mpool_t *mp, void *chunk)
+static void ucc_mc_cuda_stream_req_mpool_chunk_free(ucc_mpool_t *mp,
+                                                    void *       chunk)
 {
     cudaFreeHost(chunk);
 }
 
-static void ucc_mc_cuda_stream_req_init(ucs_mpool_t *mp, void *obj, void *chunk)
+static void ucc_mc_cuda_stream_req_init(ucc_mpool_t *mp, void *obj, void *chunk)
 {
     ucc_mc_cuda_stream_request_t *req = (ucc_mc_cuda_stream_request_t*) obj;
 
@@ -72,14 +71,14 @@ static void ucc_mc_cuda_stream_req_init(ucs_mpool_t *mp, void *obj, void *chunk)
                   (void**)(&req->dev_status), (void *)&req->status, 0));
 }
 
-static ucs_mpool_ops_t ucc_mc_cuda_stream_req_mpool_ops = {
+static ucc_mpool_ops_t ucc_mc_cuda_stream_req_mpool_ops = {
     .chunk_alloc   = ucc_mc_cuda_stream_req_mpool_chunk_malloc,
     .chunk_release = ucc_mc_cuda_stream_req_mpool_chunk_free,
     .obj_init      = ucc_mc_cuda_stream_req_init,
     .obj_cleanup   = NULL
 };
 
-static void ucc_mc_cuda_event_init(ucs_mpool_t *mp, void *obj, void *chunk)
+static void ucc_mc_cuda_event_init(ucc_mpool_t *mp, void *obj, void *chunk)
 {
     ucc_mc_cuda_event_t *base = (ucc_mc_cuda_event_t *) obj;
 
@@ -89,7 +88,7 @@ static void ucc_mc_cuda_event_init(ucs_mpool_t *mp, void *obj, void *chunk)
     }
 }
 
-static void ucc_mc_cuda_event_cleanup(ucs_mpool_t *mp, void *obj)
+static void ucc_mc_cuda_event_cleanup(ucc_mpool_t *mp, void *obj)
 {
     ucc_mc_cuda_event_t *base = (ucc_mc_cuda_event_t *) obj;
     if (cudaSuccess != cudaEventDestroy(base->event)) {
@@ -97,9 +96,9 @@ static void ucc_mc_cuda_event_cleanup(ucs_mpool_t *mp, void *obj)
     }
 }
 
-static ucs_mpool_ops_t ucc_mc_cuda_event_mpool_ops = {
-    .chunk_alloc   = ucs_mpool_hugetlb_malloc,
-    .chunk_release = ucs_mpool_hugetlb_free,
+static ucc_mpool_ops_t ucc_mc_cuda_event_mpool_ops = {
+    .chunk_alloc   = ucc_mpool_hugetlb_malloc,
+    .chunk_release = ucc_mpool_hugetlb_free,
     .obj_init      = ucc_mc_cuda_event_init,
     .obj_cleanup   = ucc_mc_cuda_event_cleanup,
 };
@@ -126,7 +125,7 @@ static ucc_status_t ucc_mc_cuda_post_driver_stream_task(uint32_t *status,
 static ucc_status_t ucc_mc_cuda_init()
 {
     struct cudaDeviceProp prop;
-    ucs_status_t status;
+    ucc_status_t          status;
     int device;
     CUdevice cu_dev;
     int mem_ops_attr;
@@ -146,21 +145,23 @@ static ucc_status_t ucc_mc_cuda_init()
     CUDACHECK(cudaStreamCreateWithFlags(&ucc_mc_cuda.stream, cudaStreamNonBlocking));
 
     /*create event pool */
-    status = ucs_mpool_init(&ucc_mc_cuda.events, 0, sizeof(ucc_mc_cuda_event_t),
+    status = ucc_mpool_init(&ucc_mc_cuda.events, 0, sizeof(ucc_mc_cuda_event_t),
                             0, UCC_CACHE_LINE_SIZE, 16, UINT_MAX,
-                            &ucc_mc_cuda_event_mpool_ops, "CUDA Event Objects");
-    if (status != UCS_OK) {
+                            &ucc_mc_cuda_event_mpool_ops, UCC_THREAD_MULTIPLE,
+                            "CUDA Event Objects");
+    if (status != UCC_OK) {
         mc_error(&ucc_mc_cuda.super, "Error to create event pool");
-        return ucs_status_to_ucc_status(status);
+        return status;
     }
 
     /* create request pool */
-    status = ucs_mpool_init(&ucc_mc_cuda.strm_reqs, 0, sizeof(ucc_mc_cuda_stream_request_t),
-                            0, UCC_CACHE_LINE_SIZE, 16, UINT_MAX,
-                            &ucc_mc_cuda_stream_req_mpool_ops, "CUDA Event Objects");
-    if (status != UCS_OK) {
+    status = ucc_mpool_init(
+        &ucc_mc_cuda.strm_reqs, 0, sizeof(ucc_mc_cuda_stream_request_t), 0,
+        UCC_CACHE_LINE_SIZE, 16, UINT_MAX, &ucc_mc_cuda_stream_req_mpool_ops,
+        UCC_THREAD_MULTIPLE, "CUDA Event Objects");
+    if (status != UCC_OK) {
         mc_error(&ucc_mc_cuda.super, "Error to create event pool");
-        return ucs_status_to_ucc_status(status);
+        return status;
     }
 
     if (cfg->strm_task_mode == UCC_MC_CUDA_TASK_KERNEL) {
@@ -344,7 +345,7 @@ ucc_status_t ucc_ee_cuda_task_post(void *ee_stream, void **ee_req)
     ucc_mc_cuda_event_t *cuda_event;
     ucc_status_t status;
 
-    req = ucs_mpool_get(&ucc_mc_cuda.strm_reqs);
+    req = ucc_mpool_get(&ucc_mc_cuda.strm_reqs);
     ucc_assert(req);
     req->status = UCC_MC_CUDA_TASK_POSTED;
     req->stream = (cudaStream_t)ee_stream;
@@ -355,7 +356,7 @@ ucc_status_t ucc_ee_cuda_task_post(void *ee_stream, void **ee_req)
             goto free_req;
         }
     } else {
-        cuda_event = ucs_mpool_get(&ucc_mc_cuda.events);
+        cuda_event = ucc_mpool_get(&ucc_mc_cuda.events);
         ucc_assert(cuda_event);
         CUDACHECK(cudaEventRecord(cuda_event->event, req->stream));
         CUDACHECK(cudaStreamWaitEvent(ucc_mc_cuda.stream, cuda_event->event, 0));
@@ -365,7 +366,7 @@ ucc_status_t ucc_ee_cuda_task_post(void *ee_stream, void **ee_req)
         }
         CUDACHECK(cudaEventRecord(cuda_event->event, ucc_mc_cuda.stream));
         CUDACHECK(cudaStreamWaitEvent(req->stream, cuda_event->event, 0));
-        ucs_mpool_put(cuda_event);
+        ucc_mpool_put(cuda_event);
     }
 
     *ee_req = (void *) req;
@@ -376,9 +377,9 @@ ucc_status_t ucc_ee_cuda_task_post(void *ee_stream, void **ee_req)
     return UCC_OK;
 
 free_event:
-    ucs_mpool_put(cuda_event);
+    ucc_mpool_put(cuda_event);
 free_req:
-    ucs_mpool_put(req);
+    ucc_mpool_put(req);
     return status;
 }
 
@@ -400,7 +401,7 @@ ucc_status_t ucc_ee_cuda_task_end(void *ee_req)
     req->status = UCC_OK;
 
     mc_info(&ucc_mc_cuda.super, "CUDA stream task done. req:%p", req);
-    ucs_mpool_put(req);
+    ucc_mpool_put(req);
     return UCC_OK;
 }
 
@@ -408,7 +409,7 @@ ucc_status_t ucc_ee_cuda_create_event(void **event)
 {
     ucc_mc_cuda_event_t *cuda_event;
 
-    cuda_event = ucs_mpool_get(&ucc_mc_cuda.events);
+    cuda_event = ucc_mpool_get(&ucc_mc_cuda.events);
     ucc_assert(cuda_event);
     *event = cuda_event;
     return UCC_OK;
@@ -418,7 +419,7 @@ ucc_status_t ucc_ee_cuda_destroy_event(void *event)
 {
     ucc_mc_cuda_event_t *cuda_event = event;
 
-    ucs_mpool_put(cuda_event);
+    ucc_mpool_put(cuda_event);
     return UCC_OK;
 }
 

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -9,7 +9,7 @@
 
 #include "components/mc/base/ucc_mc_base.h"
 #include "components/mc/ucc_mc_log.h"
-#include "ucs/datastruct/mpool.h"
+#include "utils/ucc_mpool.h"
 #include <cuda_runtime.h>
 
 typedef enum ucc_mc_cuda_strm_task_mode {
@@ -55,8 +55,8 @@ typedef struct ucc_mc_cuda_config {
 typedef struct ucc_mc_cuda {
     ucc_mc_base_t                  super;
     cudaStream_t                   stream;
-    ucs_mpool_t                    events;
-    ucs_mpool_t                    strm_reqs;
+    ucc_mpool_t                    events;
+    ucc_mpool_t                    strm_reqs;
     ucc_mc_cuda_strm_task_mode_t   strm_task_mode;
     ucc_mc_cuda_task_stream_type_t task_strm_type;
     ucc_mc_cuda_task_post_fn       post_strm_task;

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -6,6 +6,13 @@
 
 #include "tl_nccl.h"
 
+static ucc_mpool_ops_t ucc_tl_nccl_req_mpool_ops = {
+    .chunk_alloc   = ucc_mpool_hugetlb_malloc,
+    .chunk_release = ucc_mpool_hugetlb_free,
+    .obj_init      = NULL,
+    .obj_cleanup   = NULL
+};
+
 UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
                     const ucc_base_context_params_t *params,
                     const ucc_base_config_t *config)
@@ -17,8 +24,9 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_nccl_config->super.tl_lib,
                               params->context);
     memcpy(&self->cfg, tl_nccl_config, sizeof(*tl_nccl_config));
-    status = ucc_mpool_init(&self->req_mp, sizeof(ucc_tl_nccl_task_t),
-                            UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL, NULL,
+    status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_nccl_task_t), 0,
+                            UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
+                            &ucc_tl_nccl_req_mpool_ops, params->thread_mode,
                             "tl_nccl_req_mp");
     if (status != UCC_OK) {
         tl_error(self->super.super.lib,

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -10,6 +10,13 @@
 #include "tl_ucp_ep.h"
 #include <limits.h>
 
+static ucc_mpool_ops_t ucc_tl_ucp_req_mpool_ops = {
+    .chunk_alloc   = ucc_mpool_hugetlb_malloc,
+    .chunk_release = ucc_mpool_hugetlb_free,
+    .obj_init      = NULL,
+    .obj_cleanup   = NULL
+};
+
 UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
                     const ucc_base_context_params_t *params,
                     const ucc_base_config_t *config)
@@ -98,8 +105,9 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     self->ucp_worker  = ucp_worker;
     self->worker_address = NULL;
 
-    ucc_status = ucc_mpool_init(&self->req_mp, sizeof(ucc_tl_ucp_task_t),
-                                UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL, NULL,
+    ucc_status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_ucp_task_t), 0,
+                                UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
+                                &ucc_tl_ucp_req_mpool_ops, params->thread_mode,
                                 "tl_ucp_req_mp");
     if (UCC_OK != ucc_status) {
         tl_error(self->super.super.lib,

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -61,7 +61,10 @@ typedef struct ucc_context_config {
 /* Any internal UCC component (TL, CL, etc) may register its own
    progress callback fn (and argument for the callback) into core
    ucc context. Those callbacks will be triggered as part of
-   ucc_context_progress. */
+   ucc_context_progress.
+   Any progress callback fn inserted is required to be thread safe.
+   If not, we need to add to this engine a thread safe mechanism. */
+
 ucc_status_t ucc_context_progress_register(ucc_context_t *ctx,
                                            ucc_context_progress_fn_t fn,
                                            void *progress_arg);

--- a/src/core/ucc_progress_queue.c
+++ b/src/core/ucc_progress_queue.c
@@ -7,12 +7,16 @@
 #include "ucc_progress_queue.h"
 
 ucc_status_t ucc_pq_st_init(ucc_progress_queue_t **pq);
+ucc_status_t ucc_pq_mt_init(ucc_progress_queue_t **pq);
 
 ucc_status_t ucc_progress_queue_init(ucc_progress_queue_t **pq,
-                                     ucc_thread_mode_t      tm)      /* NOLINT */
+                                     ucc_thread_mode_t      tm)
 {
-    // TODO add branch if tm == THREAD_MULTIPLE return pq_mt_init and remove NOLINT
-    return ucc_pq_st_init(pq);
+    if (tm == UCC_THREAD_SINGLE) {
+        return ucc_pq_st_init(pq);
+    } else { // TODO also for UCC_THREAD_FUNNELED?
+        return ucc_pq_mt_init(pq);
+    }
 }
 
 void ucc_progress_queue_finalize(ucc_progress_queue_t *pq)

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "ucc_progress_queue.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_log.h"
+#include "utils/ucc_spinlock.h"
+#include "utils/ucc_atomic.h"
+
+// Number of tasks in a single lock free pool - could be changed, but in tests performed great
+#define LINE_SIZE 8
+#define NUM_POOLS 2 // We need exactly two pools
+
+typedef struct ucc_pq_mt {
+    ucc_progress_queue_t super;
+    ucc_spinlock_t       locked_queue_lock;
+    ucc_coll_task_t *    tasks[NUM_POOLS][LINE_SIZE];
+    uint8_t              which_pool;
+    ucc_list_link_t      locked_queue;
+    uint32_t             tasks_counters[NUM_POOLS];
+} ucc_pq_mt_t; // TODO the struct isn't a queue because not maintaining order, maybe another name
+
+static void ucc_pq_mt_enqueue(ucc_progress_queue_t *pq, ucc_coll_task_t *task)
+{
+    ucc_pq_mt_t *pq_mt      = ucc_derived_of(pq, ucc_pq_mt_t);
+    int          which_pool = task->was_progressed ^ (pq_mt->which_pool & 1);
+    int          i;
+    for (i = 0; i < LINE_SIZE; i++) {
+        if (ucc_atomic_bool_cswap64((uint64_t *)&(pq_mt->tasks[which_pool][i]),
+                                    0, (uint64_t)task)) {
+            ucc_atomic_add32(&pq_mt->tasks_counters[which_pool], 1);
+            return;
+        }
+    }
+    ucc_spin_lock(&pq_mt->locked_queue_lock);
+    ucc_list_add_tail(&pq_mt->locked_queue, &task->list_elem);
+    ucc_spin_unlock(&pq_mt->locked_queue_lock);
+}
+
+inline static void ucc_pq_mt_dequeue(ucc_pq_mt_t *     pq_mt,
+                                     ucc_coll_task_t **popped_task_ptr,
+                                     int               is_first_call)
+{
+    // Save value in the beginning of the function
+    int curr_which_pool = pq_mt->which_pool;
+    int which_pool      = curr_which_pool & 1; // turn from even/odd -> bool
+    ucc_coll_task_t *popped_task = NULL;
+    int              i;
+    if (pq_mt->tasks_counters[which_pool]) {
+        for (i = 0; i < LINE_SIZE; i++) {
+            popped_task = pq_mt->tasks[which_pool][i];
+            if (popped_task) {
+                if (ucc_atomic_bool_cswap64(
+                        (uint64_t *)&(pq_mt->tasks[which_pool][i]),
+                        (uint64_t)popped_task, 0)) {
+                    ucc_atomic_sub32(&pq_mt->tasks_counters[which_pool], 1);
+                    *popped_task_ptr            = popped_task;
+                    popped_task->was_progressed = 1;
+                    return;
+                }
+            }
+        }
+    }
+    if (is_first_call) {
+        ucc_atomic_cswap8(&pq_mt->which_pool, curr_which_pool,
+                          curr_which_pool + 1);
+        ucc_pq_mt_dequeue(pq_mt, popped_task_ptr, 0);
+        return;
+    }
+    popped_task = NULL;
+    ucc_spin_lock(&pq_mt->locked_queue_lock);
+    if (!ucc_list_is_empty(&pq_mt->locked_queue)) {
+        popped_task = ucc_list_extract_head(&pq_mt->locked_queue,
+                                            ucc_coll_task_t, list_elem);
+        popped_task->was_progressed = 1;
+    }
+    ucc_spin_unlock(&pq_mt->locked_queue_lock);
+    *popped_task_ptr = popped_task;
+}
+
+static int ucc_pq_mt_progress(ucc_progress_queue_t *pq)
+{
+    ucc_pq_mt_t *    pq_mt        = ucc_derived_of(pq, ucc_pq_mt_t);
+    int              n_progressed = 0;
+    ucc_coll_task_t *task;
+    ucc_status_t     status;
+    ucc_pq_mt_dequeue(pq_mt, &task, 1);
+    if (task) {
+        if (task->progress) {
+            status = task->progress(task);
+            if (status < 0) {
+                return status;
+            }
+        }
+        if (UCC_OK == task->super.status) {
+            n_progressed++;
+            // TODO need to decide for st/mt progress should it return #progressed/#completed tasks,
+            // and document accordingly
+            status = ucc_event_manager_notify(task, UCC_EVENT_COMPLETED);
+            if (status != UCC_OK) {
+                return status;
+            }
+            if (task->flags & UCC_COLL_TASK_FLAG_INTERNAL) {
+                task->finalize(task);
+            }
+        } else {
+            ucc_pq_mt_enqueue(pq, task);
+        }
+    }
+    return n_progressed;
+}
+
+static void ucc_pq_mt_finalize(ucc_progress_queue_t *pq)
+{
+    ucc_pq_mt_t *pq_mt = ucc_derived_of(pq, ucc_pq_mt_t);
+    ucc_spinlock_destroy(&pq_mt->locked_queue_lock);
+    ucc_free(pq_mt);
+}
+
+ucc_status_t ucc_pq_mt_init(ucc_progress_queue_t **pq)
+{
+    ucc_pq_mt_t *pq_mt = ucc_malloc(sizeof(*pq_mt), "pq_mt");
+    if (!pq_mt) {
+        ucc_error("failed to allocate %zd bytes for pq_mt", sizeof(*pq_mt));
+        return UCC_ERR_NO_MEMORY;
+    }
+    memset(&pq_mt->tasks, 0, NUM_POOLS * LINE_SIZE * sizeof(ucc_coll_task_t *));
+    ucc_spinlock_init(&pq_mt->locked_queue_lock, 0);
+    ucc_list_head_init(&pq_mt->locked_queue);
+    pq_mt->which_pool        = 0;
+    pq_mt->tasks_counters[0] = 0;
+    pq_mt->tasks_counters[1] = 0;
+    pq_mt->super.enqueue     = ucc_pq_mt_enqueue;
+    pq_mt->super.progress    = ucc_pq_mt_progress;
+    pq_mt->super.finalize    = ucc_pq_mt_finalize;
+    *pq                      = &pq_mt->super;
+    return UCC_OK;
+}

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -24,8 +24,9 @@ void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
 
 ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task)
 {
-    task->super.status = UCC_OPERATION_INITIALIZED;
-    task->ee           = NULL;
+    task->super.status   = UCC_OPERATION_INITIALIZED;
+    task->ee             = NULL;
+    task->was_progressed = 0;
     return ucc_event_manager_init(&task->em);
 }
 

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -48,6 +48,7 @@ typedef struct ucc_coll_task {
     ucc_coll_task_t             *triggered_task;
     /* used for progress queue */
     ucc_list_link_t              list_elem;
+    uint8_t                      was_progressed;
 } ucc_coll_task_t;
 
 typedef struct ucc_context ucc_context_t;

--- a/src/utils/ucc_atomic.h
+++ b/src/utils/ucc_atomic.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_ATOMIC_H_
+#define UCC_ATOMIC_H_
+
+#include "config.h"
+#include <ucs/arch/atomic.h>
+
+#define ucc_atomic_add32          ucs_atomic_add32
+#define ucc_atomic_sub32          ucs_atomic_sub32
+#define ucc_atomic_cswap8         ucs_atomic_cswap8
+#define ucc_atomic_bool_cswap64   ucs_atomic_bool_cswap64
+#endif

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -50,6 +50,25 @@ static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
     return UCC_ERR_NO_MESSAGE;
 }
 
+static inline ucs_status_t ucc_status_to_ucs_status(ucc_status_t status)
+{
+    switch (status) {
+    case UCC_OK:
+        return UCS_OK;
+    case UCC_INPROGRESS:
+        return UCS_INPROGRESS;
+    case UCC_ERR_NO_MEMORY:
+        return UCS_ERR_NO_MEMORY;
+    case UCC_ERR_INVALID_PARAM:
+        return UCS_ERR_INVALID_PARAM;
+    case UCC_ERR_NO_RESOURCE:
+        return UCS_ERR_NO_RESOURCE;
+    default:
+        break;
+    }
+    return UCS_ERR_NO_MESSAGE;
+}
+
 #if ENABLE_DEBUG == 1
 #define ucc_assert(_cond) assert(_cond)
 #else

--- a/src/utils/ucc_datastruct.h
+++ b/src/utils/ucc_datastruct.h
@@ -9,7 +9,6 @@
 #include <ucs/datastruct/list.h>
 
 #define UCC_LIST_HEAD UCS_LIST_HEAD
-#define ucc_list_link_t ucs_list_link_t
 typedef uint32_t ucc_rank_t;
 
 #endif

--- a/src/utils/ucc_list.h
+++ b/src/utils/ucc_list.h
@@ -16,4 +16,6 @@
 #define ucc_list_for_each_safe ucs_list_for_each_safe
 #define ucc_list_for_each      ucs_list_for_each
 #define ucc_list_is_empty      ucs_list_is_empty
+#define ucc_list_extract_head  ucs_list_extract_head
+
 #endif

--- a/src/utils/ucc_mpool.c
+++ b/src/utils/ucc_mpool.c
@@ -1,0 +1,85 @@
+#include "ucc_mpool.h"
+#include "ucc_malloc.h"
+#include "ucc_log.h"
+
+static ucs_status_t
+ucc_mpool_chunk_alloc_wrapper(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
+{
+    ucc_mpool_t *mpool = ucc_derived_of(mp, ucc_mpool_t);
+    ucc_status_t st;
+
+    st = mpool->ucc_ops->chunk_alloc(mpool, size_p, chunk_p);
+    return ucc_status_to_ucs_status(st);
+}
+
+static void ucc_mpool_chunk_release_wrapper(ucs_mpool_t *mp, void *chunk)
+{
+    ucc_mpool_t *mpool = ucc_derived_of(mp, ucc_mpool_t);
+    mpool->ucc_ops->chunk_release(mpool, chunk);
+}
+
+static void ucc_mpool_obj_init_wrapper(ucs_mpool_t *mp, void *obj, void *chunk)
+{
+    ucc_mpool_t *mpool = ucc_derived_of(mp, ucc_mpool_t);
+    mpool->ucc_ops->obj_init(mpool, obj, chunk);
+}
+
+static void ucc_mpool_obj_cleanup_wrapper(ucs_mpool_t *mp, void *obj)
+{
+    ucc_mpool_t *mpool = ucc_derived_of(mp, ucc_mpool_t);
+    mpool->ucc_ops->obj_cleanup(mpool, obj);
+}
+
+ucc_status_t ucc_mpool_init(ucc_mpool_t *mp, size_t priv_size, size_t elem_size,
+                            size_t align_offset, size_t alignment,
+                            unsigned elems_per_chunk, unsigned max_elems,
+                            ucc_mpool_ops_t *ops, ucc_thread_mode_t tm,
+                            const char *name)
+{
+    ucs_mpool_ops_t *ucs_ops = ucc_malloc(sizeof(*ucs_ops), "mpool_ops");
+    if (!ucs_ops) {
+        ucc_error("failed to allocate %zd bytes for mpool ucs ops",
+                  sizeof(*ucs_ops));
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    ucc_spinlock_init(&mp->lock, 0);
+    mp->tm                 = UCC_THREAD_MULTIPLE;
+    mp->ucc_ops            = ops;
+    ucs_ops->chunk_alloc   = ucc_mpool_chunk_alloc_wrapper;
+    ucs_ops->chunk_release = ucc_mpool_chunk_release_wrapper;
+    ucs_ops->obj_init      = NULL;
+    ucs_ops->obj_cleanup   = NULL;
+    if (ops->obj_init != NULL) {
+        ucs_ops->obj_init = ucc_mpool_obj_init_wrapper;
+    }
+    if (ops->obj_cleanup != NULL) {
+        ucs_ops->obj_cleanup = ucc_mpool_obj_cleanup_wrapper;
+    }
+
+    return ucs_status_to_ucc_status(
+        ucs_mpool_init(&mp->super, priv_size, elem_size, align_offset,
+                       alignment, elems_per_chunk, max_elems, ucs_ops, name));
+}
+
+void ucc_mpool_cleanup(ucc_mpool_t *mp, int leak_check)
+{
+    ucs_mpool_ops_t *ops = mp->super.data->ops;
+    ucs_mpool_cleanup(&mp->super, leak_check);
+    ucc_free(ops);
+    ucc_spinlock_destroy(&mp->lock);
+}
+
+ucc_status_t ucc_mpool_hugetlb_malloc(ucc_mpool_t *mp, size_t *size_p,
+                                      void **chunk_p)
+{
+    ucs_status_t st;
+
+    st = ucs_mpool_hugetlb_malloc(&mp->super, size_p, chunk_p);
+    return ucs_status_to_ucc_status(st);
+}
+
+void ucc_mpool_hugetlb_free(ucc_mpool_t *mp, void *chunk)
+{
+    ucs_mpool_hugetlb_free(&mp->super, chunk);
+}

--- a/src/utils/ucc_mpool.h
+++ b/src/utils/ucc_mpool.h
@@ -7,43 +7,66 @@
 #define UCC_MPOOL_H_
 
 #include "config.h"
+#include "ucc/api/ucc.h"
 #include <ucs/datastruct/mpool.h>
 #include "ucc_compiler_def.h"
+#include "ucc_spinlock.h"
 
-typedef ucs_mpool_t ucc_mpool_t;
-typedef ucs_mpool_ops_t ucc_mpool_ops_t;
-#define ucc_mpool_get(_mp) ucs_mpool_get((_mp))
-#define ucc_mpool_put(_obj) ucs_mpool_put((_obj))
+typedef struct ucc_mpool ucc_mpool_t;
 
-typedef void (*ucc_mpool_obj_init_fn_t)(ucc_mpool_t *mp, void *obj,
-                                        void *chunk);
-typedef void (*ucc_mpool_obj_cleanup_fn_t)(ucc_mpool_t *mp, void *obj);
+typedef struct ucc_mpool_ops {
+    ucc_status_t (*chunk_alloc)(ucc_mpool_t *mp, size_t *size_p,
+                                void **chunk_p);
+    void (*chunk_release)(ucc_mpool_t *mp, void *chunk);
+    void (*obj_init)(ucc_mpool_t *mp, void *obj, void *chunk);
+    void (*obj_cleanup)(ucc_mpool_t *mp, void *obj);
+} ucc_mpool_ops_t;
 
-static inline ucc_status_t
-ucc_mpool_init(ucc_mpool_t *mp, size_t elem_size, size_t alignment,
-               unsigned elems_per_chunk, unsigned max_elems,
-               ucc_mpool_obj_init_fn_t    init_fn,
-               ucc_mpool_obj_cleanup_fn_t cleanup_fn, const char *name)
+struct ucc_mpool {
+    ucs_mpool_t       super;
+    ucc_mpool_ops_t * ucc_ops;
+    ucc_thread_mode_t tm;
+    ucc_spinlock_t    lock;
+};
+
+ucc_status_t ucc_mpool_init(ucc_mpool_t *mp, size_t priv_size, size_t elem_size,
+                            size_t align_offset, size_t alignment,
+                            unsigned elems_per_chunk, unsigned max_elems,
+                            ucc_mpool_ops_t *ops, ucc_thread_mode_t tm,
+                            const char *name);
+
+void ucc_mpool_cleanup(ucc_mpool_t *mp, int leak_check);
+
+ucc_status_t ucc_mpool_hugetlb_malloc(ucc_mpool_t *mp, size_t *size_p,
+                                      void **chunk_p);
+
+void ucc_mpool_hugetlb_free(ucc_mpool_t *mp, void *chunk);
+
+static inline void *ucc_mpool_get(ucc_mpool_t *mp)
 {
-    ucs_mpool_ops_t *ops = ucc_malloc(sizeof(*ops), "mpool_ops");
-    if (!ops) {
-        ucc_error("failed to allocate %zd bytes for mpool ops", sizeof(*ops));
-        return UCC_ERR_NO_MEMORY;
-    }
+    void *ret;
 
-    ops->chunk_alloc   = ucs_mpool_hugetlb_malloc;
-    ops->chunk_release = ucs_mpool_hugetlb_free;
-    ops->obj_init      = init_fn;
-    ops->obj_cleanup   = cleanup_fn;
-    return ucs_status_to_ucc_status(ucs_mpool_init(
-        mp, 0, elem_size, 0, alignment, elems_per_chunk, max_elems, ops, name));
+    if (UCC_THREAD_SINGLE == mp->tm) {
+        return ucs_mpool_get(&mp->super);
+    }
+    ucc_spin_lock(&mp->lock);
+    ret = ucs_mpool_get(&mp->super);
+    ucc_spin_unlock(&mp->lock);
+    return ret;
 }
 
-static inline void ucc_mpool_cleanup(ucc_mpool_t *mp, int leak_check)
+static inline void ucc_mpool_put(void *obj)
 {
-    ucs_mpool_ops_t *ops = mp->data->ops;
-    ucs_mpool_cleanup(mp, leak_check);
-    ucc_free(ops);
+    ucs_mpool_elem_t *elem = (ucs_mpool_elem_t *)obj - 1;
+    ucc_mpool_t *     mp   = ucc_derived_of(elem->mpool, ucc_mpool_t);
+
+    if (UCC_THREAD_SINGLE == mp->tm) {
+        ucs_mpool_put(obj);
+        return;
+    }
+    ucc_spin_lock(&mp->lock);
+    ucs_mpool_put(obj);
+    ucc_spin_unlock(&mp->lock);
 }
 
 #endif

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -10,6 +10,7 @@
 #include "ucc/api/ucc_status.h"
 #include "utils/ucc_datastruct.h"
 #include "utils/ucc_compiler_def.h"
+#include "utils/ucc_list.h"
 
 #include <ucs/config/parser.h>
 #include <ucs/sys/preprocessor.h>

--- a/src/utils/ucc_spinlock.h
+++ b/src/utils/ucc_spinlock.h
@@ -2,6 +2,7 @@
  * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
+
 #ifndef UCC_SPINLOCK_H_
 #define UCC_SPINLOCK_H_
 

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -109,15 +109,16 @@ typedef struct ucc_test_team {
 } ucc_test_team_t;
 
 class UccTestMpi {
-    ucc_context_h ctx;
-    ucc_lib_h     lib;
+    ucc_thread_mode_t      tm;
+    ucc_context_h          ctx;
+    ucc_lib_h              lib;
     ucc_test_mpi_inplace_t inplace;
     ucc_test_mpi_root_t    root_type;
     int                    root_value;
+    int                    iterations;
     void create_team(ucc_test_mpi_team_t t);
     void destroy_team(ucc_test_team_t &team);
     ucc_team_h create_ucc_team(MPI_Comm comm);
-    std::vector<ucc_test_team_t> teams;
     std::vector<size_t> msgsizes;
     std::vector<ucc_memory_type_t> mtypes;
     std::vector<ucc_datatype_t> dtypes;
@@ -128,15 +129,19 @@ class UccTestMpi {
     std::vector<ucc_test_vsize_flag_t> displs_vsize;
     size_t test_max_size;
 public:
+    std::vector<ucc_test_team_t> teams;
+    void run_all_at_team(ucc_test_team_t &team, std::vector<ucc_status_t> &rst);
     std::vector<ucc_status_t> results;
     UccTestMpi(int argc, char *argv[], ucc_thread_mode_t tm, int is_local);
     ~UccTestMpi();
     void set_msgsizes(size_t min, size_t max, size_t power);
     void set_dtypes(std::vector<ucc_datatype_t> &_dtypes);
     void set_colls(std::vector<ucc_coll_type_t> &_colls);
+    void set_iter(int iter);
     void set_ops(std::vector<ucc_reduction_op_t> &_ops);
     void set_mtypes(std::vector<ucc_memory_type_t> &_mtypes);
-    void set_inplace(ucc_test_mpi_inplace_t _inplace) {
+    void set_inplace(ucc_test_mpi_inplace_t _inplace)
+    {
         inplace = _inplace;
     }
     void set_count_vsizes(std::vector<ucc_test_vsize_flag_t> &_counts_vsize);


### PR DESCRIPTION
## What
Implements MT ucc_context_progress 

## Why ?
Core API

## How ?
In a multi-threaded environment, where we have multiple threads inserting and progressing collective requests to the progress_queue, we need a thread safe data structure.
Here we use double array structure where all new tasks inserted to the primary array and old tasks to the secondary. tasks are being extracted only from the primary array. when primary is empty, they switch roles. All insertions & deletions are performed with atomic operations.
