### PR TITLE
MC/CUDA: fix parser segv

### DIFF
--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -13,11 +13,13 @@ static const char *stream_task_modes[] = {
     [UCC_MC_CUDA_TASK_KERNEL]  = "kernel",
     [UCC_MC_CUDA_TASK_MEM_OPS] = "driver",
     [UCC_MC_CUDA_TASK_AUTO]    = "auto",
+    [UCC_MC_CUDA_TASK_LAST]    = NULL
 };
 
 static const char *task_stream_types[] = {
-    [UCC_MC_CUDA_USER_STREAM]     = "user",
-    [UCC_MC_CUDA_INTERNAL_STREAM] = "ucc",
+    [UCC_MC_CUDA_USER_STREAM]      = "user",
+    [UCC_MC_CUDA_INTERNAL_STREAM]  = "ucc",
+    [UCC_MC_CUDA_TASK_STREAM_LAST] = NULL
 };
 
 static ucc_config_field_t ucc_mc_cuda_config_table[] = {

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -16,11 +16,13 @@ typedef enum ucc_mc_cuda_strm_task_mode {
     UCC_MC_CUDA_TASK_KERNEL,
     UCC_MC_CUDA_TASK_MEM_OPS,
     UCC_MC_CUDA_TASK_AUTO,
+    UCC_MC_CUDA_TASK_LAST,
 } ucc_mc_cuda_strm_task_mode_t;
 
 typedef enum ucc_mc_cuda_task_stream_type {
     UCC_MC_CUDA_USER_STREAM,
-    UCC_MC_CUDA_INTERNAL_STREAM
+    UCC_MC_CUDA_INTERNAL_STREAM,
+    UCC_MC_CUDA_TASK_STREAM_LAST
 } ucc_mc_cuda_task_stream_type_t;
 
 typedef enum ucc_mc_task_status {


### PR DESCRIPTION
## What
fix mc/cuda env vars setting

## Why ?
ucc_info -c crashes with segv

## How ?
add [LAST] = NULL to enum names array