### PR TITLE
TEST: MPI: fixes tests skipping

### DIFF
--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -22,10 +22,8 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 
     args.coll_type = UCC_COLL_TYPE_ALLGATHER;
 
-    if (test_max_size < (_msgsize*size)) {
-        test_skip = TEST_SKIP_MEM_LIMIT;
-    }
-    if (TEST_SKIP_NONE != skip_reduce(test_skip, team.comm)) {
+    if (TEST_SKIP_NONE != skip_reduce(test_max_size < (_msgsize*size),
+                                      TEST_SKIP_MEM_LIMIT, team.comm)) {
         return;
     }
 
@@ -52,7 +50,7 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     args.dst.info.count    = count;
     args.dst.info.datatype = TEST_DT;
     args.dst.info.mem_type = _mt;
-    UCC_CHECK(ucc_collective_init(&args, &req, team.team));
+    UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
 }
 
 ucc_status_t TestAllgather::check()

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -23,10 +23,8 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     MPI_Comm_size(team.comm, &size);
     args.coll_type = UCC_COLL_TYPE_ALLGATHERV;
 
-    if (test_max_size < (_msgsize*size)) {
-        test_skip = TEST_SKIP_MEM_LIMIT;
-    }
-    if (TEST_SKIP_NONE != skip_reduce(test_skip, team.comm)) {
+    if (TEST_SKIP_NONE != skip_reduce(test_max_size < (_msgsize*size),
+                                      TEST_SKIP_MEM_LIMIT, team.comm)) {
         return;
     }
 
@@ -64,7 +62,7 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     args.dst.info_v.displacements = (ucc_aint_t*)displacements;
     args.dst.info_v.datatype      = TEST_DT;
     args.dst.info_v.mem_type      = _mt;
-    UCC_CHECK(ucc_collective_init(&args, &req, team.team));
+    UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
 }
 
 TestAllgatherv::~TestAllgatherv() {

--- a/test/mpi/test_alltoall.cc
+++ b/test/mpi/test_alltoall.cc
@@ -24,13 +24,8 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 
     args.coll_type = UCC_COLL_TYPE_ALLTOALL;
 
-    if (TEST_INPLACE == inplace && !ucc_coll_inplace_supported(args.coll_type)) {
-        test_skip = TEST_SKIP_NOT_IMPL_INPLACE;
-    }
-    if (test_max_size < (_msgsize * nprocs)) {
-        test_skip = TEST_SKIP_MEM_LIMIT;
-    }
-    if (TEST_SKIP_NONE != skip_reduce(test_skip, team.comm)) {
+    if (TEST_SKIP_NONE != skip_reduce(test_max_size < (_msgsize * nprocs),
+                                      TEST_SKIP_MEM_LIMIT, team.comm)) {
         return;
     }
 
@@ -57,7 +52,7 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     args.dst.info.count       = count;
     args.dst.info.datatype    = TEST_DT;
     args.dst.info.mem_type    = _mt;
-    UCC_CHECK(ucc_collective_init(&args, &req, team.team));
+    UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
 }
 
 ucc_status_t TestAlltoall::check()

--- a/test/mpi/test_alltoallv.cc
+++ b/test/mpi/test_alltoallv.cc
@@ -57,14 +57,10 @@ TestAlltoallv::TestAlltoallv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &nprocs);
 
-    args.coll_type = UCC_COLL_TYPE_ALLTOALLV;
+    args.coll_type = UCC_COLL_TYPE_ALLTOALLV;  
 
-    if (TEST_INPLACE == inplace && !ucc_coll_inplace_supported(args.coll_type)) {
-        test_skip = TEST_SKIP_NOT_IMPL_INPLACE;
-    }
-
-    if (skip_reduce(test_max_size < (_msgsize * nprocs), TEST_SKIP_MEM_LIMIT,
-                    team.comm)) {
+    if (TEST_SKIP_NONE != skip_reduce(test_max_size < (_msgsize * nprocs),
+                                      TEST_SKIP_MEM_LIMIT, team.comm)) {
         return;
     }
 
@@ -142,7 +138,7 @@ TestAlltoallv::TestAlltoallv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         args.dst.info_v.displacements = (ucc_aint_t*)rdispls;
     }
 
-    UCC_CHECK(ucc_collective_init(&args, &req, team.team));
+    UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
 }
 
 TestAlltoallv::~TestAlltoallv()

--- a/test/mpi/test_bcast.cc
+++ b/test/mpi/test_bcast.cc
@@ -22,9 +22,6 @@ TestBcast::TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     root = _root;
     args.coll_type = UCC_COLL_TYPE_BCAST;
 
-    if (TEST_INPLACE == inplace && !ucc_coll_inplace_supported(args.coll_type)) {
-        test_skip = TEST_SKIP_NOT_IMPL_INPLACE;
-    }
     if (skip_reduce(test_max_size < _msgsize, TEST_SKIP_MEM_LIMIT,
                     team.comm)) {
         return;
@@ -44,7 +41,7 @@ TestBcast::TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     args.src.info.datatype    = TEST_DT;
     args.src.info.mem_type    = _mt;
     args.root                 = root;
-    UCC_CHECK(ucc_collective_init(&args, &req, team.team));
+    UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
 }
 
 ucc_status_t TestBcast::check()

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -23,7 +23,7 @@ std::shared_ptr<TestCase> TestCase::init(ucc_coll_type_t _type,
         return std::make_shared<TestBarrier>(_team);
     case UCC_COLL_TYPE_ALLREDUCE:
         return std::make_shared<TestAllreduce>(msgsize, inplace, dt,
-                                               op, mt, _team);
+                                               op, mt, _team, max_size);
     case UCC_COLL_TYPE_ALLGATHER:
         return std::make_shared<TestAllgather>(msgsize, inplace, mt, _team,
                                                max_size);


### PR DESCRIPTION
## Why ?
If the UCC returns that something is not supported, these tests are flagged as skipped. In this case, updating tests won't be required if UCC starts supporting something.