### PR TITLE
TOOLS: adding more options to perftest

### DIFF
--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -9,21 +9,29 @@
 
 bin_PROGRAMS = ucc_perftest
 
-ucc_perftest_SOURCES =       \
-	ucc_perftest.cc          \
-	ucc_pt_config.cc         \
-	ucc_pt_comm.cc           \
-	ucc_pt_benchmark.cc      \
-	ucc_pt_bootstrap_mpi.cc  \
-	ucc_pt_coll.cc           \
-    ucc_pt_coll_allgather.cc \
-    ucc_pt_coll_allreduce.cc \
-    ucc_pt_coll_alltoall.cc  \
-    ucc_pt_coll_barrier.cc   \
-    ucc_pt_coll_bcast.cc
+ucc_perftest_SOURCES =        \
+	ucc_perftest.cc           \
+	ucc_pt_config.cc          \
+	ucc_pt_comm.cc            \
+	ucc_pt_benchmark.cc       \
+	ucc_pt_bootstrap_mpi.cc   \
+	ucc_pt_coll.cc            \
+	ucc_pt_coll_allgather.cc  \
+	ucc_pt_coll_allgatherv.cc \
+	ucc_pt_coll_allreduce.cc  \
+	ucc_pt_coll_alltoall.cc   \
+	ucc_pt_coll_alltoallv.cc  \
+	ucc_pt_coll_barrier.cc    \
+	ucc_pt_coll_bcast.cc
 
 CXX=$(MPICXX)
 LD=$(MPICXX)
 ucc_perftest_CPPFLAGS=$(BASE_CPPFLAGS)
 ucc_perftest_CXXFLAGS=-std=gnu++11 $(BASE_CXXFLAGS)
-ucc_perftest_LDADD = $(UCC_TOP_BUILDDIR)/src/libucc.la
+ucc_perftest_LDADD=$(UCC_TOP_BUILDDIR)/src/libucc.la
+
+if HAVE_CUDA
+ucc_perftest_CPPFLAGS+=$(CUDA_CPPFLAGS)
+ucc_perftest_LDFLAGS=$(CUDA_LDFLAGS)
+ucc_perftest_LDADD+=$(CUDA_LIBS)
+endif

--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -9,13 +9,18 @@
 
 bin_PROGRAMS = ucc_perftest
 
-ucc_perftest_SOURCES =      \
-	ucc_perftest.cc         \
-	ucc_pt_config.cc        \
-	ucc_pt_comm.cc          \
-	ucc_pt_benchmark.cc     \
-	ucc_pt_coll.cc          \
-	ucc_pt_bootstrap_mpi.cc
+ucc_perftest_SOURCES =       \
+	ucc_perftest.cc          \
+	ucc_pt_config.cc         \
+	ucc_pt_comm.cc           \
+	ucc_pt_benchmark.cc      \
+	ucc_pt_bootstrap_mpi.cc  \
+	ucc_pt_coll.cc           \
+    ucc_pt_coll_allgather.cc \
+    ucc_pt_coll_allreduce.cc \
+    ucc_pt_coll_alltoall.cc  \
+    ucc_pt_coll_barrier.cc   \
+    ucc_pt_coll_bcast.cc
 
 CXX=$(MPICXX)
 LD=$(MPICXX)

--- a/tools/perf/ucc_perftest.cc
+++ b/tools/perf/ucc_perftest.cc
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 
     pt_config.process_args(argc, argv);
     try {
-        comm = new ucc_pt_comm();
+        comm = new ucc_pt_comm(pt_config.comm);
     } catch(std::exception &e) {
         std::cerr << e.what() << std::endl;
         std::exit(1);

--- a/tools/perf/ucc_perftest.cc
+++ b/tools/perf/ucc_perftest.cc
@@ -7,11 +7,33 @@
 int main(int argc, char *argv[])
 {
     ucc_pt_config pt_config;
+    ucc_pt_comm *comm;
+    ucc_pt_benchmark *bench;
+    ucc_status_t st;
+
     pt_config.process_args(argc, argv);
-    ucc_pt_comm comm;
-    comm.init();
-    ucc_pt_benchmark bench(pt_config.bench, &comm);
-    bench.run_bench();
-    comm.finalize();
+    try {
+        comm = new ucc_pt_comm();
+    } catch(std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        std::exit(1);
+    }
+    st = comm->init();
+    if (st != UCC_OK) {
+        delete comm;
+        std::exit(1);
+    }
+    try {
+        bench = new ucc_pt_benchmark(pt_config.bench, comm);
+    } catch(std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        comm->finalize();
+        delete comm;
+        std::exit(1);
+    }
+    bench->run_bench();
+    delete bench;
+    comm->finalize();
+    delete comm;
     return 0;
 }

--- a/tools/perf/ucc_perftest.h
+++ b/tools/perf/ucc_perftest.h
@@ -6,13 +6,29 @@
 
 #include <ucc/api/ucc.h>
 #include <iostream>
+#include "config.h"
 
 #define STR(x) #x
 #define UCCCHECK_GOTO(_call, _label, _status)                                  \
     do {                                                                       \
         _status = (_call);                                                     \
         if (UCC_OK != _status) {                                               \
-            std::cerr << "UCC perftest error: " << STR(_call) << "\n";         \
+            std::cerr << "UCC perftest error: " << ucc_status_string(_status)  \
+                      << " in " << STR(_call) << "\n";                         \
             goto _label;                                                       \
         }                                                                      \
     } while (0)
+
+#ifdef HAVE_CUDA
+#include <cuda_runtime_api.h>
+#define CUDA_CHECK_GOTO(_call, _label, _status)                                \
+    do {                                                                       \
+        _status = (_call);                                                     \
+        if (cudaSuccess != _status) {                                          \
+            std::cerr << "UCC perftest error: " << cudaGetErrorString(_status) \
+                      << " in " << STR(_call) << "\n";                         \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
+
+#endif

--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -14,12 +14,20 @@ ucc_pt_benchmark::ucc_pt_benchmark(ucc_pt_benchmark_config cfg,
         coll = new ucc_pt_coll_allgather(comm->get_size(), cfg.dt, cfg.mt,
                                          cfg.inplace);
         break;
+    case UCC_COLL_TYPE_ALLGATHERV:
+        coll = new ucc_pt_coll_allgatherv(comm->get_size(), cfg.dt, cfg.mt,
+                                          cfg.inplace);
+        break;
     case UCC_COLL_TYPE_ALLREDUCE:
         coll = new ucc_pt_coll_allreduce(cfg.dt, cfg.mt, cfg.op, cfg.inplace);
         break;
     case UCC_COLL_TYPE_ALLTOALL:
         coll = new ucc_pt_coll_alltoall(comm->get_size(), cfg.dt, cfg.mt,
                                         cfg.inplace);
+        break;
+    case UCC_COLL_TYPE_ALLTOALLV:
+        coll = new ucc_pt_coll_alltoallv(comm->get_size(), cfg.dt, cfg.mt,
+                                         cfg.inplace);
         break;
     case UCC_COLL_TYPE_BARRIER:
         coll = new ucc_pt_coll_barrier();

--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -9,17 +9,39 @@ ucc_pt_benchmark::ucc_pt_benchmark(ucc_pt_benchmark_config cfg,
     config(cfg),
     comm(communcator)
 {
-    coll = new ucc_pt_coll_allreduce(cfg.dt, cfg.mt, cfg.op, cfg.inplace);
+    switch (cfg.coll_type) {
+    case UCC_COLL_TYPE_ALLGATHER:
+        coll = new ucc_pt_coll_allgather(comm->get_size(), cfg.dt, cfg.mt,
+                                         cfg.inplace);
+        break;
+    case UCC_COLL_TYPE_ALLREDUCE:
+        coll = new ucc_pt_coll_allreduce(cfg.dt, cfg.mt, cfg.op, cfg.inplace);
+        break;
+    case UCC_COLL_TYPE_ALLTOALL:
+        coll = new ucc_pt_coll_alltoall(comm->get_size(), cfg.dt, cfg.mt,
+                                        cfg.inplace);
+        break;
+    case UCC_COLL_TYPE_BARRIER:
+        coll = new ucc_pt_coll_barrier();
+        break;
+    case UCC_COLL_TYPE_BCAST:
+        coll = new ucc_pt_coll_bcast(cfg.dt, cfg.mt);
+        break;
+    default:
+        throw std::runtime_error("not supported collective");
+    }
 }
 
-ucc_status_t ucc_pt_benchmark::run_bench()
+ucc_status_t ucc_pt_benchmark::run_bench() noexcept
 {
-    ucc_status_t st = UCC_OK;
+    size_t min_count = coll->has_range() ? config.min_count : 1;
+    size_t max_count = coll->has_range() ? config.max_count : 1;
+    ucc_status_t st;
     ucc_coll_args_t args;
     std::chrono::nanoseconds time;
 
     print_header();
-    for (size_t cnt = config.min_count; cnt <= config.max_count; cnt *= 2) {
+    for (size_t cnt = min_count; cnt <= max_count; cnt *= 2) {
         size_t coll_size = cnt * ucc_dt_size(config.dt);
         int iter = config.n_iter_small;
         int warmup = config.n_warmup_small;
@@ -43,6 +65,7 @@ exit_err:
 ucc_status_t ucc_pt_benchmark::run_single_test(ucc_coll_args_t args,
                                                int nwarmup, int niter,
                                                std::chrono::nanoseconds &time)
+                                               noexcept
 {
     ucc_team_h    team = comm->get_team();
     ucc_context_h ctx  = comm->get_context();
@@ -90,10 +113,19 @@ void ucc_pt_benchmark::print_header()
                   << "Memory type: " << ucc_memory_type_names[config.mt]
                   << std::endl;
         std::cout << std::left << std::setw(24)
-                  << "Data type: " << ucc_datatype_str(config.dt)
+                  << "Datatype: " << ucc_datatype_str(config.dt)
                   << std::endl;
         std::cout << std::left << std::setw(24)
-                  << "Operation type: " << ucc_reduction_op_str(config.op)
+                  << "Reduction: "
+                  << (coll->has_reduction() ?
+                        ucc_reduction_op_str(config.op):
+                        "N/A")
+                  << std::endl;
+        std::cout << std::left << std::setw(24)
+                  << "Inplace: "
+                  << (coll->has_inplace() ?
+                        std::to_string(config.inplace):
+                        "N/A")
                   << std::endl;
         std::cout << std::left << std::setw(24)
                   << "Warmup:" << std::endl
@@ -122,8 +154,10 @@ void ucc_pt_benchmark::print_header()
 
 void ucc_pt_benchmark::print_time(size_t count, std::chrono::nanoseconds time)
 {
-    float time_ms = time.count() / 1000.0;
+    float  time_ms = time.count() / 1000.0;
+    size_t size    = count * ucc_dt_size(config.dt);
     float time_avg, time_min, time_max;
+
     comm->allreduce(&time_ms, &time_min, 1, UCC_OP_MIN);
     comm->allreduce(&time_ms, &time_max, 1, UCC_OP_MAX);
     comm->allreduce(&time_ms, &time_avg, 1, UCC_OP_SUM);
@@ -132,13 +166,17 @@ void ucc_pt_benchmark::print_time(size_t count, std::chrono::nanoseconds time)
     if (comm->get_rank() == 0) {
         std::ios iostate(nullptr);
         iostate.copyfmt(std::cout);
-        std::cout<<std::setprecision(2) << std::fixed;
-        std::cout << std::setw(12) << count <<
-                     std::setw(12) << count * ucc_dt_size(config.dt) <<
-                     std::setw(12) << time_avg <<
-                     std::setw(12) << time_min <<
-                     std::setw(12) << time_max <<
-                     std::endl;
+        std::cout << std::setprecision(2) << std::fixed;
+        std::cout << std::setw(12) << (coll->has_range() ?
+                                        std::to_string(count):
+                                        "N/A")
+                  << std::setw(12) << (coll->has_range() ?
+                                        std::to_string(size):
+                                        "N/A")
+                  << std::setw(12) << time_avg
+                  << std::setw(12) << time_min
+                  << std::setw(12) << time_max
+                  << std::endl;
         std::cout.copyfmt(iostate);
     }
 }

--- a/tools/perf/ucc_pt_benchmark.h
+++ b/tools/perf/ucc_pt_benchmark.h
@@ -23,10 +23,10 @@ class ucc_pt_benchmark {
     void print_time(size_t count, std::chrono::nanoseconds time);
 public:
     ucc_pt_benchmark(ucc_pt_benchmark_config cfg, ucc_pt_comm *communcator);
-    ucc_status_t run_bench();
+    ucc_status_t run_bench() noexcept;
     ucc_status_t run_single_test(ucc_coll_args_t args,
                                  int nwarmup, int niter,
-                                 std::chrono::nanoseconds &time);
+                                 std::chrono::nanoseconds &time) noexcept;
     ~ucc_pt_benchmark();
 };
 

--- a/tools/perf/ucc_pt_bootstrap.h
+++ b/tools/perf/ucc_pt_bootstrap.h
@@ -19,16 +19,19 @@ protected:
     ucc_context_oob_coll_t context_oob;
     ucc_team_oob_coll_t team_oob;
     int ppn;
-    int find_ppn()
+    int local_rank;
+    void find_ppn()
     {
         int     comm_size = get_size();
+        int     comm_rank = get_rank();
         size_t *hashes    = new size_t[comm_size];
-        int     ppn       = 0;
         ucc_status_t st;
         void *req;
 
+        ppn = 0;
+        local_rank = 0;
         st = team_oob.allgather(&node_hash, hashes, sizeof(node_hash),
-                                                    team_oob.coll_info, &req);
+                                team_oob.coll_info, &req);
         if (st != UCC_OK) {
             goto exit_err;
         }
@@ -40,16 +43,23 @@ protected:
         }
         team_oob.req_free(req);
         for (int i = 0; i < comm_size; i++) {
+            if (i == comm_rank) {
+                break;
+            }
+            if (node_hash == hashes[i]) {
+                local_rank++;
+            }
+        }
+        for (int i = 0; i < comm_size; i++) {
             if (node_hash == hashes[i]) {
                 ppn++;
             }
         }
         delete[] hashes;
-        return ppn;
+        return;
 exit_err:
         std::cerr <<"failed to find ppn" <<std::endl;
         delete[] hashes;
-        return ppn;
     }
 public:
     ucc_pt_bootstrap()
@@ -58,15 +68,23 @@ public:
         gethostname(hostname, sizeof(hostname));
         node_hash = std::hash<std::string>{}(std::string(hostname));
         ppn = -1;
+        local_rank = -1;
     }
     virtual int get_rank() = 0;
     virtual int get_size() = 0;
     int get_ppn()
     {
         if (ppn == -1) {
-            ppn = find_ppn();
+            find_ppn();
         }
         return ppn;
+    }
+    int get_local_rank()
+    {
+        if (local_rank == -1) {
+            find_ppn();
+        }
+        return local_rank;
     }
     virtual ~ucc_pt_bootstrap() {};
     ucc_context_oob_coll_t get_context_oob()

--- a/tools/perf/ucc_pt_bootstrap.h
+++ b/tools/perf/ucc_pt_bootstrap.h
@@ -8,14 +8,66 @@
 #define UCC_PT_BOOTSTRAP_H
 
 #include <ucc/api/ucc.h>
+#include <unistd.h>
+#include <functional>
+#include <string>
+#include <iostream>
 
 class ucc_pt_bootstrap {
 protected:
+    size_t node_hash;
     ucc_context_oob_coll_t context_oob;
     ucc_team_oob_coll_t team_oob;
+    int ppn;
+    int find_ppn()
+    {
+        int     comm_size = get_size();
+        size_t *hashes    = new size_t[comm_size];
+        int     ppn       = 0;
+        ucc_status_t st;
+        void *req;
+
+        st = team_oob.allgather(&node_hash, hashes, sizeof(node_hash),
+                                                    team_oob.coll_info, &req);
+        if (st != UCC_OK) {
+            goto exit_err;
+        }
+        do {
+            st = team_oob.req_test(req);
+        } while (st == UCC_INPROGRESS);
+        if (st != UCC_OK) {
+            goto exit_err;
+        }
+        team_oob.req_free(req);
+        for (int i = 0; i < comm_size; i++) {
+            if (node_hash == hashes[i]) {
+                ppn++;
+            }
+        }
+        delete[] hashes;
+        return ppn;
+exit_err:
+        std::cerr <<"failed to find ppn" <<std::endl;
+        delete[] hashes;
+        return ppn;
+    }
 public:
+    ucc_pt_bootstrap()
+    {
+        char hostname[256];
+        gethostname(hostname, sizeof(hostname));
+        node_hash = std::hash<std::string>{}(std::string(hostname));
+        ppn = -1;
+    }
     virtual int get_rank() = 0;
     virtual int get_size() = 0;
+    int get_ppn()
+    {
+        if (ppn == -1) {
+            ppn = find_ppn();
+        }
+        return ppn;
+    }
     virtual ~ucc_pt_bootstrap() {};
     ucc_context_oob_coll_t get_context_oob()
     {

--- a/tools/perf/ucc_pt_bootstrap_mpi.cc
+++ b/tools/perf/ucc_pt_bootstrap_mpi.cc
@@ -24,7 +24,8 @@ static ucc_status_t mpi_oob_allgather_free(void *req)
     return UCC_OK;
 }
 
-ucc_pt_bootstrap_mpi::ucc_pt_bootstrap_mpi() {
+ucc_pt_bootstrap_mpi::ucc_pt_bootstrap_mpi()
+{
     MPI_Init(NULL, NULL);
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -42,14 +43,17 @@ ucc_pt_bootstrap_mpi::ucc_pt_bootstrap_mpi() {
     team_oob.participants = size;
 }
 
-int ucc_pt_bootstrap_mpi::get_rank() {
+int ucc_pt_bootstrap_mpi::get_rank()
+{
     return rank;
 }
 
-int ucc_pt_bootstrap_mpi::get_size() {
+int ucc_pt_bootstrap_mpi::get_size()
+{
     return size;
 }
 
-ucc_pt_bootstrap_mpi::~ucc_pt_bootstrap_mpi() {
+ucc_pt_bootstrap_mpi::~ucc_pt_bootstrap_mpi()
+{
     MPI_Finalize();
 }

--- a/tools/perf/ucc_pt_bootstrap_mpi.h
+++ b/tools/perf/ucc_pt_bootstrap_mpi.h
@@ -19,6 +19,7 @@ public:
 protected:
     int rank;
     int size;
+    int ppn;
 };
 
 #endif

--- a/tools/perf/ucc_pt_coll.cc
+++ b/tools/perf/ucc_pt_coll.cc
@@ -1,62 +1,14 @@
 #include "ucc_pt_coll.h"
-#include "ucc_perftest.h"
-#include <ucc/api/ucc.h>
-#include <utils/ucc_math.h>
-#include <utils/ucc_coll_utils.h>
-extern "C" {
-#include <core/ucc_mc.h>
-}
 
-ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
-                                             ucc_memory_type mt,
-                                             ucc_reduction_op_t op,
-                                             bool is_inplace)
+bool ucc_pt_coll::has_reduction()
 {
-    coll_args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
-    coll_args.mask = 0;
-    if (is_inplace) {
-        coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
-        coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
-    }
-    coll_args.mask |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    coll_args.reduce.predefined_op = op;
-    coll_args.src.info.datatype = dt;
-    coll_args.src.info.mem_type = mt;
-    coll_args.dst.info.mem_type = mt;
+    return has_reduction_;
 }
-
-ucc_status_t ucc_pt_coll_allreduce::init_coll_args(size_t count,
-                                                   ucc_coll_args_t &args)
+bool ucc_pt_coll::has_inplace()
 {
-    size_t       dt_size = ucc_dt_size(coll_args.src.info.datatype);
-    size_t       size    = count * dt_size;
-    ucc_status_t st      = UCC_OK;
-
-    args = coll_args;
-    args.src.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.buffer, size,
-                               args.dst.info.mem_type), exit, st);
-    if (!UCC_IS_INPLACE(args)) {
-        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size,
-                                   args.src.info.mem_type), free_dst, st);
-    }
-    return UCC_OK;
-free_dst:
-    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
-exit:
-    return st;
+    return has_inplace_;
 }
-
-void ucc_pt_coll_allreduce::free_coll_args(ucc_coll_args_t &args)
+bool ucc_pt_coll::has_range()
 {
-    if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
-    }
-    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
-}
-
-double ucc_pt_coll_allreduce::get_bus_bw(double time_us)
-{
-    //TODO
-    return 0.0;
+    return has_range_;
 }

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -11,19 +11,63 @@
 
 class ucc_pt_coll {
 protected:
+    bool has_inplace_;
+    bool has_reduction_;
+    bool has_range_;
     ucc_coll_args_t coll_args;
 public:
     virtual ucc_status_t init_coll_args(size_t count,
                                         ucc_coll_args_t &args) = 0;
     virtual void free_coll_args(ucc_coll_args_t &args) = 0;
     virtual double get_bus_bw(double time_us) = 0;
+    bool has_reduction();
+    bool has_inplace();
+    bool has_range();
     virtual ~ucc_pt_coll() {};
+};
+
+class ucc_pt_coll_allgather: public ucc_pt_coll {
+protected:
+    int comm_size;
+public:
+    ucc_pt_coll_allgather(int size, ucc_datatype_t dt, ucc_memory_type mt,
+                          bool is_inplace);
+    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
+    void free_coll_args(ucc_coll_args_t &args) override;
+    double get_bus_bw(double time_us) override;
 };
 
 class ucc_pt_coll_allreduce: public ucc_pt_coll {
 public:
     ucc_pt_coll_allreduce(ucc_datatype_t dt, ucc_memory_type mt,
                           ucc_reduction_op_t op, bool is_inplace);
+    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
+    void free_coll_args(ucc_coll_args_t &args) override;
+    double get_bus_bw(double time_us) override;
+};
+
+class ucc_pt_coll_alltoall: public ucc_pt_coll {
+protected:
+    int comm_size;
+public:
+    ucc_pt_coll_alltoall(int size, ucc_datatype_t dt, ucc_memory_type mt,
+                         bool is_inplace);
+    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
+    void free_coll_args(ucc_coll_args_t &args) override;
+    double get_bus_bw(double time_us) override;
+};
+
+class ucc_pt_coll_barrier: public ucc_pt_coll {
+public:
+    ucc_pt_coll_barrier();
+    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
+    void free_coll_args(ucc_coll_args_t &args) override;
+    double get_bus_bw(double time_us) override;
+};
+
+class ucc_pt_coll_bcast: public ucc_pt_coll {
+public:
+    ucc_pt_coll_bcast(ucc_datatype_t dt, ucc_memory_type mt);
     ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
     void free_coll_args(ucc_coll_args_t &args) override;
     double get_bus_bw(double time_us) override;

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -37,6 +37,17 @@ public:
     double get_bus_bw(double time_us) override;
 };
 
+class ucc_pt_coll_allgatherv: public ucc_pt_coll {
+protected:
+    int comm_size;
+public:
+    ucc_pt_coll_allgatherv(int size, ucc_datatype_t dt, ucc_memory_type mt,
+                           bool is_inplace);
+    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
+    void free_coll_args(ucc_coll_args_t &args) override;
+    double get_bus_bw(double time_us) override;
+};
+
 class ucc_pt_coll_allreduce: public ucc_pt_coll {
 public:
     ucc_pt_coll_allreduce(ucc_datatype_t dt, ucc_memory_type mt,
@@ -52,6 +63,17 @@ protected:
 public:
     ucc_pt_coll_alltoall(int size, ucc_datatype_t dt, ucc_memory_type mt,
                          bool is_inplace);
+    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
+    void free_coll_args(ucc_coll_args_t &args) override;
+    double get_bus_bw(double time_us) override;
+};
+
+class ucc_pt_coll_alltoallv: public ucc_pt_coll {
+protected:
+    int comm_size;
+public:
+    ucc_pt_coll_alltoallv(int size, ucc_datatype_t dt, ucc_memory_type mt,
+                          bool is_inplace);
     ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
     void free_coll_args(ucc_coll_args_t &args) override;
     double get_bus_bw(double time_us) override;

--- a/tools/perf/ucc_pt_coll_allgather.cc
+++ b/tools/perf/ucc_pt_coll_allgather.cc
@@ -1,0 +1,68 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+extern "C" {
+#include <core/ucc_mc.h>
+}
+
+ucc_pt_coll_allgather::ucc_pt_coll_allgather(int size, ucc_datatype_t dt,
+                                             ucc_memory_type mt,
+                                             bool is_inplace):
+    comm_size(size)
+{
+    has_inplace_= true;
+    has_reduction_= false;
+    has_range_ = true;
+
+    coll_args.mask = 0;
+    coll_args.coll_type = UCC_COLL_TYPE_ALLGATHER;
+    coll_args.src.info.datatype = dt;
+    coll_args.src.info.mem_type = mt;
+    coll_args.dst.info.datatype = dt;
+    coll_args.dst.info.mem_type = mt;
+    if (is_inplace) {
+        coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+}
+
+ucc_status_t ucc_pt_coll_allgather::init_coll_args(size_t count,
+                                                  ucc_coll_args_t &args)
+{
+    size_t dt_size  = ucc_dt_size(coll_args.src.info.datatype);
+    size_t size_src = count * dt_size;
+    size_t size_dst = comm_size * count * dt_size;
+    ucc_status_t st;
+
+    args = coll_args;
+    args.dst.info.count = count;
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.buffer, size_dst,
+                               args.dst.info.mem_type), exit, st);
+    if (!UCC_IS_INPLACE(args)) {
+        args.src.info.count = count;
+        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size_src,
+                                   args.src.info.mem_type), free_dst, st);
+    }
+    return UCC_OK;
+free_dst:
+    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+exit:
+    return st;
+    return UCC_OK;
+}
+
+void ucc_pt_coll_allgather::free_coll_args(ucc_coll_args_t &args)
+{
+    if (!UCC_IS_INPLACE(args)) {
+        ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+    }
+    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+}
+
+double ucc_pt_coll_allgather::get_bus_bw(double time_us)
+{
+    //TODO
+    return 0.0;
+}

--- a/tools/perf/ucc_pt_coll_allgatherv.cc
+++ b/tools/perf/ucc_pt_coll_allgatherv.cc
@@ -1,0 +1,83 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+extern "C" {
+#include <core/ucc_mc.h>
+}
+
+ucc_pt_coll_allgatherv::ucc_pt_coll_allgatherv(int size, ucc_datatype_t dt,
+                                               ucc_memory_type mt,
+                                               bool is_inplace):
+    comm_size(size)
+{
+    has_inplace_= true;
+    has_reduction_= false;
+    has_range_ = true;
+
+    coll_args.mask = 0;
+    coll_args.coll_type = UCC_COLL_TYPE_ALLGATHERV;
+    coll_args.src.info.datatype = dt;
+    coll_args.src.info.mem_type = mt;
+    coll_args.dst.info_v.datatype = dt;
+    coll_args.dst.info_v.mem_type = mt;
+    if (is_inplace) {
+        coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+}
+
+ucc_status_t ucc_pt_coll_allgatherv::init_coll_args(size_t count,
+                                                  ucc_coll_args_t &args)
+{
+    size_t dt_size  = ucc_dt_size(coll_args.src.info.datatype);
+    size_t size_src = count * dt_size;
+    size_t size_dst = comm_size * count * dt_size;
+    ucc_status_t st;
+
+    args = coll_args;
+    UCCCHECK_GOTO(ucc_mc_alloc((void**)&args.dst.info_v.counts,
+                               comm_size *sizeof(uint32_t),
+                               UCC_MEMORY_TYPE_HOST), exit, st);
+    UCCCHECK_GOTO(ucc_mc_alloc((void**)&args.dst.info_v.displacements,
+                               comm_size *sizeof(uint32_t),
+                               UCC_MEMORY_TYPE_HOST), free_count, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info_v.buffer, size_dst,
+                               args.dst.info_v.mem_type), free_displ, st);
+    if (!UCC_IS_INPLACE(args)) {
+        args.src.info.count = count;
+        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size_src,
+                                   args.src.info.mem_type), free_dst, st);
+    }
+    for (int i = 0; i < comm_size; i++) {
+        ((uint32_t*)args.dst.info_v.counts)[i] = count;
+        ((uint32_t*)args.dst.info_v.displacements)[i] = count * i;
+    }
+    return UCC_OK;
+free_dst:
+    ucc_mc_free(args.dst.info_v.buffer, args.dst.info_v.mem_type);
+free_displ:
+    ucc_mc_free(args.dst.info_v.displacements, UCC_MEMORY_TYPE_HOST);
+free_count:
+    ucc_mc_free(args.dst.info_v.counts, UCC_MEMORY_TYPE_HOST);
+exit:
+    return st;
+    return UCC_OK;
+}
+
+void ucc_pt_coll_allgatherv::free_coll_args(ucc_coll_args_t &args)
+{
+    if (!UCC_IS_INPLACE(args)) {
+        ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+    }
+    ucc_mc_free(args.dst.info_v.buffer, args.dst.info_v.mem_type);
+    ucc_mc_free(args.dst.info_v.counts, UCC_MEMORY_TYPE_HOST);
+    ucc_mc_free(args.dst.info_v.displacements, UCC_MEMORY_TYPE_HOST);
+}
+
+double ucc_pt_coll_allgatherv::get_bus_bw(double time_us)
+{
+    //TODO
+    return 0.0;
+}

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -1,0 +1,66 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+extern "C" {
+#include <core/ucc_mc.h>
+}
+
+ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
+                                             ucc_memory_type mt,
+                                             ucc_reduction_op_t op,
+                                             bool is_inplace)
+{
+    has_inplace_= true;
+    has_reduction_= true;
+    has_range_ = true;
+
+    coll_args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
+    coll_args.mask = 0;
+    if (is_inplace) {
+        coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+    coll_args.mask |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
+    coll_args.reduce.predefined_op = op;
+    coll_args.src.info.datatype = dt;
+    coll_args.src.info.mem_type = mt;
+    coll_args.dst.info.mem_type = mt;
+}
+
+ucc_status_t ucc_pt_coll_allreduce::init_coll_args(size_t count,
+                                                   ucc_coll_args_t &args)
+{
+    size_t       dt_size = ucc_dt_size(coll_args.src.info.datatype);
+    size_t       size    = count * dt_size;
+    ucc_status_t st      = UCC_OK;
+
+    args = coll_args;
+    args.src.info.count = count;
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.buffer, size,
+                               args.dst.info.mem_type), exit, st);
+    if (!UCC_IS_INPLACE(args)) {
+        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size,
+                                   args.src.info.mem_type), free_dst, st);
+    }
+    return UCC_OK;
+free_dst:
+    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+exit:
+    return st;
+}
+
+void ucc_pt_coll_allreduce::free_coll_args(ucc_coll_args_t &args)
+{
+    if (!UCC_IS_INPLACE(args)) {
+        ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+    }
+    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+}
+
+double ucc_pt_coll_allreduce::get_bus_bw(double time_us)
+{
+    //TODO
+    return 0.0;
+}

--- a/tools/perf/ucc_pt_coll_alltoall.cc
+++ b/tools/perf/ucc_pt_coll_alltoall.cc
@@ -1,0 +1,65 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+extern "C" {
+#include <core/ucc_mc.h>
+}
+
+ucc_pt_coll_alltoall::ucc_pt_coll_alltoall(int size, ucc_datatype_t dt,
+                                           ucc_memory_type mt, bool is_inplace):
+    comm_size(size)
+{
+    has_inplace_= true;
+    has_reduction_= false;
+    has_range_ = true;
+
+    coll_args.mask = 0;
+    coll_args.coll_type = UCC_COLL_TYPE_ALLTOALL;
+    coll_args.src.info.datatype = dt;
+    coll_args.src.info.mem_type = mt;
+    coll_args.dst.info.datatype = dt;
+    coll_args.dst.info.mem_type = mt;
+    if (is_inplace) {
+        coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+}
+
+ucc_status_t ucc_pt_coll_alltoall::init_coll_args(size_t count,
+                                                  ucc_coll_args_t &args)
+{
+    size_t       dt_size = ucc_dt_size(coll_args.src.info.datatype);
+    size_t       size    = comm_size * count * dt_size;
+    ucc_status_t st      = UCC_OK;
+
+    args = coll_args;
+    args.dst.info.count = count;
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.buffer, size,
+                               args.dst.info.mem_type), exit, st);
+    if (!UCC_IS_INPLACE(args)) {
+        args.src.info.count = count;
+        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size,
+                                   args.src.info.mem_type), free_dst, st);
+    }
+    return UCC_OK;
+free_dst:
+    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+exit:
+    return st;
+}
+
+void ucc_pt_coll_alltoall::free_coll_args(ucc_coll_args_t &args)
+{
+    if (!UCC_IS_INPLACE(args)) {
+        ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+    }
+    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+}
+
+double ucc_pt_coll_alltoall::get_bus_bw(double time_us)
+{
+    //TODO
+    return 0.0;
+}

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -1,0 +1,93 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+extern "C" {
+#include <core/ucc_mc.h>
+}
+
+ucc_pt_coll_alltoallv::ucc_pt_coll_alltoallv(int size, ucc_datatype_t dt,
+                                             ucc_memory_type mt, bool is_inplace):
+    comm_size(size)
+{
+    has_inplace_= true;
+    has_reduction_= false;
+    has_range_ = true;
+
+    coll_args.mask = 0;
+    coll_args.coll_type = UCC_COLL_TYPE_ALLTOALLV;
+    coll_args.src.info_v.datatype = dt;
+    coll_args.src.info_v.mem_type = mt;
+    coll_args.dst.info_v.datatype = dt;
+    coll_args.dst.info_v.mem_type = mt;
+    if (is_inplace) {
+        coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+}
+
+ucc_status_t ucc_pt_coll_alltoallv::init_coll_args(size_t count,
+                                                   ucc_coll_args_t &args)
+{
+    size_t       dt_size = ucc_dt_size(coll_args.src.info_v.datatype);
+    size_t       size    = comm_size * count * dt_size;
+    ucc_status_t st      = UCC_OK;
+
+    args = coll_args;
+    UCCCHECK_GOTO(ucc_mc_alloc((void**)&args.src.info_v.counts,
+                               comm_size * sizeof(uint32_t),
+                               UCC_MEMORY_TYPE_HOST), exit, st);
+    UCCCHECK_GOTO(ucc_mc_alloc((void**)&args.src.info_v.displacements,
+                               comm_size * sizeof(uint32_t),
+                               UCC_MEMORY_TYPE_HOST), free_src_count, st);
+    UCCCHECK_GOTO(ucc_mc_alloc((void**)&args.dst.info_v.counts,
+                               comm_size * sizeof(uint32_t),
+                               UCC_MEMORY_TYPE_HOST), free_src_displ, st);
+    UCCCHECK_GOTO(ucc_mc_alloc((void**)&args.dst.info_v.displacements,
+                               comm_size * sizeof(uint32_t),
+                               UCC_MEMORY_TYPE_HOST), free_dst_count, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info_v.buffer, size,
+                               args.dst.info_v.mem_type), free_dst_displ, st);
+    if (!UCC_IS_INPLACE(args)) {
+        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info_v.buffer, size,
+                                   args.src.info_v.mem_type), free_dst, st);
+    }
+    for (int i = 0; i < comm_size; i++) {
+        ((uint32_t*)args.src.info_v.counts)[i] = count;
+        ((uint32_t*)args.src.info_v.displacements)[i] = count * i;
+        ((uint32_t*)args.dst.info_v.counts)[i] = count;
+        ((uint32_t*)args.dst.info_v.displacements)[i] = count * i;
+    }
+    return UCC_OK;
+free_dst:
+    ucc_mc_free(args.dst.info_v.buffer, args.dst.info_v.mem_type);
+free_dst_displ:
+    ucc_mc_free(args.dst.info_v.displacements, UCC_MEMORY_TYPE_HOST);
+free_dst_count:
+    ucc_mc_free(args.dst.info_v.counts, UCC_MEMORY_TYPE_HOST);
+free_src_displ:
+    ucc_mc_free(args.src.info_v.displacements, UCC_MEMORY_TYPE_HOST);
+free_src_count:
+    ucc_mc_free(args.src.info_v.counts, UCC_MEMORY_TYPE_HOST);
+exit:
+    return st;
+}
+
+void ucc_pt_coll_alltoallv::free_coll_args(ucc_coll_args_t &args)
+{
+    if (!UCC_IS_INPLACE(args)) {
+        ucc_mc_free(args.src.info_v.buffer, args.src.info_v.mem_type);
+    }
+    ucc_mc_free(args.dst.info_v.buffer, args.dst.info_v.mem_type);
+    ucc_mc_free(args.dst.info_v.counts, UCC_MEMORY_TYPE_HOST);
+    ucc_mc_free(args.dst.info_v.displacements, UCC_MEMORY_TYPE_HOST);
+    ucc_mc_free(args.src.info_v.counts, UCC_MEMORY_TYPE_HOST);
+    ucc_mc_free(args.src.info_v.displacements, UCC_MEMORY_TYPE_HOST);
+}
+
+double ucc_pt_coll_alltoallv::get_bus_bw(double time_us)
+{
+    //TODO
+    return 0.0;
+}

--- a/tools/perf/ucc_pt_coll_barrier.cc
+++ b/tools/perf/ucc_pt_coll_barrier.cc
@@ -1,0 +1,36 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+extern "C" {
+#include <core/ucc_mc.h>
+}
+
+ucc_pt_coll_barrier::ucc_pt_coll_barrier()
+{
+    has_inplace_= false;
+    has_reduction_ = false;
+    has_range_ = false;
+
+    coll_args.mask = 0;
+    coll_args.coll_type = UCC_COLL_TYPE_BARRIER;
+}
+
+ucc_status_t ucc_pt_coll_barrier::init_coll_args(size_t count,
+                                                 ucc_coll_args_t &args)
+{
+    args = coll_args;
+    return UCC_OK;
+}
+
+void ucc_pt_coll_barrier::free_coll_args(ucc_coll_args_t &args)
+{
+    return;
+}
+
+double ucc_pt_coll_barrier::get_bus_bw(double time_us)
+{
+    //TODO
+    return 0.0;
+}

--- a/tools/perf/ucc_pt_coll_bcast.cc
+++ b/tools/perf/ucc_pt_coll_bcast.cc
@@ -1,0 +1,48 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+extern "C" {
+#include <core/ucc_mc.h>
+}
+
+ucc_pt_coll_bcast::ucc_pt_coll_bcast(ucc_datatype_t dt,
+                                             ucc_memory_type mt)
+{
+    has_inplace_ = false;
+    has_reduction_ = false;
+    has_range_ = true;
+
+    coll_args.mask = 0;
+    coll_args.coll_type = UCC_COLL_TYPE_BCAST;
+    coll_args.root = 0;
+    coll_args.src.info.datatype = dt;
+    coll_args.src.info.mem_type = mt;
+}
+
+ucc_status_t ucc_pt_coll_bcast::init_coll_args(size_t count,
+                                                   ucc_coll_args_t &args)
+{
+    size_t dt_size = ucc_dt_size(coll_args.src.info.datatype);
+    size_t size    = count * dt_size;
+    ucc_status_t st;
+
+    args = coll_args;
+    args.src.info.count = count;
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size,
+                               args.src.info.mem_type), exit, st);
+exit:
+    return st;
+}
+
+void ucc_pt_coll_bcast::free_coll_args(ucc_coll_args_t &args)
+{
+    ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+}
+
+double ucc_pt_coll_bcast::get_bus_bw(double time_us)
+{
+    //TODO
+    return 0.0;
+}

--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -42,6 +42,7 @@ ucc_status_t ucc_pt_comm::init()
     ucc_context_params_t ctx_params;
     ucc_team_params_t team_params;
     ucc_status_t st;
+    std::string cfg_mod;
 
     UCCCHECK_GOTO(ucc_lib_config_read("PERFTEST", nullptr, &lib_config),
                   exit_err, st);
@@ -51,6 +52,12 @@ ucc_status_t ucc_pt_comm::init()
     UCCCHECK_GOTO(ucc_init(&lib_params, lib_config, &lib), free_lib_config, st);
     UCCCHECK_GOTO(ucc_context_config_read(lib, NULL, &ctx_config),
                   free_lib, st);
+    cfg_mod = std::to_string(bootstrap->get_size());
+    UCCCHECK_GOTO(ucc_context_config_modify(ctx_config, NULL,
+                  "ESTIMATED_NUM_EPS", cfg_mod.c_str()), free_ctx_config, st);
+    cfg_mod = std::to_string(bootstrap->get_ppn());
+    UCCCHECK_GOTO(ucc_context_config_modify(ctx_config, NULL,
+                  "ESTIMATED_NUM_PPN", cfg_mod.c_str()), free_ctx_config, st);
     std::memset(&ctx_params, 0, sizeof(ucc_context_params_t));
     ctx_params.mask = UCC_CONTEXT_PARAM_FIELD_TYPE |
                           UCC_CONTEXT_PARAM_FIELD_OOB;

--- a/tools/perf/ucc_pt_comm.h
+++ b/tools/perf/ucc_pt_comm.h
@@ -8,16 +8,19 @@
 #define UCC_PT_COMM_H
 
 #include <ucc/api/ucc.h>
+#include "ucc_pt_config.h"
 #include "ucc_pt_bootstrap.h"
 #include "ucc_pt_bootstrap_mpi.h"
 
 class ucc_pt_comm {
+    ucc_pt_comm_config cfg;
     ucc_lib_h lib;
     ucc_context_h context;
     ucc_team_h team;
     ucc_pt_bootstrap *bootstrap;
+    void set_gpu_device();
 public:
-    ucc_pt_comm();
+    ucc_pt_comm(ucc_pt_comm_config config);
     int get_rank();
     int get_size();
     ucc_team_h get_team();

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -25,8 +25,10 @@ const std::map<std::string, ucc_reduction_op_t> ucc_pt_op_map = {
 
 const std::map<std::string, ucc_coll_type_t> ucc_pt_coll_map = {
     {"allgather", UCC_COLL_TYPE_ALLGATHER},
+    {"allgatherv", UCC_COLL_TYPE_ALLGATHERV},
     {"allreduce", UCC_COLL_TYPE_ALLREDUCE},
     {"alltoall", UCC_COLL_TYPE_ALLTOALL},
+    {"alltoallv", UCC_COLL_TYPE_ALLTOALLV},
     {"barrier", UCC_COLL_TYPE_BARRIER},
     {"bcast", UCC_COLL_TYPE_BCAST},
 };
@@ -77,6 +79,7 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
                     return UCC_ERR_INVALID_PARAM;
                 }
                 bench.mt = ucc_pt_memtype_map.at(optarg);
+                comm.mt  = bench.mt;
                 break;
             case 'd':
                 if (ucc_pt_datatype_map.count(optarg) == 0) {

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -25,9 +25,30 @@ const std::map<std::string, ucc_reduction_op_t> ucc_pt_op_map = {
 
 const std::map<std::string, ucc_coll_type_t> ucc_pt_coll_map = {
     {"allgather", UCC_COLL_TYPE_ALLGATHER},
-    {"allgatherv", UCC_COLL_TYPE_ALLGATHERV},
     {"allreduce", UCC_COLL_TYPE_ALLREDUCE},
     {"alltoall", UCC_COLL_TYPE_ALLTOALL},
+    {"barrier", UCC_COLL_TYPE_BARRIER},
+    {"bcast", UCC_COLL_TYPE_BCAST},
+};
+
+const std::map<std::string, ucc_memory_type_t> ucc_pt_memtype_map = {
+    {"host", UCC_MEMORY_TYPE_HOST},
+    {"cuda", UCC_MEMORY_TYPE_CUDA},
+};
+
+const std::map<std::string, ucc_datatype_t> ucc_pt_datatype_map = {
+    {"int8", UCC_DT_INT8},
+    {"uint8", UCC_DT_UINT8},
+    {"int16", UCC_DT_INT16},
+    {"uint16", UCC_DT_UINT16},
+    {"float16", UCC_DT_FLOAT16},
+    {"int32", UCC_DT_INT32},
+    {"float32", UCC_DT_FLOAT32},
+    {"int64", UCC_DT_INT64},
+    {"uint64", UCC_DT_UINT64},
+    {"float64", UCC_DT_FLOAT64},
+    {"int128", UCC_DT_INT128},
+    {"uint128", UCC_DT_UINT128},
 };
 
 ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
@@ -49,6 +70,20 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
                     return UCC_ERR_INVALID_PARAM;
                 }
                 bench.op = ucc_pt_op_map.at(optarg);
+                break;
+            case 'm':
+                if (ucc_pt_memtype_map.count(optarg) == 0) {
+                    std::cerr << "invalid memory type" << std::endl;
+                    return UCC_ERR_INVALID_PARAM;
+                }
+                bench.mt = ucc_pt_memtype_map.at(optarg);
+                break;
+            case 'd':
+                if (ucc_pt_datatype_map.count(optarg) == 0) {
+                    std::cerr << "invalid datatype" << std::endl;
+                    return UCC_ERR_INVALID_PARAM;
+                }
+                bench.dt = ucc_pt_datatype_map.at(optarg);
                 break;
             case 'b':
                 std::stringstream(optarg) >> bench.min_count;
@@ -78,14 +113,16 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
 
 void ucc_pt_config::print_help()
 {
-    std::cout<<"Usage: ucc_perftest [options]"<<std::endl;
-    std::cout<<"  -c <collective name>: Collective type"<<std::endl;
-    std::cout<<"  -b <count>: Min number of elements"<<std::endl;
-    std::cout<<"  -e <count>: Max number of elements"<<std::endl;
-    std::cout<<"  -i: inplace collective"<<std::endl;
-    std::cout<<"  -o <op name>: operation type for rudction"<<std::endl;
-    std::cout<<"  -n <number>: number of iterations"<<std::endl;
-    std::cout<<"  -w <number>: number of warmup iterations"<<std::endl;
-    std::cout<<"  -h: show this help message"<<std::endl;
-    std::cout<<std::endl;
+    std::cout << "Usage: ucc_perftest [options]"<<std::endl;
+    std::cout << "  -c <collective name>: Collective type"<<std::endl;
+    std::cout << "  -b <count>: Min number of elements"<<std::endl;
+    std::cout << "  -e <count>: Max number of elements"<<std::endl;
+    std::cout << "  -i: inplace collective"<<std::endl;
+    std::cout << "  -d <dt name>: datatype"<<std::endl;
+    std::cout << "  -o <op name>: reduction operation type"<<std::endl;
+    std::cout << "  -m <mtype name>: memory type"<<std::endl;
+    std::cout << "  -n <number>: number of iterations"<<std::endl;
+    std::cout << "  -w <number>: number of warmup iterations"<<std::endl;
+    std::cout << "  -h: show this help message"<<std::endl;
+    std::cout << std::endl;
 }

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -23,6 +23,10 @@ struct ucc_pt_bootstrap_config {
     ucc_pt_bootstrap_type_t bootstrap;
 };
 
+struct ucc_pt_comm_config {
+    ucc_memory_type_t mt;
+};
+
 struct ucc_pt_benchmark_config {
     ucc_coll_type_t    coll_type;
     size_t             min_count;
@@ -40,6 +44,7 @@ struct ucc_pt_benchmark_config {
 
 struct ucc_pt_config {
     ucc_pt_bootstrap_config bootstrap;
+    ucc_pt_comm_config      comm;
     ucc_pt_benchmark_config bench;
 
     ucc_pt_config();


### PR DESCRIPTION
## What
in ucc_perftest added support for:
- allgather, alltoall, broadcast, barrier
- different memory types
- different datatypes
- set esimated num eps and ppn
