### PR TITLE
TEST: reduce amount of err output

### DIFF
--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <string>
 
-#define UCC_CHECK(_call)    ASSERT_EQ(UCC_OK, (_call))
+#define UCC_CHECK(_call)    EXPECT_EQ(UCC_OK, (_call))
 
 namespace ucc {
 

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -61,7 +61,7 @@ public:
     virtual void data_init(int nprocs, ucc_datatype_t dtype,
                            size_t count, UccCollCtxVec &args) = 0;
     virtual void data_fini(UccCollCtxVec args) = 0;
-    virtual void data_validate(UccCollCtxVec args) = 0;
+    virtual bool data_validate(UccCollCtxVec args) = 0;
     void set_mem_type(ucc_memory_type_t _mt);
     void set_inplace(gtest_ucc_inplace_t _inplace);
 };

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -92,8 +92,9 @@ public:
         }
         ctxs.clear();
     }
-    void data_validate(UccCollCtxVec ctxs)
+    bool data_validate(UccCollCtxVec ctxs)
     {
+        bool                   ret = true;
         std::vector<uint8_t *> dsts(ctxs.size());
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
@@ -117,8 +118,11 @@ public:
                 rbuf += rank_size;
                 rank_size = ucc_dt_size((ctxs[r])->args->src.info.datatype) *
                         (ctxs[r])->args->src.info.count;
-                for (int i = 0; i < rank_size; i++) {
-                    EXPECT_EQ(r, rbuf[i]);
+                for (int j = 0; j < rank_size; j++) {
+                    if (r != rbuf[j]) {
+                        ret = false;
+                        break;
+                    }
                 }
             }
         }
@@ -127,6 +131,7 @@ public:
                 UCC_CHECK(ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST));
             }
         }
+        return ret;
     }
 };
 
@@ -151,7 +156,7 @@ UCC_TEST_P(test_allgatherv_0, single_host)
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
-    data_validate(ctxs);
+    EXPECT_EQ(true, data_validate(ctxs));;
     data_fini(ctxs);
 }
 
@@ -196,7 +201,7 @@ UCC_TEST_P(test_allgatherv_1, multiple)
     UccReq::waitall(reqs);
 
     for (auto ctx : ctxs) {
-        data_validate(ctx);
+        EXPECT_EQ(true, data_validate(ctx));;
         data_fini(ctx);
     }
 }

--- a/test/gtest/core/test_allreduce.cc
+++ b/test/gtest/core/test_allreduce.cc
@@ -81,7 +81,7 @@ class test_allreduce : public UccCollArgs, public testing::Test {
         }
         ctxs.clear();
     }
-    void data_validate(UccCollCtxVec ctxs)
+    bool data_validate(UccCollCtxVec ctxs)
     {
         size_t count = (ctxs[0])->args->src.info.count;
         std::vector<typename T::type *> dsts(ctxs.size());
@@ -115,7 +115,7 @@ class test_allreduce : public UccCollArgs, public testing::Test {
                 UCC_CHECK(ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST));
             }
         }
-        return;
+        return true;
     }
 };
 
@@ -135,7 +135,7 @@ TYPED_TEST_CASE(test_allreduce, ReductionTypesOps);
             UccReq    req(team, ctxs);                                         \
             req.start();                                                       \
             req.wait();                                                        \
-            this->data_validate(ctxs);                                         \
+            EXPECT_EQ(true, this->data_validate(ctxs));                           \
             this->data_fini(ctxs);                                             \
         }                                                                      \
     }                                                                          \
@@ -179,7 +179,7 @@ TYPED_TEST(test_allreduce, single_cuda_inplace) {
         UccReq::startall(reqs);                                                \
         UccReq::waitall(reqs);                                                 \
         for (auto ctx : ctxs) {                                                \
-            this->data_validate(ctx);                                          \
+            EXPECT_EQ(true, this->data_validate(ctx));                            \
             this->data_fini(ctx);                                              \
         }                                                                      \
     }                                                                          \

--- a/test/gtest/core/test_bcast.cc
+++ b/test/gtest/core/test_bcast.cc
@@ -63,9 +63,10 @@ public:
         }
         ctxs.clear();
     }
-    void data_validate(UccCollCtxVec ctxs)
+    bool data_validate(UccCollCtxVec ctxs)
     {
-        int root = ctxs[0]->args->root;
+        bool     ret  = true;
+        int      root = ctxs[0]->args->root;
         uint8_t *dsts;
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
@@ -83,13 +84,16 @@ public:
                 continue;
             }
             for (int i = 0; i < ctxs[r]->rbuf_size; i++) {
-                EXPECT_EQ((uint8_t)i, dsts[i]);
+                if ((uint8_t)i != dsts[i]) {
+                    ret = false;
+                    break;
+                }
             }
         }
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             UCC_CHECK(ucc_mc_free((void*)dsts, UCC_MEMORY_TYPE_HOST));
         }
-        return;
+        return ret;
     }
     void set_root(int _root)
     {
@@ -118,7 +122,7 @@ UCC_TEST_P(test_bcast_0, single_host)
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
-    data_validate(ctxs);
+    EXPECT_EQ(true, data_validate(ctxs));
     data_fini(ctxs);
 }
 
@@ -163,7 +167,7 @@ UCC_TEST_P(test_bcast_1, multiple)
     UccReq::waitall(reqs);
 
     for (auto ctx : ctxs) {
-        data_validate(ctx);
+        EXPECT_EQ(true, data_validate(ctx));
         data_fini(ctx);
     }
 }


### PR DESCRIPTION
## What
in gtest: Invoke EXPECT_EQ macro only on the result of data_validate

## Why ?
If the data validation failed in gtest the output would be totally clogged due to EXPECT_EQ failure for every position in a buffer.

