### PR TITLE
CORE: ucc_team_destroy nb implementation

### DIFF
--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -163,6 +163,7 @@ ucc_status_t ucc_team_create_post(ucc_context_h *contexts, uint32_t num_contexts
     return status;
 
 err_ctx_alloc:
+    *new_team = NULL;
     ucc_free(team);
     return status;
 }
@@ -266,6 +267,10 @@ ucc_status_t ucc_team_create_test_single(ucc_context_t *context,
 
 ucc_status_t ucc_team_create_test(ucc_team_h team)
 {
+    if (NULL == team) {
+        ucc_error("ucc_team_create_test: invalid team handle: NULL");
+        return UCC_ERR_INVALID_PARAM;
+    }
     /* we don't support multiple contexts per team yet */
     ucc_assert(team->num_contexts == 1);
     if (team->status == UCC_OK) {
@@ -302,8 +307,13 @@ static ucc_status_t ucc_team_destroy_single(ucc_team_h team)
     return UCC_OK;
 }
 
-ucc_status_t ucc_team_destroy_nb(ucc_team_h team)
+ucc_status_t ucc_team_destroy(ucc_team_h team)
 {
+    if (NULL == team) {
+        ucc_error("ucc_team_destroy: invalid team handle: NULL");
+        return UCC_ERR_INVALID_PARAM;
+    }
+
     if (team->status != UCC_OK) {
         ucc_error("team %p is used before team_create is completed", team);
         return UCC_ERR_INVALID_PARAM;
@@ -312,15 +322,6 @@ ucc_status_t ucc_team_destroy_nb(ucc_team_h team)
     /* we don't support multiple contexts per team yet */
     ucc_assert(team->num_contexts == 1);
     return ucc_team_destroy_single(team);
-}
-
-ucc_status_t ucc_team_destroy(ucc_team_h team)
-{
-    ucc_status_t status;
-    while (UCC_INPROGRESS == (status = ucc_team_destroy_single(team))) {
-        ; //TODO call ucc progress here
-    }
-    return status;
 }
 
 static inline int

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -41,7 +41,4 @@ typedef struct ucc_team {
 #define UCC_TEAM_ID_MAX ((uint16_t)UCC_BIT(15) - 1)
 
 void ucc_copy_team_params(ucc_team_params_t *dst, const ucc_team_params_t *src);
-
-ucc_status_t ucc_team_destroy_nb(ucc_team_h team);
-
 #endif

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -187,7 +187,7 @@ void UccTeam::destroy_team()
         all_done = true;
         for (auto &p : procs) {
             if (p.team) {
-                status = ucc_team_destroy_nb(p.team);
+                status = ucc_team_destroy(p.team);
                 if (UCC_OK == status) {
                     p.team = NULL;
                 } else if (status < 0) {

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -161,7 +161,13 @@ void UccTestMpi::create_team(ucc_test_mpi_team_t t)
 
 void UccTestMpi::destroy_team(ucc_test_team_t &team)
 {
-    UCC_CHECK(ucc_team_destroy(team.team));
+    ucc_status_t status;
+    while (UCC_INPROGRESS == (status = ucc_team_destroy(team.team))) {
+        if (UCC_OK != status) {
+            std::cerr << "ucc_team_destroy failed\n";
+            break;
+        }
+    }
     if (team.comm != MPI_COMM_WORLD) {
         MPI_Comm_free(&team.comm);
     }


### PR DESCRIPTION
## What
Makes ucc_team_destroy non-blocking. User now has to call this fn in a loop checking return status. E.g.:
```
while (UCC_INPROGRESS == (status = ucc_team_destroy(team))) {
       if (UCC_OK != status) {
               /* handle error */
               break;
       }
       /* runtime progress could be there */
} 
```

## Why ?
According the API Spec change #74 

@Sergei-Lebedev need to update Torch UCC PG when this change is merged.