### PR TITLE
CORE: remove ucc_tl_type_t

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -88,6 +88,7 @@ libucc_la_SOURCES =                  \
 	utils/ucc_proc_info.c            \
 	utils/ucc_string.c               \
 	utils/ucc_coll_utils.c           \
+	utils/ucc_parser.c               \
 	components/base/ucc_base_iface.c \
 	components/cl/ucc_cl.c           \
 	components/tl/ucc_tl.c           \

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -144,7 +144,6 @@ typedef struct ucc_base_coll_alg_info {
         UCC_IFACE_CFG(_F, _f, context, _name, _NAME),                          \
         .super.super.score = UCC_##_F##_NAME##_DEFAULT_SCORE,                  \
         .super.super.name  = UCC_PP_MAKE_STRING(_name),                        \
-        .super.type        = UCC_##_F##_NAME,                                  \
         .super.lib.init    = UCC_CLASS_NEW_FUNC_NAME(ucc_##_f##_name##_lib_t), \
         .super.lib.finalize =                                                  \
             UCC_CLASS_DELETE_FUNC_NAME(ucc_##_f##_name##_lib_t),               \

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -16,14 +16,14 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
         ucc_derived_of(config, ucc_cl_context_config_t);
     UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_config->cl_lib,
                               params->context);
-    status = ucc_tl_context_get(params->context, UCC_TL_UCP,
+    status = ucc_tl_context_get(params->context, "ucp",
                                 &self->tl_ucp_ctx);
     if (UCC_OK != status) {
         cl_warn(cl_config->cl_lib,
                 "TL UCP context is not available, CL BASIC can't proceed");
         return UCC_ERR_NOT_FOUND;
     }
-    status = ucc_tl_context_get(params->context, UCC_TL_NCCL,
+    status = ucc_tl_context_get(params->context, "nccl",
                                 &self->tl_nccl_ctx);
     if (UCC_OK != status) {
         cl_info(cl_config->cl_lib,

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -28,16 +28,16 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
 
-/* NOLINTNEXTLINE */
 ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
                                        ucc_base_attr_t *base_attr)
 {
-    ucc_cl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
-    attr->tls               = UCC_TL_UCP | UCC_TL_NCCL;
+    ucc_cl_lib_attr_t     *attr   = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
+    ucc_cl_lib_t          *cl_lib = ucc_derived_of(lib, ucc_cl_lib_t);
     ucc_status_t           status;
     ucc_tl_lib_attr_t      ucp_tl_attr, nccl_tl_attr;
     ucc_component_iface_t *ucp_iface, *nccl_iface;
     ucc_tl_iface_t        *tl_ucp_iface, *tl_nccl_iface;
+    attr->tls = &cl_lib->tls;
     ucp_iface = ucc_get_component(&ucc_global_config.tl_framework, "ucp");
     if (!ucp_iface) {
     	cl_error(lib, "failed to get UCP component");

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -12,6 +12,9 @@ ucc_config_field_t ucc_cl_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_lib_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_base_config_table)},
 
+    {"TLS", "all", NULL, ucc_offsetof(ucc_cl_lib_config_t, tls),
+     UCC_CONFIG_TYPE_STRING_ARRAY},
+
     {NULL}
 };
 
@@ -28,6 +31,7 @@ const char *ucc_cl_names[] = {
 UCC_CLASS_INIT_FUNC(ucc_cl_lib_t, ucc_cl_iface_t *cl_iface,
                     const ucc_cl_lib_config_t *cl_config)
 {
+    ucc_status_t status;
     UCC_CLASS_CALL_BASE_INIT();
     self->iface         = cl_iface;
     self->super.log_component = cl_config->super.log_component;
@@ -35,12 +39,18 @@ UCC_CLASS_INIT_FUNC(ucc_cl_lib_t, ucc_cl_iface_t *cl_iface,
                      cl_iface->cl_lib_config.name,
                      sizeof(self->super.log_component.name));
     self->super.score_str = strdup(cl_config->super.score_str);
-    return UCC_OK;
+    status = ucc_config_names_array_dup(&self->tls, &cl_config->tls);
+    if (UCC_OK != status) {
+        ucc_error("failed to dup TLS config_names_array for CL %s",
+                  cl_iface->cl_lib_config.name);
+    }
+    return status;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_lib_t)
 {
     ucc_free(self->super.score_str);
+    ucc_config_names_array_free(&self->tls);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_lib_t, void);

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -79,14 +79,14 @@ ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface,
                                 (ucc_base_config_t **)tl_config);
 }
 
-ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, ucc_tl_type_t type,
+ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, const char* name,
                                 ucc_tl_context_t **tl_context)
 {
     int i;
     ucc_tl_lib_t *tl_lib;
     for (i = 0; i < ctx->n_tl_ctx; i++) {
         tl_lib = ucc_derived_of(ctx->tl_ctx[i]->super.lib, ucc_tl_lib_t);
-        if (tl_lib->iface->type == type) {
+        if (0 == strcmp(tl_lib->iface->super.name, name)) {
             ctx->tl_ctx[i]->ref_count++;
             *tl_context = ctx->tl_ctx[i];
             return UCC_OK;

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -25,11 +25,6 @@ typedef struct ucc_tl_iface   ucc_tl_iface_t;
 typedef struct ucc_tl_context ucc_tl_context_t;
 typedef struct ucc_tl_team    ucc_tl_team_t;
 
-typedef enum ucc_tl_type {
-    UCC_TL_UCP  = UCC_BIT(0),
-    UCC_TL_NCCL = UCC_BIT(1),
-} ucc_tl_type_t;
-
 typedef struct ucc_tl_lib_config {
     ucc_base_config_t  super;
     ucc_tl_iface_t    *iface;
@@ -67,7 +62,6 @@ typedef struct ucc_tl_service_coll {
 
 typedef struct ucc_tl_iface {
     ucc_component_iface_t          super;
-    ucc_tl_type_t                  type;
     ucs_config_global_list_entry_t tl_lib_config;
     ucs_config_global_list_entry_t tl_context_config;
     ucc_base_lib_iface_t           lib;
@@ -98,7 +92,7 @@ UCC_CLASS_DECLARE(ucc_tl_team_t, ucc_tl_context_t *);
 #define UCC_TL_IFACE_DECLARE(_name, _NAME)                                     \
     UCC_BASE_IFACE_DECLARE(TL_, tl_, _name, _NAME)
 
-ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, ucc_tl_type_t type,
+ucc_status_t ucc_tl_context_get(ucc_context_t *ctx, const char *name,
                                 ucc_tl_context_t **tl_context);
 ucc_status_t ucc_tl_context_put(ucc_tl_context_t *tl_context);
 

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -11,8 +11,9 @@
 #include "components/cl/ucc_cl_type.h"
 #include "utils/ucc_parser.h"
 
-typedef struct ucc_cl_lib ucc_cl_lib_t;
-typedef struct ucc_tl_lib ucc_tl_lib_t;
+typedef struct ucc_cl_lib      ucc_cl_lib_t;
+typedef struct ucc_tl_lib      ucc_tl_lib_t;
+typedef struct ucc_cl_lib_attr ucc_cl_lib_attr_t;
 
 typedef struct ucc_lib_config {
     char                    *full_prefix;
@@ -23,13 +24,14 @@ typedef struct ucc_lib_config {
 } ucc_lib_config_t;
 
 typedef struct ucc_lib_info {
-    char          *full_prefix;
-    int            n_cl_libs_opened;
-    int            n_tl_libs_opened;
-    ucc_cl_lib_t **cl_libs;
-    ucc_tl_lib_t **tl_libs;
-    ucc_lib_attr_t attr;
-    int            specific_cls_requested;
+    char             *full_prefix;
+    int               n_cl_libs_opened;
+    int               n_tl_libs_opened;
+    ucc_cl_lib_t    **cl_libs;
+    ucc_tl_lib_t    **tl_libs;
+    ucc_lib_attr_t    attr;
+    int               specific_cls_requested;
+    ucc_cl_lib_attr_t *cl_attrs;
 } ucc_lib_info_t;
 
 void ucc_get_version(unsigned *major_version, unsigned *minor_version,

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -65,7 +65,7 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
            (external id has high bit set) - start service team creation */
         ucc_base_team_params_t b_params;
         ucc_base_team_t       *b_team;
-        status = ucc_tl_context_get(context, UCC_TL_UCP, &context->service_ctx);
+        status = ucc_tl_context_get(context, "ucp", &context->service_ctx);
         if (UCC_OK != status) {
             ucc_warn("TL UCP context is not available, "
                      "service team can not be created");

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_parser.h"
+#include "ucc_malloc.h"
+#include "ucc_log.h"
+
+ucc_status_t ucc_config_names_array_dup(ucc_config_names_array_t *dst,
+                                        const ucc_config_names_array_t *src)
+{
+    int i;
+    dst->names = ucc_malloc(sizeof(char*) * src->count, "ucc_config_names_array");
+    if (!dst->names) {
+        ucc_error("failed to allocate %zd bytes for ucc_config_names_array",
+                  sizeof(char *) * src->count);
+        return UCC_ERR_NO_MEMORY;
+    }
+    dst->count = src->count;
+    for (i = 0; i < src->count; i++) {
+        dst->names[i] = strdup(src->names[i]);
+        if (!dst->names[i]) {
+            ucc_error("failed to dup config_names_array entry");
+            goto err;
+        }
+    }
+    return UCC_OK;
+err:
+    for (i = i - 1; i >= 0; i--) {
+        free(dst->names[i]);
+    }
+    return UCC_ERR_NO_MEMORY;
+}
+
+void ucc_config_names_array_free(ucc_config_names_array_t *array)
+{
+    int i;
+    for (i = 0; i < array->count; i++) {
+        free(array->names[i]);
+    }
+    ucc_free(array->names);
+}

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -8,6 +8,7 @@
 
 #include "config.h"
 #include "ucc/api/ucc_status.h"
+#include "ucc/api/ucc_def.h"
 #include "utils/ucc_datastruct.h"
 #include "utils/ucc_compiler_def.h"
 #include "utils/ucc_list.h"
@@ -107,4 +108,8 @@ ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
     ucs_config_parser_print_all_opts(stream, prefix, ucs_flags, config_list);
 }
 
+ucc_status_t ucc_config_names_array_dup(ucc_config_names_array_t *dst,
+                                        const ucc_config_names_array_t *src);
+
+void ucc_config_names_array_free(ucc_config_names_array_t *array);
 #endif


### PR DESCRIPTION
 ## What
Now TLs are black boxes discovered in runtime and accessed via  component->name. CLs define the required TLs via
ucc_config_names_array (registered with parser) instead of tl_type_t bits.

## Why ?
This is the first PR the allows 3rd parties to create dynamically loadable TL plugins w/o ANY code integration into UCC.

## How ?
TLs are accessed via the "name" key which is part of .so tl library. No more "ucc_tl_type_t" that would require integration into ucc code.
