### PR TITLE
CORE: dbg log level for "unsupported"

### DIFF
--- a/src/components/tl/ucp/alltoall/alltoall.c
+++ b/src/components/tl/ucp/alltoall/alltoall.c
@@ -15,13 +15,13 @@ ucc_status_t ucc_tl_ucp_alltoall_init(ucc_tl_ucp_task_t *task)
 {
     if ((task->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
         (task->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) {
-        tl_error(UCC_TL_TEAM_LIB(task->team),
+        tl_debug(UCC_TL_TEAM_LIB(task->team),
                  "inplace alltoall is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     if ((task->args.src.info.datatype == UCC_DT_USERDEFINED) ||
         (task->args.dst.info.datatype == UCC_DT_USERDEFINED)) {
-        tl_error(UCC_TL_TEAM_LIB(task->team),
+        tl_debug(UCC_TL_TEAM_LIB(task->team),
                  "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -131,9 +131,11 @@ ucc_status_t ucc_collective_init(ucc_coll_args_t *coll_args,
     cl_team      = ucc_select_cl_team(coll_args, team);
     status =
         UCC_CL_TEAM_IFACE(cl_team)->coll.init(&op_args, &cl_team->super, &task);
-    if (status != UCC_OK) {
-        //TODO more descriptive error msg
-        ucc_error("failed to init collective");
+    if (UCC_ERR_NOT_SUPPORTED == status) {
+        ucc_debug("failed to init collective: not supported");
+        return status;
+    } else if (status < 0) {
+        ucc_error("failed to init collective: %s", ucc_status_string(status));
         return status;
     }
     *request = &task->super;


### PR DESCRIPTION
## What
Decrease logging level of the ucc coll_init flow from "error" to "debug" for UCC_ERR_NOT_SUPPORTED

## Why ?
Runtime can handle UCC_ERR_NOT_SUPPORTED (e.g. MPI would fallback
to another coll component). Don't spam the output with the error messages.
