### PR TITLE
Cleanup build flags

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -123,7 +123,7 @@ AC_DEFUN([COMPILER_CPU_OPTIMIZATION],
                 [AC_HELP_STRING([--with-$1], [Use $2 compiler option.])],
                 [],
                 [with_$1=$enable_optimizations])
-   
+
     AS_IF([test "x$with_$1" != "xno"],
           [SAVE_CFLAGS="$CFLAGS"
            CFLAGS="$BASE_CFLAGS $CFLAGS $3"
@@ -150,15 +150,15 @@ AC_DEFUN([DETECT_UARCH],
     cpuarch=`grep 'CPU architecture' /proc/cpuinfo 2> /dev/null | cut -d: -f2 | tr -d " " | head -n 1`
     cpuvar=`grep 'CPU variant' /proc/cpuinfo 2> /dev/null | cut -d: -f2 | tr -d " " | head -n 1`
     cpupart=`grep 'CPU part' /proc/cpuinfo 2> /dev/null | cut -d: -f2 | tr -d " " | head -n 1`
-   
+
     ax_cpu=""
     ax_arch=""
-    
+
     AC_MSG_NOTICE(Detected CPU implementation: ${cpuimpl})
     AC_MSG_NOTICE(Detected CPU architecture: ${cpuarch})
     AC_MSG_NOTICE(Detected CPU variant: ${cpuvar})
     AC_MSG_NOTICE(Detected CPU part: ${cpupart})
-   
+
     case $cpuimpl in
       0x42) case $cpupart in
         0x516 | 0x0516)
@@ -194,7 +194,7 @@ AC_DEFUN([DETECT_UARCH],
         ;;
       *)
         ;;
-    esac 
+    esac
     AM_CONDITIONAL([HAVE_AARCH64_THUNDERX2], [test x$ax_cpu = xthunderx2t99])
     AM_CONDITIONAL([HAVE_AARCH64_THUNDERX1], [test x$ax_cpu = xthunderxt88])
     AM_CONDITIONAL([HAVE_AARCH64_HI1620], [test x$ax_cpu = xtsv110])
@@ -361,9 +361,9 @@ AS_IF([test "x$ax_cpu" != "x"],
       ])
 
 
-# 
+#
 # Architecture tuning
-# 
+#
 AS_IF([test "x$ax_arch" != "x"],
       [COMPILER_CPU_OPTIMIZATION([march], [architecture tuning], [-march=$ax_arch],
                                  [int main(int argc, char** argv) { return 0;}])
@@ -519,7 +519,8 @@ ADD_COMPILER_FLAGS_IF_SUPPORTED([[-Wno-pointer-sign],
                                  [-Werror-implicit-function-declaration],
                                  [-Wno-format-zero-length],
                                  [-Wnested-externs],
-                                 [-Wshadow]],
+                                 [-Wshadow],
+                                 [-Wenum-conversion]],
                                 [AC_LANG_SOURCE([[int main(int argc, char **argv){return 0;}]])])
 
 

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -9,7 +9,7 @@
 #
 # Initialize CFLAGS
 #
-BASE_CFLAGS="-g -Wall -Werror"
+BASE_CFLAGS="-Wall -Werror"
 
 
 #
@@ -32,38 +32,6 @@ AC_DEFUN([CHECK_CXX_COMP],
                             [AC_MSG_ERROR([Cannot continue. Please install C++ compiler.])])
           AC_LANG_POP([C++])
          ])
-
-
-#
-# Debug mode
-#
-AC_ARG_ENABLE(debug,
-        AC_HELP_STRING([--enable-debug], [Enable debug mode build]),
-        [],
-        [enable_debug=no])
-AS_IF([test "x$enable_debug" = xyes],
-        [BASE_CFLAGS="-D_DEBUG $BASE_CFLAGS"
-         BASE_CXXFLAGS="-D_DEBUG" $BASE_CXXFLAGS],
-        [])
-
-
-#
-# Optimization level
-#
-AC_ARG_ENABLE(compiler-opt,
-        AC_HELP_STRING([--enable-compiler-opt], [Set optimization level [0-3]]),
-        [],
-        [enable_compiler_opt="none"])
-AS_IF([test "x$enable_compiler_opt" = "xyes"], [BASE_CFLAGS="-O3 $BASE_CFLAGS"],
-      [test "x$enable_compiler_opt" = "xnone"],
-          [AS_IF([test "x$enable_debug" = xyes],
-                 [BASE_CFLAGS="-O0 $BASE_CFLAGS"
-                  BASE_CXXFLAGS="-O0 $BASE_CXXFLAGS"],
-                 [BASE_CFLAGS="-O3 $BASE_CFLAGS"
-                  BASE_CXXFLAGS="-O0 $BASE_CXXFLAGS"])],
-      [test "x$enable_compiler_opt" = "xno"], [],
-      [BASE_CFLAGS="-O$enable_compiler_opt $BASE_CFLAGS"])
-
 
 #
 # CHECK_CROSS_COMP (program, true-action, false-action)
@@ -318,12 +286,12 @@ ADD_COMPILER_FLAG_IF_SUPPORTED([-diag-disable 269],
 # guarantee alignment for 16 bytes only. Force using compiler 16-bytes alignment
 # by default if option is supported.
 #
-UCC_ALLOC_ALIGN=16
-ADD_COMPILER_FLAG_IF_SUPPORTED([-fmax-type-align=$UCC_ALLOC_ALIGN],
-                               [-fmax-type-align=$UCC_ALLOC_ALIGN],
-                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
-                               [AC_DEFINE_UNQUOTED([UCC_ALLOC_ALIGN], $UCC_ALLOC_ALIGN, [Set aligment assumption for compiler])],
-                               [])
+#UCC_ALLOC_ALIGN=16
+#ADD_COMPILER_FLAG_IF_SUPPORTED([-fmax-type-align=$UCC_ALLOC_ALIGN],
+#                               [-fmax-type-align=$UCC_ALLOC_ALIGN],
+#                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+#                               [AC_DEFINE_UNQUOTED([UCC_ALLOC_ALIGN], $UCC_ALLOC_ALIGN, [Set aligment assumption for compiler])],
+#                               [])
 
 
 #
@@ -495,7 +463,6 @@ CHECK_COMPILER_FLAG([-pedantic], [-pedantic],
 #
 ADD_COMPILER_FLAGS_IF_SUPPORTED([[-Wno-missing-field-initializers],
                                  [-Wno-unused-parameter],
-                                 [-Wno-unused-label],
                                  [-Wno-long-long],
                                  [-Wno-endif-labels],
                                  [-Wno-sign-compare],
@@ -517,7 +484,6 @@ BASE_CXXFLAGS="$BASE_CFLAGS"
 #
 ADD_COMPILER_FLAGS_IF_SUPPORTED([[-Wno-pointer-sign],
                                  [-Werror-implicit-function-declaration],
-                                 [-Wno-format-zero-length],
                                  [-Wnested-externs],
                                  [-Wshadow],
                                  [-Wenum-conversion]],

--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,8 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/mpi.m4])
      m4_include([test/gtest/configure.m4])
 
+     mc_modules=":cpu"
+     tl_modules=""
      AC_MSG_RESULT([MPI perftest: ${mpi_enable}])
      AC_ARG_ENABLE([debug],
               AS_HELP_STRING([--enable-debug], [Enable extra debugging code (default is NO).]),
@@ -169,29 +171,33 @@ AS_IF([test "x$with_docs_only" = xyes],
         AC_DEFINE([UCS_MAX_LOG_LEVEL], [UCS_LOG_LEVEL_TRACE_POLL], [Highest log level])
      else
         AC_DEFINE([UCS_MAX_LOG_LEVEL], [UCS_LOG_LEVEL_INFO], [Highest log level])
-        CFLAGS="$CFLAGS -O3 -DNDEBUG"
-        CXXFLAGS="$CXXFLAGS -O3 -DNDEBUG"
+        CFLAGS="$CFLAGS -O3 -g -DNDEBUG"
+        CXXFLAGS="$CXXFLAGS -O3 -g -DNDEBUG"
      fi
 
      CHECK_UCX
      AC_MSG_RESULT([UCX support: $ucx_happy])
      if test $ucx_happy != "yes"; then
          AC_MSG_ERROR([UCX is not available])
+     else
+         tl_modules="${tl_modules}:ucp"
      fi
 
      CHECK_CUDA
      AC_MSG_RESULT([CUDA support: $cuda_happy; $CUDA_CPPFLAGS $CUDA_LDFLAGS])
+     if test $cuda_happy = "yes"; then
+         mc_modules="${mc_modules}:cuda"
+     fi
 
      CHECK_NCCL
      AC_MSG_RESULT([NCCL support: $nccl_happy])
+     if test $nccl_happy = "yes"; then
+         tl_modules="${tl_modules}:nccl"
+     fi
     ]) # Docs only
 
-
-
-
-includes="-I${UCC_TOP_SRCDIR}/src -I${UCC_TOP_BUILDDIR}/src"
 CFLAGS="$CFLAGS -std=gnu11"
-CPPFLAGS="$UCS_CPPFLAGS $CPPFLAGS $includes -Wall -Werror"
+CPPFLAGS="$CPPFLAGS $UCS_CPPFLAGS $includes"
 LDFLAGS="$LDFLAGS $UCS_LDFLAGS $UCS_LIBADD"
 
 AC_CONFIG_FILES([
@@ -210,3 +216,23 @@ AC_CONFIG_FILES([
                  tools/perf/Makefile
                  ])
 AC_OUTPUT
+
+#
+# Print build condiguration
+#
+AC_MSG_NOTICE([=========================================================])
+AS_IF([test "x$with_docs_only" = xyes],
+[
+AC_MSG_NOTICE([Building documents only])
+],
+[
+AC_MSG_NOTICE([UCC build configuration:])
+AC_MSG_NOTICE([      Build prefix:   ${prefix}])
+AC_MSG_NOTICE([Preprocessor flags:   ${CPPFLAGS} ${BASE_CPPFLAGS}])
+AC_MSG_NOTICE([        C compiler:   ${CC} ${CFLAGS} ${BASE_CFLAGS}])
+AC_MSG_NOTICE([      C++ compiler:   ${CXX} ${CXXFLAGS} ${BASE_CXXFLAGS}])
+AC_MSG_NOTICE([          Perftest:   ${mpi_enable}])
+AC_MSG_NOTICE([        MC modules:   <$(echo ${mc_modules}|tr ':' ' ') >])
+AC_MSG_NOTICE([        TL modules:   <$(echo ${tl_modules}|tr ':' ' ') >])
+])
+AC_MSG_NOTICE([=========================================================])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,8 +22,8 @@ SUBDIRS = . $(cl_dirs) $(tl_dirs) $(mc_dirs)
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =
 
-libucc_la_CPPFLAGS = $(AM_CPPFLAGS)
-libucc_la_CFLAGS   = -c
+libucc_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS)
+libucc_la_CFLAGS   = -c $(BASE_CFLAGS)
 libucc_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
 
 nobase_dist_libucc_la_HEADERS =	\

--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -131,7 +131,7 @@ static ucc_status_t ucc_coll_score_merge_one(ucc_list_link_t *list1,
 {
     ucc_list_link_t  lst1, lst2;
     ucc_msg_range_t *r1, *r2, *left, *right, *best, *new;
-    ucc_msg_range_t *range, *tmp, *next;
+    ucc_msg_range_t *range, *temp, *next;
     ucc_status_t     status;
 
     if (ucc_list_is_empty(list1) && ucc_list_is_empty(list2)) {
@@ -222,7 +222,7 @@ static ucc_status_t ucc_coll_score_merge_one(ucc_list_link_t *list1,
     }
     /* Merge consequtive ranges with the same score and same init fn
        if any have been produced by the algorithm above */
-    ucc_list_for_each_safe(range, tmp, out, list_elem) {
+    ucc_list_for_each_safe(range, temp, out, list_elem) {
         if (range->list_elem.next != out) {
             next = ucc_container_of(range->list_elem.next, ucc_msg_range_t,
                                     list_elem);

--- a/src/components/cl/basic/Makefile.am
+++ b/src/components/cl/basic/Makefile.am
@@ -12,7 +12,8 @@ sources =              \
 
 module_LTLIBRARIES          = libucc_cl_basic.la
 libucc_cl_basic_la_SOURCES  = $(sources)
-libucc_cl_basic_la_CPPFLAGS = $(AM_CPPFLAGS)
+libucc_cl_basic_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS)
+libucc_cl_basic_la_CFLAGS   = $(BASE_CFLAGS)
 libucc_cl_basic_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
 libucc_cl_basic_la_LIBADD   = $(UCC_TOP_BUILDDIR)/src/libucc.la
 

--- a/src/components/mc/cpu/Makefile.am
+++ b/src/components/mc/cpu/Makefile.am
@@ -9,7 +9,8 @@ sources =    \
 
 module_LTLIBRARIES        = libucc_mc_cpu.la
 libucc_mc_cpu_la_SOURCES  = $(sources)
-libucc_mc_cpu_la_CPPFLAGS = $(AM_CPPFLAGS)
+libucc_mc_cpu_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS)
+libucc_mc_cpu_la_CFLAGS   = $(BASE_CFLAGS)
 libucc_mc_cpu_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
 libucc_mc_cpu_la_LIBADD   = $(UCC_TOP_BUILDDIR)/src/libucc.la
 

--- a/src/components/mc/cuda/Makefile.am
+++ b/src/components/mc/cuda/Makefile.am
@@ -11,7 +11,8 @@ sources =    \
 
 module_LTLIBRARIES         = libucc_mc_cuda.la
 libucc_mc_cuda_la_SOURCES  = $(sources)
-libucc_mc_cuda_la_CPPFLAGS = $(AM_CPPFLAGS) $(CUDA_CPPFLAGS)
+libucc_mc_cuda_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
+libucc_mc_cuda_la_CFLAGS   = $(BASE_CFLAGS)
 libucc_mc_cuda_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLAGS)
 libucc_mc_cuda_la_LIBADD   = $(CUDA_LIBS)                      \
                              $(UCC_TOP_BUILDDIR)/src/libucc.la \

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -113,7 +113,7 @@ extern ucc_mc_cuda_t ucc_mc_cuda;
 
 #define CUDADRV_FUNC(_func)                                                    \
     ({                                                                         \
-        ucc_status_t _status = UCS_OK;                                         \
+        ucc_status_t _status = UCC_OK;                                         \
         do {                                                                   \
             CUresult _result = (_func);                                        \
             const char *cu_err_str;                                            \

--- a/src/components/tl/nccl/Makefile.am
+++ b/src/components/tl/nccl/Makefile.am
@@ -13,7 +13,8 @@ sources =             \
 
 module_LTLIBRARIES = libucc_tl_nccl.la
 libucc_tl_nccl_la_SOURCES  = $(sources)
-libucc_tl_nccl_la_CPPFLAGS = $(AM_CPPFLAGS) $(CUDA_CPPFLAGS) $(NCCL_CPPFLAGS)
+libucc_tl_nccl_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS) $(NCCL_CPPFLAGS)
+libucc_tl_nccl_la_CFLAGS   = $(BASE_CFLAGS)
 libucc_tl_nccl_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLAGS) $(NCCL_LDFLAGS)
 libucc_tl_nccl_la_LIBADD   = $(CUDA_LIBS) $(NCCL_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
 

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -132,7 +132,7 @@ static ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
 ucc_status_t ucc_tl_nccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev, ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task  = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucs_status_t status;
+    ucc_status_t status;
     ucc_ev_t *post_event;
 
     ucc_assert(ee->ee_type == UCC_EE_CUDA_STREAM);
@@ -140,7 +140,7 @@ ucc_status_t ucc_tl_nccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev, ucc_coll_task
     tl_info(task->team->super.super.context->lib, "triggered post. task:%p", coll_task);
 
     status = coll_task->post(coll_task);
-    if (status == UCS_OK) {
+    if (status == UCC_OK) {
         /* TODO: mpool */
         post_event = ucc_malloc(sizeof(ucc_ev_t), "event");
         if (post_event == NULL) {

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -58,7 +58,8 @@ sources =                 \
 
 module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)
-libucc_tl_ucp_la_CPPFLAGS = $(AM_CPPFLAGS) $(UCX_CPPFLAGS)
+libucc_tl_ucp_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(UCX_CPPFLAGS)
+libucc_tl_ucp_la_CFLAGS   = $(BASE_CFLAGS)
 libucc_tl_ucp_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(UCX_LDFLAGS)
 libucc_tl_ucp_la_LIBADD   = $(UCX_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
 

--- a/src/utils/ucc_class.h
+++ b/src/utils/ucc_class.h
@@ -25,27 +25,52 @@
     extern ucs_class_t _UCS_CLASS_DECL_NAME(_type);                            \
     UCC_CLASS_INIT_FUNC(_type, ## __VA_ARGS__);                                \
 
-#define UCC_CLASS_NEW(...)                                                     \
-    ({                                                                         \
-        ucs_status_t _ucs_status = UCS_CLASS_NEW(__VA_ARGS__);                 \
-        ucc_status_t _status     = ucs_status_to_ucc_status(_ucs_status);      \
-        _status;                                                               \
+#define UCC_CLASS_INIT(_type, _obj, ...) \
+    ({ \
+        ucs_class_t *_cls = &_UCS_CLASS_DECL_NAME(_type); \
+        int _init_counter = 1; \
+        ucc_status_t __status; \
+        \
+        __status = _UCS_CLASS_INIT_NAME(_type)((_type*)(_obj), _cls, \
+                                             &_init_counter, ## __VA_ARGS__); \
+        if (__status != UCC_OK) { \
+            ucs_class_call_cleanup_chain(&_UCS_CLASS_DECL_NAME(_type), \
+                                         (_obj), _init_counter); \
+        } \
+        \
+        (__status); \
     })
 
-#define UCC_CLASS_INIT(...)                                                    \
-    ({                                                                         \
-        ucs_status_t _ucs_status = UCS_CLASS_INIT(__VA_ARGS__);                \
-        ucc_status_t _status     = ucs_status_to_ucc_status(_ucs_status);      \
-        _status;                                                               \
+#define UCC_CLASS_NEW(_type, _obj, ...) \
+    _UCC_CLASS_NEW (_type, _obj, ## __VA_ARGS__)
+
+#define _UCC_CLASS_NEW(_type, _obj, ...) \
+    ({ \
+        ucs_class_t *cls = &_UCS_CLASS_DECL_NAME(_type); \
+        ucc_status_t _status; \
+        void *obj; \
+        \
+        obj = ucs_class_malloc(cls); \
+        if (obj != NULL) { \
+            _status = UCC_CLASS_INIT(_type, obj, ## __VA_ARGS__); \
+            if (_status == UCC_OK) { \
+                *(_obj) = (typeof(*(_obj)))obj; /* Success - assign pointer */ \
+            } else { \
+                ucs_class_free(obj); /* Initialization failure */ \
+            } \
+        } else { \
+            _status = UCC_ERR_NO_MEMORY; /* Allocation failure */ \
+        } \
+        \
+        (_status); \
     })
 
 #define UCC_CLASS_CALL_SUPER_INIT(_superclass, ...)                            \
     {                                                                          \
         {                                                                      \
-            ucs_status_t _ucs_status = _UCS_CLASS_INIT_NAME(_superclass)(      \
+            ucc_status_t _status = _UCS_CLASS_INIT_NAME(_superclass)(      \
                 &self->super, _myclass->superclass, _init_count,               \
                 ##__VA_ARGS__);                                                \
-            ucc_status_t _status = ucs_status_to_ucc_status(_ucs_status);      \
             if (_status != UCC_OK) {                                           \
                 return _status;                                                \
             }                                                                  \
@@ -73,14 +98,16 @@
 #define UCC_CLASS_DEFINE_NAMED_NEW_FUNC(_name, _type, _argtype, ...)           \
     UCC_CLASS_DECLARE_NAMED_NEW_FUNC(_name, _argtype, ##__VA_ARGS__)           \
     {                                                                          \
-        ucs_status_t status;                                                   \
+        ucc_status_t status;                                                   \
+        ucs_status_t ucs_status;                                               \
         *obj_p = NULL;                                                         \
-        status = UCS_CLASS_NEW(                                                \
+        status = UCC_CLASS_NEW(                                                \
             _type,                                                             \
             obj_p UCS_PP_FOREACH(_UCS_CLASS_INIT_ARG_PASS, _,                  \
                                  UCS_PP_SEQ(UCS_PP_NUM_ARGS(__VA_ARGS__))));   \
-        ucs_class_check_new_func_result(status, *obj_p);                       \
-        return ucs_status_to_ucc_status(status);                               \
+        ucs_status = ucc_status_to_ucs_status(status);                         \
+        ucs_class_check_new_func_result(ucs_status, *obj_p);                   \
+        return status;                                                         \
     }
 
 #define UCC_CLASS_DECLARE_NEW_FUNC(_type, _argtype, ...)                       \

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -24,8 +24,8 @@ ucc_test_mpi_SOURCES = \
 	test_alltoallv.cc
 
 CXX=mpicxx
-ucc_test_mpi_CXXFLAGS=-I${top_builddir}/src -std=gnu++11
-
+ucc_test_mpi_CPPFLAGS=$(BASE_CPPFLAGS)
+ucc_test_mpi_CXXFLAGS=$(BASE_CXXFLAGS) -std=gnu++11
 ucc_test_mpi_LDFLAGS=-L${top_builddir}/src/.libs -lucc
 
 if HAVE_CUDA

--- a/tools/info/Makefile.am
+++ b/tools/info/Makefile.am
@@ -26,6 +26,7 @@ noinst_HEADERS = \
 nodist_ucc_info_SOURCES = \
 	build_config.h
 
-ucc_info_CPPFLAGS = $(AM_CPPFLAGS) -I${UCC_TOP_BUILDDIR}/src
+ucc_info_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) -I${UCC_TOP_BUILDDIR}/src
+ucc_info_CFLAGS = $(BASE_CFLAGS)
 ucc_info_LDADD = \
 	$(UCC_TOP_BUILDDIR)/src/libucc.la

--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -19,6 +19,6 @@ ucc_perftest_SOURCES =      \
 
 CXX=$(MPICXX)
 LD=$(MPICXX)
-ucc_perftest_CPPFLAGS=-I${UCC_TOP_BUILDDIR}/src
-ucc_perftest_CXXFLAGS=-std=gnu++11
+ucc_perftest_CPPFLAGS=$(BASE_CPPFLAGS)
+ucc_perftest_CXXFLAGS=-std=gnu++11 $(BASE_CXXFLAGS)
 ucc_perftest_LDADD = $(UCC_TOP_BUILDDIR)/src/libucc.la


### PR DESCRIPTION
## What

- Use compiler and preprocessor flags configured from compiler.m4
- Unify flags across different components. Use BASE_CPFFLAGS, BASE_CFLAGS, BASE_CXXFLAGS as common options
- Print configure summary table
- Fix incorrect statuses (ucs_status messed up with ucc_status)
