### PR TITLE
API: completion callback

### DIFF
--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -81,8 +81,7 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
     status = ucc_tl_ucp_allgather_ring_progress(&task->super);
     if (UCC_INPROGRESS == status) {
         ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
-    } else if (status < 0) {
-        return status;
+        return UCC_OK;
     }
-    return UCC_OK;
+    return ucc_task_complete(coll_task);
 }

--- a/src/components/tl/ucp/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv_ring.c
@@ -96,10 +96,9 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *coll_task)
     status = ucc_tl_ucp_allgatherv_ring_progress(&task->super);
     if (UCC_INPROGRESS == status) {
         ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
-    } else if (status < 0) {
-        return status;
+        return UCC_OK;
     }
-    return UCC_OK;
+    return ucc_task_complete(coll_task);
 error:
     return task->super.super.status;
 }

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -216,8 +216,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
     status = ucc_tl_ucp_allreduce_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {
         ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
-    } else if (status < 0) {
-        return status;
+        return UCC_OK;
     }
-    return UCC_OK;
+    return ucc_task_complete(coll_task);
 }

--- a/src/components/tl/ucp/alltoall/alltoall_pairwise.c
+++ b/src/components/tl/ucp/alltoall/alltoall_pairwise.c
@@ -92,8 +92,7 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_alltoall_pairwise_progress(&task->super);
     if (UCC_INPROGRESS == task->super.super.status) {
         ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
-    } else if (task->super.super.status < 0) {
-        return task->super.super.status;
+        return UCC_OK;
     }
-    return UCC_OK;
+    return ucc_task_complete(coll_task);
 }

--- a/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
@@ -110,8 +110,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_alltoallv_pairwise_progress(&task->super);
     if (UCC_INPROGRESS == task->super.super.status) {
         ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
-    } else if (task->super.super.status < 0) {
-        return task->super.super.status;
+        return UCC_OK;
     }
-    return UCC_OK;
+    return ucc_task_complete(coll_task);
 }

--- a/src/components/tl/ucp/barrier/barrier_knomial.c
+++ b/src/components/tl/ucp/barrier/barrier_knomial.c
@@ -137,8 +137,7 @@ ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_task_t *coll_task)
     status = ucc_tl_ucp_barrier_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {
         ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
-    } else if (status < 0) {
-        return status;
+        return UCC_OK;
     }
-    return UCC_OK;
+    return ucc_task_complete(coll_task);
 }

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -86,8 +86,7 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *coll_task)
     status                   = ucc_tl_ucp_bcast_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {
         ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
-    } else if (status < 0) {
-        return status;
+        return UCC_OK;
     }
-    return UCC_OK;
+    return ucc_task_complete(coll_task);
 }

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -138,6 +138,10 @@ ucc_status_t ucc_collective_init(ucc_coll_args_t *coll_args,
         ucc_error("failed to init collective: %s", ucc_status_string(status));
         return status;
     }
+    if (coll_args->mask & UCC_COLL_ARGS_FIELD_CB) {
+        task->cb = coll_args->cb;
+        task->flags |= UCC_COLL_TASK_FLAG_CB;
+    }
     *request = &task->super;
     return UCC_OK;
 }

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -114,19 +114,13 @@ static int ucc_pq_mt_progress(ucc_progress_queue_t *pq)
                 return status;
             }
         }
-        if (UCC_OK == task->super.status) {
-            n_progressed++;
-            // TODO need to decide for st/mt progress should it return #progressed/#completed tasks,
-            // and document accordingly
-            status = ucc_event_manager_notify(task, UCC_EVENT_COMPLETED);
-            if (status != UCC_OK) {
-                return status;
-            }
-            if (task->flags & UCC_COLL_TASK_FLAG_INTERNAL) {
-                task->finalize(task);
-            }
-        } else {
+        if (UCC_INPROGRESS == task->super.status) {
             pq->enqueue(pq, task);
+            return n_progressed;
+        }
+        n_progressed++;
+        if (0 > (status = ucc_task_complete(task))) {
+            return status;
         }
     }
     return n_progressed;

--- a/src/core/ucc_progress_queue_st.c
+++ b/src/core/ucc_progress_queue_st.c
@@ -28,16 +28,13 @@ static int ucc_pq_st_progress(ucc_progress_queue_t *pq)
                 return status;
             }
         }
-        if (UCC_OK == task->super.status) {
-            n_progressed++;
-            status = ucc_event_manager_notify(task, UCC_EVENT_COMPLETED);
-            if (status != UCC_OK) {
-                return status;
-            }
-            ucc_list_del(&task->list_elem);
-            if (task->flags & UCC_COLL_TASK_FLAG_INTERNAL) {
-                task->finalize(task);
-            }
+        if (UCC_INPROGRESS == task->super.status) {
+            continue;
+        }
+        ucc_list_del(&task->list_elem);
+        n_progressed++;
+        if (0 > (status = ucc_task_complete(task))) {
+            return status;
         }
     }
     return n_progressed;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1413,6 +1413,7 @@ enum ucc_coll_args_field {
     UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS           = UCC_BIT(1),
     UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS          = UCC_BIT(2),
     UCC_COLL_ARGS_FIELD_TAG                             = UCC_BIT(3),
+    UCC_COLL_ARGS_FIELD_CB                              = UCC_BIT(4)
 };
 
 /**
@@ -1472,6 +1473,7 @@ typedef struct ucc_coll_args {
                                              collectives */
     ucc_error_type_t                error_type; /*!< Error type */
     ucc_coll_id_t                   tag; /*!< Used for ordering collectives */
+    ucc_coll_callback_t             cb;
 } ucc_coll_args_t;
 
 /**

--- a/src/ucc/api/ucc_def.h
+++ b/src/ucc/api/ucc_def.h
@@ -64,6 +64,18 @@ typedef struct ucc_coll_req {
 } ucc_coll_req_t;
 
 /**
+ * @ingroup UCC_COLLECTIVES_DT
+ * @brief UCC collective completion callback
+ *
+ * The callback is invoked whenever the collective operation is completed.
+ * It is not allowed to call UCC APIs from the completion callback except
+ * for @ref ucc_collective_finalize.
+ */
+typedef struct ucc_coll_callback {
+    void (*cb)(void *data, ucc_status_t status);
+    void  *data;
+} ucc_coll_callback_t;
+/**
  * @ingroup UCC_COLLECTIVES
  * @brief UCC memory handle
  *
@@ -144,5 +156,6 @@ typedef size_t ucc_context_addr_len_t;
  * the execution context and related queues.
  */
 typedef struct ucc_ee*      ucc_ee_h;
+
 
 #endif

--- a/test/gtest/core/test_barrier.cc
+++ b/test/gtest/core/test_barrier.cc
@@ -11,6 +11,7 @@ class test_barrier : public ucc::test
 public:
     ucc_coll_args_t coll;
     test_barrier() {
+        coll.mask      = 0;
         coll.coll_type = UCC_COLL_TYPE_BARRIER;
     }
 };


### PR DESCRIPTION
## What
According to the decision made in WG: Adds the API option to set completion callback for ucc_coll_args_t. 

## Why ?
Used to implement the support for non-blocking collectives in OpenMPI coll/ucc driver (other use-cases also possible): https://github.com/vspetrov/ompi/tree/coll_ucc_v2 . It used to handle ompi/ucc requests allocation/progress/signalling.

## How ?
User can set UCC_COLL_ARGS_FIELD_CB flag to coll_args and pass a callback function which is invoked upon collective completion. The only UCC api allowed from the callback is ucc_collective_finalize.