### PR TITLE
CORE: Fix bug in MT progress queue

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,7 @@ noinst_LIBRARIES =
 
 libucc_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS)
 libucc_la_CFLAGS   = -c $(BASE_CFLAGS)
-libucc_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
+libucc_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed -pthread
 
 nobase_dist_libucc_la_HEADERS =	\
 	ucc/api/ucc.h                   \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,6 +50,7 @@ noinst_HEADERS =                     \
 	utils/ucc_math.h                 \
 	utils/ucc_coll_utils.h           \
 	utils/ucc_list.h                 \
+	utils/ucc_lock_free_queue.h      \
 	utils/ucc_string.h               \
 	utils/ucc_queue.h                \
 	utils/ucc_proc_info.h            \

--- a/src/core/ucc_progress_queue.h
+++ b/src/core/ucc_progress_queue.h
@@ -11,7 +11,7 @@
 typedef struct ucc_progress_queue ucc_progress_queue_t;
 struct ucc_progress_queue {
     void (*enqueue)(ucc_progress_queue_t *pq, ucc_coll_task_t *task);
-    void (*dequeue)(ucc_progress_queue_t *pq, ucc_coll_task_t **task, int is_first_call);
+    void (*dequeue)(ucc_progress_queue_t *pq, ucc_coll_task_t **task);
     int  (*progress)(ucc_progress_queue_t *pq);
     void (*finalize)(ucc_progress_queue_t *pq);
 };

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -16,23 +16,29 @@
 
 typedef struct ucc_pq_mt {
     ucc_progress_queue_t super;
-    ucc_spinlock_t       locked_queue_lock;
+    ucc_spinlock_t       locked_queue_lock[NUM_POOLS];
     ucc_coll_task_t *    tasks[NUM_POOLS][LINE_SIZE];
     uint8_t              which_pool;
-    ucc_list_link_t      locked_queue;
-    uint32_t             tasks_counters[NUM_POOLS];
+    ucc_list_link_t      locked_queue[NUM_POOLS];
 } ucc_pq_mt_t; // TODO the struct isn't a queue because not maintaining order, maybe another name
 
-static void ucc_pq_mt_enqueue(ucc_progress_queue_t *pq, ucc_coll_task_t *task)
-{
-    ucc_pq_mt_t *pq_mt = ucc_derived_of(pq, ucc_pq_mt_t);
+typedef struct ucc_pq_mt_locked {
+    ucc_progress_queue_t super;
+    ucc_spinlock_t       queue_lock;
+    ucc_list_link_t      queue;
+} ucc_pq_mt_locked_t;
 
-    ucc_spin_lock(&pq_mt->locked_queue_lock);
-    ucc_list_add_tail(&pq_mt->locked_queue, &task->list_elem);
-    ucc_spin_unlock(&pq_mt->locked_queue_lock);
+static void ucc_pq_locked_mt_enqueue(ucc_progress_queue_t *pq,
+                                     ucc_coll_task_t *     task)
+{
+    ucc_pq_mt_locked_t *pq_mt = ucc_derived_of(pq, ucc_pq_mt_locked_t);
+
+    ucc_spin_lock(&pq_mt->queue_lock);
+    ucc_list_add_tail(&pq_mt->queue, &task->list_elem);
+    ucc_spin_unlock(&pq_mt->queue_lock);
 }
 
-static void ucc_pq_mt_enqueue_opt(ucc_progress_queue_t *pq, ucc_coll_task_t *task)
+static void ucc_pq_mt_enqueue(ucc_progress_queue_t *pq, ucc_coll_task_t *task)
 {
     ucc_pq_mt_t *pq_mt      = ucc_derived_of(pq, ucc_pq_mt_t);
     int          which_pool = task->was_progressed ^ (pq_mt->which_pool & 1);
@@ -40,65 +46,62 @@ static void ucc_pq_mt_enqueue_opt(ucc_progress_queue_t *pq, ucc_coll_task_t *tas
     for (i = 0; i < LINE_SIZE; i++) {
         if (ucc_atomic_bool_cswap64((uint64_t *)&(pq_mt->tasks[which_pool][i]),
                                     0, (uint64_t)task)) {
-            ucc_atomic_add32(&pq_mt->tasks_counters[which_pool], 1);
             return;
         }
     }
 
-    ucc_pq_mt_enqueue(pq, task);
+    ucc_spin_lock(&pq_mt->locked_queue_lock[which_pool]);
+    ucc_list_add_tail(&pq_mt->locked_queue[which_pool], &task->list_elem);
+    ucc_spin_unlock(&pq_mt->locked_queue_lock[which_pool]);
+}
+
+static void ucc_pq_locked_mt_dequeue(ucc_progress_queue_t *pq,
+                                     ucc_coll_task_t **    popped_task,
+                                     int                   is_first_call) //NOLINT 
+{
+    ucc_pq_mt_locked_t *pq_mt = ucc_derived_of(pq, ucc_pq_mt_locked_t);
+    *popped_task              = NULL;
+
+    ucc_spin_lock(&pq_mt->queue_lock);
+    if (!ucc_list_is_empty(&pq_mt->queue)) {
+        *popped_task =
+            ucc_list_extract_head(&pq_mt->queue, ucc_coll_task_t, list_elem);
+    }
+    ucc_spin_unlock(&pq_mt->queue_lock);
 }
 
 static void ucc_pq_mt_dequeue(ucc_progress_queue_t *pq,
-                              ucc_coll_task_t     **popped_task_ptr,
-                              int                   is_first_call) //NOLINT
-{
-    ucc_pq_mt_t *pq_mt           = ucc_derived_of(pq, ucc_pq_mt_t);
-    ucc_coll_task_t *popped_task = NULL;
-
-    ucc_spin_lock(&pq_mt->locked_queue_lock);
-    if (!ucc_list_is_empty(&pq_mt->locked_queue)) {
-        popped_task = ucc_list_extract_head(&pq_mt->locked_queue,
-                                            ucc_coll_task_t, list_elem);
-        popped_task->was_progressed = 1;
-    }
-    ucc_spin_unlock(&pq_mt->locked_queue_lock);
-    *popped_task_ptr = popped_task;
-}
-
-static void ucc_pq_mt_dequeue_opt(ucc_progress_queue_t *pq,
-                                  ucc_coll_task_t     **popped_task_ptr,
-                                  int                   is_first_call)
+                              ucc_coll_task_t **popped_task, int is_first_call)
 {
     ucc_pq_mt_t *pq_mt  = ucc_derived_of(pq, ucc_pq_mt_t);
     // Save value in the beginning of the function
     int curr_which_pool = pq_mt->which_pool;
     int which_pool      = curr_which_pool & 1; // turn from even/odd -> bool
-    ucc_coll_task_t *popped_task = NULL;
     int              i;
-    if (pq_mt->tasks_counters[which_pool]) {
-        for (i = 0; i < LINE_SIZE; i++) {
-            popped_task = pq_mt->tasks[which_pool][i];
-            if (popped_task) {
-                if (ucc_atomic_bool_cswap64(
-                        (uint64_t *)&(pq_mt->tasks[which_pool][i]),
-                        (uint64_t)popped_task, 0)) {
-                    ucc_atomic_sub32(&pq_mt->tasks_counters[which_pool], 1);
-                    *popped_task_ptr            = popped_task;
-                    popped_task->was_progressed = 1;
-                    return;
-                }
+    for (i = 0; i < LINE_SIZE; i++) {
+        *popped_task = pq_mt->tasks[which_pool][i];
+        if (*popped_task) {
+            if (ucc_atomic_bool_cswap64(
+                    (uint64_t *)&(pq_mt->tasks[which_pool][i]),
+                    (uint64_t)*popped_task, 0)) {
+                (*popped_task)->was_progressed = 1;
+                return;
             }
         }
     }
-
-    if (is_first_call) {
-        ucc_atomic_cswap8(&pq_mt->which_pool, curr_which_pool,
-                          curr_which_pool + 1);
-        pq->dequeue(pq, popped_task_ptr, 0);
-        return;
+    *popped_task = NULL;
+    ucc_spin_lock(&pq_mt->locked_queue_lock[which_pool]);
+    if (!ucc_list_is_empty(&pq_mt->locked_queue[which_pool])) {
+        *popped_task = ucc_list_extract_head(&pq_mt->locked_queue[which_pool],
+                                             ucc_coll_task_t, list_elem);
+        (*popped_task)->was_progressed = 1;
     }
-
-    ucc_pq_mt_dequeue(pq, popped_task_ptr, 0);
+    ucc_spin_unlock(&pq_mt->locked_queue_lock[which_pool]);
+    ucc_atomic_cswap8(&pq_mt->which_pool, curr_which_pool, curr_which_pool + 1);
+    if (is_first_call) {
+        // TODO maybe only when which_pool increase is OK
+        pq->dequeue(pq, popped_task, 0);
+    }
 }
 
 static int ucc_pq_mt_progress(ucc_progress_queue_t *pq)
@@ -126,37 +129,55 @@ static int ucc_pq_mt_progress(ucc_progress_queue_t *pq)
     return n_progressed;
 }
 
+static void ucc_pq_locked_mt_finalize(ucc_progress_queue_t *pq)
+{
+    ucc_pq_mt_locked_t *pq_mt = ucc_derived_of(pq, ucc_pq_mt_locked_t);
+    ucc_spinlock_destroy(&pq_mt->queue_lock);
+    ucc_free(pq_mt);
+}
+
 static void ucc_pq_mt_finalize(ucc_progress_queue_t *pq)
 {
     ucc_pq_mt_t *pq_mt = ucc_derived_of(pq, ucc_pq_mt_t);
-    ucc_spinlock_destroy(&pq_mt->locked_queue_lock);
+    ucc_spinlock_destroy(&pq_mt->locked_queue_lock[0]);
+    ucc_spinlock_destroy(&pq_mt->locked_queue_lock[1]);
     ucc_free(pq_mt);
 }
 
 ucc_status_t ucc_pq_mt_init(ucc_progress_queue_t **pq,
                             uint32_t lock_free_progress_q)
 {
-    ucc_pq_mt_t *pq_mt = ucc_malloc(sizeof(*pq_mt), "pq_mt");
-    if (!pq_mt) {
-        ucc_error("failed to allocate %zd bytes for pq_mt", sizeof(*pq_mt));
-        return UCC_ERR_NO_MEMORY;
-    }
-    memset(&pq_mt->tasks, 0, NUM_POOLS * LINE_SIZE * sizeof(ucc_coll_task_t *));
-    ucc_spinlock_init(&pq_mt->locked_queue_lock, 0);
-    ucc_list_head_init(&pq_mt->locked_queue);
-    pq_mt->which_pool        = 0;
-    pq_mt->tasks_counters[0] = 0;
-    pq_mt->tasks_counters[1] = 0;
-
     if (lock_free_progress_q) {
-        pq_mt->super.enqueue    = ucc_pq_mt_enqueue_opt;
-        pq_mt->super.dequeue    = ucc_pq_mt_dequeue_opt;
-    } else {
+        ucc_pq_mt_t *pq_mt = ucc_malloc(sizeof(*pq_mt), "pq_mt");
+        if (!pq_mt) {
+            ucc_error("failed to allocate %zd bytes for pq_mt", sizeof(*pq_mt));
+            return UCC_ERR_NO_MEMORY;
+        }
+        memset(&pq_mt->tasks, 0,
+               NUM_POOLS * LINE_SIZE * sizeof(ucc_coll_task_t *));
+        ucc_spinlock_init(&pq_mt->locked_queue_lock[0], 0);
+        ucc_spinlock_init(&pq_mt->locked_queue_lock[1], 0);
+        ucc_list_head_init(&pq_mt->locked_queue[0]);
+        ucc_list_head_init(&pq_mt->locked_queue[1]);
+        pq_mt->which_pool       = 0;
         pq_mt->super.enqueue    = ucc_pq_mt_enqueue;
         pq_mt->super.dequeue    = ucc_pq_mt_dequeue;
+        pq_mt->super.progress   = ucc_pq_mt_progress;
+        pq_mt->super.finalize   = ucc_pq_mt_finalize;
+        *pq                     = &pq_mt->super;
+    } else {
+        ucc_pq_mt_locked_t *pq_mt = ucc_malloc(sizeof(*pq_mt), "pq_mt");
+        if (!pq_mt) {
+            ucc_error("failed to allocate %zd bytes for pq_mt", sizeof(*pq_mt));
+            return UCC_ERR_NO_MEMORY;
+        }
+        ucc_spinlock_init(&pq_mt->queue_lock, 0);
+        ucc_list_head_init(&pq_mt->queue);
+        pq_mt->super.enqueue  = ucc_pq_locked_mt_enqueue;
+        pq_mt->super.dequeue  = ucc_pq_locked_mt_dequeue;
+        pq_mt->super.progress = ucc_pq_mt_progress;
+        pq_mt->super.finalize = ucc_pq_locked_mt_finalize;
+        *pq                   = &pq_mt->super;
     }
-    pq_mt->super.progress    = ucc_pq_mt_progress;
-    pq_mt->super.finalize    = ucc_pq_mt_finalize;
-    *pq                      = &pq_mt->super;
     return UCC_OK;
 }

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -14,7 +14,7 @@
 typedef struct ucc_pq_mt {
     ucc_progress_queue_t super;
     ucc_lf_queue_t       lf_queue;
-} ucc_pq_mt_t; // TODO the struct isn't a queue because not maintaining order, maybe another name
+} ucc_pq_mt_t;
 
 typedef struct ucc_pq_mt_locked {
     ucc_progress_queue_t super;

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -26,7 +26,7 @@ ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task)
 {
     task->super.status   = UCC_OPERATION_INITIALIZED;
     task->ee             = NULL;
-    task->was_progressed = 0;
+    task->lf_elem.was_progressed = 0;
     task->flags          = 0;
     return ucc_event_manager_init(&task->em);
 }

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -8,6 +8,8 @@
 #include "ucc/api/ucc.h"
 #include "utils/ucc_list.h"
 #include "utils/ucc_log.h"
+#include "utils/ucc_lock_free_queue.h"
+
 #define MAX_LISTENERS 4
 
 typedef enum {
@@ -49,9 +51,10 @@ typedef struct ucc_coll_task {
     ucc_ev_t                    *ev;
     void                        *ee_task;
     ucc_coll_task_t             *triggered_task;
-    /* used for progress queue */
+    /* used for st & locked mt progress queue */
     ucc_list_link_t              list_elem;
-    uint8_t                      was_progressed;
+    /* used for lf mt progress queue */
+    ucc_lf_queue_elem_t          lf_elem;
 } ucc_coll_task_t;
 
 typedef struct ucc_context ucc_context_t;

--- a/src/utils/ucc_atomic.h
+++ b/src/utils/ucc_atomic.h
@@ -11,6 +11,9 @@
 
 #define ucc_atomic_add32          ucs_atomic_add32
 #define ucc_atomic_sub32          ucs_atomic_sub32
+#define ucc_atomic_add64          ucs_atomic_add64
+#define ucc_atomic_sub64          ucs_atomic_sub64
 #define ucc_atomic_cswap8         ucs_atomic_cswap8
+#define ucc_atomic_bool_cswap8    ucs_atomic_bool_cswap8
 #define ucc_atomic_bool_cswap64   ucs_atomic_bool_cswap64
 #endif

--- a/src/utils/ucc_lock_free_queue.h
+++ b/src/utils/ucc_lock_free_queue.h
@@ -10,7 +10,6 @@
 #include "utils/ucc_atomic.h"
 #include "utils/ucc_list.h"
 #include <string.h>
-#include <stdio.h>
 
 /* This data structure is thread safe */
 
@@ -28,7 +27,7 @@ typedef struct ucc_lf_queue {
     ucc_lf_queue_elem_t *elements[NUM_POOLS][LINE_SIZE];
     uint8_t              which_pool;
     ucc_list_link_t      locked_queue[NUM_POOLS];
-} ucc_lf_queue_t; // TODO the struct isn't a queue because not maintaining order, maybe another name
+} ucc_lf_queue_t;
 
 static inline void ucc_lf_queue_enqueue(ucc_lf_queue_t *     queue,
                                         ucc_lf_queue_elem_t *elem)

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -83,6 +83,7 @@ gtest_SOURCES =                     \
 	core/test_bcast.cc              \
 	core/test_allreduce.cc          \
 	utils/test_string.cc            \
+	utils/test_lock_free_queue.cc   \
 	coll_score/test_score.cc        \
 	coll_score/test_score_str.cc    \
 	coll_score/test_score_update.cc

--- a/test/gtest/utils/test_lock_free_queue.cc
+++ b/test/gtest/utils/test_lock_free_queue.cc
@@ -14,9 +14,11 @@ extern "C" {
 #include <common/test.h>
 #include <vector>
 
+#define NUM_ITERS 5000000
+
 typedef struct ucc_test_queue {
-	ucc_lf_queue_t      lf_queue;
-	int64_t            test_sum;
+    ucc_lf_queue_t      lf_queue;
+    int64_t             test_sum;
     uint32_t            elems_num;
     uint32_t            active_producers_threads;
     uint32_t            memory_err;
@@ -25,8 +27,7 @@ typedef struct ucc_test_queue {
 void *producer_thread(void *arg)
 {
 	ucc_test_queue_t *test = (ucc_test_queue_t *)arg;
-    for(int j = 0; j < 5000000; j++){
-    	// TODO: should we use ucc_mc_alloc instead of ucc_malloc?
+    for(int j = 0; j < NUM_ITERS; j++){
     	ucc_lf_queue_elem_t * elem = (ucc_lf_queue_elem_t *) ucc_malloc(sizeof(ucc_lf_queue_elem_t));
     	elem->was_progressed = 0;
     	if (!elem) {

--- a/test/gtest/utils/test_lock_free_queue.cc
+++ b/test/gtest/utils/test_lock_free_queue.cc
@@ -1,0 +1,113 @@
+
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include "utils/ucc_lock_free_queue.h"
+#include "utils/ucc_atomic.h"
+#include "utils/ucc_malloc.h"
+#include <pthread.h>
+#include <stdio.h>
+}
+#include <common/test.h>
+#include <vector>
+
+typedef struct ucc_test_queue {
+	ucc_lf_queue_t      lf_queue;
+	int64_t            test_sum;
+    uint32_t            elems_num;
+    uint32_t            active_producers_threads;
+    uint32_t            memory_err;
+} ucc_test_queue_t;
+
+void *producer_thread(void *arg)
+{
+	ucc_test_queue_t *test = (ucc_test_queue_t *)arg;
+    for(int j = 0; j < 5000000; j++){
+    	// TODO: should we use ucc_mc_alloc instead of ucc_malloc?
+    	ucc_lf_queue_elem_t * elem = (ucc_lf_queue_elem_t *) ucc_malloc(sizeof(ucc_lf_queue_elem_t));
+    	elem->was_progressed = 0;
+    	if (!elem) {
+    		ucc_atomic_add32(&test->memory_err, 1);
+    		goto exit;
+    	}
+    	ucc_lf_queue_enqueue(&test->lf_queue, elem);
+    	ucc_atomic_add64((uint64_t*) &test->test_sum, (uint64_t) elem);
+    	ucc_atomic_add32(&test->elems_num, 1);
+    }
+exit:
+    ucc_atomic_sub32(&test->active_producers_threads,1);
+    return 0;
+}
+
+void *consumer_thread(void *arg)
+{
+	ucc_test_queue_t *test = (ucc_test_queue_t *)arg;
+    while(test->active_producers_threads || test->elems_num){
+    	ucc_lf_queue_elem_t *elem = ucc_lf_queue_dequeue(&test->lf_queue, 1);
+    	if (elem){
+    	ucc_atomic_sub64((uint64_t*) &test->test_sum, (uint64_t) elem);
+    	ucc_atomic_sub32(&test->elems_num, 1);
+    	ucc_free(elem);
+    	}
+    }
+    return 0;
+}
+
+class test_lf_queue : public ucc::test
+{
+public:
+	ucc_test_queue_t     test;
+	int i;
+	std::vector<pthread_t> producers_threads;
+		std::vector<pthread_t> consumers_threads;
+		int lf_test(int num_of_producers, int num_of_consumers);
+};
+
+int test_lf_queue::lf_test(int num_of_producers, int num_of_consumers){
+	producers_threads.resize(num_of_producers);
+	consumers_threads.resize(num_of_consumers);
+		memset(&test,0,sizeof(ucc_test_queue_t));
+		ucc_lf_queue_init(&test.lf_queue);
+		for (i =0; i < num_of_producers;i++){
+			ucc_atomic_add32(&test.active_producers_threads,1);
+			pthread_create(&producers_threads[i], NULL, &producer_thread,
+			                           (void *)&test);
+		}
+		for (i =0; i < num_of_consumers;i++){
+					pthread_create(&consumers_threads[i], NULL, &consumer_thread,
+					                           (void *)&test);
+				}
+		for (i =0; i < num_of_producers;i++){
+			pthread_join(producers_threads[i], NULL);
+				}
+		for (i =0; i < num_of_consumers;i++){
+					pthread_join(consumers_threads[i], NULL);
+						}
+		ucc_lf_queue_destroy(&test.lf_queue);
+		if (test.memory_err){
+			return 1;
+		}
+		if (test.test_sum){
+			return 1;
+		}
+		return 0;
+}
+
+
+UCC_TEST_F(test_lf_queue, oneProducerOneConsumer)
+{
+	EXPECT_EQ(lf_test(1,1),0);
+}
+
+UCC_TEST_F(test_lf_queue, oneProducerManyConsumers)
+{
+	EXPECT_EQ(lf_test(1,7),0);
+}
+
+UCC_TEST_F(test_lf_queue, manyProducersManyConsumers)
+{
+	EXPECT_EQ(lf_test(7,7),0);
+}


### PR DESCRIPTION
## What
Fix bug in MT progress queue

## Why ?
Hang while using mt progress queue after PR 125

## How ?
Create locked queue per pool instead of global. Also, organize the structs in a more accurate way.
In addition, remove counters (seems like only hure performance) - add unnecessary actions per call. When empty, dequeue func simply finish the iteration.
