### PR TITLE
CORE: set default task type

### DIFF
--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -27,6 +27,7 @@ ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task)
     task->super.status   = UCC_OPERATION_INITIALIZED;
     task->ee             = NULL;
     task->was_progressed = 0;
+    task->flags          = 0;
     return ucc_event_manager_init(&task->em);
 }
 


### PR DESCRIPTION
## What
Set task flags to zero.

## Why ?
Undefined task flags leads to double finalize
