### PR TITLE
CL/BASIC: use ALL available TLs by default

### DIFF
--- a/src/components/cl/basic/cl_basic.c
+++ b/src/components/cl/basic/cl_basic.c
@@ -20,10 +20,6 @@ static ucs_config_field_t ucc_cl_basic_context_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_basic_context_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_cl_context_config_table)},
 
-    {"TEST_PARAM", "5", "For dbg test purpuse : don't commit",
-     ucc_offsetof(ucc_cl_basic_context_config_t, test_param),
-     UCC_CONFIG_TYPE_UINT},
-
     {NULL}
 };
 

--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -29,7 +29,6 @@ typedef struct ucc_cl_basic_lib_config {
 
 typedef struct ucc_cl_basic_context_config {
     ucc_cl_context_config_t super;
-    int                     test_param;
 } ucc_cl_basic_context_config_t;
 
 typedef struct ucc_cl_basic_lib {
@@ -39,9 +38,9 @@ UCC_CLASS_DECLARE(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);
 
 typedef struct ucc_cl_basic_context {
-    ucc_cl_context_t super;
-    ucc_tl_context_t *tl_ucp_ctx;
-    ucc_tl_context_t *tl_nccl_ctx;
+    ucc_cl_context_t   super;
+    ucc_tl_context_t **tl_ctxs;
+    unsigned           n_tl_ctxs;
 } ucc_cl_basic_context_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
@@ -49,8 +48,8 @@ UCC_CLASS_DECLARE(ucc_cl_basic_context_t, const ucc_base_context_params_t *,
 typedef struct ucc_cl_basic_team {
     ucc_cl_team_t            super;
     ucc_team_multiple_req_t *team_create_req;
-    ucc_tl_team_t           *tl_ucp_team;
-    ucc_tl_team_t           *tl_nccl_team;
+    ucc_tl_team_t          **tl_teams;
+    unsigned                 n_tl_teams;
     ucc_score_map_t         *score_map;
 } ucc_cl_basic_team_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_team_t, ucc_base_context_t *,

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -34,19 +34,20 @@ typedef struct ucc_context_id {
 } ucc_context_id_t;
 
 typedef struct ucc_context {
-    ucc_lib_info_t         *lib;
-    ucc_context_params_t    params;
-    ucc_context_attr_t      attr;
-    ucc_thread_mode_t       thread_mode;
-    ucc_cl_context_t      **cl_ctx;
-    ucc_tl_context_t      **tl_ctx;
-    ucc_tl_context_t       *service_ctx;
-    int                     n_cl_ctx;
-    int                     n_tl_ctx;
-    ucc_list_link_t         progress_list;
-    ucc_progress_queue_t   *pq;
-    ucc_team_id_pool_t      ids;
-    ucc_context_id_t        id;
+    ucc_lib_info_t          *lib;
+    ucc_context_params_t     params;
+    ucc_context_attr_t       attr;
+    ucc_thread_mode_t        thread_mode;
+    ucc_cl_context_t       **cl_ctx;
+    ucc_tl_context_t       **tl_ctx;
+    ucc_tl_context_t        *service_ctx;
+    int                      n_cl_ctx;
+    int                      n_tl_ctx;
+    ucc_config_names_array_t all_tls;
+    ucc_list_link_t          progress_list;
+    ucc_progress_queue_t    *pq;
+    ucc_team_id_pool_t       ids;
+    ucc_context_id_t         id;
 } ucc_context_t;
 
 typedef struct ucc_context_config {

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -170,3 +170,30 @@ ucc_component_check_scores_uniq(ucc_component_framework_t *framework)
     }
     return UCC_OK;
 }
+
+char* ucc_get_framework_components_list(ucc_component_framework_t *framework,
+                                        char delimiter)
+{
+    size_t len;
+    int    i;
+    char  *list;
+
+    len = 0;
+    for (i = 0; i < framework->n_components; i++) {
+        /* component name + ',' delimiter */
+        len += strlen(framework->components[i]->name) + 1;
+    }
+    list = ucc_malloc(len, "components_list");
+    if (!list) {
+        ucc_error("failed to allocate %zd bytes for components_list", len);
+        return NULL;
+    }
+    list[0] = '\0';
+    for (i = 0; i < framework->n_components; i++) {
+        strcat(list, framework->components[i]->name);
+        if (i < framework->n_components - 1) {
+            strcat(list, &delimiter);
+        }
+    }
+    return list;
+}

--- a/src/utils/ucc_component.h
+++ b/src/utils/ucc_component.h
@@ -42,4 +42,6 @@ ucc_component_iface_t* ucc_get_component(ucc_component_framework_t *framework,
                                          const char *component_name);
 ucc_status_t
 ucc_component_check_scores_uniq(ucc_component_framework_t *framework);
+char* ucc_get_framework_components_list(ucc_component_framework_t *framework,
+                                        char delimiter);
 #endif

--- a/test/gtest/core/test_context_config.cc
+++ b/test/gtest/core/test_context_config.cc
@@ -45,17 +45,8 @@ UCC_TEST_F(test_context_config, print)
 UCC_TEST_F(test_context_config, modify)
 {
     ucc_context_config_h ctx_config;
-    unsigned             flags;
     std::string          output;
-    flags = UCC_CONFIG_PRINT_CONFIG;
     EXPECT_EQ(UCC_OK, ucc_context_config_read(lib_h, NULL, &ctx_config));
-
-    /* modify known field to expected value */
-    EXPECT_EQ(UCC_OK, ucc_context_config_modify(ctx_config, "basic", "TEST_PARAM", "12345"));
-    testing::internal::CaptureStdout();
-    ucc_context_config_print(ctx_config, stdout, "", (ucc_config_print_flags_t)flags);
-    output = testing::internal::GetCapturedStdout();
-    EXPECT_NE(std::string::npos, output.find("UCC_CL_BASIC_TEST_PARAM=12345"));
 
     /* modify uknown field */
     testing::internal::CaptureStdout();


### PR DESCRIPTION
 ## What
All CLs (even though we have only 1 at the moment  - basic) have the parameter UCC_CL_BASIC_TLS which defines the TLS the given CL requires. It can be ALL which is set to default for BASIC. CL/BASIC will try to use ALL tls specified with this variable (can be controlled). The logic of tl context/team/score creation in CL/BASIC is unified. 

## Why ?
After that change any 3rd party TL plugin (.so) can be just distributed separately and will be enabled via CL basic OOB according to default scoring settings. 

