### PR TITLE
UCC context address query

### DIFF
--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -30,9 +30,9 @@ typedef struct ucc_base_config {
     char                           *score_str;
 } ucc_base_config_t;
 
-typedef struct ucc_base_attr_t {
+typedef struct ucc_base_lib_attr_t {
     ucc_lib_attr_t attr;
-} ucc_base_attr_t;
+} ucc_base_lib_attr_t;
 
 typedef struct ucc_base_lib_params {
     ucc_lib_params_t params;
@@ -43,7 +43,8 @@ typedef struct ucc_base_lib_iface {
     ucc_status_t (*init)(const ucc_base_lib_params_t *params,
                          const ucc_base_config_t *config, ucc_base_lib_t **lib);
     void         (*finalize)(ucc_base_lib_t *lib);
-    ucc_status_t (*get_attr)(const ucc_base_lib_t *lib, ucc_base_attr_t *attr);
+    ucc_status_t (*get_attr)(const ucc_base_lib_t *lib,
+                             ucc_base_lib_attr_t *attr);
 } ucc_base_lib_iface_t;
 
 typedef struct ucc_base_context_params {
@@ -60,13 +61,17 @@ typedef struct ucc_base_context {
     ucc_base_lib_t *lib;
 } ucc_base_context_t;
 
+typedef struct ucc_base_ctx_attr_t {
+    ucc_context_attr_t attr;
+} ucc_base_ctx_attr_t;
+
 typedef struct ucc_base_context_iface {
     ucc_status_t (*create)(const ucc_base_context_params_t *params,
                            const ucc_base_config_t *config,
                            ucc_base_context_t **ctx);
     void         (*destroy)(ucc_base_context_t *ctx);
     ucc_status_t (*get_attr)(const ucc_base_context_t *context,
-                             ucc_base_attr_t *attr);
+                             ucc_base_ctx_attr_t *attr);
 } ucc_base_context_iface_t;
 
 typedef struct ucc_base_team_params {

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -44,7 +44,7 @@ typedef struct ucc_base_lib_iface {
                          const ucc_base_config_t *config, ucc_base_lib_t **lib);
     void         (*finalize)(ucc_base_lib_t *lib);
     ucc_status_t (*get_attr)(const ucc_base_lib_t *lib,
-                             ucc_base_lib_attr_t *attr);
+                             ucc_base_lib_attr_t  *attr);
 } ucc_base_lib_iface_t;
 
 typedef struct ucc_base_context_params {
@@ -71,7 +71,7 @@ typedef struct ucc_base_context_iface {
                            ucc_base_context_t **ctx);
     void         (*destroy)(ucc_base_context_t *ctx);
     ucc_status_t (*get_attr)(const ucc_base_context_t *context,
-                             ucc_base_ctx_attr_t *attr);
+                             ucc_base_ctx_attr_t      *attr);
 } ucc_base_context_iface_t;
 
 typedef struct ucc_base_team_params {

--- a/src/components/cl/basic/cl_basic.c
+++ b/src/components/cl/basic/cl_basic.c
@@ -6,8 +6,10 @@
 
 #include "cl_basic.h"
 #include "utils/ucc_malloc.h"
-ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *base_attr);
-ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context, ucc_base_attr_t *base_attr);
+ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
+                                       ucc_base_lib_attr_t *base_attr);
+ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context,
+                                           ucc_base_ctx_attr_t *base_attr);
 
 static ucc_config_field_t ucc_cl_basic_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_basic_lib_config_t, super),

--- a/src/components/cl/basic/cl_basic.c
+++ b/src/components/cl/basic/cl_basic.c
@@ -7,9 +7,9 @@
 #include "cl_basic.h"
 #include "utils/ucc_malloc.h"
 ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
-                                       ucc_base_lib_attr_t *base_attr);
+                                       ucc_base_lib_attr_t  *base_attr);
 ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context,
-                                           ucc_base_ctx_attr_t *base_attr);
+                                           ucc_base_ctx_attr_t      *base_attr);
 
 static ucc_config_field_t ucc_cl_basic_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_basic_lib_config_t, super),

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -63,9 +63,13 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_context_t)
 
 UCC_CLASS_DEFINE(ucc_cl_basic_context_t, ucc_cl_context_t);
 
-ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
-                                           ucc_base_attr_t *attr)             /* NOLINT */
+ucc_status_t
+ucc_cl_basic_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
+                              ucc_base_ctx_attr_t      *attr)
 {
-    /* TODO */
-    return UCC_ERR_NOT_IMPLEMENTED;
+    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
+        attr->attr.ctx_addr_len = 0;
+    }
+    // attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR - nothing to do
+    return UCC_OK;
 }

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -28,6 +28,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
 
+
 static inline ucc_status_t check_tl_lib_attr(const ucc_base_lib_t *lib,
                                              ucc_tl_iface_t *      tl_iface,
                                              ucc_cl_lib_attr_t *   attr)
@@ -49,7 +50,7 @@ static inline ucc_status_t check_tl_lib_attr(const ucc_base_lib_t *lib,
 }
 
 ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
-                                       ucc_base_attr_t *     base_attr)
+                                       ucc_base_lib_attr_t  *base_attr)
 {
     ucc_cl_lib_attr_t *attr   = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
     ucc_cl_lib_t *     cl_lib = ucc_derived_of(lib, ucc_cl_lib_t);

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -28,7 +28,6 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
 
-
 static inline ucc_status_t check_tl_lib_attr(const ucc_base_lib_t *lib,
                                              ucc_tl_iface_t *      tl_iface,
                                              ucc_cl_lib_attr_t *   attr)

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -87,7 +87,7 @@ typedef struct ucc_cl_team {
 UCC_CLASS_DECLARE(ucc_cl_team_t, ucc_cl_context_t *);
 
 typedef struct ucc_cl_lib_attr {
-    ucc_base_attr_t           super;
+    ucc_base_lib_attr_t       super;
     ucc_config_names_array_t *tls;
 } ucc_cl_lib_attr_t;
 

--- a/src/components/tl/nccl/tl_nccl.c
+++ b/src/components/tl/nccl/tl_nccl.c
@@ -8,10 +8,10 @@
 #include "components/mc/base/ucc_mc_base.h"
 
 ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib,
-                                      ucc_base_attr_t *base_attr);
+                                      ucc_base_lib_attr_t *base_attr);
 
 ucc_status_t ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context,
-                                          ucc_base_attr_t *base_attr);
+                                          ucc_base_ctx_attr_t *base_attr);
 
 static ucc_config_field_t ucc_tl_nccl_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_nccl_lib_config_t, super),

--- a/src/components/tl/nccl/tl_nccl.c
+++ b/src/components/tl/nccl/tl_nccl.c
@@ -8,10 +8,10 @@
 #include "components/mc/base/ucc_mc_base.h"
 
 ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib,
-                                      ucc_base_lib_attr_t *base_attr);
+                                      ucc_base_lib_attr_t  *base_attr);
 
 ucc_status_t ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context,
-                                          ucc_base_ctx_attr_t *base_attr);
+                                          ucc_base_ctx_attr_t      *base_attr);
 
 static ucc_config_field_t ucc_tl_nccl_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_nccl_lib_config_t, super),

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -45,8 +45,9 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_context_t)
 
 UCC_CLASS_DEFINE(ucc_tl_nccl_context_t, ucc_tl_context_t);
 
-ucc_status_t ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
-                                          ucc_base_ctx_attr_t *attr) /* NOLINT */
+ucc_status_t
+ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
+                             ucc_base_ctx_attr_t      *attr)    /* NOLINT */
 {
     /* TODO */
     return UCC_ERR_NOT_IMPLEMENTED;

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -46,7 +46,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_context_t)
 UCC_CLASS_DEFINE(ucc_tl_nccl_context_t, ucc_tl_context_t);
 
 ucc_status_t ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
-                                          ucc_base_attr_t *attr) /* NOLINT */
+                                          ucc_base_ctx_attr_t *attr) /* NOLINT */
 {
     /* TODO */
     return UCC_ERR_NOT_IMPLEMENTED;

--- a/src/components/tl/nccl/tl_nccl_lib.c
+++ b/src/components/tl/nccl/tl_nccl_lib.c
@@ -25,10 +25,10 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_lib_t)
 UCC_CLASS_DEFINE(ucc_tl_nccl_lib_t, ucc_tl_lib_t);
 
 ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
-                                     ucc_base_lib_attr_t *base_attr)
+                                      ucc_base_lib_attr_t  *base_attr)
 {
     ucc_tl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
-    attr->super.attr.coll_types = UCC_TL_NCCL_SUPPORTED_COLLS;
+    attr->super.attr.coll_types  = UCC_TL_NCCL_SUPPORTED_COLLS;
     return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl_lib.c
+++ b/src/components/tl/nccl/tl_nccl_lib.c
@@ -25,7 +25,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_lib_t)
 UCC_CLASS_DEFINE(ucc_tl_nccl_lib_t, ucc_tl_lib_t);
 
 ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
-                                     ucc_base_attr_t *base_attr)
+                                     ucc_base_lib_attr_t *base_attr)
 {
     ucc_tl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -117,7 +117,7 @@ ucc_status_t ucc_tl_team_destroy_multiple(ucc_team_multiple_req_t *req);
 void ucc_team_multiple_req_free(ucc_team_multiple_req_t *req);
 
 typedef struct ucc_tl_lib_attr {
-    ucc_base_attr_t super;
+    ucc_base_lib_attr_t super;
 } ucc_tl_lib_attr_t;
 
 #define UCC_TL_CTX_IFACE(_tl_ctx)                                              \

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -11,9 +11,9 @@
 #include "allreduce/allreduce.h"
 
 ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib,
-                                     ucc_base_lib_attr_t *base_attr);
+                                     ucc_base_lib_attr_t  *base_attr);
 ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
-                                         ucc_base_ctx_attr_t *base_attr);
+                                         ucc_base_ctx_attr_t      *base_attr);
 
 static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_ucp_lib_config_t, super),

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -10,8 +10,10 @@
 #include "components/mc/base/ucc_mc_base.h"
 #include "allreduce/allreduce.h"
 
-ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, ucc_base_attr_t *base_attr);
-ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context, ucc_base_attr_t *base_attr);
+ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib,
+                                     ucc_base_lib_attr_t *base_attr);
+ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
+                                         ucc_base_ctx_attr_t *base_attr);
 
 static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_ucp_lib_config_t, super),

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -36,7 +36,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_lib_t)
 UCC_CLASS_DEFINE(ucc_tl_ucp_lib_t, ucc_tl_lib_t);
 
 ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
-                                     ucc_base_attr_t *base_attr)
+                                     ucc_base_lib_attr_t *base_attr)
 {
     ucc_tl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
     ucs_status_t   status;

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -36,7 +36,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_lib_t)
 UCC_CLASS_DEFINE(ucc_tl_ucp_lib_t, ucc_tl_lib_t);
 
 ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
-                                     ucc_base_lib_attr_t *base_attr)
+                                     ucc_base_lib_attr_t  *base_attr)
 {
     ucc_tl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
     ucs_status_t   status;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -697,7 +697,7 @@ typedef struct ucc_context_attr {
     uint64_t                mask;
     ucc_context_type_t      type;
     ucc_coll_sync_type_t    sync_type;
-    ucc_context_addr_t      ctx_addr;
+    ucc_context_addr_h      ctx_addr;
     ucc_context_addr_len_t  ctx_addr_len;
 } ucc_context_attr_t;
 
@@ -908,7 +908,6 @@ ucc_status_t ucc_context_destroy(ucc_context_h context);
 
 ucc_status_t ucc_context_get_attr(ucc_context_h context,
                                   ucc_context_attr_t *context_attr);
-
 
 /*
  * *************************************************************

--- a/src/ucc/api/ucc_def.h
+++ b/src/ucc/api/ucc_def.h
@@ -140,7 +140,7 @@ typedef void *ucc_p2p_conn_t;
 /**
  * @ingroup UCC_TEAM_DT
  */
-typedef void *ucc_context_addr_t;
+typedef void* ucc_context_addr_h;
 
 /**
  * @ingroup UCC_TEAM_DT

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -6,6 +6,7 @@
 #include "ucc_malloc.h"
 #include "ucc_component.h"
 #include "ucc_log.h"
+#include "ucc_math.h"
 #include "core/ucc_global_opts.h"
 
 #include <sys/types.h>
@@ -62,6 +63,7 @@ static ucc_status_t ucc_component_load_one(const char *so_path,
         goto iface_error;
     }
     iface->dl_handle = handle;
+    iface->id        = ucc_str_hash_djb2(iface->name);
     (*c_iface)       = iface;
     return UCC_OK;
 
@@ -70,6 +72,36 @@ iface_error:
 error:
     *c_iface = NULL;
     return UCC_ERR_NO_MESSAGE;
+}
+
+#define CHECK_COMPONENT_UNIQ(_framework, _field) do {                       \
+        ucc_component_iface_t **c = _framework->components;                 \
+        int i, j;                                                           \
+        for (i = 0; i < framework->n_components; i++) {                     \
+            for (j = i+1; j < framework->n_components; j++) {               \
+                if (c[i]-> _field == c[j]-> _field) {                       \
+                    ucc_error("components %s and %s have the same default " \
+                              UCC_PP_MAKE_STRING(_field) " %lu",            \
+                              c[i]->name, c[j]->name,                       \
+                              (unsigned long) c[i]-> _field);               \
+                    return UCC_ERR_INVALID_PARAM;                           \
+                }                                                           \
+            }                                                               \
+        }                                                                   \
+    } while(0)
+
+ucc_status_t
+ucc_component_check_scores_uniq(ucc_component_framework_t *framework)
+{
+    CHECK_COMPONENT_UNIQ(framework, score);
+    return UCC_OK;
+}
+
+static ucc_status_t
+ucc_component_check_ids_uniq(ucc_component_framework_t *framework)
+{
+    CHECK_COMPONENT_UNIQ(framework, id);
+    return UCC_OK;
 }
 
 ucc_status_t ucc_components_load(const char *framework_name,
@@ -124,22 +156,32 @@ ucc_status_t ucc_components_load(const char *framework_name,
         n_loaded++;
     }
 
+    assert(n_loaded <= globbuf.gl_pathc);
     if (globbuf.gl_pathc > 0) {
         globfree(&globbuf);
     }
-    if (n_loaded) {
-        assert(n_loaded <= globbuf.gl_pathc);
-        ifaces = ucc_realloc(ifaces, n_loaded * sizeof(ucc_component_iface_t *),
-                             "ifaces");
-        framework->components   = ifaces;
-        framework->n_components = n_loaded;
-        return UCC_OK;
-    } else {
+    if (!n_loaded) {
         if (ifaces) {
             ucc_free(ifaces);
         }
         return UCC_ERR_NOT_FOUND;
     }
+
+
+    ifaces = ucc_realloc(ifaces, n_loaded * sizeof(ucc_component_iface_t *),
+                         "ifaces");
+    framework->components   = ifaces;
+    framework->n_components = n_loaded;
+    if (UCC_OK != ucc_component_check_ids_uniq(framework)) {
+        /* This can only happen when the new component is added
+           (potentially as a plugin - black box) and its name hash
+           will produce collision with some other component.
+           This has nearly 0 probability and must be resolved by
+           the component developer via just a rename of a component. */
+        ucc_error("all components of a framwork must have uniq name hash");
+        return UCC_ERR_INVALID_PARAM;
+    }
+    return UCC_OK;
 }
 
 ucc_component_iface_t* ucc_get_component(ucc_component_framework_t *framework,

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -74,21 +74,22 @@ error:
     return UCC_ERR_NO_MESSAGE;
 }
 
-#define CHECK_COMPONENT_UNIQ(_framework, _field) do {                       \
-        ucc_component_iface_t **c = _framework->components;                 \
-        int i, j;                                                           \
-        for (i = 0; i < framework->n_components; i++) {                     \
-            for (j = i+1; j < framework->n_components; j++) {               \
-                if (c[i]-> _field == c[j]-> _field) {                       \
-                    ucc_error("components %s and %s have the same default " \
-                              UCC_PP_MAKE_STRING(_field) " %lu",            \
-                              c[i]->name, c[j]->name,                       \
-                              (unsigned long) c[i]-> _field);               \
-                    return UCC_ERR_INVALID_PARAM;                           \
-                }                                                           \
-            }                                                               \
-        }                                                                   \
-    } while(0)
+#define CHECK_COMPONENT_UNIQ(_framework, _field)                               \
+    do {                                                                       \
+        ucc_component_iface_t **c = _framework->components;                    \
+        int                     i, j;                                          \
+        for (i = 0; i < framework->n_components; i++) {                        \
+            for (j = i + 1; j < framework->n_components; j++) {                \
+                if (c[i]->_field == c[j]->_field) {                            \
+                    ucc_error("components %s and %s have the same "            \
+                              "default " UCC_PP_MAKE_STRING(_field) " %lu",    \
+                              c[i]->name, c[j]->name,                          \
+                              (unsigned long)c[i]->_field);                    \
+                    return UCC_ERR_INVALID_PARAM;                              \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+    } while (0)
 
 ucc_status_t
 ucc_component_check_scores_uniq(ucc_component_framework_t *framework)
@@ -167,7 +168,6 @@ ucc_status_t ucc_components_load(const char *framework_name,
         return UCC_ERR_NOT_FOUND;
     }
 
-
     ifaces = ucc_realloc(ifaces, n_loaded * sizeof(ucc_component_iface_t *),
                          "ifaces");
     framework->components   = ifaces;
@@ -194,23 +194,6 @@ ucc_component_iface_t* ucc_get_component(ucc_component_framework_t *framework,
         }
     }
     return NULL;
-}
-
-ucc_status_t
-ucc_component_check_scores_uniq(ucc_component_framework_t *framework)
-{
-    ucc_component_iface_t **c = framework->components;
-    int i, j;
-    for (i = 0; i < framework->n_components; i++) {
-        for (j = i+1; j < framework->n_components; j++) {
-            if (c[i]->score == c[j]->score) {
-                ucc_error("components %s and %s have the same default score %d",
-                          c[i]->name, c[j]->name, c[i]->score);
-                return UCC_ERR_INVALID_PARAM;
-            }
-        }
-    }
-    return UCC_OK;
 }
 
 char* ucc_get_framework_components_list(ucc_component_framework_t *framework,

--- a/src/utils/ucc_component.h
+++ b/src/utils/ucc_component.h
@@ -14,9 +14,10 @@
 #define UCC_MAX_COMPONENT_NAME_LEN 64
 
 typedef struct ucc_component_iface {
-    const char *name;
-    void       *dl_handle;
-    ucc_score_t score;
+    const char    *name;
+    unsigned long  id;
+    void          *dl_handle;
+    ucc_score_t    score;
 } ucc_component_iface_t;
 
 typedef struct ucc_component_framework {

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -50,4 +50,5 @@ static inline unsigned long ucc_str_hash_djb2(const char *str)
     }
     return hash;
 }
+
 #endif

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -34,6 +34,20 @@ static inline size_t ucc_dt_size(ucc_datatype_t dt)
     return 0;
 }
 
+
 #define PTR_OFFSET(_ptr, _offset)                                              \
     ((void *)((ptrdiff_t)(_ptr) + (size_t)(_offset)))
+
+/* http://www.cse.yorku.ca/~oz/hash.html - Dan Bernstein string
+   hash function */
+static inline unsigned long ucc_str_hash_djb2(const char *str)
+{
+    unsigned long hash = 5381;
+    int           c;
+
+    while ('\0' != (c = *str++)) {
+        hash = ((hash << 5) + hash) + c;
+    }
+    return hash;
+}
 #endif

--- a/test/gtest/core/test_context.cc
+++ b/test/gtest/core/test_context.cc
@@ -45,3 +45,32 @@ UCC_TEST_F(test_context, init_multiple)
         EXPECT_EQ(UCC_OK, ucc_context_destroy(ctx_h));
     }
 }
+
+test_context_get_attr::test_context_get_attr()
+{
+    ucc_context_params_t ctx_params;
+    ctx_params.mask = UCC_CONTEXT_PARAM_FIELD_TYPE;
+    ctx_params.type = UCC_CONTEXT_EXCLUSIVE;
+    EXPECT_EQ(UCC_OK,
+              ucc_context_create(lib_h, &ctx_params, ctx_config, &ctx_h));
+}
+
+test_context_get_attr::~test_context_get_attr()
+{
+    EXPECT_EQ(UCC_OK, ucc_context_destroy(ctx_h));
+}
+
+UCC_TEST_F(test_context_get_attr, addr_len)
+{
+    ucc_context_attr_t attr;
+    attr.mask = UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN;
+    EXPECT_EQ(UCC_OK, ucc_context_get_attr(ctx_h, &attr));
+}
+
+UCC_TEST_F(test_context_get_attr, addr)
+{
+    ucc_context_attr_t attr;
+    attr.mask = UCC_CONTEXT_ATTR_FIELD_CTX_ADDR;
+    EXPECT_EQ(UCC_OK, ucc_context_get_attr(ctx_h, &attr));
+    EXPECT_EQ(true, ((attr.ctx_addr_len == 0) || (NULL != attr.ctx_addr)));
+}

--- a/test/gtest/core/test_context.h
+++ b/test/gtest/core/test_context.h
@@ -24,5 +24,11 @@ public:
     ~test_context();
 };
 
+class test_context_get_attr : public test_context {
+  public:
+    ucc_context_h ctx_h;
+    test_context_get_attr();
+    ~test_context_get_attr();
+};
 
 #endif


### PR DESCRIPTION
## What
Implements ucc_context_get_attr with UCC_CONTEXT_ATTR_FIELD_CTX_ADDR flag.

## Why ?
CORE API. It serves 2 purposes:
1. User can use PMIx-like (key-value storage) method for UCC address exchange.
2. Internally this will unify the address-exchange of different TLs. E.g. currently TL/UCP and TL/NCCL use 2 separate allgathers to collect addressing info. We will be able to move that to 1 common place in CORE team create (or ctx create if it has oob): we will query the TLs addresses and pack the data, do allgather once and then each TL will extract its own part of address. Additional data will be later added to the packed address: e..g ctx id hash (used for ep hash in tl/ucp currently); generic process info (bound socket/numa/core number, pid, nodename/nodehash) - will be used for hierarchical CL.

## How ?
The address layout is described in ucc_context.h
