### PR TITLE
MC/CUDA: check device count

### DIFF
--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -17,6 +17,9 @@ static ucc_config_field_t ucc_mc_cpu_config_table[] = {
 
 static ucc_status_t ucc_mc_cpu_init()
 {
+    ucc_strncpy_safe(ucc_mc_cpu.super.config->log_component.name,
+                     ucc_mc_cpu.super.super.name,
+                     sizeof(ucc_mc_cpu.super.config->log_component.name));
     return UCC_OK;
 }
 

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -135,13 +135,21 @@ static ucc_status_t ucc_mc_cuda_post_driver_stream_task(uint32_t *status,
 
 static ucc_status_t ucc_mc_cuda_init()
 {
-    struct cudaDeviceProp prop;
-    ucc_status_t          status;
-    int device;
-    CUdevice cu_dev;
-    int mem_ops_attr;
-
     ucc_mc_cuda_config_t *cfg = MC_CUDA_CONFIG;
+    struct cudaDeviceProp prop;
+    ucc_status_t status;
+    int device, num_devices, mem_ops_attr;
+    CUdevice cu_dev;
+    cudaError_t cuda_st;
+
+    ucc_strncpy_safe(ucc_mc_cuda.super.config->log_component.name,
+                     ucc_mc_cuda.super.super.name,
+                     sizeof(ucc_mc_cuda.super.config->log_component.name));
+    cuda_st = cudaGetDeviceCount(&num_devices);
+    if ((cuda_st != cudaSuccess) || (num_devices == 0)) {
+        mc_info(&ucc_mc_cuda.super, "cuda devices are not found");
+        return UCC_ERR_NO_RESOURCE;
+    }
     CUDACHECK(cudaGetDevice(&device));
     CUDACHECK(cudaGetDeviceProperties(&prop, device));
     cfg->reduce_num_threads = prop.maxThreadsPerBlock;

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -240,11 +240,16 @@ void set_cuda_device(test_set_cuda_device_t set_device)
     int cuda_dev_count;
     int local_rank;
     int device_id;
+
+    if (set_device == TEST_SET_DEV_NONE) {
+        return;
+    }
+
     MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
                         &local_comm);
     MPI_Comm_rank(local_comm, &local_rank);
-    CUDA_CHECK(cudaGetDeviceCount(&cuda_dev_count));
 
+    CUDA_CHECK(cudaGetDeviceCount(&cuda_dev_count));
     switch (set_device) {
     case TEST_SET_DEV_LRANK:
         if(local_rank >= cuda_dev_count) {


### PR DESCRIPTION
## What
Don't initialize cuda memory component if there are no cuda devices.
Set component name for logger
fixing #163 