### PR TITLE
CORE: change COLL_SCORE separator

### DIFF
--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -496,7 +496,7 @@ ucc_status_t ucc_coll_score_alloc_from_str(const char *str,
     if (UCC_OK != status) {
         return status;
     }
-    tokens = ucc_str_split(str, ";");
+    tokens = ucc_str_split(str, "#");
     if (!tokens) {
         status = UCC_ERR_INVALID_PARAM;
         goto error;

--- a/src/components/base/ucc_base_iface.c
+++ b/src/components/base/ucc_base_iface.c
@@ -10,8 +10,8 @@ ucc_config_field_t ucc_base_config_table[] = {
      "poll.",
      ucc_offsetof(ucc_base_config_t, log_component), UCC_CONFIG_TYPE_LOG_COMP},
 
-    {"COLL_SCORE", "", "Collective score modifier for a CL/TL component\n"
-     "format: \";\"-separated list of score values with optional qualifiers:\n"
+    {"SCORE", "", "Collective score modifier for a CL/TL component\n"
+     "format: \"#\"-separated list of score values with optional qualifiers:\n"
      "        <coll_type_1,..,coll_type_n>:<mem_type_1,..,mem_type_n>:"
      "<msg_range_1,..,msg_range_n>:score\n"
      "        msg_range has the format: start-end, where start,end - integers"

--- a/test/gtest/coll_score/test_score_str.cc
+++ b/test/gtest/coll_score/test_score_str.cc
@@ -40,7 +40,7 @@ UCC_TEST_F(test_score_str, check_valid)
     EXPECT_EQ(UCC_SCORE_MAX, SCORE(score, GATHERV, HOST));
     ucc_coll_score_free(score);
 
-    str = "alltoall,bCAst:hOst:10;scatter:inf;reduce:1";
+    str = "alltoall,bCAst:hOst:10#scatter:inf#reduce:1";
     EXPECT_EQ(UCC_OK, ucc_coll_score_alloc_from_str(str.c_str(), &score, 0));
     EXPECT_EQ(10, SCORE(score, BCAST, HOST));
     EXPECT_EQ(UCC_SCORE_MAX, SCORE(score, SCATTER, HOST));
@@ -91,7 +91,7 @@ UCC_TEST_F(test_score_str, check_range_multiple)
                           RLIST({RANGE(64, 256, 10), RANGE(1024,2048,10), RANGE(4096,5000,10)})));
     ucc_coll_score_free(score);
 
-    str = "alltoall,barrier:1k-4K,64-256:cuda:10;20:99-12M:bcast";
+    str = "alltoall,barrier:1k-4K,64-256:cuda:10#20:99-12M:bcast";
     EXPECT_EQ(UCC_OK, ucc_coll_score_alloc_from_str(str.c_str(), &score, 0));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_ALLTOALL, UCC_MEMORY_TYPE_CUDA,


### PR DESCRIPTION
Changes separator character in UCC_*_COLL_SCORE parsing from ";"
to "#". The reason is that some runtimes (MPIs, e.g. OpenMPI)
incorrectly parse ";" token. W/o that change one has to always use
quote marks to guard the string.

This is just minor usability improvement.
