### PR TITLE
TOOLS/PERFTEST: ucc perftest

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,9 +3,13 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2020.  All rights reserved.
 # $HEADER$
 #
-SUBDIRS = \
-       src \
-       tools/info
+SUBDIRS =      \
+	src        \
+	tools/info
+
+if HAVE_MPICXX
+SUBDIRS += tools/perf
+endif
 
 if HAVE_GTEST
 SUBDIRS += test/gtest

--- a/config/m4/mpi.m4
+++ b/config/m4/mpi.m4
@@ -1,0 +1,45 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+#
+# Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+
+#
+# Enable compiling ucc_perftest with MPI
+#
+AC_ARG_WITH([mpi],
+            [AS_HELP_STRING([--with-mpi@<:@=MPIHOME@:>@],
+            [Compile ucc_perftest with MPI (default is NO).])],[:],[with_mpi=no])
+
+    AS_IF([test "x$with_mpi" != xyes && test "x$with_mpi" != xno],
+            [
+            AS_IF([test -d "$with_mpi/bin"],[with_mpi="$with_mpi/bin"],[:])
+            mpi_path=$with_mpi;with_mpi=yes
+            ],
+            mpi_path=$PATH)
+
+#
+# Search for mpicc and mpirun in the given path.
+#
+AS_IF([test "x$with_mpi" = xyes],
+        [
+        AC_ARG_VAR(MPICC,[MPI C compiler command])
+        AC_PATH_PROGS(MPICC,mpicc mpiicc,"",$mpi_path)
+        AC_ARG_VAR(MPICXX,[MPI CXX compiler command])
+        AC_PATH_PROGS(MPICXX,mpicxx mpiicpc,"",$mpi_path)
+        AC_ARG_VAR(MPIRUN,[MPI launch command])
+        AC_PATH_PROGS(MPIRUN,mpirun mpiexec aprun orterun,"",$mpi_path)
+        AS_IF([test -z "$MPIRUN"],
+              AC_MSG_ERROR([--with-mpi was requested but MPI was not found in the PATH in $mpi_path]),[:])
+        ],[:])
+
+AS_IF([test -n "$MPICC" -a  -n "$MPICXX"],
+      [AC_DEFINE([HAVE_MPI], [1], [MPI support])
+       mpi_enable=enabled],
+      [mpi_enable=disabled])
+AM_CONDITIONAL([HAVE_MPI],    [test -n "$MPIRUN"])
+AM_CONDITIONAL([HAVE_MPICC],  [test -n "$MPICC"])
+AM_CONDITIONAL([HAVE_MPICXX], [test -n "$MPICXX"])
+AM_CONDITIONAL([HAVE_MPIRUN], [test -n "$MPIRUN"])

--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,10 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_UCX], [false])
      AM_CONDITIONAL([HAVE_CUDA], [false])
      AM_CONDITIONAL([HAVE_NCCL], [false])
+     AM_CONDITIONAL([HAVE_MPI], [false])
+     AM_CONDITIONAL([HAVE_MPIRUN], [false])
+     AM_CONDITIONAL([HAVE_MPICC], [false])
+     AM_CONDITIONAL([HAVE_MPICXX], [false])
     ],
     [
      AM_CONDITIONAL([DOCS_ONLY], [false])
@@ -150,8 +154,10 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/ucx.m4])
      m4_include([config/m4/cuda.m4])
      m4_include([config/m4/nccl.m4])
+     m4_include([config/m4/mpi.m4])
      m4_include([test/gtest/configure.m4])
 
+     AC_MSG_RESULT([MPI perftest: ${mpi_enable}])
      AC_ARG_ENABLE([debug],
               AS_HELP_STRING([--enable-debug], [Enable extra debugging code (default is NO).]),
               [], [enable_debug=no])
@@ -191,7 +197,6 @@ LDFLAGS="$LDFLAGS $UCS_LDFLAGS $UCS_LIBADD"
 AC_CONFIG_FILES([
                  Makefile
                  src/Makefile
-                 tools/info/Makefile
                  src/ucc/api/ucc_version.h
                  src/core/ucc_version.c
                  src/components/cl/basic/Makefile
@@ -201,5 +206,7 @@ AC_CONFIG_FILES([
                  src/components/mc/cuda/Makefile
                  src/components/mc/cuda/kernel/Makefile
                  test/mpi/Makefile
+                 tools/info/Makefile
+                 tools/perf/Makefile
                  ])
 AC_OUTPUT

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -56,7 +56,7 @@ ucc_coll_args_get_total_count(const ucc_coll_args_t *args,
                               const ucc_count_t *counts, ucc_rank_t size)
 {
     size_t count = 0;
-    int i;
+    ucc_rank_t i;
     // TODO switch to base args and cache total count there - can we do it ?
     if ((args->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
         (args->flags & UCC_COLL_ARGS_FLAG_COUNT_64BIT)) {

--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2021 Mellanox Technologies.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+bin_PROGRAMS = ucc_perftest
+
+ucc_perftest_SOURCES =      \
+	ucc_perftest.cc         \
+	ucc_pt_config.cc        \
+	ucc_pt_comm.cc          \
+	ucc_pt_benchmark.cc     \
+	ucc_pt_coll.cc          \
+	ucc_pt_bootstrap_mpi.cc
+
+CXX=$(MPICXX)
+LD=$(MPICXX)
+ucc_perftest_CPPFLAGS=-I${UCC_TOP_BUILDDIR}/src
+ucc_perftest_CXXFLAGS=-std=gnu++11
+ucc_perftest_LDADD = $(UCC_TOP_BUILDDIR)/src/libucc.la

--- a/tools/perf/ucc_perftest.cc
+++ b/tools/perf/ucc_perftest.cc
@@ -1,0 +1,17 @@
+#include <ucc/api/ucc.h>
+#include "ucc_pt_comm.h"
+#include "ucc_pt_config.h"
+#include "ucc_pt_coll.h"
+#include "ucc_pt_benchmark.h"
+
+int main(int argc, char *argv[])
+{
+    ucc_pt_config pt_config;
+    pt_config.process_args(argc, argv);
+    ucc_pt_comm comm;
+    comm.init();
+    ucc_pt_benchmark bench(pt_config.bench, &comm);
+    bench.run_bench();
+    comm.finalize();
+    return 0;
+}

--- a/tools/perf/ucc_perftest.h
+++ b/tools/perf/ucc_perftest.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <ucc/api/ucc.h>
+#include <iostream>
+
+#define STR(x) #x
+#define UCCCHECK_GOTO(_call, _label, _status)                                  \
+    do {                                                                       \
+        ucc_status_t _status = (_call);                                        \
+        if (UCC_OK != _status) {                                               \
+            std::cerr << "UCC perftest error: " << STR(_call) << "\n";         \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)

--- a/tools/perf/ucc_perftest.h
+++ b/tools/perf/ucc_perftest.h
@@ -10,7 +10,7 @@
 #define STR(x) #x
 #define UCCCHECK_GOTO(_call, _label, _status)                                  \
     do {                                                                       \
-        ucc_status_t _status = (_call);                                        \
+        _status = (_call);                                                     \
         if (UCC_OK != _status) {                                               \
             std::cerr << "UCC perftest error: " << STR(_call) << "\n";         \
             goto _label;                                                       \

--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -1,0 +1,119 @@
+#include <iomanip>
+#include "ucc_pt_benchmark.h"
+#include "core/ucc_mc.h"
+#include "ucc_perftest.h"
+#include "utils/ucc_coll_utils.h"
+
+ucc_pt_benchmark::ucc_pt_benchmark(ucc_pt_benchmark_config cfg,
+                                   ucc_pt_comm *communcator):
+    config(cfg),
+    comm(communcator)
+{
+    coll = new ucc_pt_coll_allreduce(cfg.dt, cfg.mt, cfg.op, cfg.inplace);
+}
+
+ucc_status_t ucc_pt_benchmark::run_bench()
+{
+    ucc_status_t st = UCC_OK;
+    ucc_coll_args_t args;
+    std::chrono::nanoseconds time;
+
+    print_header();
+    for (size_t cnt = config.min_count; cnt <= config.max_count; cnt *= 2) {
+        UCCCHECK_GOTO(coll->get_coll(cnt, args), exit_err, st);
+        UCCCHECK_GOTO(run_single_test(args, time), free_coll, st);
+        coll->free_coll(args);
+        print_time(cnt, time);
+    }
+
+    return UCC_OK;
+free_coll:
+    coll->free_coll(args);
+exit_err:
+    return st;
+}
+
+ucc_status_t ucc_pt_benchmark::run_single_test(ucc_coll_args_t args,
+                                               std::chrono::nanoseconds &time)
+{
+    ucc_team_h    team = comm->get_team();
+    ucc_context_h ctx  = comm->get_context();
+    ucc_status_t  st   = UCC_OK;
+    ucc_coll_req_h req;
+
+    UCCCHECK_GOTO(comm->barrier(), exit_err, st);
+    time = std::chrono::nanoseconds::zero();
+    for (int i = 0; i < config.n_warmup + config.n_iter; i++) {
+        auto s = std::chrono::high_resolution_clock::now();
+        UCCCHECK_GOTO(ucc_collective_init(&args, &req, team), exit_err, st);
+        UCCCHECK_GOTO(ucc_collective_post(req), free_req, st);
+        do {
+            UCCCHECK_GOTO(ucc_context_progress(ctx), free_req, st);
+        } while (ucc_collective_test(req) == UCC_INPROGRESS);
+        ucc_collective_finalize(req);
+        auto f = std::chrono::high_resolution_clock::now();
+        if (i >= config.n_warmup) {
+            time += std::chrono::duration_cast<std::chrono::nanoseconds>(f - s);
+        }
+        UCCCHECK_GOTO(comm->barrier(), exit_err, st);
+    }
+    time /= config.n_iter;
+    return UCC_OK;
+free_req:
+    ucc_collective_finalize(req);
+exit_err:
+    return st;
+}
+
+void ucc_pt_benchmark::print_header()
+{
+    if (comm->get_rank() == 0) {
+        std::cout << "Collective: " << ucc_coll_type_str(config.coll_type)
+                  << std::endl;
+        std::cout << "Memory type: " << ucc_memory_type_names[config.mt]
+                  << std::endl;
+        std::cout << "Data type: " << config.dt
+                  << std::endl;
+        std::cout << "Operation type: " << config.op
+                  << std::endl;
+        std::cout << "Warmup: "<< config.n_warmup << "; "
+                     "Iterations: "<< config.n_iter
+                  << std::endl;
+        std::cout << std::setw(12) << "Count" <<
+                     std::setw(12) << "Size" <<
+                     std::setw(24) << "Time, us" <<
+                     std::endl;
+        std::cout << std::setw(36) << "avg" <<
+                     std::setw(12) << "min" <<
+                     std::setw(12) << "max" <<
+                     std::endl;
+    }
+}
+
+void ucc_pt_benchmark::print_time(size_t count, std::chrono::nanoseconds time)
+{
+    float time_ms = time.count() / 1000.0;
+    float time_avg, time_min, time_max;
+    comm->allreduce(&time_ms, &time_min, 1, UCC_OP_MIN);
+    comm->allreduce(&time_ms, &time_max, 1, UCC_OP_MAX);
+    comm->allreduce(&time_ms, &time_avg, 1, UCC_OP_SUM);
+    time_avg /= comm->get_size();
+
+    if (comm->get_rank() == 0) {
+        std::ios iostate(nullptr);
+        iostate.copyfmt(std::cout);
+        std::cout<<std::setprecision(2) << std::fixed;
+        std::cout << std::setw(12) << count <<
+                     std::setw(12) << count * ucc_dt_size(config.dt) <<
+                     std::setw(12) << time_avg <<
+                     std::setw(12) << time_min <<
+                     std::setw(12) << time_max <<
+                     std::endl;
+        std::cout.copyfmt(iostate);
+    }
+}
+
+ucc_pt_benchmark::~ucc_pt_benchmark()
+{
+    delete coll;
+}

--- a/tools/perf/ucc_pt_benchmark.h
+++ b/tools/perf/ucc_pt_benchmark.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PT_BENCH_H
+#define UCC_PT_BENCH_H
+
+#include "ucc_pt_config.h"
+#include "ucc_pt_coll.h"
+#include "ucc_pt_comm.h"
+#include <ucc/api/ucc.h>
+#include <chrono>
+
+class ucc_pt_benchmark {
+    ucc_pt_benchmark_config config;
+    ucc_pt_comm *comm;
+    ucc_pt_coll *coll;
+
+    ucc_status_t barrier();
+    void print_header();
+    void print_time(size_t count, std::chrono::nanoseconds time);
+public:
+    ucc_pt_benchmark(ucc_pt_benchmark_config cfg, ucc_pt_comm *communcator);
+    ucc_status_t run_bench();
+    ucc_status_t run_single_test(ucc_coll_args_t args,
+                                 std::chrono::nanoseconds &time);
+    ~ucc_pt_benchmark();
+};
+
+#endif

--- a/tools/perf/ucc_pt_benchmark.h
+++ b/tools/perf/ucc_pt_benchmark.h
@@ -25,6 +25,7 @@ public:
     ucc_pt_benchmark(ucc_pt_benchmark_config cfg, ucc_pt_comm *communcator);
     ucc_status_t run_bench();
     ucc_status_t run_single_test(ucc_coll_args_t args,
+                                 int nwarmup, int niter,
                                  std::chrono::nanoseconds &time);
     ~ucc_pt_benchmark();
 };

--- a/tools/perf/ucc_pt_bootstrap.h
+++ b/tools/perf/ucc_pt_bootstrap.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PT_BOOTSTRAP_H
+#define UCC_PT_BOOTSTRAP_H
+
+#include <ucc/api/ucc.h>
+
+class ucc_pt_bootstrap {
+protected:
+    ucc_context_oob_coll_t context_oob;
+    ucc_team_oob_coll_t team_oob;
+public:
+    virtual int get_rank() = 0;
+    virtual int get_size() = 0;
+    virtual ~ucc_pt_bootstrap() {};
+    ucc_context_oob_coll_t get_context_oob()
+    {
+        return context_oob;
+    }
+
+    ucc_team_oob_coll_t get_team_oob() {
+        return team_oob;
+    }
+};
+
+#endif

--- a/tools/perf/ucc_pt_bootstrap_mpi.cc
+++ b/tools/perf/ucc_pt_bootstrap_mpi.cc
@@ -1,0 +1,55 @@
+#include "ucc_pt_bootstrap_mpi.h"
+
+static ucc_status_t mpi_oob_allgather(void *sbuf, void *rbuf, size_t msglen,
+                                      void *coll_info, void **req)
+{
+    MPI_Comm    comm = (MPI_Comm)coll_info;
+    MPI_Request request;
+    MPI_Iallgather(sbuf, msglen, MPI_BYTE, rbuf, msglen, MPI_BYTE, comm,
+                   &request);
+    *req = (void *)request;
+    return UCC_OK;
+}
+
+static ucc_status_t mpi_oob_allgather_test(void *req)
+{
+    MPI_Request request = (MPI_Request)req;
+    int         completed;
+    MPI_Test(&request, &completed, MPI_STATUS_IGNORE);
+    return completed ? UCC_OK : UCC_INPROGRESS;
+}
+
+static ucc_status_t mpi_oob_allgather_free(void *req)
+{
+    return UCC_OK;
+}
+
+ucc_pt_bootstrap_mpi::ucc_pt_bootstrap_mpi() {
+    MPI_Init(NULL, NULL);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    context_oob.coll_info    = (void*)MPI_COMM_WORLD;
+    context_oob.allgather    = mpi_oob_allgather;
+    context_oob.req_test     = mpi_oob_allgather_test;
+    context_oob.req_free     = mpi_oob_allgather_free;
+    context_oob.participants = size;
+
+    team_oob.coll_info    = (void*)MPI_COMM_WORLD;
+    team_oob.allgather    = mpi_oob_allgather;
+    team_oob.req_test     = mpi_oob_allgather_test;
+    team_oob.req_free     = mpi_oob_allgather_free;
+    team_oob.participants = size;
+}
+
+int ucc_pt_bootstrap_mpi::get_rank() {
+    return rank;
+}
+
+int ucc_pt_bootstrap_mpi::get_size() {
+    return size;
+}
+
+ucc_pt_bootstrap_mpi::~ucc_pt_bootstrap_mpi() {
+    MPI_Finalize();
+}

--- a/tools/perf/ucc_pt_bootstrap_mpi.h
+++ b/tools/perf/ucc_pt_bootstrap_mpi.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PT_BOOTSTRAP_MPI_H
+#define UCC_PT_BOOTSTRAP_MPI_H
+
+#include <mpi.h>
+#include "ucc_pt_bootstrap.h"
+
+class ucc_pt_bootstrap_mpi: public ucc_pt_bootstrap {
+public:
+    ucc_pt_bootstrap_mpi();
+    ~ucc_pt_bootstrap_mpi();
+    int get_rank() override;
+    int get_size() override;
+protected:
+    int rank;
+    int size;
+};
+
+#endif

--- a/tools/perf/ucc_pt_coll.cc
+++ b/tools/perf/ucc_pt_coll.cc
@@ -25,8 +25,8 @@ ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
     coll_args.dst.info.mem_type = mt;
 }
 
-ucc_status_t ucc_pt_coll_allreduce::get_coll(size_t count,
-                                             ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_allreduce::init_coll_args(size_t count,
+                                                   ucc_coll_args_t &args)
 {
     size_t       dt_size = ucc_dt_size(coll_args.src.info.datatype);
     size_t       size    = count * dt_size;
@@ -47,7 +47,7 @@ exit:
     return st;
 }
 
-void ucc_pt_coll_allreduce::free_coll(ucc_coll_args_t &args)
+void ucc_pt_coll_allreduce::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
         ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);

--- a/tools/perf/ucc_pt_coll.cc
+++ b/tools/perf/ucc_pt_coll.cc
@@ -1,0 +1,62 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+extern "C" {
+#include <core/ucc_mc.h>
+}
+
+ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
+                                             ucc_memory_type mt,
+                                             ucc_reduction_op_t op,
+                                             bool is_inplace)
+{
+    coll_args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
+    coll_args.mask = 0;
+    if (is_inplace) {
+        coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+    coll_args.mask |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
+    coll_args.reduce.predefined_op = op;
+    coll_args.src.info.datatype = dt;
+    coll_args.src.info.mem_type = mt;
+    coll_args.dst.info.mem_type = mt;
+}
+
+ucc_status_t ucc_pt_coll_allreduce::get_coll(size_t count,
+                                             ucc_coll_args_t &args)
+{
+    size_t       dt_size = ucc_dt_size(coll_args.src.info.datatype);
+    size_t       size    = count * dt_size;
+    ucc_status_t st      = UCC_OK;
+
+    args = coll_args;
+    args.src.info.count = count;
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.buffer, size,
+                               args.dst.info.mem_type), exit, st);
+    if (!UCC_IS_INPLACE(args)) {
+        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size,
+                                   args.src.info.mem_type), free_dst, st);
+    }
+    return UCC_OK;
+free_dst:
+    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+exit:
+    return st;
+}
+
+void ucc_pt_coll_allreduce::free_coll(ucc_coll_args_t &args)
+{
+    if (!UCC_IS_INPLACE(args)) {
+        ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+    }
+    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+}
+
+double ucc_pt_coll_allreduce::get_bus_bw(double time_us)
+{
+    //TODO
+    return 0.0;
+}

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PT_COLL_H
+#define UCC_PT_COLL_H
+
+#include <ucc/api/ucc.h>
+
+class ucc_pt_coll {
+protected:
+    ucc_coll_args_t coll_args;
+public:
+    virtual ucc_status_t get_coll(size_t count, ucc_coll_args_t &args) = 0;
+    virtual void free_coll(ucc_coll_args_t &args) = 0;
+    virtual double get_bus_bw(double time_us) = 0;
+    virtual ~ucc_pt_coll() {};
+};
+
+class ucc_pt_coll_allreduce: public ucc_pt_coll {
+public:
+    ucc_pt_coll_allreduce(ucc_datatype_t dt, ucc_memory_type mt,
+                          ucc_reduction_op_t op, bool is_inplace);
+    ucc_status_t get_coll(size_t count, ucc_coll_args_t &args) override;
+    void free_coll(ucc_coll_args_t &args) override;
+    double get_bus_bw(double time_us) override;
+};
+
+#endif

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -13,8 +13,9 @@ class ucc_pt_coll {
 protected:
     ucc_coll_args_t coll_args;
 public:
-    virtual ucc_status_t get_coll(size_t count, ucc_coll_args_t &args) = 0;
-    virtual void free_coll(ucc_coll_args_t &args) = 0;
+    virtual ucc_status_t init_coll_args(size_t count,
+                                        ucc_coll_args_t &args) = 0;
+    virtual void free_coll_args(ucc_coll_args_t &args) = 0;
     virtual double get_bus_bw(double time_us) = 0;
     virtual ~ucc_pt_coll() {};
 };
@@ -23,8 +24,8 @@ class ucc_pt_coll_allreduce: public ucc_pt_coll {
 public:
     ucc_pt_coll_allreduce(ucc_datatype_t dt, ucc_memory_type mt,
                           ucc_reduction_op_t op, bool is_inplace);
-    ucc_status_t get_coll(size_t count, ucc_coll_args_t &args) override;
-    void free_coll(ucc_coll_args_t &args) override;
+    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
+    void free_coll_args(ucc_coll_args_t &args) override;
     double get_bus_bw(double time_us) override;
 };
 

--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -1,0 +1,156 @@
+#include <iostream>
+#include <cstring>
+#include "ucc_pt_comm.h"
+#include "ucc_pt_bootstrap_mpi.h"
+
+ucc_pt_comm::ucc_pt_comm()
+{
+    bootstrap = new ucc_pt_bootstrap_mpi();
+}
+
+ucc_pt_comm::~ucc_pt_comm()
+{
+    delete bootstrap;
+}
+
+int ucc_pt_comm::get_rank()
+{
+    return bootstrap->get_rank();
+}
+
+int ucc_pt_comm::get_size()
+{
+    return bootstrap->get_size();
+}
+
+ucc_team_h ucc_pt_comm::get_team()
+{
+    return team;
+}
+
+ucc_context_h ucc_pt_comm::get_context()
+{
+    return context;
+}
+
+ucc_status_t ucc_pt_comm::init()
+{
+    ucc_lib_config_h lib_config;
+    ucc_context_config_h context_config;
+    ucc_lib_params_t lib_params;
+    ucc_context_params_t context_params;
+    ucc_team_params_t team_params;
+    ucc_status_t st;
+    st = ucc_lib_config_read("TORCH", nullptr, &lib_config);
+
+    if (st != UCC_OK) {
+        std::cerr << "failed to read UCC lib config: " << ucc_status_string(st);
+        return st;
+    }
+    std::memset(&lib_params, 0, sizeof(ucc_lib_params_t));
+    lib_params.mask = UCC_LIB_PARAM_FIELD_THREAD_MODE;
+    lib_params.thread_mode = UCC_THREAD_SINGLE;
+    st = ucc_init(&lib_params, lib_config, &lib);
+    ucc_lib_config_release(lib_config);
+
+    st = ucc_context_config_read(lib, NULL, &context_config);
+    if (st != UCC_OK) {
+        ucc_finalize(lib);
+        std::cerr << "failed to read UCC context config: "
+                  << ucc_status_string(st);
+        return st;
+    }
+    std::memset(&context_params, 0, sizeof(ucc_context_params_t));
+    context_params.mask = UCC_CONTEXT_PARAM_FIELD_TYPE |
+                          UCC_CONTEXT_PARAM_FIELD_OOB;
+    context_params.type = UCC_CONTEXT_SHARED;
+    context_params.oob  = bootstrap->get_context_oob();
+    ucc_context_create(lib, &context_params, context_config, &context);
+    ucc_context_config_release(context_config);
+    if (st != UCC_OK) {
+        ucc_finalize(lib);
+        std::cerr << "failed to create UCC context: " << ucc_status_string(st);
+        return st;
+    }
+    team_params.mask     = UCC_TEAM_PARAM_FIELD_EP |
+                           UCC_TEAM_PARAM_FIELD_EP_RANGE |
+                           UCC_TEAM_PARAM_FIELD_OOB;
+    team_params.oob      = bootstrap->get_team_oob();
+    team_params.ep       = bootstrap->get_rank();
+    team_params.ep_range = UCC_COLLECTIVE_EP_RANGE_CONTIG;
+    st = ucc_team_create_post(&context, 1, &team_params, &team);
+    if (st != UCC_OK) {
+        std::cerr << "failed to post UCC team create: " <<
+                     ucc_status_string(st);
+        ucc_context_destroy(context);
+        ucc_finalize(lib);
+        return st;
+    }
+    do {
+        st = ucc_team_create_test(team);
+    } while(st == UCC_INPROGRESS);
+    if (st != UCC_OK) {
+        std::cerr << "failed to create UCC team: " << ucc_status_string(st);
+        ucc_context_destroy(context);
+        ucc_finalize(lib);
+        return st;
+    }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_pt_comm::finalize()
+{
+    ucc_status_t status;
+
+    do {
+        status = ucc_team_destroy(team);
+    } while (status == UCC_INPROGRESS);
+    if (status != UCC_OK) {
+        std::cerr << "ucc team destroy error: " << ucc_status_string(status);
+    }
+    ucc_context_destroy(context);
+    ucc_finalize(lib);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_pt_comm::barrier()
+{
+    ucc_coll_args_t args;
+    ucc_coll_req_h req;
+
+    args.mask = 0;
+    args.coll_type = UCC_COLL_TYPE_BARRIER;
+    ucc_collective_init(&args, &req, team);
+    ucc_collective_post(req);
+    do {
+        ucc_context_progress(context);
+    } while (ucc_collective_test(req) == UCC_INPROGRESS);
+    ucc_collective_finalize(req);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_pt_comm::allreduce(float* in, float* out, size_t size,
+                                    ucc_reduction_op_t op)
+{
+    ucc_coll_args_t args;
+    ucc_coll_req_h req;
+
+    args.mask                 = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
+    args.coll_type            = UCC_COLL_TYPE_ALLREDUCE;
+    args.reduce.predefined_op = op;
+    args.src.info.buffer      = in;
+    args.src.info.count       = size;
+    args.src.info.datatype    = UCC_DT_FLOAT32;
+    args.src.info.mem_type    = UCC_MEMORY_TYPE_HOST;
+    args.dst.info.buffer      = out;
+    args.dst.info.count       = size;
+    args.dst.info.datatype    = UCC_DT_FLOAT32;
+    args.dst.info.mem_type    = UCC_MEMORY_TYPE_HOST;
+    ucc_collective_init(&args, &req, team);
+    ucc_collective_post(req);
+    do {
+        ucc_context_progress(context);
+    } while (ucc_collective_test(req) == UCC_INPROGRESS);
+    ucc_collective_finalize(req);
+    return UCC_OK;
+}

--- a/tools/perf/ucc_pt_comm.h
+++ b/tools/perf/ucc_pt_comm.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PT_COMM_H
+#define UCC_PT_COMM_H
+
+#include <ucc/api/ucc.h>
+#include "ucc_pt_bootstrap.h"
+#include "ucc_pt_bootstrap_mpi.h"
+
+class ucc_pt_comm {
+    ucc_lib_h lib;
+    ucc_context_h context;
+    ucc_team_h team;
+    ucc_pt_bootstrap *bootstrap;
+public:
+    ucc_pt_comm();
+    int get_rank();
+    int get_size();
+    ucc_team_h get_team();
+    ucc_context_h get_context();
+    ~ucc_pt_comm();
+    ucc_status_t init();
+    ucc_status_t barrier();
+    ucc_status_t allreduce(float* in, float *out, size_t size,
+                           ucc_reduction_op_t op);
+    ucc_status_t finalize();
+};
+
+#endif

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -1,16 +1,19 @@
 #include "ucc_pt_config.h"
 
 ucc_pt_config::ucc_pt_config() {
-    bootstrap.bootstrap = UCC_PT_BOOTSTRAP_MPI;
-    bench.coll_type     = UCC_COLL_TYPE_ALLREDUCE;
-    bench.min_count     = 128;
-    bench.max_count     = 128;
-    bench.dt            = UCC_DT_FLOAT32;
-    bench.mt            = UCC_MEMORY_TYPE_HOST;
-    bench.op            = UCC_OP_SUM;
-    bench.inplace       = false;
-    bench.n_iter        = 10;
-    bench.n_warmup      = 10;
+    bootstrap.bootstrap  = UCC_PT_BOOTSTRAP_MPI;
+    bench.coll_type      = UCC_COLL_TYPE_ALLREDUCE;
+    bench.min_count      = 128;
+    bench.max_count      = 128;
+    bench.dt             = UCC_DT_FLOAT32;
+    bench.mt             = UCC_MEMORY_TYPE_HOST;
+    bench.op             = UCC_OP_SUM;
+    bench.inplace        = false;
+    bench.n_iter_small   = 1000;
+    bench.n_warmup_small = 100;
+    bench.n_iter_large   = 200;
+    bench.n_warmup_large = 20;
+    bench.large_thresh   = 64 * 1024;
 }
 
 const std::map<std::string, ucc_reduction_op_t> ucc_pt_op_map = {
@@ -38,14 +41,14 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
                     std::cerr << "invalid collective" << std::endl;
                     return UCC_ERR_INVALID_PARAM;
                 }
-                bench.coll_type = ucc_pt_coll_map.at(std::string(optarg));
+                bench.coll_type = ucc_pt_coll_map.at(optarg);
                 break;
             case 'o':
                 if (ucc_pt_op_map.count(optarg) == 0) {
                     std::cerr << "invalid operation" << std::endl;
                     return UCC_ERR_INVALID_PARAM;
                 }
-                bench.op = ucc_pt_op_map.at(std::string(optarg));
+                bench.op = ucc_pt_op_map.at(optarg);
                 break;
             case 'b':
                 std::stringstream(optarg) >> bench.min_count;
@@ -54,10 +57,12 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
                 std::stringstream(optarg) >> bench.max_count;
                 break;
             case 'n':
-                std::stringstream(optarg) >> bench.n_iter;
+                std::stringstream(optarg) >> bench.n_iter_small;
+                bench.n_iter_large = bench.n_iter_small;
                 break;
             case 'w':
-                std::stringstream(optarg) >> bench.n_warmup;
+                std::stringstream(optarg) >> bench.n_warmup_small;
+                bench.n_warmup_large = bench.n_warmup_small;
                 break;
             case 'i':
                 bench.inplace = true;

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -1,0 +1,86 @@
+#include "ucc_pt_config.h"
+
+ucc_pt_config::ucc_pt_config() {
+    bootstrap.bootstrap = UCC_PT_BOOTSTRAP_MPI;
+    bench.coll_type     = UCC_COLL_TYPE_ALLREDUCE;
+    bench.min_count     = 128;
+    bench.max_count     = 128;
+    bench.dt            = UCC_DT_FLOAT32;
+    bench.mt            = UCC_MEMORY_TYPE_HOST;
+    bench.op            = UCC_OP_SUM;
+    bench.inplace       = false;
+    bench.n_iter        = 10;
+    bench.n_warmup      = 10;
+}
+
+const std::map<std::string, ucc_reduction_op_t> ucc_pt_op_map = {
+    {"sum", UCC_OP_SUM},
+    {"prod", UCC_OP_PROD},
+    {"min", UCC_OP_MIN},
+    {"max", UCC_OP_MAX},
+};
+
+const std::map<std::string, ucc_coll_type_t> ucc_pt_coll_map = {
+    {"allgather", UCC_COLL_TYPE_ALLGATHER},
+    {"allgatherv", UCC_COLL_TYPE_ALLGATHERV},
+    {"allreduce", UCC_COLL_TYPE_ALLREDUCE},
+    {"alltoall", UCC_COLL_TYPE_ALLTOALL},
+};
+
+ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
+{
+    int c;
+
+    while ((c = getopt(argc, argv, "c:b:e:d:m:n:w:o:ih")) != -1) {
+        switch (c) {
+            case 'c':
+                if (ucc_pt_coll_map.count(optarg) == 0) {
+                    std::cerr << "invalid collective" << std::endl;
+                    return UCC_ERR_INVALID_PARAM;
+                }
+                bench.coll_type = ucc_pt_coll_map.at(std::string(optarg));
+                break;
+            case 'o':
+                if (ucc_pt_op_map.count(optarg) == 0) {
+                    std::cerr << "invalid operation" << std::endl;
+                    return UCC_ERR_INVALID_PARAM;
+                }
+                bench.op = ucc_pt_op_map.at(std::string(optarg));
+                break;
+            case 'b':
+                std::stringstream(optarg) >> bench.min_count;
+                break;
+            case 'e':
+                std::stringstream(optarg) >> bench.max_count;
+                break;
+            case 'n':
+                std::stringstream(optarg) >> bench.n_iter;
+                break;
+            case 'w':
+                std::stringstream(optarg) >> bench.n_warmup;
+                break;
+            case 'i':
+                bench.inplace = true;
+                break;
+            case 'h':
+            default:
+                print_help();
+                std::exit(0);
+        }
+    }
+    return UCC_OK;
+}
+
+void ucc_pt_config::print_help()
+{
+    std::cout<<"Usage: ucc_perftest [options]"<<std::endl;
+    std::cout<<"  -c <collective name>: Collective type"<<std::endl;
+    std::cout<<"  -b <count>: Min number of elements"<<std::endl;
+    std::cout<<"  -e <count>: Max number of elements"<<std::endl;
+    std::cout<<"  -i: inplace collective"<<std::endl;
+    std::cout<<"  -o <op name>: operation type for rudction"<<std::endl;
+    std::cout<<"  -n <number>: number of iterations"<<std::endl;
+    std::cout<<"  -w <number>: number of warmup iterations"<<std::endl;
+    std::cout<<"  -h: show this help message"<<std::endl;
+    std::cout<<std::endl;
+}

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PT_CONFIG_H
+#define UCC_PT_CONFIG_H
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <map>
+#include <getopt.h>
+#include <ucc/api/ucc.h>
+
+enum ucc_pt_bootstrap_type_t {
+    UCC_PT_BOOTSTRAP_MPI,
+    UCC_PT_BOOTSTRAP_UCX
+};
+
+struct ucc_pt_bootstrap_config {
+    ucc_pt_bootstrap_type_t bootstrap;
+};
+
+struct ucc_pt_benchmark_config {
+    ucc_coll_type_t         coll_type;
+    size_t                  min_count;
+    size_t                  max_count;
+    ucc_datatype_t          dt;
+    ucc_memory_type_t       mt;
+    ucc_reduction_op_t      op;
+    bool                    inplace;
+    int                     n_iter;
+    int                     n_warmup;
+};
+
+struct ucc_pt_config {
+    ucc_pt_bootstrap_config bootstrap;
+    ucc_pt_benchmark_config bench;
+
+    ucc_pt_config();
+    ucc_status_t process_args(int argc, char *argv[]);
+    void print_help();
+};
+
+#endif

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -24,15 +24,18 @@ struct ucc_pt_bootstrap_config {
 };
 
 struct ucc_pt_benchmark_config {
-    ucc_coll_type_t         coll_type;
-    size_t                  min_count;
-    size_t                  max_count;
-    ucc_datatype_t          dt;
-    ucc_memory_type_t       mt;
-    ucc_reduction_op_t      op;
-    bool                    inplace;
-    int                     n_iter;
-    int                     n_warmup;
+    ucc_coll_type_t    coll_type;
+    size_t             min_count;
+    size_t             max_count;
+    ucc_datatype_t     dt;
+    ucc_memory_type_t  mt;
+    ucc_reduction_op_t op;
+    bool               inplace;
+    size_t             large_thresh;
+    int                n_iter_small;
+    int                n_warmup_small;
+    int                n_iter_large;
+    int                n_warmup_large;
 };
 
 struct ucc_pt_config {


### PR DESCRIPTION
## What
Adding UCC internal performance tests

## Why ?
UCC perftest is not a replacement for other well known benchmark such as OSU, instead the goal here is to cover different usage scenarios specific for UCC such as persistent collectives, asymmetric memory type, multithreading, measuring collective bw.

## How ?

ucc_perftest is compiled as a separate binary file in tools/perftest. Different backends might be used for OOB, but right now only MPI is available.
ucc_pt_benchmark - common logic for starting benchmark
ucc_pt_coll - collective abstraction for benchmarking
ucc_pt_bootstrap - OOB backend abstraction
ucc_pt_comm - ucc_lib + ucc_context + ucc_team

Running allreduce on 8 ranks with ucc_perftest and OSU with ucc coll component (using Val's MPI driver):
* UCC Perftest

```shell
Collective: Allreduce
Memory type: host
Data type: 11
Operation type: 2
Warmup: 200; Iterations: 100
       Count        Size                Time, us
                                 avg         min         max
         128         512        6.48        5.76        7.18
         256        1024        7.65        7.19        8.10
         512        2048        9.89        9.56       10.14
        1024        4096       16.18       16.02       16.41
        2048        8192       25.03       24.55       25.46
        4096       16384       41.91       41.30       43.14
        8192       32768       56.47       55.63       57.13
       16384       65536      101.32      100.09      103.56
       32768      131072      182.24      179.16      185.13
       65536      262144      352.69      320.45      377.47
      131072      524288      682.40      624.88      727.74
      262144     1048576     1304.06     1286.65     1320.36
      524288     2097152     2641.49     2627.99     2674.91
     1048576     4194304     6433.45     6370.56     6472.88
     2097152     8388608    15113.78    14921.75    15312.76
     4194304    16777216    44856.27    44334.32    45363.89
```
 
* OSU Allreduce
```shell
# OSU MPI Allreduce Latency Test v5.6.2
# Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
512                     7.24              6.86              7.52         100
1024                    8.29              8.01              8.46         100
2048                   10.53              9.93             11.18         100
4096                   15.03             14.50             15.64         100
8192                   25.11             24.40             25.80         100
16384                  37.26             36.14             38.33         100
32768                  60.45             58.65             62.75         100
65536                 109.76            107.78            112.19         100
131072                190.86            180.98            196.24         100
262144                355.12            349.44            363.02         100
524288                708.33            678.93            734.56         100
1048576              1356.70           1325.77           1399.61         100
2097152              2690.97           2642.03           2774.06         100
4194304              6500.48           6298.73           6777.99         100
8388608             15228.75          14709.94          15732.21         100
16777216            45990.79          45844.17          46254.13         100

```
