### PR TITLE
CL/BASIC: fill coll_types attribute

### DIFF
--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -51,6 +51,7 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
         return status;
     }
     attr->super.attr.thread_mode = ucp_tl_attr.super.attr.thread_mode;
+    attr->super.attr.coll_types  = ucp_tl_attr.super.attr.coll_types;
     nccl_iface = ucc_get_component(&ucc_global_config.tl_framework, "nccl");
     if (nccl_iface) {
         tl_nccl_iface = ucc_derived_of(nccl_iface, ucc_tl_iface_t);
@@ -62,7 +63,8 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
         }
         attr->super.attr.thread_mode = ucc_min(attr->super.attr.thread_mode,
     			nccl_tl_attr.super.attr.thread_mode);
+        attr->super.attr.coll_types  |= nccl_tl_attr.super.attr.coll_types;
     }
-    /* TODO: fill coll_types, reduction_types, sync_mode.*/
+
     return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl_lib.c
+++ b/src/components/tl/nccl/tl_nccl_lib.c
@@ -29,5 +29,6 @@ ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
 {
     ucc_tl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
+    attr->super.attr.coll_types = UCC_TL_NCCL_SUPPORTED_COLLS;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -58,5 +58,6 @@ ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
             ucc_error("Unsupported UCS thread mode");
             return UCC_ERR_NO_RESOURCE;
     }
+    attr->super.attr.coll_types = UCC_TL_UCP_SUPPORTED_COLLS;
     return UCC_OK;
 }


### PR DESCRIPTION
## What
Fill lib_attr.coll_types for CL/BASIC 

## Why ?
Part of the API. Used in ompi/coll/ucc component (https://github.com/open-mpi/ompi/pull/8843)

## How ?
Check TL/ucp/nccl attrs