### PR TITLE
TL collective plugin interface

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,21 @@
 #!/bin/sh
+
+rm -rf config/m4/tl_coll_plugins_list.m4
+touch config/m4/tl_coll_plugins_list.m4
+for t in $(ls -d src/components/tl/*/); do
+    if [ -d $t/coll_plugins ]; then
+        rm -rf $t/makefile.coll_plugins.am
+        for cp in $(ls -d $t/coll_plugins/*/); do
+            echo "m4_include([$cp/configure.m4])" >> config/m4/tl_coll_plugins_list.m4
+            plugin=$(basename $cp)
+            echo "SUBDIRS += coll_plugins/$plugin" >> $t/makefile.coll_plugins.am
+        done
+    fi
+done
+
 rm -rf autom4te.cache
 mkdir -p config/m4 config/aux
 autoreconf -f -v --install || exit 1
 rm -rf autom4te.cache
+
 exit 0

--- a/config/m4/tl_coll_plugins.m4
+++ b/config/m4/tl_coll_plugins.m4
@@ -1,0 +1,32 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+AC_DEFUN([CHECK_TL_COLL_PLUGINS],[
+    AC_ARG_WITH([tlcp],
+            [AS_HELP_STRING([--with-tlcp=(cp1,cp2)], [Enable build of TL collectives plugins])],
+            [TLCP_REQUIRED=${with_tlcp}], [TLCP_REQUIRED=no])
+
+    AS_IF([test "x$with_tlcp" != "xno"],
+    [
+        AM_CONDITIONAL([BUILD_TL_COLL_PLUGINS], [true])
+        m4_include([config/m4/tl_coll_plugins_list.m4])
+    ],
+    [
+        AC_MSG_RESULT([TL coll plugins are disabled])
+        AM_CONDITIONAL([BUILD_TL_COLL_PLUGINS], [false])
+    ])
+])
+
+AC_DEFUN([CHECK_TLCP_REQUIRED], [
+    tlcp_name=$1
+    CHECKED_TLCP_REQUIRED=n
+    AS_IF([ test "$TLCP_REQUIRED" = "all" || test "$TLCP_REQUIRED" = "yes" ],
+          [CHECKED_TLCP_REQUIRED=y],
+    [
+        for t in $(echo ${TLCP_REQUIRED} | tr "," " "); do
+            AS_IF([ test "$t" == "$tlcp_name" ], [CHECKED_TLCP_REQUIRED=y], [])
+        done
+    ])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -159,10 +159,12 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/sharp.m4])
      m4_include([config/m4/mpi.m4])
      m4_include([config/m4/configure.m4])
+     m4_include([config/m4/tl_coll_plugins.m4])
      m4_include([test/gtest/configure.m4])
 
      mc_modules=":cpu"
      tl_modules=""
+     tlcp_modules=""
      AC_MSG_RESULT([MPI perftest: ${mpi_enable}])
 
      CHECK_UCX
@@ -196,6 +198,7 @@ CFLAGS="$CFLAGS -std=gnu11"
 CPPFLAGS="$CPPFLAGS $UCS_CPPFLAGS $includes"
 LDFLAGS="$LDFLAGS $UCS_LDFLAGS $UCS_LIBADD"
 
+CHECK_TL_COLL_PLUGINS
 AC_CONFIG_FILES([
                  Makefile
                  src/Makefile
@@ -236,6 +239,7 @@ AC_MSG_NOTICE([      C++ compiler:   ${CXX} ${CXXFLAGS} ${BASE_CXXFLAGS}])
 AC_MSG_NOTICE([          Perftest:   ${mpi_enable}])
 AC_MSG_NOTICE([        MC modules:   <$(echo ${mc_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([        TL modules:   <$(echo ${tl_modules}|tr ':' ' ') >])
+AC_MSG_NOTICE([      TLCP modules:   <$(echo ${tlcp_modules}|tr ':' ' ') >])
 AS_IF([test "x$enable_profiling" = xyes],[
 AC_MSG_NOTICE([ Profiling modules:   <$(echo ${prof_modules}|tr ':' ' ') >])
 ])

--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -424,6 +424,17 @@ out:
     return status;
 }
 
+ ucc_status_t ucc_coll_score_merge_in(ucc_coll_score_t **dst,
+                                     ucc_coll_score_t *src)
+{
+    ucc_coll_score_t *tmp = NULL;
+    ucc_status_t      status;
+
+    status = ucc_coll_score_merge(src, *dst, &tmp, 1);
+    *dst = tmp;
+    return status;
+}
+
 static ucc_status_t str_to_coll_type(const char *str, unsigned *ct_n,
                                      ucc_coll_type_t **ct)
 {

--- a/src/coll_score/ucc_coll_score.h
+++ b/src/coll_score/ucc_coll_score.h
@@ -119,6 +119,9 @@ ucc_status_t ucc_coll_score_update_from_str(const char *            str,
                                             ucc_score_t             def_score,
                                             ucc_alg_id_to_init_fn_t alg_fn);
 
+ucc_status_t ucc_coll_score_merge_in(ucc_coll_score_t **dst,
+                                     ucc_coll_score_t *src);
+
 ucc_status_t ucc_coll_score_update(ucc_coll_score_t *score,
                                    ucc_coll_score_t *update,
                                    ucc_score_t       default_score);

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -47,6 +47,7 @@ typedef struct ucc_base_lib_attr_t {
 
 typedef struct ucc_base_lib_params {
     ucc_lib_params_t params;
+    char            *full_prefix;
 } ucc_base_lib_params_t;
 extern ucc_config_field_t ucc_base_config_table[];
 
@@ -111,13 +112,16 @@ typedef struct ucc_base_team {
     ucc_base_team_params_t params;
 } ucc_base_team_t;
 
+typedef ucc_status_t (*ucc_get_coll_scores_fn_t)(ucc_base_team_t *team,
+                                                 ucc_coll_score_t **score);
+
 typedef struct ucc_base_team_iface {
     ucc_status_t (*create_post)(ucc_base_context_t *context,
                                 const ucc_base_team_params_t *params,
                                 ucc_base_team_t **team);
     ucc_status_t (*create_test)(ucc_base_team_t *team);
     ucc_status_t (*destroy)(ucc_base_team_t *team);
-    ucc_status_t (*get_scores)(ucc_base_team_t *team, ucc_coll_score_t **score);
+    ucc_get_coll_scores_fn_t get_scores;
 } ucc_base_team_iface_t;
 
 typedef struct ucc_base_coll_args {

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -57,6 +57,13 @@ typedef struct ucc_tl_service_coll {
     void         (*update_id)(ucc_base_team_t *team, uint16_t id);
 } ucc_tl_service_coll_t;
 
+typedef struct ucc_tl_coll_plugin_iface {
+    ucc_component_iface_t          super;
+    ucs_config_global_list_entry_t config;
+    ucc_get_coll_scores_fn_t       get_scores;
+    uint32_t                       id;
+} ucc_tl_coll_plugin_iface_t;
+
 typedef struct ucc_tl_iface {
     ucc_component_iface_t          super;
     ucs_config_global_list_entry_t tl_lib_config;
@@ -67,6 +74,7 @@ typedef struct ucc_tl_iface {
     ucc_base_coll_iface_t          coll;
     ucc_tl_service_coll_t          scoll;
     ucc_base_coll_alg_info_t *     alg_info[UCC_COLL_TYPE_NUM];
+    ucc_component_framework_t      coll_plugins;
 } ucc_tl_iface_t;
 
 typedef struct ucc_tl_lib {

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -1,7 +1,10 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
 #
-
+if BUILD_TL_COLL_PLUGINS
+SUBDIRS = .
+include makefile.coll_plugins.am
+endif
 barrier =                     \
 	barrier/barrier.h         \
 	barrier/barrier.c         \

--- a/src/components/tl/ucp/coll_plugins/example/Makefile.am
+++ b/src/components/tl/ucp/coll_plugins/example/Makefile.am
@@ -1,0 +1,18 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+
+if TLCP_UCP_EXAMPLE_ENABLED
+sources = example.c
+
+module_LTLIBRARIES = libucc_tlcp_ucp_example.la
+libucc_tlcp_ucp_example_la_SOURCES  = $(sources)
+libucc_tlcp_ucp_example_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(UCX_CPPFLAGS)
+libucc_tlcp_ucp_example_la_CFLAGS   = $(BASE_CFLAGS)
+libucc_tlcp_ucp_example_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(UCX_LDFLAGS)
+libucc_tlcp_ucp_example_la_LIBADD   = $(UCX_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la \
+                                      $(UCC_TOP_BUILDDIR)/src/components/tl/ucp/libucc_tl_ucp.la
+
+include $(top_srcdir)/config/module.am
+
+endif

--- a/src/components/tl/ucp/coll_plugins/example/configure.m4
+++ b/src/components/tl/ucp/coll_plugins/example/configure.m4
@@ -1,0 +1,14 @@
+# Copyright (c) 2021      Mellanox Technologies. All rights reserved.
+# $COPYRIGHT$
+# Additional copyrights may follow
+
+CHECK_TLCP_REQUIRED("ucp_example")
+
+AS_IF([test "$CHECKED_TLCP_REQUIRED" = "y"],
+[
+    tlcp_modules="${tlcp_modules}:ucp_example"
+    tlcp_ucp_example_enabled=y
+], [])
+
+AM_CONDITIONAL([TLCP_UCP_EXAMPLE_ENABLED], [test "$tlcp_ucp_example_enabled" = "y"])
+AC_CONFIG_FILES([src/components/tl/ucp/coll_plugins/example/Makefile])

--- a/src/components/tl/ucp/coll_plugins/example/example.c
+++ b/src/components/tl/ucp/coll_plugins/example/example.c
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "components/tl/ucp/tl_ucp.h"
+#include "components/tl/ucp/tl_ucp_coll.h"
+#include "core/ucc_progress_queue.h"
+#include "components/tl/ucp/tl_ucp_sendrecv.h"
+#include "coll_patterns/recursive_knomial.h"
+#include "coll_score/ucc_coll_score.h"
+#include "utils/ucc_math.h"
+
+ucc_tl_coll_plugin_iface_t ucc_tlcp_ucp_example;
+
+typedef struct ucc_tlcp_ucp_example_config {
+    char *score_str;
+} ucc_tlcp_ucp_example_config_t;
+
+#define CONFIG(_lib) ((ucc_tlcp_ucp_example_config_t*)((_lib)->tlcp_configs[ucc_tlcp_ucp_example.id]))
+
+static ucc_config_field_t ucc_tlcp_ucp_example_table[] = {
+    {"TLCP_EXAMPLE_TUNE", "", "Collective score modifier",
+     ucc_offsetof(ucc_tlcp_ucp_example_config_t, score_str), UCC_CONFIG_TYPE_STRING},
+
+    {NULL}};
+
+static ucs_config_global_list_entry_t ucc_tlcp_ucp_example_cfg_entry =
+{
+    .name   = "TLCP_EXAMPLE",
+    .prefix = "TL_UCP_",
+    .table  = ucc_tlcp_ucp_example_table,
+    .size   = sizeof(ucc_tlcp_ucp_example_config_t)
+};
+
+UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_tlcp_ucp_example_cfg_entry,
+                                &ucc_config_global_list);
+
+#define UCC_TLCP_UCP_EXAMPLE_SCORE 100
+ucc_status_t ucc_tlcp_ucp_example_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t     *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+
+    tl_info(TASK_LIB(task), "completing tl_ucp_example coll task");
+
+    ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
+    task->super.super.status = UCC_OK;
+
+    return task->super.super.status;
+}
+
+ucc_status_t ucc_tlcp_ucp_example_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+
+    tl_info(TASK_LIB(task), "starting tl_ucp_example coll task");
+
+    task->super.super.status = UCC_INPROGRESS;
+    ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tlcp_ucp_example_coll_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t *team,
+                                             ucc_coll_task_t **task_h)
+{
+    ucc_tl_ucp_team_t    *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_tl_ucp_task_t    *task    = ucc_tl_ucp_get_task(tl_team);
+
+    ucc_coll_task_init(&task->super, coll_args, team);
+    task->tag            = tl_team->seq_num;
+    tl_team->seq_num     = (tl_team->seq_num + 1) % UCC_TL_UCP_MAX_COLL_TAG;
+    task->super.finalize = ucc_tl_ucp_coll_finalize;
+    task->super.post     = ucc_tlcp_ucp_example_start;
+    task->super.progress = ucc_tlcp_ucp_example_progress;
+    *task_h              = &task->super;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tlcp_ucp_example_get_scores(ucc_base_team_t   *tl_team,
+                                              ucc_coll_score_t **score_p)
+{
+    ucc_tl_ucp_team_t *team = ucc_derived_of(tl_team, ucc_tl_ucp_team_t);
+    ucc_tl_ucp_lib_t  *lib  = UCC_TL_UCP_TEAM_LIB(team);
+    const char        *score_str;
+    ucc_coll_score_t  *score;
+    ucc_status_t       status;
+
+    /* There can be a different logic for different coll_type/mem_type.
+       Right now just init everything the same way. */
+    status = ucc_coll_score_alloc(&score);
+    if (UCC_OK != status) {
+        tl_error(lib, "failed to alloc score");
+        return status;
+    }
+    status = ucc_coll_score_add_range(score, UCC_COLL_TYPE_ALLTOALL, UCC_MEMORY_TYPE_HOST,
+                                      0, 4096, UCC_TLCP_UCP_EXAMPLE_SCORE,
+                                      ucc_tlcp_ucp_example_coll_init, tl_team);
+    if (UCC_OK != status) {
+        tl_error(lib, "failed to add range");
+        return status;
+    }
+    score_str = CONFIG(lib)->score_str;
+    if (strlen(score_str) > 0) {
+        status = ucc_coll_score_update_from_str(score_str, score, UCC_TL_TEAM_SIZE(team),
+                                                ucc_tlcp_ucp_example_coll_init,
+                                                &team->super.super, UCC_TLCP_UCP_EXAMPLE_SCORE,
+                                                NULL);
+        if (status == UCC_ERR_INVALID_PARAM) {
+            /* User provided incorrect input - try to proceed */
+            status = UCC_OK;
+        }
+    }
+    *score_p = score;
+    return status;
+}
+
+ucc_tl_coll_plugin_iface_t ucc_tlcp_ucp_example = {
+    .super.name   = "tl_ucp_example",
+    .super.score  = UCC_TLCP_UCP_EXAMPLE_SCORE,
+    .config.table = ucc_tlcp_ucp_example_table,
+    .config.size  = sizeof(ucc_tlcp_ucp_example_config_t),
+    .get_scores   = ucc_tlcp_ucp_example_get_scores
+};

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -244,4 +244,5 @@ __attribute__((constructor)) static void tl_ucp_iface_init(void)
         ucc_tl_ucp_bcast_algs;
     ucc_tl_ucp.super.alg_info[ucc_ilog2(UCC_COLL_TYPE_ALLTOALL)] =
         ucc_tl_ucp_alltoall_algs;
+    ucc_components_load("tlcp_ucp", &ucc_tl_ucp.super.coll_plugins);
 }

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -73,6 +73,7 @@ typedef struct ucc_tl_ucp_context_config {
 typedef struct ucc_tl_ucp_lib {
     ucc_tl_lib_t            super;
     ucc_tl_ucp_lib_config_t cfg;
+    void                  **tlcp_configs;
 } ucc_tl_ucp_lib_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -202,4 +202,5 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
                                        ucc_memory_type_t        mem_type,
                                        ucc_base_coll_init_fn_t *init);
 
+
 #endif

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -237,8 +237,9 @@ static ucc_status_t ucc_tl_lib_init(const ucc_lib_params_t *user_params,
     ucc_tl_iface_t       *tl_iface;
 
     ucc_copy_lib_params(&b_params.params, user_params);
-    n_tls = ucc_global_config.tl_framework.n_components;
-    lib->tl_libs =
+    b_params.full_prefix = lib->full_prefix;
+    n_tls                = ucc_global_config.tl_framework.n_components;
+    lib->tl_libs         =
         (ucc_tl_lib_t **)ucc_malloc(sizeof(ucc_tl_lib_t *) * n_tls, "tl_libs");
     lib->n_tl_libs_opened = 0;
     if (!lib->tl_libs) {


### PR DESCRIPTION
## What
PR adds the interface for the custom/closed/vendor plugins inside TL, i.e. plugin at the collective algorithm implementation level

## Why ?
The use case is: given the existing open source TL (TL/UCP is the most obvious example) provide a way for 3rd party implement an algorithm re-using TL/UCP resources and functionality and distribute this algorithm as a closed plug-in.

## How ?
The tl level iface is provided. Added a necessary logic to the build process that searches for the plugins. The build of plugins can be enabled with "--with-tlcp", where tlcp stands for "tl collective plugin".
Example reference implementation of a TL/UCP plugin is added in components/tl/ucp/coll_plugins/example.

The development flow for the 3rd party: fork UCC repo, add a "git submodule" with the code of the plugin. The code base of a plugin can be stored separately. The sync with the main ucc becomes easy and smooth: git pull. Since plugin code is in a separate folder (submodule) no merge issues. 

The integration of a plugin algorithm into score-based selection logic is made naturally. Plugin provides "get_scores" interface and thus reports to the TL dering team creation. This allows vendor to define which collective, which msg range, which mem type thier plugin will run on. And this can be altered in runtime with the same parameter "SCORE". For the example plugin above it is: UCC_TL_UCP_TLCP_EXAMPLE_SCORE.

Plugin may implement several algorithms for different collectives if needed. So, no more than 1 plugin from single vendor is required.
