### PR TITLE
TL/UCP: knomial allreduce move memory allocation from post to init

### DIFF
--- a/src/components/tl/ucp/allreduce/allreduce.c
+++ b/src/components/tl/ucp/allreduce/allreduce.c
@@ -27,9 +27,7 @@ ucc_status_t ucc_tl_ucp_allreduce_init(ucc_tl_ucp_task_t *task)
 {
     ucc_status_t status;
     ALLREDUCE_TASK_CHECK(task->args, task->team);
-    task->super.post     = ucc_tl_ucp_allreduce_knomial_start;
-    task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
-    return UCC_OK;
+    status = ucc_tl_ucp_allreduce_knomial_init_common(task);
 out:
     return status;
 }
@@ -43,10 +41,8 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_init(ucc_base_coll_args_t *coll_args,
     ucc_status_t       status;
     ALLREDUCE_TASK_CHECK(coll_args->args, tl_team);
     task                 = ucc_tl_ucp_init_task(coll_args, team);
-    task->super.post     = ucc_tl_ucp_allreduce_knomial_start;
-    task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     *task_h              = &task->super;
-    return UCC_OK;
+    status = ucc_tl_ucp_allreduce_knomial_init_common(task);
 out:
     return status;
 }

--- a/src/components/tl/ucp/allreduce/allreduce.h
+++ b/src/components/tl/ucp/allreduce/allreduce.h
@@ -3,6 +3,7 @@
  *
  * See file LICENSE for terms.
  */
+
 #ifndef ALLREDUCE_H_
 #define ALLREDUCE_H_
 #include "../tl_ucp.h"
@@ -46,19 +47,19 @@ ucc_status_t ucc_tl_ucp_allreduce_init(ucc_tl_ucp_task_t *task);
     CHECK_USERDEFINED_OP((_args), (_team));                                    \
     CHECK_SAME_MEMTYPE((_args), (_team));
 
-ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_allreduce_knomial_progress(ucc_coll_task_t *task);
 ucc_status_t ucc_tl_ucp_allreduce_knomial_init(ucc_base_coll_args_t *coll_args,
                                                ucc_base_team_t *     team,
                                                ucc_coll_task_t **    task_h);
+ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task);
+ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *task);
+ucc_status_t ucc_tl_ucp_allreduce_knomial_progress(ucc_coll_task_t *task);
+ucc_status_t ucc_tl_ucp_allreduce_knomial_finalize(ucc_coll_task_t *task);
 
+ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
+                                                   ucc_base_team_t *     team,
+                                                   ucc_coll_task_t **    task_h);
 ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_start(ucc_coll_task_t *task);
 ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_progress(ucc_coll_task_t *task);
-ucc_status_t
-ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
-                                      ucc_base_team_t *     team,
-                                      ucc_coll_task_t **    task_h);
-
 static inline int ucc_tl_ucp_allreduce_alg_from_str(const char *str)
 {
     int i;

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -17,6 +17,7 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_task_t *task    = ucc_tl_ucp_get_task(tl_team);
+    ucc_status_t status;
     ucc_coll_args_t args = {
         .coll_type            = UCC_COLL_TYPE_ALLREDUCE,
         .mask                 = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS,
@@ -34,7 +35,10 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
             .mem_type = UCC_MEMORY_TYPE_HOST
         }
     };
-    ucc_coll_task_init(&task->super);
+    status = ucc_coll_task_init(&task->super);
+    if (status != UCC_OK) {
+        goto free_task;
+    }
     task->subset = subset;
     task->team = tl_team;
     task->tag  = UCC_TL_UCP_SERVICE_TAG;
@@ -42,7 +46,21 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     memcpy(&task->args, &args, sizeof(ucc_coll_args_t));
     *task_p = &task->super;
-    return ucc_tl_ucp_allreduce_knomial_start(&task->super);
+    status = ucc_tl_ucp_allreduce_knomial_init_common(task);
+    if (status != UCC_OK) {
+        goto free_task;
+    }
+    status = ucc_tl_ucp_allreduce_knomial_start(&task->super);
+    if (status != UCC_OK) {
+        goto finalize_coll;
+    }
+
+    return status;
+finalize_coll:
+   ucc_tl_ucp_allreduce_knomial_finalize(*task_p);
+free_task:
+    ucc_tl_ucp_put_task(task);
+    return status;
 }
 
 ucc_status_t ucc_tl_ucp_service_test(ucc_coll_task_t *task)
@@ -53,8 +71,7 @@ ucc_status_t ucc_tl_ucp_service_test(ucc_coll_task_t *task)
 
 void ucc_tl_ucp_service_cleanup(ucc_coll_task_t *task)
 {
-    ucc_tl_ucp_task_t *tl_task = ucc_derived_of(task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_put_task(tl_task);
+    ucc_tl_ucp_allreduce_knomial_finalize(task);
 }
 
 void ucc_tl_ucp_service_update_id(ucc_base_team_t *team, uint16_t id) {


### PR DESCRIPTION
## What
Split knomial allreduce post into init and post. Init function allocates memory.

## Why ?
1. In case of triggered post cuda malloc might hang if wait kernel is running, we can do allocation earlier in init and free it in finalize to avoid deadlock
2. For persistent collectives we don't need to allocate/free scratch space on each collective post, instead do it just once in init/finalize.
