### PR TITLE
MC: Adding ucc mpool implementation

### DIFF
--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -11,6 +11,7 @@
 #include "utils/ucc_component.h"
 #include "utils/ucc_class.h"
 #include "utils/ucc_parser.h"
+#include "utils/ucc_mpool.h"
 #include "core/ucc_global_opts.h"
 
 /**
@@ -74,8 +75,8 @@ extern ucc_config_field_t ucc_mc_config_table[];
 
 typedef struct ucc_mc_ops {
     ucc_status_t (*mem_query)(const void *ptr, ucc_mem_attr_t *mem_attr);
-    ucc_status_t (*mem_alloc)(void **ptr, size_t size);
-    ucc_status_t (*mem_free)(void *ptr);
+    ucc_status_t (*mem_alloc)(ucc_mc_buffer_header_t **ptr, size_t size);
+    ucc_status_t (*mem_free)(ucc_mc_buffer_header_t *ptr);
     ucc_status_t (*reduce)(const void *src1, const void *src2, void *dst,
                            size_t count, ucc_datatype_t dt,
                            ucc_reduction_op_t op);
@@ -106,7 +107,7 @@ typedef struct ucc_mc_base {
     ucc_config_global_list_entry_t  config_table;
     ucc_status_t                   (*init)();
     ucc_status_t                   (*finalize)();
-    const ucc_mc_ops_t              ops;
+    ucc_mc_ops_t                    ops;
     const ucc_ee_ops_t              ee_ops;
 } ucc_mc_base_t;
 

--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -17,6 +17,8 @@
 
 typedef struct ucc_mc_buffer_header ucc_mc_buffer_header_t;
 
+typedef struct ucc_mc_params ucc_mc_params_t;
+
 /**
  * UCC memory attributes field mask
  */
@@ -78,8 +80,8 @@ extern ucc_config_field_t ucc_mc_config_table[];
 
 typedef struct ucc_mc_ops {
     ucc_status_t (*mem_query)(const void *ptr, ucc_mem_attr_t *mem_attr);
-    ucc_status_t (*mem_alloc)(ucc_mc_buffer_header_t **ptr, size_t size);
-    ucc_status_t (*mem_free)(ucc_mc_buffer_header_t *ptr);
+    ucc_status_t (*mem_alloc)(ucc_mc_buffer_header_t **h_ptr, size_t size);
+    ucc_status_t (*mem_free)(ucc_mc_buffer_header_t *h_ptr);
     ucc_status_t (*reduce)(const void *src1, const void *src2, void *dst,
                            size_t count, ucc_datatype_t dt,
                            ucc_reduction_op_t op);
@@ -108,7 +110,7 @@ typedef struct ucc_mc_base {
     ucc_memory_type_t               type;
     ucc_mc_config_t                *config;
     ucc_config_global_list_entry_t  config_table;
-    ucc_status_t                   (*init)(ucc_thread_mode_t thread_mode);
+    ucc_status_t                   (*init)(const ucc_mc_params_t *mc_params);
     ucc_status_t                   (*finalize)();
     ucc_mc_ops_t                    ops;
     const ucc_ee_ops_t              ee_ops;

--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -13,6 +13,9 @@
 #include "utils/ucc_parser.h"
 #include "utils/ucc_mpool.h"
 #include "core/ucc_global_opts.h"
+#include "core/ucc_mc.h"
+
+typedef struct ucc_mc_buffer_header ucc_mc_buffer_header_t;
 
 /**
  * UCC memory attributes field mask
@@ -105,7 +108,7 @@ typedef struct ucc_mc_base {
     ucc_memory_type_t               type;
     ucc_mc_config_t                *config;
     ucc_config_global_list_entry_t  config_table;
-    ucc_status_t                   (*init)();
+    ucc_status_t                   (*init)(ucc_thread_mode_t thread_mode);
     ucc_status_t                   (*finalize)();
     ucc_mc_ops_t                    ops;
     const ucc_ee_ops_t              ee_ops;

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -9,50 +9,37 @@
 #include "utils/ucc_malloc.h"
 #include <sys/types.h>
 
-static ucc_status_t ucc_mc_cpu_mem_alloc_pool_with_init(ucc_mc_buffer_header_t **ptr,
-                                                   size_t size);
-
 static ucc_config_field_t ucc_mc_cpu_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_mc_cpu_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_mc_config_table)},
 
-    {"ELEM_SIZE", "1048576", "The size of each element in mc cpu mpool",
-     ucc_offsetof(ucc_mc_cpu_config_t, cpu_elem_size),
+    {"MPOOL_ELEM_SIZE", "1Mb", "The size of each element in mc cpu mpool",
+     ucc_offsetof(ucc_mc_cpu_config_t, mpool_elem_size),
      UCC_CONFIG_TYPE_MEMUNITS},
 
-    {"MAX_ELEMS", "8", "The max amount of elements in mc cpu mpool",
-     ucc_offsetof(ucc_mc_cpu_config_t, cpu_max_elems), UCC_CONFIG_TYPE_UINT},
+    {"MPOOL_MAX_ELEMS", "8", "The max amount of elements in mc cpu mpool",
+     ucc_offsetof(ucc_mc_cpu_config_t, mpool_max_elems), UCC_CONFIG_TYPE_UINT},
 
     {NULL}
 
 };
 
-static ucc_status_t ucc_mc_cpu_init(ucc_thread_mode_t thread_mode)
+static ucc_status_t ucc_mc_cpu_init(const ucc_mc_params_t *mc_params)
 {
     ucc_strncpy_safe(ucc_mc_cpu.super.config->log_component.name,
                      ucc_mc_cpu.super.super.name,
                      sizeof(ucc_mc_cpu.super.config->log_component.name));
-    // spinlock assures 1 thread only initiates mpool and allocates its buffers
-    ucc_mc_cpu.tm = thread_mode;
+    ucc_mc_cpu.thread_mode = mc_params->thread_mode;
+    // lock assures single mpool initiation when multiple threads concurrently execute
+    // different collective operations thus concurrently entering init function.
     ucc_spinlock_init(&ucc_mc_cpu.mpool_init_spinlock, 0);
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_cpu_finalize()
+static ucc_status_t ucc_mc_cpu_mem_alloc(ucc_mc_buffer_header_t **h_ptr,
+                                         size_t                   size)
 {
-    if (ucc_mc_cpu.mpool_init_flag) {
-        ucc_mpool_cleanup(&ucc_mc_cpu.mpool, 1);
-        ucc_mc_cpu.mpool_init_flag     = 0;
-        ucc_mc_cpu.super.ops.mem_alloc = ucc_mc_cpu_mem_alloc_pool_with_init;
-    }
-    ucc_spinlock_destroy(&ucc_mc_cpu.mpool_init_spinlock);
-    return UCC_OK;
-}
-
-static ucc_status_t
-ucc_mc_cpu_mem_alloc(ucc_mc_buffer_header_t **ptr, size_t size)
-{
-    size_t size_with_h = size + sizeof(ucc_mc_buffer_header_t);
+    size_t        size_with_h = size + sizeof(ucc_mc_buffer_header_t);
     ucc_mc_buffer_header_t *h =
         (ucc_mc_buffer_header_t *)ucc_malloc(size_with_h, "mc cpu");
     if (ucc_unlikely(!h)) {
@@ -61,47 +48,49 @@ ucc_mc_cpu_mem_alloc(ucc_mc_buffer_header_t **ptr, size_t size)
         return UCC_ERR_NO_MEMORY;
     }
     h->from_pool = 0;
-    h->addr = PTR_OFFSET(h, sizeof(ucc_mc_buffer_header_t));
-    *ptr         = h;
+    h->addr      = PTR_OFFSET(h, sizeof(ucc_mc_buffer_header_t));
+    *h_ptr       = h;
+    mc_debug(&ucc_mc_cpu.super, "MC allocated %ld bytes with ucc_malloc", size);
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_cpu_mem_alloc_pool(ucc_mc_buffer_header_t **ptr,
-                                         size_t                   size)
+static ucc_status_t ucc_mc_cpu_mem_pool_alloc(ucc_mc_buffer_header_t **h_ptr,
+                                              size_t                   size)
 {
     ucc_mc_buffer_header_t *h = NULL;
-    if (size <= MC_CPU_CONFIG->cpu_elem_size) {
+    if (size <= MC_CPU_CONFIG->mpool_elem_size) {
         h = (ucc_mc_buffer_header_t *)ucc_mpool_get(&ucc_mc_cpu.mpool);
     }
     if (!h) {
         // Slow path
-    	return ucc_mc_cpu_mem_alloc(ptr, size);
+        return ucc_mc_cpu_mem_alloc(h_ptr, size);
     }
-    *ptr = h;
+    mc_debug(&ucc_mc_cpu.super, "MC allocated %ld bytes from cpu mpool", size);
+    *h_ptr = h;
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_cpu_chunk_alloc(ucc_mpool_t *mp, size_t *size_p,
+static ucc_status_t ucc_mc_cpu_chunk_alloc(ucc_mpool_t *mp, //NOLINT
+                                           size_t *size_p,
                                            void **chunk_p)
 {
-    *chunk_p = ucc_malloc(
-        *size_p, "mc cpu");
+    *chunk_p = ucc_malloc(*size_p, "mc cpu");
     if (!*chunk_p) {
         mc_error(&ucc_mc_cpu.super, "failed to allocate %zd bytes", *size_p);
         return UCC_ERR_NO_MEMORY;
     }
-
     return UCC_OK;
 }
 
-static void ucc_mc_cpu_chunk_init(ucc_mpool_t *mp, void *obj, void *chunk)
+static void ucc_mc_cpu_chunk_init(ucc_mpool_t *mp, //NOLINT
+                                  void *obj, void *chunk) //NOLINT
 {
     ucc_mc_buffer_header_t *h = (ucc_mc_buffer_header_t *)obj;
     h->from_pool              = 1;
-    h->addr = PTR_OFFSET(h, sizeof(ucc_mc_buffer_header_t));
+    h->addr                   = PTR_OFFSET(h, sizeof(ucc_mc_buffer_header_t));
 }
 
-static void ucc_mc_cpu_chunk_release(ucc_mpool_t *mp, void *chunk)
+static void ucc_mc_cpu_chunk_release(ucc_mpool_t *mp, void *chunk) //NOLINT
 {
     ucc_free(chunk);
 }
@@ -111,49 +100,50 @@ static ucc_mpool_ops_t ucc_mc_ops = {.chunk_alloc   = ucc_mc_cpu_chunk_alloc,
                                      .obj_init      = ucc_mc_cpu_chunk_init,
                                      .obj_cleanup   = NULL};
 
-static ucc_status_t ucc_mc_cpu_mem_free(ucc_mc_buffer_header_t *ptr)
+static ucc_status_t ucc_mc_cpu_mem_free(ucc_mc_buffer_header_t *h_ptr)
 {
-    ucc_free(ptr);
+    ucc_free(h_ptr);
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_cpu_mem_free_with_pool(ucc_mc_buffer_header_t *ptr)
+static ucc_status_t ucc_mc_cpu_mem_pool_free(ucc_mc_buffer_header_t *h_ptr)
 {
-    if (!ptr->from_pool) {
-    	return ucc_mc_cpu_mem_free(ptr);
+    if (!h_ptr->from_pool) {
+        return ucc_mc_cpu_mem_free(h_ptr);
     }
-    ucc_mpool_put(ptr);
+    ucc_mpool_put(h_ptr);
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_cpu_mem_alloc_pool_with_init(ucc_mc_buffer_header_t **ptr,
-                                                   size_t size)
+static ucc_status_t
+ucc_mc_cpu_mem_pool_alloc_with_init(ucc_mc_buffer_header_t **h_ptr, size_t size)
 {
-	// spinlock assures 1 thread only initiates mpool and allocates its buffers
+    // lock assures single mpool initiation when multiple threads concurrently
+    // execute different collective operations each entering init function.
     ucc_spin_lock(&ucc_mc_cpu.mpool_init_spinlock);
 
-    if (MC_CPU_CONFIG->cpu_max_elems == 0) {
+    if (MC_CPU_CONFIG->mpool_max_elems == 0) {
         ucc_mc_cpu.super.ops.mem_alloc = ucc_mc_cpu_mem_alloc;
-        ucc_mc_cpu.super.ops.mem_free = ucc_mc_cpu_mem_free;
+        ucc_mc_cpu.super.ops.mem_free  = ucc_mc_cpu_mem_free;
         ucc_spin_unlock(&ucc_mc_cpu.mpool_init_spinlock);
-        return ucc_mc_cpu_mem_alloc(ptr, size);
+        return ucc_mc_cpu_mem_alloc(h_ptr, size);
     }
 
     if (!ucc_mc_cpu.mpool_init_flag) {
-        // TODO: currently only with thread multiple, need to change?
         ucc_status_t status = ucc_mpool_init(
             &ucc_mc_cpu.mpool, 0,
-            sizeof(ucc_mc_buffer_header_t) + MC_CPU_CONFIG->cpu_elem_size, 0,
-            UCC_CACHE_LINE_SIZE, 1, MC_CPU_CONFIG->cpu_max_elems, &ucc_mc_ops,
-            ucc_mc_cpu.tm, "mc cpu mpool buffers");
-        if (status != UCC_OK) {
+            sizeof(ucc_mc_buffer_header_t) + MC_CPU_CONFIG->mpool_elem_size, 0,
+            UCC_CACHE_LINE_SIZE, 1, MC_CPU_CONFIG->mpool_max_elems, &ucc_mc_ops,
+            ucc_mc_cpu.thread_mode, "mc cpu mpool buffers");
+        if (ucc_unlikely(status != UCC_OK)) {
+            ucc_spin_unlock(&ucc_mc_cpu.mpool_init_spinlock);
             return status;
         }
-        ucc_mc_cpu.super.ops.mem_alloc = ucc_mc_cpu_mem_alloc_pool;
+        ucc_mc_cpu.super.ops.mem_alloc = ucc_mc_cpu_mem_pool_alloc;
         ucc_mc_cpu.mpool_init_flag     = 1;
     }
     ucc_spin_unlock(&ucc_mc_cpu.mpool_init_spinlock);
-    return ucc_mc_cpu_mem_alloc_pool(ptr, size);
+    return ucc_mc_cpu_mem_pool_alloc(h_ptr, size);
 }
 
 static ucc_status_t ucc_mc_cpu_reduce_multi(const void *src1, const void *src2,
@@ -267,6 +257,17 @@ ucc_status_t ucc_ee_cpu_event_test(void *event) //NOLINT
     return UCC_OK;
 }
 
+static ucc_status_t ucc_mc_cpu_finalize()
+{
+    if (ucc_mc_cpu.mpool_init_flag) {
+        ucc_mpool_cleanup(&ucc_mc_cpu.mpool, 1);
+        ucc_mc_cpu.mpool_init_flag     = 0;
+        ucc_mc_cpu.super.ops.mem_alloc = ucc_mc_cpu_mem_pool_alloc_with_init;
+    }
+    ucc_spinlock_destroy(&ucc_mc_cpu.mpool_init_spinlock);
+    return UCC_OK;
+}
+
 ucc_mc_cpu_t ucc_mc_cpu = {
     .super.super.name       = "cpu mc",
     .super.ref_cnt          = 0,
@@ -275,8 +276,8 @@ ucc_mc_cpu_t ucc_mc_cpu = {
     .super.init             = ucc_mc_cpu_init,
     .super.finalize         = ucc_mc_cpu_finalize,
     .super.ops.mem_query    = ucc_mc_cpu_mem_query,
-    .super.ops.mem_alloc    = ucc_mc_cpu_mem_alloc_pool_with_init,
-    .super.ops.mem_free     = ucc_mc_cpu_mem_free_with_pool,
+    .super.ops.mem_alloc    = ucc_mc_cpu_mem_pool_alloc_with_init,
+    .super.ops.mem_free     = ucc_mc_cpu_mem_pool_free,
     .super.ops.reduce       = ucc_mc_cpu_reduce,
     .super.ops.reduce_multi = ucc_mc_cpu_reduce_multi,
     .super.ops.memcpy       = ucc_mc_cpu_memcpy,

--- a/src/components/mc/cpu/mc_cpu.h
+++ b/src/components/mc/cpu/mc_cpu.h
@@ -12,8 +12,8 @@
 
 typedef struct ucc_mc_cpu_config {
     ucc_mc_config_t super;
-    size_t          cpu_elem_size;
-    int             cpu_max_elems;
+    size_t          mpool_elem_size;
+    int             mpool_max_elems;
 } ucc_mc_cpu_config_t;
 
 typedef struct ucc_mc_cpu {
@@ -21,7 +21,7 @@ typedef struct ucc_mc_cpu {
     ucc_mpool_t       mpool;
     int               mpool_init_flag;
     ucc_spinlock_t    mpool_init_spinlock;
-    ucc_thread_mode_t tm;
+    ucc_thread_mode_t thread_mode;
 } ucc_mc_cpu_t;
 
 extern ucc_mc_cpu_t ucc_mc_cpu;

--- a/src/components/mc/cpu/mc_cpu.h
+++ b/src/components/mc/cpu/mc_cpu.h
@@ -17,10 +17,11 @@ typedef struct ucc_mc_cpu_config {
 } ucc_mc_cpu_config_t;
 
 typedef struct ucc_mc_cpu {
-    ucc_mc_base_t super;
-    ucc_mpool_t    mpool;
-    int            mpool_init_flag;
-    ucc_spinlock_t mpool_init_spinlock;
+    ucc_mc_base_t     super;
+    ucc_mpool_t       mpool;
+    int               mpool_init_flag;
+    ucc_spinlock_t    mpool_init_spinlock;
+    ucc_thread_mode_t tm;
 } ucc_mc_cpu_t;
 
 extern ucc_mc_cpu_t ucc_mc_cpu;

--- a/src/components/mc/cpu/mc_cpu.h
+++ b/src/components/mc/cpu/mc_cpu.h
@@ -12,11 +12,18 @@
 
 typedef struct ucc_mc_cpu_config {
     ucc_mc_config_t super;
+    size_t          cpu_elem_size;
+    int             cpu_max_elems;
 } ucc_mc_cpu_config_t;
 
 typedef struct ucc_mc_cpu {
     ucc_mc_base_t super;
+    ucc_mpool_t    mpool;
+    int            mpool_init_flag;
+    ucc_spinlock_t mpool_init_spinlock;
 } ucc_mc_cpu_t;
 
 extern ucc_mc_cpu_t ucc_mc_cpu;
+#define MC_CPU_CONFIG                                                          \
+    (ucc_derived_of(ucc_mc_cpu.super.config, ucc_mc_cpu_config_t))
 #endif

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -9,6 +9,9 @@
 #include <cuda_runtime.h>
 #include <cuda.h>
 
+static ucc_status_t
+ucc_mc_cuda_mem_alloc_with_init(ucc_mc_buffer_header_t **ptr, size_t size);
+
 static const char *stream_task_modes[] = {
     [UCC_MC_CUDA_TASK_KERNEL]  = "kernel",
     [UCC_MC_CUDA_TASK_MEM_OPS] = "driver",
@@ -51,7 +54,15 @@ static ucc_config_field_t ucc_mc_cuda_config_table[] = {
      ucc_offsetof(ucc_mc_cuda_config_t, stream_blocking_wait),
      UCC_CONFIG_TYPE_UINT},
 
+    {"ELEM_SIZE", "1024", "The size of each element in mc cuda mpool",
+     ucc_offsetof(ucc_mc_cuda_config_t, cuda_elem_size),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"MAX_ELEMS", "8", "The max amount of elements in mc cuda mpool",
+     ucc_offsetof(ucc_mc_cuda_config_t, cuda_max_elems), UCC_CONFIG_TYPE_UINT},
+
     {NULL}
+
 };
 
 static ucc_status_t ucc_mc_cuda_stream_req_mpool_chunk_malloc(ucc_mpool_t *mp,
@@ -212,6 +223,7 @@ static ucc_status_t ucc_mc_cuda_init()
     }
 
     ucc_mc_cuda.task_strm_type = cfg->task_strm_type;
+    ucc_spinlock_init(&ucc_mc_cuda.mpool_init_spinlock, 0);
 
     return UCC_OK;
 }
@@ -219,15 +231,62 @@ static ucc_status_t ucc_mc_cuda_init()
 static ucc_status_t ucc_mc_cuda_finalize()
 {
     CUDACHECK(cudaStreamDestroy(ucc_mc_cuda.stream));
+    if (ucc_mc_cuda.mpool_init_flag) {
+        ucc_mpool_cleanup(&ucc_mc_cuda.mpool, 1);
+        ucc_mc_cuda.mpool_init_flag     = 0;
+        ucc_mc_cuda.super.ops.mem_alloc = ucc_mc_cuda_mem_alloc_with_init;
+    }
+    ucc_spinlock_destroy(&ucc_mc_cuda.mpool_init_spinlock);
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_cuda_mem_alloc(void **ptr, size_t size)
+static ucc_status_t ucc_mc_cuda_mem_alloc(ucc_mc_buffer_header_t **ptr,
+                                          size_t                   size)
 {
-    cudaError_t st;
+    ucc_mc_buffer_header_t *h = NULL;
+    if (size <= MC_CUDA_CONFIG->cuda_elem_size) {
+        h = (ucc_mc_buffer_header_t *)ucc_mpool_get(&ucc_mc_cuda.mpool);
+    }
+    if (!h) {
+        // Slow path
+        cudaError_t st;
+        h = ucc_malloc(sizeof(ucc_mc_buffer_header_t), "mc cuda");
+        if (!h) {
+            mc_error(&ucc_mc_cuda.super, "failed to allocate %zd bytes",
+                     sizeof(ucc_mc_buffer_header_t));
+            return UCC_ERR_NO_MEMORY;
+        }
+        st = cudaMalloc(&h->addr, size);
+        if (st != cudaSuccess) {
+            cudaGetLastError();
+            mc_error(&ucc_mc_cuda.super,
+                     "failed to allocate %zd bytes, "
+                     "cuda error %d(%s)",
+                     size, st, cudaGetErrorString(st));
+            return UCC_ERR_NO_MEMORY;
+        }
+        mc_debug(
+            &ucc_mc_cuda.super, "ucc_mc_cuda_mem_alloc size:%zd",
+            size); // TODO: should i keep this? add it also to chunk alloc? in cpu?
+        h->from_pool = 0;
+    }
+    *ptr = h;
+    return UCC_OK;
+}
 
-    st = cudaMalloc(ptr, size);
-    if (ucc_unlikely(st != cudaSuccess)) {
+static ucc_status_t
+ucc_mc_cuda_mem_alloc_slow_path_only(ucc_mc_buffer_header_t **ptr, size_t size)
+{
+    cudaError_t             st;
+    ucc_mc_buffer_header_t *h =
+        ucc_malloc(sizeof(ucc_mc_buffer_header_t), "mc cuda");
+    if (!h) {
+        mc_error(&ucc_mc_cuda.super, "failed to allocate %zd bytes",
+                 sizeof(ucc_mc_buffer_header_t));
+        return UCC_ERR_NO_MEMORY;
+    }
+    st = cudaMalloc(&h->addr, size);
+    if (st != cudaSuccess) {
         cudaGetLastError();
         mc_error(&ucc_mc_cuda.super,
                  "failed to allocate %zd bytes, "
@@ -235,23 +294,108 @@ static ucc_status_t ucc_mc_cuda_mem_alloc(void **ptr, size_t size)
                  size, st, cudaGetErrorString(st));
         return UCC_ERR_NO_MEMORY;
     }
-
-    mc_debug(&ucc_mc_cuda.super, "ucc_mc_cuda_mem_alloc size:%ld", size);
+    mc_debug(
+        &ucc_mc_cuda.super, "ucc_mc_cuda_mem_alloc size:%zd",
+        size); // TODO: should i keep this? add it also to chunk alloc? in cpu?
+    h->from_pool = 0;
+    *ptr         = h;
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_cuda_mem_free(void *ptr)
+static ucc_status_t ucc_mc_cuda_chunk_alloc(ucc_mpool_t *mp, size_t *size_p,
+                                            void **chunk_p)
 {
-    cudaError_t st;
+    *chunk_p = ucc_malloc(*size_p, "mc cuda");
+    if (!*chunk_p) {
+        mc_error(&ucc_mc_cuda.super, "failed to allocate %zd bytes", *size_p);
+        return UCC_ERR_NO_MEMORY;
+    }
 
-    st = cudaFree(ptr);
-    if (ucc_unlikely(st != cudaSuccess)) {
+    return UCC_OK;
+}
+
+static void ucc_mc_cuda_chunk_init(ucc_mpool_t *mp, void *obj, void *chunk)
+{
+    ucc_mc_buffer_header_t *h = (ucc_mc_buffer_header_t *)obj;
+    cudaError_t st = cudaMalloc(&h->addr, MC_CUDA_CONFIG->cuda_elem_size);
+    if (st != cudaSuccess) {
+        cudaGetLastError();
+        mc_error(&ucc_mc_cuda.super,
+                 "failed to allocate %zd bytes, "
+                 "cuda error %d(%s)",
+                 MC_CUDA_CONFIG->cuda_elem_size, st, cudaGetErrorString(st));
+    }
+    h->from_pool = 1;
+}
+
+static void ucc_mc_cuda_chunk_release(ucc_mpool_t *mp, void *chunk)
+{
+    ucc_free(chunk);
+}
+
+static void ucc_mc_cuda_chunk_cleanup(ucc_mpool_t *mp, void *obj)
+{
+    ucc_mc_buffer_header_t *h = (ucc_mc_buffer_header_t *)obj;
+    cudaError_t             st;
+    st = cudaFree(h->addr);
+    if (st != cudaSuccess) {
         cudaGetLastError();
         mc_error(&ucc_mc_cuda.super,
                  "failed to free mem at %p, "
                  "cuda error %d(%s)",
-                 ptr, st, cudaGetErrorString(st));
-        return UCC_ERR_NO_MESSAGE;
+                 obj, st, cudaGetErrorString(st));
+    }
+}
+
+static ucc_mpool_ops_t ucc_mc_ops = {.chunk_alloc   = ucc_mc_cuda_chunk_alloc,
+                                     .chunk_release = ucc_mc_cuda_chunk_release,
+                                     .obj_init      = ucc_mc_cuda_chunk_init,
+                                     .obj_cleanup = ucc_mc_cuda_chunk_cleanup};
+
+static ucc_status_t
+ucc_mc_cuda_mem_alloc_with_init(ucc_mc_buffer_header_t **ptr, size_t size)
+{
+    ucc_spin_lock(&ucc_mc_cuda.mpool_init_spinlock);
+
+    if (MC_CUDA_CONFIG->cuda_max_elems == 0) {
+        ucc_mc_cuda.super.ops.mem_alloc = ucc_mc_cuda_mem_alloc_slow_path_only;
+        ucc_spin_unlock(&ucc_mc_cuda.mpool_init_spinlock);
+        return ucc_mc_cuda_mem_alloc_slow_path_only(ptr, size);
+    }
+
+    if (!ucc_mc_cuda.mpool_init_flag) {
+        // TODO: currently only with thread multiple, need to change?
+        ucc_status_t status = ucc_mpool_init(
+            &ucc_mc_cuda.mpool, 0, sizeof(ucc_mc_buffer_header_t), 0,
+            UCC_CACHE_LINE_SIZE, 1, MC_CUDA_CONFIG->cuda_max_elems, &ucc_mc_ops,
+            UCC_THREAD_MULTIPLE, "mc cuda mpool buffers");
+        if (status != UCC_OK) {
+            return status;
+        }
+        ucc_mc_cuda.super.ops.mem_alloc = ucc_mc_cuda_mem_alloc;
+        ucc_mc_cuda.mpool_init_flag     = 1;
+    }
+    ucc_spin_unlock(&ucc_mc_cuda.mpool_init_spinlock);
+    return ucc_mc_cuda_mem_alloc(ptr, size);
+}
+
+static ucc_status_t ucc_mc_cuda_mem_free(ucc_mc_buffer_header_t *ptr)
+{
+    if (!ptr->from_pool) {
+        cudaError_t st;
+        st = cudaFree(ptr->addr);
+        if (st != cudaSuccess) {
+            cudaGetLastError();
+            mc_error(&ucc_mc_cuda.super,
+                     "failed to free mem at %p, "
+                     "cuda error %d(%s)",
+                     ptr->addr, st, cudaGetErrorString(st));
+            return UCC_ERR_NO_MESSAGE;
+        }
+        ucc_free(ptr);
+    }
+    else {
+        ucc_mpool_put(ptr);
     }
     return UCC_OK;
 }
@@ -481,7 +625,7 @@ ucc_mc_cuda_t ucc_mc_cuda = {
     .super.init             = ucc_mc_cuda_init,
     .super.finalize         = ucc_mc_cuda_finalize,
     .super.ops.mem_query    = ucc_mc_cuda_mem_query,
-    .super.ops.mem_alloc    = ucc_mc_cuda_mem_alloc,
+    .super.ops.mem_alloc    = ucc_mc_cuda_mem_alloc_with_init,
     .super.ops.mem_free     = ucc_mc_cuda_mem_free,
     .super.ops.reduce       = ucc_mc_cuda_reduce,
     .super.ops.reduce_multi = ucc_mc_cuda_reduce_multi,
@@ -500,6 +644,7 @@ ucc_mc_cuda_t ucc_mc_cuda = {
     .super.ee_ops.ee_destroy_event = ucc_ee_cuda_destroy_event,
     .super.ee_ops.ee_event_post    = ucc_ee_cuda_event_post,
     .super.ee_ops.ee_event_test    = ucc_ee_cuda_event_test,
+    .mpool_init_flag               = 0,
 };
 
 UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_mc_cuda.super.config_table,

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -56,6 +56,9 @@ typedef struct ucc_mc_cuda_config {
     ucc_mc_cuda_strm_task_mode_t   strm_task_mode;
     ucc_mc_cuda_task_stream_type_t task_strm_type;
     int                            stream_blocking_wait;
+    size_t                         cuda_elem_size;
+    int                            cuda_max_elems;
+
 } ucc_mc_cuda_config_t;
 
 typedef struct ucc_mc_cuda {
@@ -63,6 +66,9 @@ typedef struct ucc_mc_cuda {
     cudaStream_t                   stream;
     ucc_mpool_t                    events;
     ucc_mpool_t                    strm_reqs;
+    ucc_mpool_t                    mpool;
+    int                            mpool_init_flag;
+    ucc_spinlock_t                 mpool_init_spinlock;
     ucc_mc_cuda_strm_task_mode_t   strm_task_mode;
     ucc_mc_cuda_task_stream_type_t task_strm_type;
     ucc_mc_cuda_task_post_fn       post_strm_task;

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -56,9 +56,8 @@ typedef struct ucc_mc_cuda_config {
     ucc_mc_cuda_strm_task_mode_t   strm_task_mode;
     ucc_mc_cuda_task_stream_type_t task_strm_type;
     int                            stream_blocking_wait;
-    size_t                         cuda_elem_size;
-    int                            cuda_max_elems;
-
+    size_t                         mpool_elem_size;
+    int                            mpool_max_elems;
 } ucc_mc_cuda_config_t;
 
 typedef struct ucc_mc_cuda {
@@ -69,7 +68,7 @@ typedef struct ucc_mc_cuda {
     ucc_mpool_t                    mpool;
     int                            mpool_init_flag;
     ucc_spinlock_t                 mpool_init_spinlock;
-    ucc_thread_mode_t              tm;
+    ucc_thread_mode_t              thread_mode;
     ucc_mc_cuda_strm_task_mode_t   strm_task_mode;
     ucc_mc_cuda_task_stream_type_t task_strm_type;
     ucc_mc_cuda_task_post_fn       post_strm_task;

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -69,6 +69,7 @@ typedef struct ucc_mc_cuda {
     ucc_mpool_t                    mpool;
     int                            mpool_init_flag;
     ucc_spinlock_t                 mpool_init_spinlock;
+    ucc_thread_mode_t              tm;
     ucc_mc_cuda_strm_task_mode_t   strm_task_mode;
     ucc_mc_cuda_task_stream_type_t task_strm_type;
     ucc_mc_cuda_task_post_fn       post_strm_task;

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -200,9 +200,10 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
     task->super.post     = ucc_tl_ucp_allreduce_knomial_start;
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;
-    status = ucc_mc_alloc(&task->allreduce_kn.mc_header, (radix - 1) * data_size,
-                          task->args.src.info.mem_type);
-    task->allreduce_kn.scratch = task->allreduce_kn.mc_header->addr;
+    status =
+        ucc_mc_alloc(&task->allreduce_kn.scratch_mc_header,
+                     (radix - 1) * data_size, task->args.src.info.mem_type);
+    task->allreduce_kn.scratch = task->allreduce_kn.scratch_mc_header->addr;
     if (ucc_unlikely(status != UCC_OK)) {
         tl_error(UCC_TL_TEAM_LIB(task->team),
                  "failed to allocate scratch buffer");
@@ -216,7 +217,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_finalize(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_status_t st, global_st;
 
-    global_st = ucc_mc_free(task->allreduce_kn.mc_header,
+    global_st = ucc_mc_free(task->allreduce_kn.scratch_mc_header,
                             task->args.src.info.mem_type);
     if (ucc_unlikely(global_st != UCC_OK)) {
         tl_error(UCC_TL_TEAM_LIB(task->team),

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -203,7 +203,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
     status = ucc_mc_alloc(&task->allreduce_kn.mc_header, (radix - 1) * data_size,
                           task->args.src.info.mem_type);
     task->allreduce_kn.scratch = task->allreduce_kn.mc_header->addr;
-    if (status != UCC_OK) {
+    if (ucc_unlikely(status != UCC_OK)) {
         tl_error(UCC_TL_TEAM_LIB(task->team),
                  "failed to allocate scratch buffer");
         return status;

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -200,9 +200,10 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
     task->super.post     = ucc_tl_ucp_allreduce_knomial_start;
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;
-    status = ucc_mc_alloc(&task->allreduce_kn.scratch, (radix - 1) * data_size,
+    status = ucc_mc_alloc(&task->allreduce_kn.mc_header, (radix - 1) * data_size,
                           task->args.src.info.mem_type);
-    if (ucc_unlikely(status != UCC_OK)) {
+    task->allreduce_kn.scratch = task->allreduce_kn.mc_header->addr;
+    if (status != UCC_OK) {
         tl_error(UCC_TL_TEAM_LIB(task->team),
                  "failed to allocate scratch buffer");
         return status;
@@ -215,7 +216,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_finalize(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_status_t st, global_st;
 
-    global_st = ucc_mc_free(task->allreduce_kn.scratch,
+    global_st = ucc_mc_free(task->allreduce_kn.mc_header,
                             task->args.src.info.mem_type);
     if (ucc_unlikely(global_st != UCC_OK)) {
         tl_error(UCC_TL_TEAM_LIB(task->team),

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -192,7 +192,7 @@ ucc_tl_ucp_reduce_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
     uint8_t            node_type = task->reduce_scatter_kn.p.node_type;
     ucc_memory_type_t  mem_type  = task->args.src.info.mem_type;
     if (UCC_IS_INPLACE(task->args) || (KN_NODE_PROXY == node_type)) {
-        ucc_mc_free(task->reduce_scatter_kn.mc_header, mem_type);
+        ucc_mc_free(task->reduce_scatter_kn.scratch_mc_header, mem_type);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);
 }
@@ -224,8 +224,10 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
 
     if (UCC_IS_INPLACE(task->args) ||
         (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type)) {
-        status = ucc_mc_alloc(&task->reduce_scatter_kn.mc_header, data_size, mem_type);
-        task->reduce_scatter_kn.scratch = task->reduce_scatter_kn.mc_header->addr;
+        status = ucc_mc_alloc(&task->reduce_scatter_kn.scratch_mc_header,
+                              data_size, mem_type);
+        task->reduce_scatter_kn.scratch =
+            task->reduce_scatter_kn.scratch_mc_header->addr;
         if (UCC_OK != status) {
             return status;
         }

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -192,7 +192,7 @@ ucc_tl_ucp_reduce_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
     uint8_t            node_type = task->reduce_scatter_kn.p.node_type;
     ucc_memory_type_t  mem_type  = task->args.src.info.mem_type;
     if (UCC_IS_INPLACE(task->args) || (KN_NODE_PROXY == node_type)) {
-        ucc_mc_free(task->reduce_scatter_kn.scratch, mem_type);
+        ucc_mc_free(task->mc_header, mem_type);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);
 }
@@ -224,8 +224,8 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
 
     if (UCC_IS_INPLACE(task->args) ||
         (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type)) {
-        status =
-            ucc_mc_alloc(&task->reduce_scatter_kn.scratch, data_size, mem_type);
+        status = ucc_mc_alloc(&task->mc_header, data_size, mem_type);
+        task->reduce_scatter_kn.scratch = task->mc_header->addr;
         if (UCC_OK != status) {
             return status;
         }

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -192,7 +192,7 @@ ucc_tl_ucp_reduce_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
     uint8_t            node_type = task->reduce_scatter_kn.p.node_type;
     ucc_memory_type_t  mem_type  = task->args.src.info.mem_type;
     if (UCC_IS_INPLACE(task->args) || (KN_NODE_PROXY == node_type)) {
-        ucc_mc_free(task->mc_header, mem_type);
+        ucc_mc_free(task->reduce_scatter_kn.mc_header, mem_type);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);
 }
@@ -224,8 +224,8 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
 
     if (UCC_IS_INPLACE(task->args) ||
         (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type)) {
-        status = ucc_mc_alloc(&task->mc_header, data_size, mem_type);
-        task->reduce_scatter_kn.scratch = task->mc_header->addr;
+        status = ucc_mc_alloc(&task->reduce_scatter_kn.mc_header, data_size, mem_type);
+        task->reduce_scatter_kn.scratch = task->reduce_scatter_kn.mc_header->addr;
         if (UCC_OK != status) {
             return status;
         }

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -18,16 +18,16 @@ extern const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR];
 
 typedef struct ucc_tl_ucp_task {
-    ucc_coll_task_t         super;
-    ucc_coll_args_t         args;
-    ucc_tl_ucp_team_t *     team;
-    uint32_t                send_posted;
-    uint32_t                send_completed;
-    uint32_t                recv_posted;
-    uint32_t                recv_completed;
-    uint32_t                tag;
-    uint32_t                n_polls;
-    ucc_tl_team_subset_t    subset;
+    ucc_coll_task_t      super;
+    ucc_coll_args_t      args;
+    ucc_tl_ucp_team_t *  team;
+    uint32_t             send_posted;
+    uint32_t             send_completed;
+    uint32_t             recv_posted;
+    uint32_t             recv_completed;
+    uint32_t             tag;
+    uint32_t             n_polls;
+    ucc_tl_team_subset_t subset;
     union {
         struct {
             int                     phase;
@@ -37,13 +37,13 @@ typedef struct ucc_tl_ucp_task {
             int                     phase;
             ucc_knomial_pattern_t   p;
             void                   *scratch;
-            ucc_mc_buffer_header_t *mc_header;
+            ucc_mc_buffer_header_t *scratch_mc_header;
         } allreduce_kn;
         struct {
             int                     phase;
             ucc_knomial_pattern_t   p;
             void                   *scratch;
-            ucc_mc_buffer_header_t *mc_header;
+            ucc_mc_buffer_header_t *scratch_mc_header;
         } reduce_scatter_kn;
         struct {
             int                     phase;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -30,28 +30,28 @@ typedef struct ucc_tl_ucp_task {
     ucc_tl_team_subset_t    subset;
     union {
         struct {
-            int                   phase;
-            ucc_knomial_pattern_t p;
+            int                     phase;
+            ucc_knomial_pattern_t   p;
         } barrier;
         struct {
-            int                   phase;
-            ucc_knomial_pattern_t p;
-            void                 *scratch;
+            int                     phase;
+            ucc_knomial_pattern_t   p;
+            void                   *scratch;
             ucc_mc_buffer_header_t *mc_header;
         } allreduce_kn;
         struct {
-            int                   phase;
-            ucc_knomial_pattern_t p;
-            void                 *scratch;
+            int                     phase;
+            ucc_knomial_pattern_t   p;
+            void                   *scratch;
             ucc_mc_buffer_header_t *mc_header;
         } reduce_scatter_kn;
         struct {
-            int                   phase;
-            ucc_knomial_pattern_t p;
+            int                     phase;
+            ucc_knomial_pattern_t   p;
         } allgather_kn;
         struct {
-            ucc_rank_t            dist;
-            uint32_t              radix;
+            ucc_rank_t              dist;
+            uint32_t                radix;
         } bcast_kn;
     };
 } ucc_tl_ucp_task_t;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -10,6 +10,7 @@
 #include "tl_ucp.h"
 #include "schedule/ucc_schedule.h"
 #include "coll_patterns/recursive_knomial.h"
+#include "components/mc/base/ucc_mc_base.h"
 #include "tl_ucp_tag.h"
 
 #define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 1
@@ -17,16 +18,17 @@ extern const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR];
 
 typedef struct ucc_tl_ucp_task {
-    ucc_coll_task_t      super;
-    ucc_coll_args_t      args;
-    ucc_tl_ucp_team_t   *team;
-    uint32_t             send_posted;
-    uint32_t             send_completed;
-    uint32_t             recv_posted;
-    uint32_t             recv_completed;
-    uint32_t             tag;
-    uint32_t             n_polls;
-    ucc_tl_team_subset_t subset;
+    ucc_coll_task_t         super;
+    ucc_coll_args_t         args;
+    ucc_tl_ucp_team_t *     team;
+    uint32_t                send_posted;
+    uint32_t                send_completed;
+    uint32_t                recv_posted;
+    uint32_t                recv_completed;
+    uint32_t                tag;
+    uint32_t                n_polls;
+    ucc_tl_team_subset_t    subset;
+    ucc_mc_buffer_header_t *mc_header;
     union {
         struct {
             int                   phase;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -28,7 +28,6 @@ typedef struct ucc_tl_ucp_task {
     uint32_t                tag;
     uint32_t                n_polls;
     ucc_tl_team_subset_t    subset;
-    ucc_mc_buffer_header_t *mc_header;
     union {
         struct {
             int                   phase;
@@ -38,11 +37,13 @@ typedef struct ucc_tl_ucp_task {
             int                   phase;
             ucc_knomial_pattern_t p;
             void                 *scratch;
+            ucc_mc_buffer_header_t *mc_header;
         } allreduce_kn;
         struct {
             int                   phase;
             ucc_knomial_pattern_t p;
             void                 *scratch;
+            ucc_mc_buffer_header_t *mc_header;
         } reduce_scatter_kn;
         struct {
             int                   phase;

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -292,7 +292,7 @@ ucc_status_t ucc_init_version(unsigned api_major_version,
     if (UCC_OK != (status = ucc_constructor())) {
         return status;
     }
-    if (UCC_OK != (status = ucc_mc_init())) {
+    if (UCC_OK != (status = ucc_mc_init(params->thread_mode))) {
         return status;
     }
 
@@ -365,7 +365,7 @@ ucc_status_t ucc_lib_config_read(const char *env_prefix, const char *filename,
     /* full_prefix for a UCC lib config is either just
           (i)  "UCC_" - if no "env_prefix" is provided, or
           (ii) "AAA_UCC" - where AAA is the value of "env_prefix".
-       Allocate space to build prefix str and two characters ("_" and “\0”) */
+       Allocate space to build prefix str and two characters ("_" and "\0") */
     full_prefix_len =
         strlen(base_prefix) + (env_prefix ? strlen(env_prefix) : 0) + 2;
     config->full_prefix = ucc_malloc(full_prefix_len, "full_prefix");

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -286,13 +286,16 @@ ucc_status_t ucc_init_version(unsigned api_major_version,
     unsigned        major_version, minor_version, release_number;
     ucc_status_t    status;
     ucc_lib_info_t *lib;
+    ucc_mc_params_t mc_params = {
+        .thread_mode = params->thread_mode,
+    };
 
     *lib_p = NULL;
 
     if (UCC_OK != (status = ucc_constructor())) {
         return status;
     }
-    if (UCC_OK != (status = ucc_mc_init(params->thread_mode))) {
+    if (UCC_OK != (status = ucc_mc_init(&mc_params))) {
         return status;
     }
 

--- a/src/core/ucc_mc.c
+++ b/src/core/ucc_mc.c
@@ -30,7 +30,7 @@ static const ucc_ee_ops_t *ee_ops[UCC_EE_LAST];
         }                                                                      \
     } while (0)
 
-ucc_status_t ucc_mc_init()
+ucc_status_t ucc_mc_init(ucc_thread_mode_t thread_mode)
 {
     int            i, n_mcs;
     ucc_mc_base_t *mc;
@@ -58,7 +58,7 @@ ucc_status_t ucc_mc_init()
                 ucc_free(mc->config);
                 continue;
             }
-            status = mc->init();
+            status = mc->init(thread_mode);
             if (UCC_OK != status) {
                 ucc_info("mc_init failed for component: %s, skipping (%d)",
                          mc->super.name, status);

--- a/src/core/ucc_mc.c
+++ b/src/core/ucc_mc.c
@@ -110,7 +110,8 @@ ucc_status_t ucc_mc_get_mem_attr(const void *ptr, ucc_mem_attr_t *mem_attr)
     return UCC_OK;
 }
 
-ucc_status_t ucc_mc_alloc(void **ptr, size_t size, ucc_memory_type_t mem_type)
+ucc_status_t ucc_mc_alloc(ucc_mc_buffer_header_t **ptr, size_t size,
+                          ucc_memory_type_t mem_type)
 {
     UCC_CHECK_MC_AVAILABLE(mem_type);
     return mc_ops[mem_type]->mem_alloc(ptr, size);
@@ -140,7 +141,8 @@ ucc_status_t ucc_mc_reduce_multi(void *src1, void *src2, void *dst,
                                           dtype, op);
 }
 
-ucc_status_t ucc_mc_free(void *ptr, ucc_memory_type_t mem_type)
+ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *ptr,
+                         ucc_memory_type_t       mem_type)
 {
     UCC_CHECK_MC_AVAILABLE(mem_type);
     return mc_ops[mem_type]->mem_free(ptr);

--- a/src/core/ucc_mc.c
+++ b/src/core/ucc_mc.c
@@ -30,7 +30,7 @@ static const ucc_ee_ops_t *ee_ops[UCC_EE_LAST];
         }                                                                      \
     } while (0)
 
-ucc_status_t ucc_mc_init(ucc_thread_mode_t thread_mode)
+ucc_status_t ucc_mc_init(const ucc_mc_params_t *mc_params)
 {
     int            i, n_mcs;
     ucc_mc_base_t *mc;
@@ -58,7 +58,7 @@ ucc_status_t ucc_mc_init(ucc_thread_mode_t thread_mode)
                 ucc_free(mc->config);
                 continue;
             }
-            status = mc->init(thread_mode);
+            status = mc->init(mc_params);
             if (UCC_OK != status) {
                 ucc_info("mc_init failed for component: %s, skipping (%d)",
                          mc->super.name, status);
@@ -110,11 +110,11 @@ ucc_status_t ucc_mc_get_mem_attr(const void *ptr, ucc_mem_attr_t *mem_attr)
     return UCC_OK;
 }
 
-ucc_status_t ucc_mc_alloc(ucc_mc_buffer_header_t **ptr, size_t size,
+ucc_status_t ucc_mc_alloc(ucc_mc_buffer_header_t **h_ptr, size_t size,
                           ucc_memory_type_t mem_type)
 {
     UCC_CHECK_MC_AVAILABLE(mem_type);
-    return mc_ops[mem_type]->mem_alloc(ptr, size);
+    return mc_ops[mem_type]->mem_alloc(h_ptr, size);
 }
 
 ucc_status_t ucc_mc_reduce(const void *src1, const void *src2, void *dst,
@@ -141,11 +141,11 @@ ucc_status_t ucc_mc_reduce_multi(void *src1, void *src2, void *dst,
                                           dtype, op);
 }
 
-ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *ptr,
+ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *h_ptr,
                          ucc_memory_type_t       mem_type)
 {
     UCC_CHECK_MC_AVAILABLE(mem_type);
-    return mc_ops[mem_type]->mem_free(ptr);
+    return mc_ops[mem_type]->mem_free(h_ptr);
 }
 
 ucc_status_t ucc_mc_memcpy(void *dst, const void *src, size_t len,

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -16,7 +16,11 @@ typedef struct ucc_mc_buffer_header {
     void *addr;
 } ucc_mc_buffer_header_t;
 
-ucc_status_t ucc_mc_init(ucc_thread_mode_t thread_mode);
+typedef struct ucc_mc_params {
+    ucc_thread_mode_t thread_mode;
+} ucc_mc_params_t;
+
+ucc_status_t ucc_mc_init(const ucc_mc_params_t *mc_params);
 
 ucc_status_t ucc_mc_available(ucc_memory_type_t mem_type);
 
@@ -27,10 +31,10 @@ ucc_status_t ucc_mc_available(ucc_memory_type_t mem_type);
  */
 ucc_status_t ucc_mc_get_mem_attr(const void *ptr, ucc_mem_attr_t *mem_attr);
 
-ucc_status_t ucc_mc_alloc(ucc_mc_buffer_header_t **ptr, size_t len,
+ucc_status_t ucc_mc_alloc(ucc_mc_buffer_header_t **h_ptr, size_t len,
                           ucc_memory_type_t mem_type);
 
-ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *ptr,
+ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *h_ptr,
                          ucc_memory_type_t       mem_type);
 
 ucc_status_t ucc_mc_finalize();
@@ -87,7 +91,6 @@ ucc_status_t ucc_mc_reduce_multi(void *src1, void *src2, void *dst,
                                  size_t count, size_t size, size_t stride,
                                  ucc_datatype_t dtype, ucc_reduction_op_t op,
                                  ucc_memory_type_t mem_type);
-
 
 static inline ucc_status_t ucc_dt_reduce(const void *src1, const void *src2,
                                          void *dst, size_t count,

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -20,9 +20,11 @@ ucc_status_t ucc_mc_available(ucc_memory_type_t mem_type);
  */
 ucc_status_t ucc_mc_get_mem_attr(const void *ptr, ucc_mem_attr_t *mem_attr);
 
-ucc_status_t ucc_mc_alloc(void **ptr, size_t len, ucc_memory_type_t mem_type);
+ucc_status_t ucc_mc_alloc(ucc_mc_buffer_header_t **ptr, size_t len,
+                          ucc_memory_type_t mem_type);
 
-ucc_status_t ucc_mc_free(void *ptr, ucc_memory_type_t mem_type);
+ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *ptr,
+                         ucc_memory_type_t       mem_type);
 
 ucc_status_t ucc_mc_finalize();
 

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -9,7 +9,14 @@
 #include "ucc/api/ucc.h"
 #include "components/mc/base/ucc_mc_base.h"
 
-ucc_status_t ucc_mc_init();
+typedef struct ucc_mem_attr ucc_mem_attr_t;
+
+typedef struct ucc_mc_buffer_header {
+    int   from_pool;
+    void *addr;
+} ucc_mc_buffer_header_t;
+
+ucc_status_t ucc_mc_init(ucc_thread_mode_t thread_mode);
 
 ucc_status_t ucc_mc_available(ucc_memory_type_t mem_type);
 
@@ -80,6 +87,7 @@ ucc_status_t ucc_mc_reduce_multi(void *src1, void *src2, void *dst,
                                  size_t count, size_t size, size_t stride,
                                  ucc_datatype_t dtype, ucc_reduction_op_t op,
                                  ucc_memory_type_t mem_type);
+
 
 static inline ucc_status_t ucc_dt_reduce(const void *src1, const void *src2,
                                          void *dst, size_t count,

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -14,8 +14,7 @@
 #include <ucc/api/ucc_version.h>
 #include <ucc/api/ucc_status.h>
 #include <stdio.h>
-//#include "components/mc/base/ucc_mc_base.h"
-typedef struct ucc_mc_buffer_header ucc_mc_buffer_header_t;
+
 
 BEGIN_C_DECLS
 
@@ -1384,9 +1383,6 @@ typedef enum ucc_memory_type {
 } ucc_memory_type_t;
 
 typedef struct ucc_coll_buffer_info_v {
-    ucc_mc_buffer_header_t *mc_header;
-    ucc_mc_buffer_header_t *counts_header;
-    ucc_mc_buffer_header_t *displacements_header;
     void *                  buffer;
     ucc_count_t *           counts;
     ucc_aint_t *            displacements;
@@ -1395,7 +1391,6 @@ typedef struct ucc_coll_buffer_info_v {
 } ucc_coll_buffer_info_v_t;
 
 typedef struct ucc_coll_buffer_info {
-    ucc_mc_buffer_header_t *mc_header;
     void *                  buffer;
     ucc_count_t             count;
     ucc_datatype_t          datatype;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -196,7 +196,7 @@ typedef enum {
  *
  *  Description
  *
- *  @ref ucc_datatype_t represents the datatypes supported by the UCC library’s
+ *  @ref ucc_datatype_t represents the datatypes supported by the UCC library's
  *  collective and reduction operations. The standard operations are signed and
  *  unsigned integers of various sizes, float 16, 32, and 64, and user-defined
  *  datatypes. The UCC_DT_USERDEFINED represents the user-defined datatype. The
@@ -235,7 +235,7 @@ typedef enum {
  *
  *  Description
  *
- *  @ref ucc_thread_mode_t is used to initialize the UCC library’s thread mode.
+ *  @ref ucc_thread_mode_t is used to initialize the UCC library's thread mode.
  *  The UCC library can be configured in three thread modes UCC_THREAD_SINGLE,
  *  UCC_THREAD_FUNNELED, and UCC_LIB_THREAD_MULTIPLE. In the UCC_THREAD_SINGLE
  *  mode, the user program must not be multithreaded. In the UCC_THREAD_FUNNELED
@@ -1385,6 +1385,8 @@ typedef enum ucc_memory_type {
 
 typedef struct ucc_coll_buffer_info_v {
     ucc_mc_buffer_header_t *mc_header;
+    ucc_mc_buffer_header_t *counts_header;
+    ucc_mc_buffer_header_t *displacements_header;
     void *                  buffer;
     ucc_count_t *           counts;
     ucc_aint_t *            displacements;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -15,7 +15,6 @@
 #include <ucc/api/ucc_status.h>
 #include <stdio.h>
 
-
 BEGIN_C_DECLS
 
 /** Unified Collective Communications (UCC) Library Specification
@@ -195,7 +194,7 @@ typedef enum {
  *
  *  Description
  *
- *  @ref ucc_datatype_t represents the datatypes supported by the UCC library's
+ *  @ref ucc_datatype_t represents the datatypes supported by the UCC library’s
  *  collective and reduction operations. The standard operations are signed and
  *  unsigned integers of various sizes, float 16, 32, and 64, and user-defined
  *  datatypes. The UCC_DT_USERDEFINED represents the user-defined datatype. The
@@ -234,7 +233,7 @@ typedef enum {
  *
  *  Description
  *
- *  @ref ucc_thread_mode_t is used to initialize the UCC library's thread mode.
+ *  @ref ucc_thread_mode_t is used to initialize the UCC library’s thread mode.
  *  The UCC library can be configured in three thread modes UCC_THREAD_SINGLE,
  *  UCC_THREAD_FUNNELED, and UCC_LIB_THREAD_MULTIPLE. In the UCC_THREAD_SINGLE
  *  mode, the user program must not be multithreaded. In the UCC_THREAD_FUNNELED
@@ -1383,18 +1382,18 @@ typedef enum ucc_memory_type {
 } ucc_memory_type_t;
 
 typedef struct ucc_coll_buffer_info_v {
-    void *                  buffer;
-    ucc_count_t *           counts;
-    ucc_aint_t *            displacements;
-    ucc_datatype_t          datatype;
-    ucc_memory_type_t       mem_type;
+    void             *buffer;
+    ucc_count_t      *counts;
+    ucc_aint_t       *displacements;
+    ucc_datatype_t    datatype;
+    ucc_memory_type_t mem_type;
 } ucc_coll_buffer_info_v_t;
 
 typedef struct ucc_coll_buffer_info {
-    void *                  buffer;
-    ucc_count_t             count;
-    ucc_datatype_t          datatype;
-    ucc_memory_type_t       mem_type;
+    void             *buffer;
+    ucc_count_t       count;
+    ucc_datatype_t    datatype;
+    ucc_memory_type_t mem_type;
 } ucc_coll_buffer_info_t;
 
 /**

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -14,6 +14,8 @@
 #include <ucc/api/ucc_version.h>
 #include <ucc/api/ucc_status.h>
 #include <stdio.h>
+//#include "components/mc/base/ucc_mc_base.h"
+typedef struct ucc_mc_buffer_header ucc_mc_buffer_header_t;
 
 BEGIN_C_DECLS
 
@@ -1382,18 +1384,20 @@ typedef enum ucc_memory_type {
 } ucc_memory_type_t;
 
 typedef struct ucc_coll_buffer_info_v {
-    void             *buffer;
-    ucc_count_t      *counts;
-    ucc_aint_t       *displacements;
-    ucc_datatype_t    datatype;
-    ucc_memory_type_t mem_type;
+    ucc_mc_buffer_header_t *mc_header;
+    void *                  buffer;
+    ucc_count_t *           counts;
+    ucc_aint_t *            displacements;
+    ucc_datatype_t          datatype;
+    ucc_memory_type_t       mem_type;
 } ucc_coll_buffer_info_v_t;
 
 typedef struct ucc_coll_buffer_info {
-    void             *buffer;
-    ucc_count_t       count;
-    ucc_datatype_t    datatype;
-    ucc_memory_type_t mem_type;
+    ucc_mc_buffer_header_t *mc_header;
+    void *                  buffer;
+    ucc_count_t             count;
+    ucc_datatype_t          datatype;
+    ucc_memory_type_t       mem_type;
 } ucc_coll_buffer_info_t;
 
 /**

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -35,6 +35,7 @@ typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
 #define UCC_CONFIG_TYPE_TABLE           UCS_CONFIG_TYPE_TABLE
 #define UCC_CONFIG_TYPE_ULUNITS         UCS_CONFIG_TYPE_ULUNITS
 #define UCC_CONFIG_TYPE_ENUM            UCS_CONFIG_TYPE_ENUM
+#define UCC_CONFIG_TYPE_MEMUNITS UCS_CONFIG_TYPE_MEMUNITS
 #define UCC_ULUNITS_AUTO                UCS_ULUNITS_AUTO
 
 static inline ucc_status_t

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -35,7 +35,7 @@ typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
 #define UCC_CONFIG_TYPE_TABLE           UCS_CONFIG_TYPE_TABLE
 #define UCC_CONFIG_TYPE_ULUNITS         UCS_CONFIG_TYPE_ULUNITS
 #define UCC_CONFIG_TYPE_ENUM            UCS_CONFIG_TYPE_ENUM
-#define UCC_CONFIG_TYPE_MEMUNITS UCS_CONFIG_TYPE_MEMUNITS
+#define UCC_CONFIG_TYPE_MEMUNITS        UCS_CONFIG_TYPE_MEMUNITS
 #define UCC_ULUNITS_AUTO                UCS_ULUNITS_AUTO
 
 static inline ucc_status_t

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -16,7 +16,8 @@ extern "C" {
 #include <memory>
 
 typedef struct {
-    ucc_mc_buffer_header_t *mc_header;
+    ucc_mc_buffer_header_t *dst_header;
+    ucc_mc_buffer_header_t *src_header;
     void *                  init_buf;
     size_t                  rbuf_size;
     ucc_coll_args_t *       args;

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -16,11 +16,11 @@ extern "C" {
 #include <memory>
 
 typedef struct {
-    ucc_mc_buffer_header_t *dst_header;
-    ucc_mc_buffer_header_t *src_header;
-    void *                  init_buf;
+    ucc_mc_buffer_header_t *dst_mc_header;
+    ucc_mc_buffer_header_t *src_mc_header;
+    void                   *init_buf;
     size_t                  rbuf_size;
-    ucc_coll_args_t *       args;
+    ucc_coll_args_t        *args;
 } gtest_ucc_coll_ctx_t;
 
 typedef std::vector<gtest_ucc_coll_ctx_t*> UccCollCtxVec;

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -16,9 +16,10 @@ extern "C" {
 #include <memory>
 
 typedef struct {
-   void *init_buf;
-   size_t rbuf_size;
-   ucc_coll_args_t *args;
+    ucc_mc_buffer_header_t *mc_header;
+    void *                  init_buf;
+    size_t                  rbuf_size;
+    ucc_coll_args_t *       args;
 } gtest_ucc_coll_ctx_t;
 
 typedef std::vector<gtest_ucc_coll_ctx_t*> UccCollCtxVec;

--- a/test/gtest/core/test_allgather.cc
+++ b/test/gtest/core/test_allgather.cc
@@ -3,9 +3,6 @@
  * See file LICENSE for terms.
  */
 
-extern "C" {
-#include <core/ucc_mc.h>
-}
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
@@ -43,9 +40,9 @@ public:
             }
 
             ctxs[r]->rbuf_size = ucc_dt_size(dtype) * count * nprocs;
-            UCC_CHECK(ucc_mc_alloc(&coll->dst.info.mc_header,
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_header,
                                    ctxs[r]->rbuf_size, mem_type));
-            coll->dst.info.buffer = coll->dst.info.mc_header->addr;
+            coll->dst.info.buffer = ctxs[r]->dst_header->addr;
             if (TEST_INPLACE == inplace) {
                 coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
                 coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
@@ -54,9 +51,9 @@ public:
                                         ctxs[r]->init_buf, ucc_dt_size(dtype) * count,
                                         mem_type, UCC_MEMORY_TYPE_HOST));
             } else {
-                UCC_CHECK(ucc_mc_alloc(&coll->src.info.mc_header,
+                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_header,
                                        ucc_dt_size(dtype) * count, mem_type));
-                coll->src.info.buffer = coll->src.info.mc_header->addr;
+                coll->src.info.buffer = ctxs[r]->src_header->addr;
                 UCC_CHECK(ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
                                         ucc_dt_size(dtype) * count, mem_type,
                                         UCC_MEMORY_TYPE_HOST));
@@ -65,17 +62,16 @@ public:
     }
     void data_fini(UccCollCtxVec ctxs)
     {
-        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
-            ucc_coll_args_t* coll = ctx->args;
+//        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+    	for (int r = 0; r < ctxs.size(); r++) {
+            ucc_coll_args_t* coll = ctxs[r]->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(coll->src.info.mc_header, mem_type));
+                UCC_CHECK(ucc_mc_free(ctxs[r]->src_header, mem_type));
             }
-            UCC_CHECK(ucc_mc_free(coll->dst.info.buffer, mem_type));
-            ucc_free(ctx->init_buf);
-            UCC_CHECK(ucc_mc_free(coll->dst.info.mc_header, mem_type));
-            UCC_CHECK(ucc_mc_free(ctx->mc_header, UCC_MEMORY_TYPE_HOST));
+            UCC_CHECK(ucc_mc_free(ctxs[r]->dst_header, mem_type));
+            ucc_free(ctxs[r]->init_buf);
             free(coll);
-            free(ctx);
+            free(ctxs[r]);
         }
         ctxs.clear();
     }
@@ -83,7 +79,6 @@ public:
     {
         bool                   ret = true;
         std::vector<uint8_t *> dsts(ctxs.size());
-        std::vector<ucc_mc_buffer_header_t *> dsts_mc_headers(ctxs.size());
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
                 dsts[r] = (uint8_t *) ucc_malloc(ctxs[r]->rbuf_size, "dsts buf");

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -3,9 +3,6 @@
  * See file LICENSE for terms.
  */
 
-extern "C" {
-#include <core/ucc_mc.h>
-}
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
@@ -56,9 +53,9 @@ public:
             }
 
             ctxs[r]->rbuf_size = ucc_dt_size(dtype) * all_counts;
-            UCC_CHECK(ucc_mc_alloc(&coll->dst.info_v.mc_header,
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_header,
                                    ctxs[r]->rbuf_size, mem_type));
-            coll->dst.info_v.buffer = coll->dst.info_v.mc_header->addr;
+            coll->dst.info_v.buffer = ctxs[r]->dst_header->addr;
             if (TEST_INPLACE == inplace) {
                 coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
                 coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
@@ -67,10 +64,10 @@ public:
                                         ctxs[r]->init_buf, ucc_dt_size(dtype) * my_count,
                                         mem_type, UCC_MEMORY_TYPE_HOST));
             } else {
-                UCC_CHECK(ucc_mc_alloc(&coll->src.info.mc_header,
+                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_header,
                                        ucc_dt_size(dtype) * my_count,
                                        mem_type));
-                coll->src.info.buffer = coll->src.info.mc_header->addr;
+                coll->src.info.buffer = ctxs[r]->src_header->addr;
                 UCC_CHECK(ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
                                         ucc_dt_size(dtype) * my_count, mem_type,
                                         UCC_MEMORY_TYPE_HOST));
@@ -80,19 +77,18 @@ public:
     }
     void data_fini(UccCollCtxVec ctxs)
     {
-        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
-            ucc_coll_args_t* coll = ctx->args;
+//        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+    	for (int r = 0; r < ctxs.size(); r++) {
+            ucc_coll_args_t* coll = ctxs[r]->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(coll->src.info.mc_header, mem_type));
+                UCC_CHECK(ucc_mc_free(ctxs[r]->src_header, mem_type));
             }
-            UCC_CHECK(ucc_mc_free(
-                coll->dst.info_v.mc_header,
-                mem_type)); // TODO: check if needs to b via info or info_v
+            UCC_CHECK(ucc_mc_free(ctxs[r]->dst_header, mem_type));
             free(coll->dst.info_v.displacements);
             free(coll->dst.info_v.counts);
-            ucc_free(ctx->init_buf);
+            ucc_free(ctxs[r]->init_buf);
             free(coll);
-            free(ctx);
+            free(ctxs[r]);
         }
         ctxs.clear();
     }
@@ -100,7 +96,6 @@ public:
     {
         bool                   ret = true;
         std::vector<uint8_t *> dsts(ctxs.size());
-        std::vector<ucc_mc_buffer_header_t *> dsts_mc_headers(ctxs.size());
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -56,8 +56,9 @@ public:
             }
 
             ctxs[r]->rbuf_size = ucc_dt_size(dtype) * all_counts;
-            UCC_CHECK(ucc_mc_alloc(&coll->dst.info_v.buffer, ctxs[r]->rbuf_size,
-                      mem_type));
+            UCC_CHECK(ucc_mc_alloc(&coll->dst.info_v.mc_header,
+                                   ctxs[r]->rbuf_size, mem_type));
+            coll->dst.info_v.buffer = coll->dst.info_v.mc_header->addr;
             if (TEST_INPLACE == inplace) {
                 coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
                 coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
@@ -66,8 +67,10 @@ public:
                                         ctxs[r]->init_buf, ucc_dt_size(dtype) * my_count,
                                         mem_type, UCC_MEMORY_TYPE_HOST));
             } else {
-                UCC_CHECK(ucc_mc_alloc(&coll->src.info.buffer,
-                          ucc_dt_size(dtype) * my_count, mem_type));
+                UCC_CHECK(ucc_mc_alloc(&coll->src.info.mc_header,
+                                       ucc_dt_size(dtype) * my_count,
+                                       mem_type));
+                coll->src.info.buffer = coll->src.info.mc_header->addr;
                 UCC_CHECK(ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
                                         ucc_dt_size(dtype) * my_count, mem_type,
                                         UCC_MEMORY_TYPE_HOST));
@@ -80,9 +83,11 @@ public:
         for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
             ucc_coll_args_t* coll = ctx->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(coll->src.info.buffer, mem_type));
+                UCC_CHECK(ucc_mc_free(coll->src.info.mc_header, mem_type));
             }
-            UCC_CHECK(ucc_mc_free(coll->dst.info.buffer, mem_type));
+            UCC_CHECK(ucc_mc_free(
+                coll->dst.info_v.mc_header,
+                mem_type)); // TODO: check if needs to b via info or info_v
             free(coll->dst.info_v.displacements);
             free(coll->dst.info_v.counts);
             ucc_free(ctx->init_buf);
@@ -95,6 +100,7 @@ public:
     {
         bool                   ret = true;
         std::vector<uint8_t *> dsts(ctxs.size());
+        std::vector<ucc_mc_buffer_header_t *> dsts_mc_headers(ctxs.size());
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
@@ -127,7 +133,7 @@ public:
         }
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
-                ucc_free (dsts[r]);
+                ucc_free(dsts[r]);
             }
         }
         return ret;

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -53,9 +53,9 @@ public:
             }
 
             ctxs[r]->rbuf_size = ucc_dt_size(dtype) * all_counts;
-            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_header,
-                                   ctxs[r]->rbuf_size, mem_type));
-            coll->dst.info_v.buffer = ctxs[r]->dst_header->addr;
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_mc_header, ctxs[r]->rbuf_size,
+                                   mem_type));
+            coll->dst.info_v.buffer = ctxs[r]->dst_mc_header->addr;
             if (TEST_INPLACE == inplace) {
                 coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
                 coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
@@ -64,10 +64,10 @@ public:
                                         ctxs[r]->init_buf, ucc_dt_size(dtype) * my_count,
                                         mem_type, UCC_MEMORY_TYPE_HOST));
             } else {
-                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_header,
+                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_mc_header,
                                        ucc_dt_size(dtype) * my_count,
                                        mem_type));
-                coll->src.info.buffer = ctxs[r]->src_header->addr;
+                coll->src.info.buffer = ctxs[r]->src_mc_header->addr;
                 UCC_CHECK(ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
                                         ucc_dt_size(dtype) * my_count, mem_type,
                                         UCC_MEMORY_TYPE_HOST));
@@ -77,18 +77,17 @@ public:
     }
     void data_fini(UccCollCtxVec ctxs)
     {
-//        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
-    	for (int r = 0; r < ctxs.size(); r++) {
-            ucc_coll_args_t* coll = ctxs[r]->args;
+        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+            ucc_coll_args_t* coll = ctx->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(ctxs[r]->src_header, mem_type));
+                UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
             }
-            UCC_CHECK(ucc_mc_free(ctxs[r]->dst_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header, mem_type));
             free(coll->dst.info_v.displacements);
             free(coll->dst.info_v.counts);
-            ucc_free(ctxs[r]->init_buf);
+            ucc_free(ctx->init_buf);
             free(coll);
-            free(ctxs[r]);
+            free(ctx);
         }
         ctxs.clear();
     }

--- a/test/gtest/core/test_allreduce.cc
+++ b/test/gtest/core/test_allreduce.cc
@@ -41,9 +41,9 @@ class test_allreduce : public UccCollArgs, public testing::Test {
                 ptr[i] = (typename T::type)(2 * i + r + 1);
             }
 
-            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_header,
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_mc_header,
                                    ucc_dt_size(dt) * count, mem_type));
-            coll->dst.info.buffer = ctxs[r]->dst_header->addr;
+            coll->dst.info.buffer = ctxs[r]->dst_mc_header->addr;
             if (TEST_INPLACE == inplace) {
                 coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
                 coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
@@ -51,9 +51,9 @@ class test_allreduce : public UccCollArgs, public testing::Test {
                                         ucc_dt_size(dt) * count, mem_type,
                                         UCC_MEMORY_TYPE_HOST));
             } else {
-                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_header,
+                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_mc_header,
                                        ucc_dt_size(dt) * count, mem_type));
-                coll->src.info.buffer = ctxs[r]->src_header->addr;
+                coll->src.info.buffer = ctxs[r]->src_mc_header->addr;
                 UCC_CHECK(ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
                                         ucc_dt_size(dt) * count, mem_type,
                                         UCC_MEMORY_TYPE_HOST));
@@ -68,16 +68,15 @@ class test_allreduce : public UccCollArgs, public testing::Test {
         }
     }
     void data_fini(UccCollCtxVec ctxs) {
-    	for (int r = 0; r < ctxs.size(); r++) {
-//        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
-            ucc_coll_args_t* coll = ctxs[r]->args;
+        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+            ucc_coll_args_t* coll = ctx->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(ctxs[r]->src_header, mem_type));
+                UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
             }
-            UCC_CHECK(ucc_mc_free(ctxs[r]->dst_header, mem_type));
-            ucc_free(ctxs[r]->init_buf);
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header, mem_type));
+            ucc_free(ctx->init_buf);
             free(coll);
-            free(ctxs[r]);
+            free(ctx);
         }
         ctxs.clear();
     }

--- a/test/gtest/core/test_alltoall.cc
+++ b/test/gtest/core/test_alltoall.cc
@@ -44,8 +44,10 @@ public:
                                    rank_size);
             }
 
-            UCC_CHECK(ucc_mc_alloc(&coll->dst.info.buffer,
-                      ucc_dt_size(dtype) * count * nprocs, mem_type));
+            UCC_CHECK(ucc_mc_alloc(&coll->dst.info.mc_header,
+                                   ucc_dt_size(dtype) * count * nprocs,
+                                   mem_type));
+            coll->dst.info.buffer = coll->dst.info.mc_header->addr;
             if (TEST_INPLACE == inplace) {
                 coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
                 coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
@@ -53,8 +55,10 @@ public:
                                         ucc_dt_size(dtype) * count, mem_type,
                                         UCC_MEMORY_TYPE_HOST));
             } else {
-                UCC_CHECK(ucc_mc_alloc(&coll->src.info.buffer,
-                          ucc_dt_size(dtype) * count * nprocs, mem_type));
+                UCC_CHECK(ucc_mc_alloc(&coll->src.info.mc_header,
+                                       ucc_dt_size(dtype) * count * nprocs,
+                                       mem_type));
+                coll->src.info.buffer = coll->src.info.mc_header->addr;
                 UCC_CHECK(ucc_mc_memcpy(coll->src.info.buffer, ctxs[i]->init_buf,
                                         ucc_dt_size(dtype) * count * nprocs, mem_type,
                                         UCC_MEMORY_TYPE_HOST));
@@ -66,7 +70,7 @@ public:
         for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
             ucc_coll_args_t* coll = ctx->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(coll->src.info.buffer, mem_type));
+                UCC_CHECK(ucc_mc_free(coll->src.info.mc_header, mem_type));
             }
             UCC_CHECK(ucc_mc_free(coll->dst.info.buffer, mem_type));
             ucc_free(ctx->init_buf);
@@ -79,6 +83,7 @@ public:
     {
         bool                   ret = true;
         std::vector<uint8_t *> dsts(ctxs.size());
+        std::vector<ucc_mc_buffer_header_t *> dsts_mc_headers(ctxs.size());
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -3,9 +3,6 @@
  * See file LICENSE for terms.
  */
 
-extern "C" {
-#include <core/ucc_mc.h>
-}
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
@@ -61,9 +58,9 @@ public:
                                ((T*)coll->src.info_v.displacements)[i] * ucc_dt_size(dtype),
                                ((T*)coll->src.info_v.counts)[i] * ucc_dt_size(dtype));
             }
-            UCC_CHECK(ucc_mc_alloc(&coll->src.info_v.mc_header,
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_header,
                                    buf_count * ucc_dt_size(dtype), mem_type));
-            coll->src.info_v.buffer = coll->src.info_v.mc_header->addr;
+            coll->src.info_v.buffer = ctxs[r]->src_header->addr;
             UCC_CHECK(ucc_mc_memcpy(coll->src.info_v.buffer, ctxs[r]->init_buf,
                                     buf_count * ucc_dt_size(dtype), mem_type,
                                     UCC_MEMORY_TYPE_HOST));
@@ -78,16 +75,15 @@ public:
                 buf_count += rank_count;
             }
             ctxs[r]->rbuf_size = buf_count * ucc_dt_size(dtype);
-            UCC_CHECK(ucc_mc_alloc(&coll->dst.info_v.mc_header,
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_header,
                                    buf_count * ucc_dt_size(dtype), mem_type));
-            coll->dst.info_v.buffer = coll->dst.info_v.mc_header->addr;
+            coll->dst.info_v.buffer = ctxs[r]->dst_header->addr;
         }
     }
     bool  data_validate(UccCollCtxVec ctxs)
     {
         bool                   ret = true;
         std::vector<uint8_t *> dsts(ctxs.size());
-        std::vector<ucc_mc_buffer_header_t *> dsts_mc_headers(ctxs.size());
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
@@ -125,17 +121,18 @@ public:
     }
     void data_fini(UccCollCtxVec ctxs)
     {
-        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
-            ucc_coll_args_t* coll = ctx->args;
-            UCC_CHECK(ucc_mc_free(coll->src.info_v.mc_header, mem_type));
+//        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+    	for (int r = 0; r < ctxs.size(); r++) {
+            ucc_coll_args_t* coll = ctxs[r]->args;
+            UCC_CHECK(ucc_mc_free(ctxs[r]->src_header, mem_type));
             free(coll->src.info_v.counts);
             free(coll->src.info_v.displacements);
-            UCC_CHECK(ucc_mc_free(coll->dst.info_v.mc_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctxs[r]->dst_header, mem_type));
             free(coll->dst.info_v.counts);
             free(coll->dst.info_v.displacements);
-            ucc_free(ctx->init_buf);
+            ucc_free(ctxs[r]->init_buf);
             free(coll);
-            free(ctx);
+            free(ctxs[r]);
         }
         ctxs.clear();
     }

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -58,9 +58,9 @@ public:
                                ((T*)coll->src.info_v.displacements)[i] * ucc_dt_size(dtype),
                                ((T*)coll->src.info_v.counts)[i] * ucc_dt_size(dtype));
             }
-            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_header,
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_mc_header,
                                    buf_count * ucc_dt_size(dtype), mem_type));
-            coll->src.info_v.buffer = ctxs[r]->src_header->addr;
+            coll->src.info_v.buffer = ctxs[r]->src_mc_header->addr;
             UCC_CHECK(ucc_mc_memcpy(coll->src.info_v.buffer, ctxs[r]->init_buf,
                                     buf_count * ucc_dt_size(dtype), mem_type,
                                     UCC_MEMORY_TYPE_HOST));
@@ -75,9 +75,9 @@ public:
                 buf_count += rank_count;
             }
             ctxs[r]->rbuf_size = buf_count * ucc_dt_size(dtype);
-            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_header,
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_mc_header,
                                    buf_count * ucc_dt_size(dtype), mem_type));
-            coll->dst.info_v.buffer = ctxs[r]->dst_header->addr;
+            coll->dst.info_v.buffer = ctxs[r]->dst_mc_header->addr;
         }
     }
     bool  data_validate(UccCollCtxVec ctxs)
@@ -121,18 +121,17 @@ public:
     }
     void data_fini(UccCollCtxVec ctxs)
     {
-//        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
-    	for (int r = 0; r < ctxs.size(); r++) {
-            ucc_coll_args_t* coll = ctxs[r]->args;
-            UCC_CHECK(ucc_mc_free(ctxs[r]->src_header, mem_type));
+        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+            ucc_coll_args_t* coll = ctx->args;
+            UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
             free(coll->src.info_v.counts);
             free(coll->src.info_v.displacements);
-            UCC_CHECK(ucc_mc_free(ctxs[r]->dst_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header, mem_type));
             free(coll->dst.info_v.counts);
             free(coll->dst.info_v.displacements);
-            ucc_free(ctxs[r]->init_buf);
+            ucc_free(ctx->init_buf);
             free(coll);
-            free(ctxs[r]);
+            free(ctx);
         }
         ctxs.clear();
     }

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -61,9 +61,9 @@ public:
                                ((T*)coll->src.info_v.displacements)[i] * ucc_dt_size(dtype),
                                ((T*)coll->src.info_v.counts)[i] * ucc_dt_size(dtype));
             }
-            UCC_CHECK(ucc_mc_alloc(&coll->src.info_v.buffer,
-                                   buf_count * ucc_dt_size(dtype),
-                                   mem_type));
+            UCC_CHECK(ucc_mc_alloc(&coll->src.info_v.mc_header,
+                                   buf_count * ucc_dt_size(dtype), mem_type));
+            coll->src.info_v.buffer = coll->src.info_v.mc_header->addr;
             UCC_CHECK(ucc_mc_memcpy(coll->src.info_v.buffer, ctxs[r]->init_buf,
                                     buf_count * ucc_dt_size(dtype), mem_type,
                                     UCC_MEMORY_TYPE_HOST));
@@ -78,15 +78,16 @@ public:
                 buf_count += rank_count;
             }
             ctxs[r]->rbuf_size = buf_count * ucc_dt_size(dtype);
-            UCC_CHECK(ucc_mc_alloc(&coll->dst.info_v.buffer,
-                                   buf_count * ucc_dt_size(dtype),
-                                   mem_type));
+            UCC_CHECK(ucc_mc_alloc(&coll->dst.info_v.mc_header,
+                                   buf_count * ucc_dt_size(dtype), mem_type));
+            coll->dst.info_v.buffer = coll->dst.info_v.mc_header->addr;
         }
     }
     bool  data_validate(UccCollCtxVec ctxs)
     {
         bool                   ret = true;
         std::vector<uint8_t *> dsts(ctxs.size());
+        std::vector<ucc_mc_buffer_header_t *> dsts_mc_headers(ctxs.size());
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
@@ -126,10 +127,10 @@ public:
     {
         for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
             ucc_coll_args_t* coll = ctx->args;
-            UCC_CHECK(ucc_mc_free(coll->src.info_v.buffer, mem_type));
+            UCC_CHECK(ucc_mc_free(coll->src.info_v.mc_header, mem_type));
             free(coll->src.info_v.counts);
             free(coll->src.info_v.displacements);
-            UCC_CHECK(ucc_mc_free(coll->dst.info_v.buffer, mem_type));
+            UCC_CHECK(ucc_mc_free(coll->dst.info_v.mc_header, mem_type));
             free(coll->dst.info_v.counts);
             free(coll->dst.info_v.displacements);
             ucc_free(ctx->init_buf);

--- a/test/gtest/core/test_bcast.cc
+++ b/test/gtest/core/test_bcast.cc
@@ -3,9 +3,6 @@
  * See file LICENSE for terms.
  */
 
-extern "C" {
-#include <core/ucc_mc.h>
-}
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
@@ -37,9 +34,9 @@ public:
 
             ctxs[r]->rbuf_size = ucc_dt_size(dtype) * count;
 
-            UCC_CHECK(ucc_mc_alloc(&coll->src.info.mc_header,
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_header,
                                    ctxs[r]->rbuf_size, mem_type));
-            coll->src.info.buffer = coll->src.info.mc_header->addr;
+            coll->src.info.buffer = ctxs[r]->src_header->addr;
             if (r == root) {
                 ctxs[r]->init_buf = ucc_malloc(ctxs[r]->rbuf_size, "init buf");
                 EXPECT_NE(ctxs[r]->init_buf, nullptr);
@@ -58,7 +55,7 @@ public:
         for (auto r = 0; r < ctxs.size(); r++) {
             gtest_ucc_coll_ctx_t *ctx = ctxs[r];
             ucc_coll_args_t* coll = ctx->args;
-            UCC_CHECK(ucc_mc_free(coll->src.info.mc_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->src_header, mem_type));
             if (r == coll->root) {
                 ucc_free(ctx->init_buf);
             }
@@ -72,7 +69,6 @@ public:
         bool     ret  = true;
         int      root = ctxs[0]->args->root;
         uint8_t *dsts;
-        ucc_mc_buffer_header_t *dsts_mc_header;
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
                 dsts = (uint8_t*) ucc_malloc(ctxs[root]->rbuf_size, "dsts buf");

--- a/test/gtest/core/test_bcast.cc
+++ b/test/gtest/core/test_bcast.cc
@@ -37,8 +37,9 @@ public:
 
             ctxs[r]->rbuf_size = ucc_dt_size(dtype) * count;
 
-            UCC_CHECK(ucc_mc_alloc(&coll->src.info.buffer, ctxs[r]->rbuf_size,
-                                   mem_type));
+            UCC_CHECK(ucc_mc_alloc(&coll->src.info.mc_header,
+                                   ctxs[r]->rbuf_size, mem_type));
+            coll->src.info.buffer = coll->src.info.mc_header->addr;
             if (r == root) {
                 ctxs[r]->init_buf = ucc_malloc(ctxs[r]->rbuf_size, "init buf");
                 EXPECT_NE(ctxs[r]->init_buf, nullptr);
@@ -57,7 +58,7 @@ public:
         for (auto r = 0; r < ctxs.size(); r++) {
             gtest_ucc_coll_ctx_t *ctx = ctxs[r];
             ucc_coll_args_t* coll = ctx->args;
-            UCC_CHECK(ucc_mc_free(coll->src.info.buffer, mem_type));
+            UCC_CHECK(ucc_mc_free(coll->src.info.mc_header, mem_type));
             if (r == coll->root) {
                 ucc_free(ctx->init_buf);
             }
@@ -71,6 +72,7 @@ public:
         bool     ret  = true;
         int      root = ctxs[0]->args->root;
         uint8_t *dsts;
+        ucc_mc_buffer_header_t *dsts_mc_header;
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
                 dsts = (uint8_t*) ucc_malloc(ctxs[root]->rbuf_size, "dsts buf");

--- a/test/gtest/core/test_bcast.cc
+++ b/test/gtest/core/test_bcast.cc
@@ -34,9 +34,9 @@ public:
 
             ctxs[r]->rbuf_size = ucc_dt_size(dtype) * count;
 
-            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_header,
-                                   ctxs[r]->rbuf_size, mem_type));
-            coll->src.info.buffer = ctxs[r]->src_header->addr;
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_mc_header, ctxs[r]->rbuf_size,
+                                   mem_type));
+            coll->src.info.buffer = ctxs[r]->src_mc_header->addr;
             if (r == root) {
                 ctxs[r]->init_buf = ucc_malloc(ctxs[r]->rbuf_size, "init buf");
                 EXPECT_NE(ctxs[r]->init_buf, nullptr);
@@ -55,7 +55,7 @@ public:
         for (auto r = 0; r < ctxs.size(); r++) {
             gtest_ucc_coll_ctx_t *ctx = ctxs[r];
             ucc_coll_args_t* coll = ctx->args;
-            UCC_CHECK(ucc_mc_free(ctx->src_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
             if (r == coll->root) {
                 ucc_free(ctx->init_buf);
             }

--- a/test/gtest/core/test_mc.cc
+++ b/test/gtest/core/test_mc.cc
@@ -37,7 +37,7 @@ class test_mc : public ucc::test {
 UCC_TEST_F(test_mc, init_finalize)
 {
     EXPECT_EQ(UCC_OK, ucc_constructor());
-    EXPECT_EQ(UCC_OK, ucc_mc_init());
+    EXPECT_EQ(UCC_OK, ucc_mc_init(UCC_THREAD_SINGLE));
     EXPECT_EQ(UCC_OK, ucc_mc_finalize());
 }
 
@@ -45,7 +45,7 @@ UCC_TEST_F(test_mc, init_is_required)
 {
     ASSERT_EQ(UCC_OK, ucc_constructor());
     EXPECT_NE(UCC_OK, ucc_mc_available(UCC_MEMORY_TYPE_HOST));
-    EXPECT_EQ(UCC_OK, ucc_mc_init());
+    EXPECT_EQ(UCC_OK, ucc_mc_init(UCC_THREAD_SINGLE));
     EXPECT_EQ(UCC_OK, ucc_mc_available(UCC_MEMORY_TYPE_HOST));
     ucc_mc_finalize();
 }
@@ -58,7 +58,7 @@ UCC_TEST_F(test_mc, can_alloc_and_free_host_mem)
     void *ptr = NULL;
 
     ASSERT_EQ(UCC_OK, ucc_constructor());
-    ASSERT_EQ(UCC_OK, ucc_mc_init());
+    ASSERT_EQ(UCC_OK, ucc_mc_init(UCC_THREAD_SINGLE));
     EXPECT_EQ(UCC_OK, ucc_mc_alloc(&h, size, UCC_MEMORY_TYPE_HOST));
     ptr = h->addr;
     memset(ptr, 0, size);
@@ -69,15 +69,16 @@ UCC_TEST_F(test_mc, can_alloc_and_free_host_mem)
 UCC_TEST_F(test_mc, can_alloc_and_free_host_mem_mt)
 {
 	// mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1024 and is configurable at runtime.
-	size_t size = 1024;
-    int num_of_threads = 20;
+	size_t size = 128;
+    int num_of_threads = 10;
 
     std::vector<pthread_t> threads;
     threads.resize(num_of_threads);
     ASSERT_EQ(UCC_OK, ucc_constructor());
-    ASSERT_EQ(UCC_OK, ucc_mc_init());
+    ASSERT_EQ(UCC_OK, ucc_mc_init(UCC_THREAD_MULTIPLE));
     for (int i = 0; i < num_of_threads; i++) {
     	pthread_create(&threads[i], NULL, &mt_ucc_mc_cpu_calls, (void *)&size);
+    	size = size*2;
     }
     for (int i = 0; i < num_of_threads; i++) {
         pthread_join(threads[i], NULL);

--- a/test/gtest/core/test_mc.cc
+++ b/test/gtest/core/test_mc.cc
@@ -10,25 +10,32 @@ extern "C" {
 #include <common/test.h>
 #include <vector>
 
-void *mt_ucc_mc_cpu_calls(void * args)
+void *mt_ucc_mc_cpu_allocs(void *args)
 {
-	size_t *size = (size_t *) args;
-	int num_of_alloc_calls = 50;
-	std::vector<ucc_mc_buffer_header_t *> headers;
-	std::vector<void *> pointers;
+    // Final size will be:
+    // size * (quantifier^(num_of_allocs/2))
+    // and should be larger than mpool buffer size which is 1MB by default,
+    // to assure testing both fast and slow ucc_mc_alloc path.
+    // if num_of_allocs is changed, change quantifier accordingly.
+    size_t                                size          = 4;
+    int                                   quantifier    = 2;
+    int                                   num_of_allocs = 40;
+    std::vector<ucc_mc_buffer_header_t *> headers;
+    std::vector<void *>                   pointers;
+    headers.resize(num_of_allocs);
+    pointers.resize(num_of_allocs);
 
-	headers.resize(num_of_alloc_calls);
-	pointers.resize(num_of_alloc_calls);
-
-	for (int i = 0; i < num_of_alloc_calls; i++){
-		pointers[i] = NULL;
-		EXPECT_EQ(UCC_OK, ucc_mc_alloc(&headers[i], *size, UCC_MEMORY_TYPE_HOST));
-		pointers[i] = headers[i]->addr;
-		memset(pointers[i], 0, *size);
-		EXPECT_EQ(UCC_OK, ucc_mc_free(headers[i], UCC_MEMORY_TYPE_HOST));
-	}
-
-	return 0;
+    for (int i = 0; i < num_of_allocs; i++) {
+        EXPECT_EQ(UCC_OK,
+                  ucc_mc_alloc(&headers[i], size, UCC_MEMORY_TYPE_HOST));
+        pointers[i] = headers[i]->addr;
+        memset(pointers[i], 0, size);
+        EXPECT_EQ(UCC_OK, ucc_mc_free(headers[i], UCC_MEMORY_TYPE_HOST));
+        if (i % 2) {
+            size *= quantifier;
+        }
+    }
+    return 0;
 }
 
 class test_mc : public ucc::test {
@@ -37,7 +44,10 @@ class test_mc : public ucc::test {
 UCC_TEST_F(test_mc, init_finalize)
 {
     EXPECT_EQ(UCC_OK, ucc_constructor());
-    EXPECT_EQ(UCC_OK, ucc_mc_init(UCC_THREAD_SINGLE));
+    ucc_mc_params_t mc_params = {
+        .thread_mode = UCC_THREAD_SINGLE,
+    };
+    EXPECT_EQ(UCC_OK, ucc_mc_init(&mc_params));
     EXPECT_EQ(UCC_OK, ucc_mc_finalize());
 }
 
@@ -45,20 +55,26 @@ UCC_TEST_F(test_mc, init_is_required)
 {
     ASSERT_EQ(UCC_OK, ucc_constructor());
     EXPECT_NE(UCC_OK, ucc_mc_available(UCC_MEMORY_TYPE_HOST));
-    EXPECT_EQ(UCC_OK, ucc_mc_init(UCC_THREAD_SINGLE));
+    ucc_mc_params_t mc_params = {
+        .thread_mode = UCC_THREAD_SINGLE,
+    };
+    EXPECT_EQ(UCC_OK, ucc_mc_init(&mc_params));
     EXPECT_EQ(UCC_OK, ucc_mc_available(UCC_MEMORY_TYPE_HOST));
     ucc_mc_finalize();
 }
 
 UCC_TEST_F(test_mc, can_alloc_and_free_host_mem)
 {
-	// mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1024 and is configurable at runtime.
-	size_t size = 4096;
-    ucc_mc_buffer_header_t *h    = NULL;
+    // mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1MB and is configurable at runtime.
+    size_t                  size = 4096;
+    ucc_mc_buffer_header_t *h;
     void *ptr = NULL;
 
     ASSERT_EQ(UCC_OK, ucc_constructor());
-    ASSERT_EQ(UCC_OK, ucc_mc_init(UCC_THREAD_SINGLE));
+    ucc_mc_params_t mc_params = {
+        .thread_mode = UCC_THREAD_SINGLE,
+    };
+    ASSERT_EQ(UCC_OK, ucc_mc_init(&mc_params));
     EXPECT_EQ(UCC_OK, ucc_mc_alloc(&h, size, UCC_MEMORY_TYPE_HOST));
     ptr = h->addr;
     memset(ptr, 0, size);
@@ -68,17 +84,18 @@ UCC_TEST_F(test_mc, can_alloc_and_free_host_mem)
 
 UCC_TEST_F(test_mc, can_alloc_and_free_host_mem_mt)
 {
-	// mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1024 and is configurable at runtime.
-	size_t size = 128;
-    int num_of_threads = 10;
-
+    // mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1MB and is configurable at runtime.
+    int                    num_of_threads = 10;
     std::vector<pthread_t> threads;
     threads.resize(num_of_threads);
+
     ASSERT_EQ(UCC_OK, ucc_constructor());
-    ASSERT_EQ(UCC_OK, ucc_mc_init(UCC_THREAD_MULTIPLE));
+    ucc_mc_params_t mc_params = {
+        .thread_mode = UCC_THREAD_MULTIPLE,
+    };
+    ASSERT_EQ(UCC_OK, ucc_mc_init(&mc_params));
     for (int i = 0; i < num_of_threads; i++) {
-    	pthread_create(&threads[i], NULL, &mt_ucc_mc_cpu_calls, (void *)&size);
-    	size = size*2;
+        pthread_create(&threads[i], NULL, &mt_ucc_mc_cpu_allocs, NULL);
     }
     for (int i = 0; i < num_of_threads; i++) {
         pthread_join(threads[i], NULL);

--- a/test/gtest/core/test_mc.cc
+++ b/test/gtest/core/test_mc.cc
@@ -29,16 +29,21 @@ UCC_TEST_F(test_mc, init_is_required)
 
 UCC_TEST_F(test_mc, can_alloc_and_free_host_mem)
 {
+    ucc_mc_buffer_header_t *h    = NULL;
     void *ptr = NULL;
     size_t size = 4096;
 
     ASSERT_EQ(UCC_OK, ucc_constructor());
     ASSERT_EQ(UCC_OK, ucc_mc_init());
-    EXPECT_EQ(UCC_OK, ucc_mc_alloc(&ptr, size, UCC_MEMORY_TYPE_HOST));
+    EXPECT_EQ(UCC_OK, ucc_mc_alloc(&h, size, UCC_MEMORY_TYPE_HOST));
+    ptr = h->addr;
     memset(ptr, 0, size);
-    EXPECT_EQ(UCC_OK, ucc_mc_free(ptr, UCC_MEMORY_TYPE_HOST));
+    EXPECT_EQ(UCC_OK, ucc_mc_free(h, UCC_MEMORY_TYPE_HOST));
     ucc_mc_finalize();
 }
+
+// TODO: add UCC_TEST_F for multi threaded: spawn (multiple times - in a loop) pthreads and call ucc_mc_alloc/free.
+// Make sure to allocate more than max amount of elems so it should test slow path as well
 
 UCC_TEST_F(test_mc, init_twice)
 {

--- a/test/gtest/core/test_mc_cuda.cc
+++ b/test/gtest/core/test_mc_cuda.cc
@@ -11,9 +11,10 @@ extern "C" {
 
 class test_mc_cuda : public ucc::test {
   protected:
-    const int         TEST_ALLOC_SIZE = 1024;
-    void *            test_ptr;
-    ucc_memory_type_t test_mtype;
+    const int               TEST_ALLOC_SIZE = 1024;
+    ucc_mc_buffer_header_t *mc_header;
+    void *                  test_ptr;
+    ucc_memory_type_t       test_mtype;
     virtual void SetUp() override
     {
         ucc::test::SetUp();
@@ -37,10 +38,14 @@ UCC_TEST_F(test_mc_cuda, mc_cuda_load)
 UCC_TEST_F(test_mc_cuda, can_alloc_and_free_mem)
 {
     EXPECT_EQ(UCC_OK,
-              ucc_mc_alloc(&test_ptr, TEST_ALLOC_SIZE, UCC_MEMORY_TYPE_CUDA));
+              ucc_mc_alloc(&mc_header, TEST_ALLOC_SIZE, UCC_MEMORY_TYPE_CUDA));
+    test_ptr = mc_header->addr;
     EXPECT_EQ(cudaSuccess, cudaMemset(test_ptr, 0, TEST_ALLOC_SIZE));
-    EXPECT_EQ(UCC_OK, ucc_mc_free(test_ptr, UCC_MEMORY_TYPE_CUDA));
+    EXPECT_EQ(UCC_OK, ucc_mc_free(mc_header, UCC_MEMORY_TYPE_CUDA));
 }
+
+// TODO: add UCC_TEST_F for multi threaded: spawn (multiple times - in a loop) pthreads and call ucc_mc_alloc/free.
+// Make sure to allocate more than max amount of elems so it should test slow path as well
 
 UCC_TEST_F(test_mc_cuda, can_detect_host_mem)
 {

--- a/test/gtest/core/test_mc_cuda.cc
+++ b/test/gtest/core/test_mc_cuda.cc
@@ -11,26 +11,32 @@ extern "C" {
 #include <cuda_runtime.h>
 #include <vector>
 
-void *mt_ucc_mc_cuda_calls(void * args)
+void *mt_ucc_mc_cuda_allocs(void *args)
 {
-	size_t *size = (size_t *) args;
-	int num_of_alloc_calls = 50;
-	std::vector<ucc_mc_buffer_header_t *> headers;
-	std::vector<void *> pointers;
+    // Final size will be:
+    // size * (quantifier^(num_of_allocs/2))
+    // and should be larger than mpool buffer size which is 1MB by default,
+    // to assure testing both fast and slow ucc_mc_alloc path.
+    // if num_of_allocs is changed, change quantifier accordingly.
+    int                                   quantifier    = 2;
+    size_t                                size          = 4;
+    int                                   num_of_allocs = 40;
+    std::vector<ucc_mc_buffer_header_t *> headers;
+    std::vector<void *>                   pointers;
+    headers.resize(num_of_allocs);
+    pointers.resize(num_of_allocs);
 
-	headers.resize(num_of_alloc_calls);
-	pointers.resize(num_of_alloc_calls);
-
-	for (int i = 0; i < num_of_alloc_calls; i++){
-		pointers[i] = NULL;
-		EXPECT_EQ(UCC_OK,
-			  ucc_mc_alloc(&headers[i], *size, UCC_MEMORY_TYPE_CUDA));
-		pointers[i] = headers[i]->addr;
-		EXPECT_EQ(cudaSuccess, cudaMemset(pointers[i], 0, *size));
-		EXPECT_EQ(UCC_OK, ucc_mc_free(headers[i], UCC_MEMORY_TYPE_CUDA));
-	}
-
-	return 0;
+    for (int i = 0; i < num_of_allocs; i++) {
+        EXPECT_EQ(UCC_OK,
+                  ucc_mc_alloc(&headers[i], size, UCC_MEMORY_TYPE_CUDA));
+        pointers[i] = headers[i]->addr;
+        EXPECT_EQ(cudaSuccess, cudaMemset(pointers[i], 0, size));
+        EXPECT_EQ(UCC_OK, ucc_mc_free(headers[i], UCC_MEMORY_TYPE_CUDA));
+        if (i % 2) {
+            size *= quantifier;
+        }
+    }
+    return 0;
 }
 
 class test_mc_cuda : public ucc::test {
@@ -39,13 +45,20 @@ class test_mc_cuda : public ucc::test {
     ucc_mc_buffer_header_t *mc_header;
     void *                  test_ptr;
     ucc_memory_type_t       test_mtype;
-    virtual void SetUp() override
+    void TestMCCudaSetUp(ucc_mc_params_t mc_params)
     {
         ucc::test::SetUp();
         ucc_constructor();
-        ucc_mc_init(UCC_THREAD_SINGLE);
+        ucc_mc_init(&mc_params);
         test_ptr   = NULL;
         test_mtype = UCC_MEMORY_TYPE_UNKNOWN;
+    }
+    virtual void SetUp() override
+    {
+        ucc_mc_params_t mc_params = {
+            .thread_mode = UCC_THREAD_SINGLE,
+        };
+        TestMCCudaSetUp(mc_params);
     }
     virtual void TearDown() override
     {
@@ -54,16 +67,15 @@ class test_mc_cuda : public ucc::test {
     }
 };
 
-class test_mc_cuda_mt : public test_mc_cuda{
-protected:
-  virtual void SetUp() override
-  {
-      ucc::test::SetUp();
-      ucc_constructor();
-      ucc_mc_init(UCC_THREAD_MULTIPLE);
-      test_ptr   = NULL;
-      test_mtype = UCC_MEMORY_TYPE_UNKNOWN;
-  }
+class test_mc_cuda_mt : public test_mc_cuda {
+  protected:
+    virtual void SetUp() override
+    {
+        ucc_mc_params_t mc_params = {
+            .thread_mode = UCC_THREAD_MULTIPLE,
+        };
+        TestMCCudaSetUp(mc_params);
+    }
 };
 
 UCC_TEST_F(test_mc_cuda, mc_cuda_load)
@@ -73,7 +85,7 @@ UCC_TEST_F(test_mc_cuda, mc_cuda_load)
 
 UCC_TEST_F(test_mc_cuda, can_alloc_and_free_mem)
 {
-	// mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1024 and is configurable at runtime.
+    // mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1MB and is configurable at runtime.
     EXPECT_EQ(UCC_OK,
               ucc_mc_alloc(&mc_header, TEST_ALLOC_SIZE, UCC_MEMORY_TYPE_CUDA));
     test_ptr = mc_header->addr;
@@ -83,19 +95,17 @@ UCC_TEST_F(test_mc_cuda, can_alloc_and_free_mem)
 
 UCC_TEST_F(test_mc_cuda_mt, can_alloc_and_free_mem_mt)
 {
-	// mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1024 and is configurable at runtime.
-	size_t size = 128;
-	int num_of_threads = 10;
-	std::vector<pthread_t> threads;
-	threads.resize(num_of_threads);
+    // mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1MB and is configurable at runtime.
+    int                    num_of_threads = 10;
+    std::vector<pthread_t> threads;
+    threads.resize(num_of_threads);
 
-	for (int i = 0; i < num_of_threads; i++) {
-		pthread_create(&threads[i], NULL, &mt_ucc_mc_cuda_calls, (void *)&size);
-		size = size*2;
-	}
-	for (int i = 0; i < num_of_threads; i++) {
-		pthread_join(threads[i], NULL);
-	}
+    for (int i = 0; i < num_of_threads; i++) {
+        pthread_create(&threads[i], NULL, &mt_ucc_mc_cuda_allocs, NULL);
+    }
+    for (int i = 0; i < num_of_threads; i++) {
+        pthread_join(threads[i], NULL);
+    }
 }
 
 UCC_TEST_F(test_mc_cuda, can_detect_host_mem)

--- a/test/gtest/core/test_mc_reduce.h
+++ b/test/gtest/core/test_mc_reduce.h
@@ -194,9 +194,12 @@ class test_mc_reduce : public testing::Test {
         size_t n_bytes = COUNT*sizeof(typename T::type);
         mem_type = mtype;
 
-        ucc_mc_alloc((void**)&res_h, n_bytes, UCC_MEMORY_TYPE_HOST);
-        ucc_mc_alloc((void**)&buf1_h, n_bytes, UCC_MEMORY_TYPE_HOST);
-        ucc_mc_alloc((void**)&buf2_h, n * n_bytes, UCC_MEMORY_TYPE_HOST);
+        ucc_mc_alloc(&res_h_mc_header, n_bytes, UCC_MEMORY_TYPE_HOST);
+        res_h = (typename T::type *)res_h_mc_header->addr;
+        ucc_mc_alloc(&buf1_h_mc_header, n_bytes, UCC_MEMORY_TYPE_HOST);
+        buf1_h = (typename T::type *)buf1_h_mc_header->addr;
+        ucc_mc_alloc(&buf2_h_mc_header, n * n_bytes, UCC_MEMORY_TYPE_HOST);
+        buf2_h = (typename T::type *)buf2_h_mc_header->addr;
 
         for (int i = 0; i < COUNT; i++) {
             res_h[i] = (typename T::type)(0);
@@ -210,9 +213,12 @@ class test_mc_reduce : public testing::Test {
             }
         }
         if (mtype != UCC_MEMORY_TYPE_HOST) {
-            ucc_mc_alloc((void**)&res_d, n_bytes, mtype);
-            ucc_mc_alloc((void**)&buf1_d, n_bytes, mtype);
-            ucc_mc_alloc((void**)&buf2_d, n*n_bytes, mtype);
+            ucc_mc_alloc(&res_d_mc_header, n_bytes, mtype);
+            res_d = (typename T::type *)res_d_mc_header->addr;
+            ucc_mc_alloc(&buf1_d_mc_header, n_bytes, mtype);
+            buf1_d = (typename T::type *)buf1_d_mc_header->addr;
+            ucc_mc_alloc(&buf2_d_mc_header, n * n_bytes, mtype);
+            buf2_d = (typename T::type *)buf2_d_mc_header->addr;
             ucc_mc_memcpy(res_d, res_h, n_bytes, mtype, UCC_MEMORY_TYPE_HOST);
             ucc_mc_memcpy(buf1_d, buf1_h, n_bytes, mtype, UCC_MEMORY_TYPE_HOST);
             ucc_mc_memcpy(buf2_d, buf2_h, n * n_bytes, mtype,
@@ -225,22 +231,22 @@ class test_mc_reduce : public testing::Test {
     ucc_status_t free_bufs(ucc_memory_type_t mtype)
     {
         if (buf1_h != nullptr) {
-            ucc_mc_free((void*)buf1_h, UCC_MEMORY_TYPE_HOST);
+            ucc_mc_free(buf1_h_mc_header, UCC_MEMORY_TYPE_HOST);
         }
         if (buf2_h != nullptr) {
-            ucc_mc_free((void*)buf2_h, UCC_MEMORY_TYPE_HOST);
+            ucc_mc_free(buf2_h_mc_header, UCC_MEMORY_TYPE_HOST);
         }
         if (res_h != nullptr) {
-            ucc_mc_free((void*)res_h, UCC_MEMORY_TYPE_HOST);
+            ucc_mc_free(res_h_mc_header, UCC_MEMORY_TYPE_HOST);
         }
         if (buf1_d != nullptr) {
-            ucc_mc_free((void*)buf1_d, mtype);
+            ucc_mc_free(buf1_d_mc_header, mtype);
         }
         if (buf2_d != nullptr) {
-            ucc_mc_free((void*)buf2_d, mtype);
+            ucc_mc_free(buf2_d_mc_header, mtype);
         }
         if (res_d != nullptr) {
-            ucc_mc_free((void*)res_d, mtype);
+            ucc_mc_free(res_d_mc_header, mtype);
         }
 
         return UCC_OK;
@@ -251,6 +257,13 @@ class test_mc_reduce : public testing::Test {
         free_bufs(mem_type);
         ucc_mc_finalize();
     }
+
+    ucc_mc_buffer_header_t *buf1_h_mc_header;
+    ucc_mc_buffer_header_t *buf2_h_mc_header;
+    ucc_mc_buffer_header_t *res_h_mc_header;
+    ucc_mc_buffer_header_t *buf1_d_mc_header;
+    ucc_mc_buffer_header_t *buf2_d_mc_header;
+    ucc_mc_buffer_header_t *res_d_mc_header;
     typename T::type *buf1_h;
     typename T::type *buf2_h;
     typename T::type *res_h;

--- a/test/gtest/core/test_mc_reduce.h
+++ b/test/gtest/core/test_mc_reduce.h
@@ -184,7 +184,10 @@ class test_mc_reduce : public testing::Test {
     virtual void SetUp() override
     {
         ucc_constructor();
-        ucc_mc_init(UCC_THREAD_SINGLE);
+        ucc_mc_params_t mc_params = {
+            .thread_mode = UCC_THREAD_SINGLE,
+        };
+        ucc_mc_init(&mc_params);
         buf1_h = buf2_h = res_h = nullptr;
         buf1_d = buf2_d = res_d = nullptr;
     }
@@ -258,7 +261,9 @@ class test_mc_reduce : public testing::Test {
         ucc_mc_finalize();
     }
 
-    ucc_mc_buffer_header_t *buf1_h_mc_header, *buf2_h_mc_header, *res_h_mc_header, *buf1_d_mc_header, *buf2_d_mc_header, *res_d_mc_header;
+    ucc_mc_buffer_header_t *buf1_h_mc_header, *buf2_h_mc_header,
+        *res_h_mc_header, *buf1_d_mc_header, *buf2_d_mc_header,
+        *res_d_mc_header;
     typename T::type *buf1_h;
     typename T::type *buf2_h;
     typename T::type *res_h;

--- a/test/gtest/core/test_mc_reduce.h
+++ b/test/gtest/core/test_mc_reduce.h
@@ -184,7 +184,7 @@ class test_mc_reduce : public testing::Test {
     virtual void SetUp() override
     {
         ucc_constructor();
-        ucc_mc_init();
+        ucc_mc_init(UCC_THREAD_SINGLE);
         buf1_h = buf2_h = res_h = nullptr;
         buf1_d = buf2_d = res_d = nullptr;
     }
@@ -258,12 +258,7 @@ class test_mc_reduce : public testing::Test {
         ucc_mc_finalize();
     }
 
-    ucc_mc_buffer_header_t *buf1_h_mc_header;
-    ucc_mc_buffer_header_t *buf2_h_mc_header;
-    ucc_mc_buffer_header_t *res_h_mc_header;
-    ucc_mc_buffer_header_t *buf1_d_mc_header;
-    ucc_mc_buffer_header_t *buf2_d_mc_header;
-    ucc_mc_buffer_header_t *res_d_mc_header;
+    ucc_mc_buffer_header_t *buf1_h_mc_header, *buf2_h_mc_header, *res_h_mc_header, *buf1_d_mc_header, *buf2_d_mc_header, *res_d_mc_header;
     typename T::type *buf1_h;
     typename T::type *buf2_h;
     typename T::type *res_h;

--- a/test/mpi/buffer.cc
+++ b/test/mpi/buffer.cc
@@ -26,7 +26,6 @@ void init_buffer_host(void *buf, size_t count, int _value)
 void init_buffer(void *_buf, size_t count, ucc_datatype_t dt,
                  ucc_memory_type_t mt, int value)
 {
-    ucc_mc_buffer_header_t *h   = NULL;
     void *buf = NULL;
     if (mt == UCC_MEMORY_TYPE_CUDA) {
         buf = ucc_malloc(count * ucc_dt_size(dt), "buf");
@@ -101,7 +100,7 @@ ucc_status_t compare_buffers(void *_rst, void *expected, size_t count,
                              ucc_datatype_t dt, ucc_memory_type_t mt)
 {
     ucc_status_t status = UCC_ERR_NO_MESSAGE;
-    ucc_mc_buffer_header_t *rst_header = NULL;
+    ucc_mc_buffer_header_t *rst_header;
     void *rst = NULL;
 
     if (UCC_MEMORY_TYPE_HOST == mt) {

--- a/test/mpi/buffer.cc
+++ b/test/mpi/buffer.cc
@@ -26,6 +26,7 @@ void init_buffer_host(void *buf, size_t count, int _value)
 void init_buffer(void *_buf, size_t count, ucc_datatype_t dt,
                  ucc_memory_type_t mt, int value)
 {
+    ucc_mc_buffer_header_t *h   = NULL;
     void *buf = NULL;
     if (mt == UCC_MEMORY_TYPE_CUDA) {
         buf = ucc_malloc(count * ucc_dt_size(dt), "buf");
@@ -100,13 +101,15 @@ ucc_status_t compare_buffers(void *_rst, void *expected, size_t count,
                              ucc_datatype_t dt, ucc_memory_type_t mt)
 {
     ucc_status_t status = UCC_ERR_NO_MESSAGE;
+    ucc_mc_buffer_header_t *rst_header = NULL;
     void *rst = NULL;
 
     if (UCC_MEMORY_TYPE_HOST == mt) {
         rst = _rst;
     } else if (UCC_MEMORY_TYPE_CUDA == mt) {
-        UCC_ALLOC_COPY_BUF(rst, UCC_MEMORY_TYPE_HOST, _rst, mt,
+        UCC_ALLOC_COPY_BUF(rst_header, UCC_MEMORY_TYPE_HOST, _rst, mt,
                            count * ucc_dt_size(dt));
+        rst = rst_header->addr;
     } else {
         std::cerr << "Unsupported mt\n";
         MPI_Abort(MPI_COMM_WORLD, -1);
@@ -123,7 +126,7 @@ ucc_status_t compare_buffers(void *_rst, void *expected, size_t count,
     }
 
     if (UCC_MEMORY_TYPE_HOST != mt) {
-        UCC_CHECK(ucc_mc_free(rst, UCC_MEMORY_TYPE_HOST));
+        UCC_CHECK(ucc_mc_free(rst_header, UCC_MEMORY_TYPE_HOST));
     }
 
     return status;

--- a/test/mpi/buffer.cc
+++ b/test/mpi/buffer.cc
@@ -100,15 +100,15 @@ ucc_status_t compare_buffers(void *_rst, void *expected, size_t count,
                              ucc_datatype_t dt, ucc_memory_type_t mt)
 {
     ucc_status_t status = UCC_ERR_NO_MESSAGE;
-    ucc_mc_buffer_header_t *rst_header;
+    ucc_mc_buffer_header_t *rst_mc_header;
     void *rst = NULL;
 
     if (UCC_MEMORY_TYPE_HOST == mt) {
         rst = _rst;
     } else if (UCC_MEMORY_TYPE_CUDA == mt) {
-        UCC_ALLOC_COPY_BUF(rst_header, UCC_MEMORY_TYPE_HOST, _rst, mt,
+        UCC_ALLOC_COPY_BUF(rst_mc_header, UCC_MEMORY_TYPE_HOST, _rst, mt,
                            count * ucc_dt_size(dt));
-        rst = rst_header->addr;
+        rst = rst_mc_header->addr;
     } else {
         std::cerr << "Unsupported mt\n";
         MPI_Abort(MPI_COMM_WORLD, -1);
@@ -125,7 +125,7 @@ ucc_status_t compare_buffers(void *_rst, void *expected, size_t count,
     }
 
     if (UCC_MEMORY_TYPE_HOST != mt) {
-        UCC_CHECK(ucc_mc_free(rst_header, UCC_MEMORY_TYPE_HOST));
+        UCC_CHECK(ucc_mc_free(rst_mc_header, UCC_MEMORY_TYPE_HOST));
     }
 
     return status;

--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -27,13 +27,17 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc(&rbuf, _msgsize*size, _mt));
+    UCC_CHECK(ucc_mc_alloc(&rbuf_header, _msgsize * size, _mt));
+    rbuf = rbuf_header->addr;
     check_rbuf = ucc_malloc(_msgsize*size, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
-        UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize, _mt));
+        UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize, _mt));
+        sbuf = sbuf_header->addr;
         init_buffer(sbuf, count, TEST_DT, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf, UCC_MEMORY_TYPE_HOST, sbuf, _mt, _msgsize);
+        UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
+                           _msgsize);
+        check_sbuf = check_sbuf_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;

--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -27,17 +27,17 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc(&rbuf_header, _msgsize * size, _mt));
-    rbuf = rbuf_header->addr;
+    UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, _msgsize * size, _mt));
+    rbuf       = rbuf_mc_header->addr;
     check_rbuf = ucc_malloc(_msgsize*size, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
-        UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize, _mt));
-        sbuf = sbuf_header->addr;
+        UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
+        sbuf = sbuf_mc_header->addr;
         init_buffer(sbuf, count, TEST_DT, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
-                           _msgsize);
-        check_sbuf = check_sbuf_header->addr;
+        UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
+                           _mt, _msgsize);
+        check_sbuf = check_sbuf_mc_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -32,8 +32,8 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     UCC_MALLOC_CHECK(counts);
     displacements = (int *) ucc_malloc(size * sizeof(uint32_t), "displacements buf");
     UCC_MALLOC_CHECK(displacements);
-    UCC_CHECK(ucc_mc_alloc(&rbuf_header, _msgsize * size, _mt));
-    rbuf = rbuf_header->addr;
+    UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, _msgsize * size, _mt));
+    rbuf       = rbuf_mc_header->addr;
     check_rbuf = ucc_malloc(_msgsize*size, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
     for (int i = 0; i < size; i++) {
@@ -42,12 +42,12 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     }
     if (TEST_NO_INPLACE == inplace) {
         args.mask = 0;
-        UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize, _mt));
-        sbuf = sbuf_header->addr;
+        UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
+        sbuf = sbuf_mc_header->addr;
         init_buffer(sbuf, count, TEST_DT, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
-                           _msgsize);
-        check_sbuf = check_sbuf_header->addr;
+        UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
+                           _mt, _msgsize);
+        check_sbuf = check_sbuf_mc_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -17,8 +17,6 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     size_t dt_size = ucc_dt_size(TEST_DT);
     size_t count = _msgsize/dt_size;
     int rank, size;
-    counts_header        = NULL;
-    displacements_header = NULL;
     counts = NULL;
     displacements = NULL;
     MPI_Comm_rank(team.comm, &rank);

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -17,6 +17,8 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     size_t dt_size = ucc_dt_size(TEST_DT);
     size_t count = _msgsize/dt_size;
     int rank, size;
+    counts_header        = NULL;
+    displacements_header = NULL;
     counts = NULL;
     displacements = NULL;
     MPI_Comm_rank(team.comm, &rank);
@@ -32,7 +34,8 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     UCC_MALLOC_CHECK(counts);
     displacements = (int *) ucc_malloc(size * sizeof(uint32_t), "displacements buf");
     UCC_MALLOC_CHECK(displacements);
-    UCC_CHECK(ucc_mc_alloc(&rbuf, _msgsize*size, _mt));
+    UCC_CHECK(ucc_mc_alloc(&rbuf_header, _msgsize * size, _mt));
+    rbuf = rbuf_header->addr;
     check_rbuf = ucc_malloc(_msgsize*size, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
     for (int i = 0; i < size; i++) {
@@ -41,9 +44,12 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     }
     if (TEST_NO_INPLACE == inplace) {
         args.mask = 0;
-        UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize, _mt));
+        UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize, _mt));
+        sbuf = sbuf_header->addr;
         init_buffer(sbuf, count, TEST_DT, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf, UCC_MEMORY_TYPE_HOST, sbuf, _mt, _msgsize);
+        UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
+                           _msgsize);
+        check_sbuf = check_sbuf_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;

--- a/test/mpi/test_allreduce.cc
+++ b/test/mpi/test_allreduce.cc
@@ -26,13 +26,17 @@ TestAllreduce::TestAllreduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc(&rbuf, _msgsize, _mt));
+    UCC_CHECK(ucc_mc_alloc(&rbuf_header, _msgsize, _mt));
+    rbuf = rbuf_header->addr;
     check_rbuf = ucc_malloc(_msgsize, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
-        UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize, _mt));
+        UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize, _mt));
+        sbuf = sbuf_header->addr;
         init_buffer(sbuf, count, dt, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf, UCC_MEMORY_TYPE_HOST, sbuf, _mt, _msgsize);
+        UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
+                           _msgsize);
+        check_sbuf = check_sbuf_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;

--- a/test/mpi/test_allreduce.cc
+++ b/test/mpi/test_allreduce.cc
@@ -26,17 +26,17 @@ TestAllreduce::TestAllreduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc(&rbuf_header, _msgsize, _mt));
-    rbuf = rbuf_header->addr;
+    UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, _msgsize, _mt));
+    rbuf       = rbuf_mc_header->addr;
     check_rbuf = ucc_malloc(_msgsize, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
-        UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize, _mt));
-        sbuf = sbuf_header->addr;
+        UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
+        sbuf = sbuf_mc_header->addr;
         init_buffer(sbuf, count, dt, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
-                           _msgsize);
-        check_sbuf = check_sbuf_header->addr;
+        UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
+                           _mt, _msgsize);
+        check_sbuf = check_sbuf_mc_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;

--- a/test/mpi/test_alltoall.cc
+++ b/test/mpi/test_alltoall.cc
@@ -29,14 +29,17 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc(&rbuf, _msgsize * nprocs, _mt));
+    UCC_CHECK(ucc_mc_alloc(&rbuf_header, _msgsize * nprocs, _mt));
+    rbuf = rbuf_header->addr;
     check_rbuf = ucc_malloc(_msgsize * nprocs, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
-        UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize * nprocs, _mt));
+        UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize * nprocs, _mt));
+        sbuf = sbuf_header->addr;
         init_buffer(sbuf, count * nprocs, TEST_DT, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
+        UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
                            _msgsize * nprocs);
+        check_sbuf = check_sbuf_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;

--- a/test/mpi/test_alltoall.cc
+++ b/test/mpi/test_alltoall.cc
@@ -29,17 +29,17 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc(&rbuf_header, _msgsize * nprocs, _mt));
-    rbuf = rbuf_header->addr;
+    UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, _msgsize * nprocs, _mt));
+    rbuf       = rbuf_mc_header->addr;
     check_rbuf = ucc_malloc(_msgsize * nprocs, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
-        UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize * nprocs, _mt));
-        sbuf = sbuf_header->addr;
+        UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize * nprocs, _mt));
+        sbuf = sbuf_mc_header->addr;
         init_buffer(sbuf, count * nprocs, TEST_DT, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
-                           _msgsize * nprocs);
-        check_sbuf = check_sbuf_header->addr;
+        UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
+                           _mt, _msgsize * nprocs);
+        check_sbuf = check_sbuf_mc_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;

--- a/test/mpi/test_alltoallv.cc
+++ b/test/mpi/test_alltoallv.cc
@@ -103,11 +103,13 @@ TestAlltoallv::TestAlltoallv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc(&sbuf, sncounts * dt_size, _mt));
+    UCC_CHECK(ucc_mc_alloc(&sbuf_header, sncounts * dt_size, _mt));
+    sbuf = sbuf_header->addr;
     init_buffer(sbuf, sncounts, TEST_DT, _mt, rank);
-    UCC_ALLOC_COPY_BUF(check_sbuf, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
+    UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
                        sncounts * dt_size);
-    UCC_CHECK(ucc_mc_alloc(&rbuf, rncounts * dt_size, _mt));
+    UCC_CHECK(ucc_mc_alloc(&rbuf_header, rncounts * dt_size, _mt));
+    rbuf = rbuf_header->addr;
     check_rbuf = ucc_malloc(rncounts * dt_size, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
 

--- a/test/mpi/test_alltoallv.cc
+++ b/test/mpi/test_alltoallv.cc
@@ -103,14 +103,14 @@ TestAlltoallv::TestAlltoallv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc(&sbuf_header, sncounts * dt_size, _mt));
-    sbuf = sbuf_header->addr;
+    UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, sncounts * dt_size, _mt));
+    sbuf = sbuf_mc_header->addr;
     init_buffer(sbuf, sncounts, TEST_DT, _mt, rank);
-    UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
+    UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
                        sncounts * dt_size);
-    check_sbuf = check_sbuf_header->addr;
-    UCC_CHECK(ucc_mc_alloc(&rbuf_header, rncounts * dt_size, _mt));
-    rbuf = rbuf_header->addr;
+    check_sbuf = check_sbuf_mc_header->addr;
+    UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, rncounts * dt_size, _mt));
+    rbuf       = rbuf_mc_header->addr;
     check_rbuf = ucc_malloc(rncounts * dt_size, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
 

--- a/test/mpi/test_alltoallv.cc
+++ b/test/mpi/test_alltoallv.cc
@@ -108,6 +108,7 @@ TestAlltoallv::TestAlltoallv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     init_buffer(sbuf, sncounts, TEST_DT, _mt, rank);
     UCC_ALLOC_COPY_BUF(check_sbuf_header, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
                        sncounts * dt_size);
+    check_sbuf = check_sbuf_header->addr;
     UCC_CHECK(ucc_mc_alloc(&rbuf_header, rncounts * dt_size, _mt));
     rbuf = rbuf_header->addr;
     check_rbuf = ucc_malloc(rncounts * dt_size, "check rbuf");

--- a/test/mpi/test_bcast.cc
+++ b/test/mpi/test_bcast.cc
@@ -29,11 +29,11 @@ TestBcast::TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 
     check_rbuf = ucc_malloc(_msgsize * size, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
-    UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize, _mt));
-    sbuf = sbuf_header->addr;
-    UCC_CHECK(ucc_mc_alloc(&check_sbuf_header, _msgsize, UCC_MEMORY_TYPE_HOST));
-    check_sbuf = check_sbuf_header->addr;
-
+    UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
+    sbuf = sbuf_mc_header->addr;
+    UCC_CHECK(
+        ucc_mc_alloc(&check_sbuf_mc_header, _msgsize, UCC_MEMORY_TYPE_HOST));
+    check_sbuf = check_sbuf_mc_header->addr;
     if (rank == root) {
         init_buffer(sbuf, count, TEST_DT, _mt, rank);
         UCC_CHECK(ucc_mc_memcpy(check_sbuf, sbuf, _msgsize,                        \

--- a/test/mpi/test_bcast.cc
+++ b/test/mpi/test_bcast.cc
@@ -29,7 +29,8 @@ TestBcast::TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 
     check_rbuf = ucc_malloc(_msgsize * size, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
-    UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize, _mt));
+    UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize, _mt));
+    sbuf = sbuf_header->addr;
     check_sbuf = ucc_malloc(_msgsize, "check sbuf");
     UCC_MALLOC_CHECK(check_sbuf);
     if (rank == root) {

--- a/test/mpi/test_bcast.cc
+++ b/test/mpi/test_bcast.cc
@@ -31,8 +31,9 @@ TestBcast::TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     UCC_MALLOC_CHECK(check_rbuf);
     UCC_CHECK(ucc_mc_alloc(&sbuf_header, _msgsize, _mt));
     sbuf = sbuf_header->addr;
-    check_sbuf = ucc_malloc(_msgsize, "check sbuf");
-    UCC_MALLOC_CHECK(check_sbuf);
+    UCC_CHECK(ucc_mc_alloc(&check_sbuf_header, _msgsize, UCC_MEMORY_TYPE_HOST));
+    check_sbuf = check_sbuf_header->addr;
+
     if (rank == root) {
         init_buffer(sbuf, count, TEST_DT, _mt, rank);
         UCC_CHECK(ucc_mc_memcpy(check_sbuf, sbuf, _msgsize,                        \

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -159,13 +159,13 @@ TestCase::~TestCase()
         UCC_CHECK(ucc_collective_finalize(req));
     }
     if (sbuf) {
-        UCC_CHECK(ucc_mc_free(sbuf_header, mem_type));
+        UCC_CHECK(ucc_mc_free(sbuf_mc_header, mem_type));
     }
     if (rbuf) {
-        UCC_CHECK(ucc_mc_free(rbuf_header, mem_type));
+        UCC_CHECK(ucc_mc_free(rbuf_mc_header, mem_type));
     }
     if (check_sbuf) {
-        UCC_CHECK(ucc_mc_free(check_sbuf_header, mem_type));
+        UCC_CHECK(ucc_mc_free(check_sbuf_mc_header, mem_type));
     }
     if (check_rbuf) {
         ucc_free(check_rbuf);

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -165,7 +165,7 @@ TestCase::~TestCase()
         UCC_CHECK(ucc_mc_free(rbuf_header, mem_type));
     }
     if (check_sbuf) {
-        ucc_free(check_sbuf);
+        UCC_CHECK(ucc_mc_free(check_sbuf_header, mem_type));
     }
     if (check_rbuf) {
         ucc_free(check_rbuf);

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -159,10 +159,10 @@ TestCase::~TestCase()
         UCC_CHECK(ucc_collective_finalize(req));
     }
     if (sbuf) {
-        UCC_CHECK(ucc_mc_free(sbuf, mem_type));
+        UCC_CHECK(ucc_mc_free(sbuf_header, mem_type));
     }
     if (rbuf) {
-        UCC_CHECK(ucc_mc_free(rbuf, mem_type));
+        UCC_CHECK(ucc_mc_free(rbuf_header, mem_type));
     }
     if (check_sbuf) {
         ucc_free(check_sbuf);

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -56,12 +56,12 @@ END_C_DECLS
 
 extern int test_rand_seed;
 
-#define UCC_ALLOC_COPY_BUF(_new_buf, _new_mtype, _old_buf, _old_mtype, _size) \
-{                                                                             \
-    UCC_CHECK(ucc_mc_alloc(&(_new_buf), _size, _new_mtype));                  \
-    UCC_CHECK(ucc_mc_memcpy(_new_buf, _old_buf, _size,                        \
-              _new_mtype, _old_mtype));                                       \
-}
+#define UCC_ALLOC_COPY_BUF(_new_buf, _new_mtype, _old_buf, _old_mtype, _size)  \
+    {                                                                          \
+        UCC_CHECK(ucc_mc_alloc(&(_new_buf), _size, _new_mtype));               \
+        UCC_CHECK(ucc_mc_memcpy(_new_buf->addr, _old_buf, _size, _new_mtype,   \
+                                _old_mtype));                                  \
+    }
 
 #ifdef HAVE_CUDA
 #define CUDA_CHECK(_call) {                                         \
@@ -218,6 +218,10 @@ protected:
     ucc_test_mpi_inplace_t inplace;
     ucc_coll_args_t args;
     ucc_coll_req_h req;
+    ucc_mc_buffer_header_t *sbuf_header;
+    ucc_mc_buffer_header_t *rbuf_header;
+    ucc_mc_buffer_header_t *check_sbuf_header;
+    ucc_mc_buffer_header_t *check_rbuf_header;
     void *sbuf;
     void *rbuf;
     void *check_sbuf;
@@ -286,6 +290,8 @@ public:
 };
 
 class TestAllgatherv : public TestCase {
+    ucc_mc_buffer_header_t *counts_header;
+    ucc_mc_buffer_header_t *displacements_header;
     int *counts;
     int *displacements;
 public:

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -218,7 +218,8 @@ protected:
     ucc_test_mpi_inplace_t inplace;
     ucc_coll_args_t args;
     ucc_coll_req_h req;
-    ucc_mc_buffer_header_t *sbuf_header, *rbuf_header, *check_sbuf_header; //, *check_rbuf_header;
+    ucc_mc_buffer_header_t *sbuf_mc_header, *rbuf_mc_header,
+        *check_sbuf_mc_header;
     void *sbuf;
     void *rbuf;
     void *check_sbuf;

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -218,10 +218,7 @@ protected:
     ucc_test_mpi_inplace_t inplace;
     ucc_coll_args_t args;
     ucc_coll_req_h req;
-    ucc_mc_buffer_header_t *sbuf_header;
-    ucc_mc_buffer_header_t *rbuf_header;
-    ucc_mc_buffer_header_t *check_sbuf_header;
-    ucc_mc_buffer_header_t *check_rbuf_header;
+    ucc_mc_buffer_header_t *sbuf_header, *rbuf_header, *check_sbuf_header; //, *check_rbuf_header;
     void *sbuf;
     void *rbuf;
     void *check_sbuf;
@@ -290,8 +287,6 @@ public:
 };
 
 class TestAllgatherv : public TestCase {
-    ucc_mc_buffer_header_t *counts_header;
-    ucc_mc_buffer_header_t *displacements_header;
     int *counts;
     int *displacements;
 public:

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -8,6 +8,9 @@
 #define UCC_PT_COLL_H
 
 #include <ucc/api/ucc.h>
+extern "C" {
+#include <core/ucc_mc.h>
+}
 
 class ucc_pt_coll {
 protected:
@@ -15,6 +18,8 @@ protected:
     bool has_reduction_;
     bool has_range_;
     ucc_coll_args_t coll_args;
+    ucc_mc_buffer_header_t *dst_header;
+    ucc_mc_buffer_header_t *src_header;
 public:
     virtual ucc_status_t init_coll_args(size_t count,
                                         ucc_coll_args_t &args) = 0;

--- a/tools/perf/ucc_pt_coll_allgather.cc
+++ b/tools/perf/ucc_pt_coll_allgather.cc
@@ -35,13 +35,14 @@ ucc_status_t ucc_pt_coll_allgather::init_coll_args(size_t count,
 
     args = coll_args;
     args.dst.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size_dst,
-                               args.dst.info.mem_type), exit, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size_dst, args.dst.info.mem_type),
+                  exit, st);
     args.dst.info.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
         args.src.info.count = count;
-        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size_src,
-                                   args.src.info.mem_type), free_dst, st);
+        UCCCHECK_GOTO(
+            ucc_mc_alloc(&src_header, size_src, args.src.info.mem_type),
+            free_dst, st);
         args.src.info.buffer = src_header->addr;
     }
     return UCC_OK;

--- a/tools/perf/ucc_pt_coll_allgather.cc
+++ b/tools/perf/ucc_pt_coll_allgather.cc
@@ -38,16 +38,18 @@ ucc_status_t ucc_pt_coll_allgather::init_coll_args(size_t count,
 
     args = coll_args;
     args.dst.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.buffer, size_dst,
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.mc_header, size_dst,
                                args.dst.info.mem_type), exit, st);
+    args.dst.info.buffer = args.dst.info.mc_header->addr;
     if (!UCC_IS_INPLACE(args)) {
         args.src.info.count = count;
-        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size_src,
+        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.mc_header, size_src,
                                    args.src.info.mem_type), free_dst, st);
+        args.src.info.buffer = args.src.info.mc_header->addr;
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
 exit:
     return st;
     return UCC_OK;
@@ -56,9 +58,9 @@ exit:
 void ucc_pt_coll_allgather::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+        ucc_mc_free(args.src.info.mc_header, args.src.info.mem_type);
     }
-    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
 }
 
 double ucc_pt_coll_allgather::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_allgather.cc
+++ b/tools/perf/ucc_pt_coll_allgather.cc
@@ -3,9 +3,6 @@
 #include <ucc/api/ucc.h>
 #include <utils/ucc_math.h>
 #include <utils/ucc_coll_utils.h>
-extern "C" {
-#include <core/ucc_mc.h>
-}
 
 ucc_pt_coll_allgather::ucc_pt_coll_allgather(int size, ucc_datatype_t dt,
                                              ucc_memory_type mt,
@@ -38,29 +35,28 @@ ucc_status_t ucc_pt_coll_allgather::init_coll_args(size_t count,
 
     args = coll_args;
     args.dst.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.mc_header, size_dst,
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size_dst,
                                args.dst.info.mem_type), exit, st);
-    args.dst.info.buffer = args.dst.info.mc_header->addr;
+    args.dst.info.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
         args.src.info.count = count;
-        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.mc_header, size_src,
+        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size_src,
                                    args.src.info.mem_type), free_dst, st);
-        args.src.info.buffer = args.src.info.mc_header->addr;
+        args.src.info.buffer = src_header->addr;
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header, args.dst.info.mem_type);
 exit:
     return st;
-    return UCC_OK;
 }
 
 void ucc_pt_coll_allgather::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(args.src.info.mc_header, args.src.info.mem_type);
+        ucc_mc_free(src_header, args.src.info.mem_type);
     }
-    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header, args.dst.info.mem_type);
 }
 
 double ucc_pt_coll_allgather::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_allgatherv.cc
+++ b/tools/perf/ucc_pt_coll_allgatherv.cc
@@ -38,13 +38,14 @@ ucc_status_t ucc_pt_coll_allgatherv::init_coll_args(size_t count,
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.counts, exit, st);
     args.dst.info_v.displacements = (ucc_aint_t *) ucc_malloc(comm_size * sizeof(uint32_t), "displacements buf");
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.displacements, free_count, st);
-    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size_dst,
-                               args.dst.info_v.mem_type), free_displ, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size_dst, args.dst.info_v.mem_type),
+                  free_displ, st);
     args.dst.info_v.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
         args.src.info.count = count;
-        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size_src,
-                                   args.src.info.mem_type), free_dst, st);
+        UCCCHECK_GOTO(
+            ucc_mc_alloc(&src_header, size_src, args.src.info.mem_type),
+            free_dst, st);
         args.src.info.buffer = src_header->addr;
     }
     for (int i = 0; i < comm_size; i++) {

--- a/tools/perf/ucc_pt_coll_allgatherv.cc
+++ b/tools/perf/ucc_pt_coll_allgatherv.cc
@@ -3,9 +3,6 @@
 #include <ucc/api/ucc.h>
 #include <utils/ucc_math.h>
 #include <utils/ucc_coll_utils.h>
-extern "C" {
-#include <core/ucc_mc.h>
-}
 
 ucc_pt_coll_allgatherv::ucc_pt_coll_allgatherv(int size, ucc_datatype_t dt,
                                                ucc_memory_type mt,
@@ -41,14 +38,14 @@ ucc_status_t ucc_pt_coll_allgatherv::init_coll_args(size_t count,
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.counts, exit, st);
     args.dst.info_v.displacements = (ucc_aint_t *) ucc_malloc(comm_size * sizeof(uint32_t), "displacements buf");
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.displacements, free_count, st);
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info_v.mc_header, size_dst,
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size_dst,
                                args.dst.info_v.mem_type), free_displ, st);
-    args.dst.info_v.buffer = args.dst.info_v.mc_header->addr;
+    args.dst.info_v.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
         args.src.info.count = count;
-        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.mc_header, size_src,
+        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size_src,
                                    args.src.info.mem_type), free_dst, st);
-        args.src.info.buffer = args.src.info.mc_header->addr;
+        args.src.info.buffer = src_header->addr;
     }
     for (int i = 0; i < comm_size; i++) {
         ((uint32_t*)args.dst.info_v.counts)[i] = count;
@@ -56,7 +53,7 @@ ucc_status_t ucc_pt_coll_allgatherv::init_coll_args(size_t count,
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(args.dst.info_v.mc_header, args.dst.info_v.mem_type);
+    ucc_mc_free(dst_header, args.dst.info_v.mem_type);
 free_displ:
     ucc_free(args.dst.info_v.displacements);
 free_count:
@@ -68,11 +65,11 @@ exit:
 void ucc_pt_coll_allgatherv::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(args.src.info.mc_header, args.src.info.mem_type);
+        ucc_mc_free(src_header, args.src.info.mem_type);
     }
+    ucc_mc_free(dst_header, args.dst.info_v.mem_type);
     ucc_free(args.dst.info_v.counts);
     ucc_free(args.dst.info_v.displacements);
-    ucc_mc_free(args.dst.info_v.mc_header, args.dst.info_v.mem_type);
 }
 
 double ucc_pt_coll_allgatherv::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -35,12 +35,12 @@ ucc_status_t ucc_pt_coll_allreduce::init_coll_args(size_t count,
 
     args = coll_args;
     args.src.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size,
-                               args.dst.info.mem_type), exit, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size, args.dst.info.mem_type), exit,
+                  st);
     args.dst.info.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
-        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size,
-                                   args.src.info.mem_type), free_dst, st);
+        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size, args.src.info.mem_type),
+                      free_dst, st);
         args.src.info.buffer = src_header->addr;
     }
     return UCC_OK;

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -38,15 +38,17 @@ ucc_status_t ucc_pt_coll_allreduce::init_coll_args(size_t count,
 
     args = coll_args;
     args.src.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.buffer, size,
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.mc_header, size,
                                args.dst.info.mem_type), exit, st);
+    args.dst.info.buffer = args.dst.info.mc_header->addr;
     if (!UCC_IS_INPLACE(args)) {
-        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size,
+        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.mc_header, size,
                                    args.src.info.mem_type), free_dst, st);
+        args.src.info.buffer = args.src.info.mc_header->addr;
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
 exit:
     return st;
 }
@@ -54,9 +56,9 @@ exit:
 void ucc_pt_coll_allreduce::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+        ucc_mc_free(args.src.info.mc_header, args.src.info.mem_type);
     }
-    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
 }
 
 double ucc_pt_coll_allreduce::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -3,9 +3,6 @@
 #include <ucc/api/ucc.h>
 #include <utils/ucc_math.h>
 #include <utils/ucc_coll_utils.h>
-extern "C" {
-#include <core/ucc_mc.h>
-}
 
 ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
                                              ucc_memory_type mt,
@@ -38,17 +35,17 @@ ucc_status_t ucc_pt_coll_allreduce::init_coll_args(size_t count,
 
     args = coll_args;
     args.src.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.mc_header, size,
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size,
                                args.dst.info.mem_type), exit, st);
-    args.dst.info.buffer = args.dst.info.mc_header->addr;
+    args.dst.info.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
-        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.mc_header, size,
+        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size,
                                    args.src.info.mem_type), free_dst, st);
-        args.src.info.buffer = args.src.info.mc_header->addr;
+        args.src.info.buffer = src_header->addr;
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header, args.dst.info.mem_type);
 exit:
     return st;
 }
@@ -56,9 +53,9 @@ exit:
 void ucc_pt_coll_allreduce::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(args.src.info.mc_header, args.src.info.mem_type);
+        ucc_mc_free(src_header, args.src.info.mem_type);
     }
-    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header, args.dst.info.mem_type);
 }
 
 double ucc_pt_coll_allreduce::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_alltoall.cc
+++ b/tools/perf/ucc_pt_coll_alltoall.cc
@@ -3,9 +3,6 @@
 #include <ucc/api/ucc.h>
 #include <utils/ucc_math.h>
 #include <utils/ucc_coll_utils.h>
-extern "C" {
-#include <core/ucc_mc.h>
-}
 
 ucc_pt_coll_alltoall::ucc_pt_coll_alltoall(int size, ucc_datatype_t dt,
                                            ucc_memory_type mt, bool is_inplace):
@@ -36,18 +33,18 @@ ucc_status_t ucc_pt_coll_alltoall::init_coll_args(size_t count,
 
     args = coll_args;
     args.dst.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.mc_header, size,
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size,
                                args.dst.info.mem_type), exit, st);
-    args.dst.info.buffer = args.dst.info.mc_header->addr;
+    args.dst.info.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
         args.src.info.count = count;
-        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.mc_header, size,
+        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size,
                                    args.src.info.mem_type), free_dst, st);
-        args.src.info.buffer = args.src.info.mc_header->addr;
+        args.src.info.buffer = src_header->addr;
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header, args.dst.info.mem_type);
 exit:
     return st;
 }
@@ -55,9 +52,9 @@ exit:
 void ucc_pt_coll_alltoall::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(args.src.info.mc_header, args.src.info.mem_type);
+        ucc_mc_free(src_header, args.src.info.mem_type);
     }
-    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header, args.dst.info.mem_type);
 }
 
 double ucc_pt_coll_alltoall::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_alltoall.cc
+++ b/tools/perf/ucc_pt_coll_alltoall.cc
@@ -36,16 +36,18 @@ ucc_status_t ucc_pt_coll_alltoall::init_coll_args(size_t count,
 
     args = coll_args;
     args.dst.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.buffer, size,
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info.mc_header, size,
                                args.dst.info.mem_type), exit, st);
+    args.dst.info.buffer = args.dst.info.mc_header->addr;
     if (!UCC_IS_INPLACE(args)) {
         args.src.info.count = count;
-        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size,
+        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.mc_header, size,
                                    args.src.info.mem_type), free_dst, st);
+        args.src.info.buffer = args.src.info.mc_header->addr;
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
 exit:
     return st;
 }
@@ -53,9 +55,9 @@ exit:
 void ucc_pt_coll_alltoall::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+        ucc_mc_free(args.src.info.mc_header, args.src.info.mem_type);
     }
-    ucc_mc_free(args.dst.info.buffer, args.dst.info.mem_type);
+    ucc_mc_free(args.dst.info.mc_header, args.dst.info.mem_type);
 }
 
 double ucc_pt_coll_alltoall::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_alltoall.cc
+++ b/tools/perf/ucc_pt_coll_alltoall.cc
@@ -33,13 +33,13 @@ ucc_status_t ucc_pt_coll_alltoall::init_coll_args(size_t count,
 
     args = coll_args;
     args.dst.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size,
-                               args.dst.info.mem_type), exit, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size, args.dst.info.mem_type), exit,
+                  st);
     args.dst.info.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
         args.src.info.count = count;
-        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size,
-                                   args.src.info.mem_type), free_dst, st);
+        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size, args.src.info.mem_type),
+                      free_dst, st);
         args.src.info.buffer = src_header->addr;
     }
     return UCC_OK;

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -40,12 +40,12 @@ ucc_status_t ucc_pt_coll_alltoallv::init_coll_args(size_t count,
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.counts, free_src_displ, st);
     args.dst.info_v.displacements = (ucc_aint_t *) ucc_malloc(comm_size * sizeof(uint32_t), "displacements buf");
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.displacements, free_dst_count, st);
-    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size,
-                               args.dst.info_v.mem_type), free_dst_displ, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size, args.dst.info_v.mem_type),
+                  free_dst_displ, st);
     args.dst.info_v.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
-        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size,
-                                   args.src.info_v.mem_type), free_dst, st);
+        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size, args.src.info_v.mem_type),
+                      free_dst, st);
         args.src.info_v.buffer = src_header->addr;
     }
     for (int i = 0; i < comm_size; i++) {

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -3,9 +3,6 @@
 #include <ucc/api/ucc.h>
 #include <utils/ucc_math.h>
 #include <utils/ucc_coll_utils.h>
-extern "C" {
-#include <core/ucc_mc.h>
-}
 
 ucc_pt_coll_alltoallv::ucc_pt_coll_alltoallv(int size, ucc_datatype_t dt,
                                              ucc_memory_type mt, bool is_inplace):
@@ -43,13 +40,13 @@ ucc_status_t ucc_pt_coll_alltoallv::init_coll_args(size_t count,
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.counts, free_src_displ, st);
     args.dst.info_v.displacements = (ucc_aint_t *) ucc_malloc(comm_size * sizeof(uint32_t), "displacements buf");
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.displacements, free_dst_count, st);
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.dst.info_v.mc_header, size,
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size,
                                args.dst.info_v.mem_type), free_dst_displ, st);
-    args.dst.info_v.buffer = args.dst.info_v.mc_header->addr;
+    args.dst.info_v.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
-        UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info_v.mc_header, size,
+        UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size,
                                    args.src.info_v.mem_type), free_dst, st);
-        args.src.info_v.buffer = args.src.info_v.mc_header->addr;
+        args.src.info_v.buffer = src_header->addr;
     }
     for (int i = 0; i < comm_size; i++) {
         ((uint32_t*)args.src.info_v.counts)[i] = count;
@@ -59,7 +56,7 @@ ucc_status_t ucc_pt_coll_alltoallv::init_coll_args(size_t count,
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(args.dst.info_v.mc_header, args.dst.info_v.mem_type);
+    ucc_mc_free(dst_header, args.dst.info_v.mem_type);
 free_dst_displ:
     ucc_free(args.dst.info_v.displacements);
 free_dst_count:
@@ -75,12 +72,13 @@ exit:
 void ucc_pt_coll_alltoallv::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(args.src.info_v.mc_header, args.src.info_v.mem_type);
+        ucc_mc_free(src_header, args.src.info_v.mem_type);
     }
-    ucc_mc_free(args.dst.info_v.mc_header, args.dst.info_v.mem_type);
+    ucc_mc_free(dst_header, args.dst.info_v.mem_type);
     ucc_free(args.dst.info_v.counts);
     ucc_free(args.dst.info_v.displacements);
     ucc_free(args.src.info_v.counts);
+    ucc_free(args.src.info_v.displacements);
 }
 
 double ucc_pt_coll_alltoallv::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_barrier.cc
+++ b/tools/perf/ucc_pt_coll_barrier.cc
@@ -3,9 +3,6 @@
 #include <ucc/api/ucc.h>
 #include <utils/ucc_math.h>
 #include <utils/ucc_coll_utils.h>
-extern "C" {
-#include <core/ucc_mc.h>
-}
 
 ucc_pt_coll_barrier::ucc_pt_coll_barrier()
 {

--- a/tools/perf/ucc_pt_coll_bcast.cc
+++ b/tools/perf/ucc_pt_coll_bcast.cc
@@ -27,8 +27,8 @@ ucc_status_t ucc_pt_coll_bcast::init_coll_args(size_t count,
 
     args = coll_args;
     args.src.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size,
-                               args.src.info.mem_type), exit, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size, args.src.info.mem_type), exit,
+                  st);
     args.src.info.buffer = src_header->addr;
 exit:
     return st;

--- a/tools/perf/ucc_pt_coll_bcast.cc
+++ b/tools/perf/ucc_pt_coll_bcast.cc
@@ -3,9 +3,6 @@
 #include <ucc/api/ucc.h>
 #include <utils/ucc_math.h>
 #include <utils/ucc_coll_utils.h>
-extern "C" {
-#include <core/ucc_mc.h>
-}
 
 ucc_pt_coll_bcast::ucc_pt_coll_bcast(ucc_datatype_t dt,
                                              ucc_memory_type mt)
@@ -30,16 +27,16 @@ ucc_status_t ucc_pt_coll_bcast::init_coll_args(size_t count,
 
     args = coll_args;
     args.src.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.mc_header, size,
+    UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size,
                                args.src.info.mem_type), exit, st);
-    args.src.info.buffer = args.src.info.mc_header->addr;
+    args.src.info.buffer = src_header->addr;
 exit:
     return st;
 }
 
 void ucc_pt_coll_bcast::free_coll_args(ucc_coll_args_t &args)
 {
-    ucc_mc_free(args.src.info.mc_header, args.src.info.mem_type);
+    ucc_mc_free(src_header, args.src.info.mem_type);
 }
 
 double ucc_pt_coll_bcast::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_bcast.cc
+++ b/tools/perf/ucc_pt_coll_bcast.cc
@@ -30,15 +30,16 @@ ucc_status_t ucc_pt_coll_bcast::init_coll_args(size_t count,
 
     args = coll_args;
     args.src.info.count = count;
-    UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.buffer, size,
+    UCCCHECK_GOTO(ucc_mc_alloc(&args.src.info.mc_header, size,
                                args.src.info.mem_type), exit, st);
+    args.src.info.buffer = args.src.info.mc_header->addr;
 exit:
     return st;
 }
 
 void ucc_pt_coll_bcast::free_coll_args(ucc_coll_args_t &args)
 {
-    ucc_mc_free(args.src.info.buffer, args.src.info.mem_type);
+    ucc_mc_free(args.src.info.mc_header, args.src.info.mem_type);
 }
 
 double ucc_pt_coll_bcast::get_bus_bw(double time_us)


### PR DESCRIPTION
## What
Implementation of ucc mc using mpool, for both CPU and CUDA.

## Why ?
To improve performance. 

## How ?
ucc_mc_alloc will now have two options - fast and slow path.
Fast path initiates an mpool with preallocated buffers at initiation time. From there on any time ucc_mc_alloc is called it will take a buffer from the mpool (and when freeing it will return the buffer to the mpool). We monitor this using a header (which lead to a minor API change).
If all buffers are being used and another alloc call is made, or the alloc size needed is too big, we move to the slow path in which we call regular ucc_malloc.
