### PR TITLE
TEST: fixed mpi test build with cuda

### DIFF
--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -24,11 +24,11 @@ ucc_test_mpi_SOURCES = \
 	test_alltoallv.cc
 
 CXX=mpicxx
-CXXFLAGS+=-I${top_builddir}/src -std=gnu++11
+ucc_test_mpi_CXXFLAGS=-I${top_builddir}/src -std=gnu++11
 
-LDFLAGS=-L${top_builddir}/src/.libs -lucc
+ucc_test_mpi_LDFLAGS=-L${top_builddir}/src/.libs -lucc
 
 if HAVE_CUDA
-CFLAGS += $(CUDA_CFLAGS) -DUCC_TEST_WITH_CUDA
-LDFLAGS+= $(CUDA_LDFLAGS) -lcudart
+ucc_test_mpi_CXXFLAGS+=$(CUDA_CPPFLAGS) -DUCC_TEST_WITH_CUDA
+ucc_test_mpi_LDFLAGS+=$(CUDA_LDFLAGS) $(CUDA_LIBS)
 endif


### PR DESCRIPTION
Fixes build with cuda:
```bash
...
04:39:16  In file included from /opt/nvidia/torch-ucc/src/ucc/test/mpi/mpi_util.h:9,
04:39:16                   from /opt/nvidia/torch-ucc/src/ucc/test/mpi/mpi_util.cc:7:
04:39:16  /opt/nvidia/torch-ucc/src/ucc/test/mpi/test_mpi.h:21:10: fatal error: cuda.h: No such file or directory
04:39:16   #include <cuda.h>
04:39:16            ^~~~~~~~
...
```


