### PR TITLE
UCC/DPU client WIP

### DIFF
--- a/config/m4/dpu.m4
+++ b/config/m4/dpu.m4
@@ -1,0 +1,17 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+AC_DEFUN([CHECK_DPU],[
+AS_IF([test "x$dpu_checked" != "xyes"],[
+    dpu_happy="no"
+    
+    AC_ARG_WITH([dpu],
+            AC_HELP_STRING([--with-dpu=yes/no], [Enable/Disable DPU team]),
+            [AS_IF([test "x$with_dpu" != "xno"], dpu_happy="yes", dpu_happy="no")],
+            [dpu_happy="no"])
+    AM_CONDITIONAL([HAVE_DPU], [test "x$dpu_happy" != xno])
+    AC_MSG_RESULT([DPU support: $dpu_happy])
+])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_UCX], [false])
      AM_CONDITIONAL([HAVE_CUDA], [false])
      AM_CONDITIONAL([HAVE_NCCL], [false])
+     AM_CONDITIONAL([HAVE_DPU], [false])
      AM_CONDITIONAL([HAVE_MPI], [false])
      AM_CONDITIONAL([HAVE_MPIRUN], [false])
      AM_CONDITIONAL([HAVE_MPICC], [false])
@@ -155,6 +156,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/ucx.m4])
      m4_include([config/m4/cuda.m4])
      m4_include([config/m4/nccl.m4])
+     m4_include([config/m4/dpu.m4])
      m4_include([config/m4/mpi.m4])
      m4_include([config/m4/configure.m4])
      m4_include([test/gtest/configure.m4])
@@ -182,6 +184,12 @@ AS_IF([test "x$with_docs_only" = xyes],
      if test $nccl_happy = "yes"; then
          tl_modules="${tl_modules}:nccl"
      fi
+
+     CHECK_DPU
+     AC_MSG_RESULT([NCCL support: $dpu_happy])
+     if test $dpu_happy = "yes"; then
+         tl_modules="${tl_modules}:dpu"
+     fi
     ]) # Docs only
 
 CFLAGS="$CFLAGS -std=gnu11"
@@ -196,6 +204,7 @@ AC_CONFIG_FILES([
                  src/components/cl/basic/Makefile
                  src/components/tl/ucp/Makefile
                  src/components/tl/nccl/Makefile
+                 src/components/tl/dpu/Makefile
                  src/components/mc/cpu/Makefile
                  src/components/mc/cuda/Makefile
                  src/components/mc/cuda/kernel/Makefile

--- a/contrib/dpu_daemon/Makefile
+++ b/contrib/dpu_daemon/Makefile
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2020 Mellanox Technologies.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+CFLAGS = -I$(UCC_DIR)/include -I$(UCX_DIR)/include
+LDFLAGS = -L$(UCC_DIR)/lib $(UCC_DIR)/lib/libucc.so $(UCX_DIR)/lib/libucs.so $(UCX_DIR)/lib/libucp.so -Wl,-rpath -Wl,$(UCC_DIR)/lib -Wl,-rpath -Wl,$(UCC_DIR)/lib
+
+rel:
+	mpicc -O3 -DNDEBUG -std=c11 $(CFLAGS) -o dpu_server dpu_server.c host_channel.c server_ucc.c $(LDFLAGS)
+
+dbg:
+	mpicc -O0 -g -std=c11 $(CFLAGS) -o dpu_server dpu_server.c host_channel.c server_ucc.c $(LDFLAGS)
+
+clean:
+	rm -f dpu_server

--- a/contrib/dpu_daemon/dpu_server.c
+++ b/contrib/dpu_daemon/dpu_server.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include "server_ucc.h"
+#include "host_channel.h"
+#include "ucc/api/ucc.h"
+
+#define CORES 8
+#define MAX_THREADS 128
+typedef struct {
+    pthread_t id;
+    int idx, nthreads;
+    dpu_ucc_comm_t comm;
+    dpu_hc_t *hc;
+    unsigned int itt;
+} thread_ctx_t;
+
+/* thread accisble data - split reader/writer */
+typedef struct {
+    volatile unsigned long g_itt;  /* first cache line */
+    volatile unsigned long pad[3]; /* pad to 64bytes */
+    volatile unsigned long l_itt;  /* second cache line */
+    volatile unsigned long pad2[3]; /* pad to 64 bytes */
+} thread_sync_t;
+
+static thread_sync_t *thread_sync = NULL;
+
+void *dpu_worker(void *arg)
+{
+    thread_ctx_t *ctx = (thread_ctx_t*)arg;
+    int places = CORES/ctx->nthreads;
+    int i = 0, j = 0;
+
+    ucc_coll_req_h request;
+    cpu_set_t cpuset;
+    pthread_t thread;
+
+    thread = pthread_self();
+
+    CPU_ZERO(&cpuset);
+    
+	for (i = 0; i < places; i++) {
+		CPU_SET((ctx->idx*places)+i, &cpuset);
+	}
+
+    i = pthread_setaffinity_np(thread, sizeof(cpuset), &cpuset);
+
+    while(1) {
+        ctx->itt++;
+        if (ctx->idx > 0) {
+            while (thread_sync[ctx->idx].g_itt < ctx->itt) {
+                /* busy wait */
+            }
+        }
+        else {
+            dpu_hc_wait(ctx->hc, ctx->itt);
+            for (i = 0; i < ctx->nthreads; i++) {
+                thread_sync[i].g_itt++;
+            }
+        }
+    
+        int offset, block;
+        int count = dpu_hc_get_count_total(ctx->hc);
+        int ready = 0;
+        int dt_size = dpu_ucc_dt_size(dpu_hc_get_dtype(ctx->hc));
+
+        block = count / ctx->nthreads;
+        offset = block * ctx->idx;
+        if(ctx->idx < (count % ctx->nthreads)) {
+            offset += ctx->idx;
+            block++;
+        } else {
+            offset += (count % ctx->nthreads);
+        }
+        
+        ucc_coll_args_t coll = {
+            .mask      = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS,
+            .coll_type = UCC_COLL_TYPE_ALLREDUCE,
+            .src.info = {
+                .buffer   = ctx->hc->mem_segs.put.base + offset * dt_size,
+                .count    = block * dt_size,
+                .datatype = dpu_hc_get_dtype(ctx->hc),
+                .mem_type = UCC_MEMORY_TYPE_HOST,
+            },
+            .dst.info = {
+                .buffer     = ctx->hc->mem_segs.get.base + offset * dt_size,
+                .count      = block * dt_size,
+                .datatype   = dpu_hc_get_dtype(ctx->hc),
+                .mem_type = UCC_MEMORY_TYPE_HOST,
+            },
+            .reduce = {
+                .predefined_op = dpu_hc_get_op(ctx->hc),
+            },
+        };
+
+        if (coll.reduce.predefined_op == UCC_OP_USERDEFINED &&
+			coll.src.info.datatype    == UCC_DT_USERDEFINED) {
+            break;
+        }
+
+        UCC_CHECK(ucc_collective_init(&coll, &request, ctx->comm.team));
+        UCC_CHECK(ucc_collective_post(request));
+        while (UCC_OK != ucc_collective_test(request)) {
+            ucc_context_progress(ctx->comm.ctx);
+        }
+        UCC_CHECK(ucc_collective_finalize(request));
+
+        thread_sync[ctx->idx].l_itt++;
+
+        if (ctx->idx == 0) {
+            while (ready != ctx->nthreads) {
+                ready = 0;
+                for (i = 0; i < ctx->nthreads; i++) {
+                    if (thread_sync[i].l_itt == ctx->itt) {
+                        ready++;
+                    }
+                    else {
+                        break;
+                    }
+                }
+            }
+    
+            dpu_hc_reply(ctx->hc, ctx->itt);
+        }
+    }
+
+//     fprintf(stderr, "ctx->itt = %u\n", ctx->itt);
+
+    return NULL;
+}
+
+int main(int argc, char **argv)
+{
+//     fprintf (stderr, "%s\n", __FUNCTION__);
+//     sleep(20);
+
+    int nthreads = 0, i;
+    thread_ctx_t *tctx_pool = NULL;
+    dpu_ucc_global_t ucc_glob;
+    dpu_hc_t hc_b, *hc = &hc_b;
+
+    if (argc < 2 ) {
+        printf("Need thread # as an argument\n");
+        return 1;
+    }
+    nthreads = atoi(argv[1]);
+    if (MAX_THREADS < nthreads || 0 >= nthreads) {
+        printf("ERROR: bad thread #: %d\n", nthreads);
+        return 1;
+    }
+    printf("DPU daemon: Running with %d threads\n", nthreads);
+    tctx_pool = calloc(nthreads, sizeof(*tctx_pool));
+    UCC_CHECK(dpu_ucc_init(argc, argv, &ucc_glob));
+
+//     thread_sync = calloc(nthreads, sizeof(*thread_sync));
+    thread_sync = aligned_alloc(64, nthreads * sizeof(*thread_sync));
+    memset(thread_sync, 0, nthreads * sizeof(*thread_sync));
+
+    dpu_hc_init(hc);
+    dpu_hc_accept(hc);
+
+    for(i = 0; i < nthreads; i++) {
+//         printf("Thread %d spawned!\n", i);
+        UCC_CHECK(dpu_ucc_alloc_team(&ucc_glob, &tctx_pool[i].comm));
+        tctx_pool[i].idx = i;
+        tctx_pool[i].nthreads = nthreads;
+        tctx_pool[i].hc       = hc;
+        tctx_pool[i].itt = 0;
+
+        if (i < nthreads - 1) {
+            pthread_create(&tctx_pool[i].id, NULL, dpu_worker,
+                           (void*)&tctx_pool[i]);
+        }
+    }
+
+    /* The final DPU worker is executed in this context */
+    dpu_worker((void*)&tctx_pool[i-1]);
+
+    for(i = 0; i < nthreads; i++) {
+        if (i < nthreads - 1) {
+            pthread_join(tctx_pool[i].id, NULL);
+        }
+        dpu_ucc_free_team(&ucc_glob, &tctx_pool[i].comm);
+//         printf("Thread %d joined!\n", i);
+    }
+
+    dpu_ucc_finalize(&ucc_glob);
+    return 0;
+}

--- a/contrib/dpu_daemon/host_channel.c
+++ b/contrib/dpu_daemon/host_channel.c
@@ -1,0 +1,675 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "host_channel.h"
+#include <unistd.h>
+#include <ucc/api/ucc.h>
+
+size_t dpu_ucc_dt_sizes[UCC_DT_USERDEFINED] = {
+    [UCC_DT_INT8]    = 1,
+    [UCC_DT_UINT8]   = 1,
+    [UCC_DT_INT16]   = 2,
+    [UCC_DT_UINT16]  = 2,
+    [UCC_DT_FLOAT16] = 2,
+    [UCC_DT_INT32]   = 4,
+    [UCC_DT_UINT32]  = 4,
+    [UCC_DT_FLOAT32] = 4,
+    [UCC_DT_INT64]   = 8,
+    [UCC_DT_UINT64]  = 8,
+    [UCC_DT_FLOAT64] = 8,
+    [UCC_DT_INT128]  = 16,
+    [UCC_DT_UINT128] = 16,
+};
+
+size_t dpu_ucc_dt_size(ucc_datatype_t dt)
+{
+    if (dt < UCC_DT_USERDEFINED) {
+        return dpu_ucc_dt_sizes[dt];
+    }
+    return 0;
+}
+
+static int _dpu_host_to_ip(dpu_hc_t *hc)
+{
+//     printf ("%s\n", __FUNCTION__);
+    struct hostent *he;
+    struct in_addr **addr_list;
+    int i;
+
+    hc->hname = calloc(1, 100 * sizeof(char));
+    hc->ip = malloc(100 * sizeof(char));
+
+    int ret = gethostname(hc->hname, 100);
+    if (ret) {
+        return 1;
+    }
+
+    if ( (he = gethostbyname( hc->hname ) ) == NULL)
+    {
+        // get the host info
+        herror("gethostbyname");
+        return 1;
+    }
+
+    addr_list = (struct in_addr **) he->h_addr_list;
+    for(i = 0; addr_list[i] != NULL; i++)
+    {
+        //Return the first one;
+        strcpy(hc->ip , inet_ntoa(*addr_list[i]) );
+        return UCC_OK;
+    }
+    return UCC_ERR_NO_MESSAGE;
+}
+
+static int _dpu_listen(dpu_hc_t *hc)
+{
+    struct sockaddr_in serv_addr;
+
+    if(_dpu_host_to_ip(hc)) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    hc->port = DEFAULT_PORT;
+    /* TODO: if envar(port) - replace */
+
+    /* creates an UN-named socket inside the kernel and returns
+     * an integer known as socket descriptor
+     * This function takes domain/family as its first argument.
+     * For Internet family of IPv4 addresses we use AF_INET
+     */
+    hc->listenfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (0 > hc->listenfd) {
+        fprintf(stderr, "socket() failed (%s)\n", strerror(errno));
+        goto err_ip;
+    }
+    memset(&serv_addr, 0, sizeof(serv_addr));
+
+    serv_addr.sin_family = AF_INET;
+    serv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    serv_addr.sin_port = htons(hc->port);
+
+    /* The call to the function "bind()" assigns the details specified
+     * in the structure 『serv_addr' to the socket created in the step above
+     */
+    if (0 > bind(hc->listenfd, (struct sockaddr*)&serv_addr,
+                 sizeof(serv_addr))) {
+        fprintf(stderr, "Failed to bind() (%s)\n", strerror(errno));
+        goto err_sock;
+    }
+
+    /* The call to the function "listen()" with second argument as 10 specifies
+     * maximum number of client connections that server will queue for this listening
+     * socket.
+     */
+    if (0 > listen(hc->listenfd, 10)) {
+        fprintf(stderr, "listen() failed (%s)\n", strerror(errno));
+        goto err_sock;
+    }
+
+    return UCC_OK;
+err_sock:
+    close(hc->listenfd);
+err_ip:
+    free(hc->ip);
+    free(hc->hname);
+    return UCC_ERR_NO_MESSAGE;
+}
+
+static int _dpu_listen_cleanup(dpu_hc_t *hc)
+{
+    close(hc->listenfd);
+    free(hc->ip);
+    free(hc->hname);
+}
+
+static void tag_recv_cb (void *request, ucs_status_t status,
+                         const ucp_tag_recv_info_t *info, void *user_data)
+{
+    dpu_req_t *ctx = user_data;
+    ctx->complete = 1;
+}
+
+static void send_cb(void *request, ucs_status_t status, void *user_data)
+{
+    dpu_req_t *ctx = user_data;
+    ctx->complete = 1;
+}
+
+static void err_cb(void *arg, ucp_ep_h ep, ucs_status_t status)
+{
+    printf ("error handling callback was invoked with status %d (%s)\n",
+            status, ucs_status_string(status));
+}
+
+static int _dpu_ucx_init(dpu_hc_t *hc)
+{
+    ucp_params_t ucp_params;
+    ucs_status_t status;
+    ucp_worker_params_t worker_params;
+    int ret = SUCCESS;
+
+//     printf ("%s\n", __FUNCTION__);
+
+    memset(&ucp_params, 0, sizeof(ucp_params));
+    ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES;
+    ucp_params.features = UCP_FEATURE_TAG |
+                          UCP_FEATURE_RMA;
+/*
+                          UCP_FEATURE_AMO64 |
+                          UCP_FEATURE_AMO32;
+*/
+    status = ucp_init(&ucp_params, NULL, &hc->ucp_ctx);
+    if (status != UCS_OK) {
+        fprintf(stderr, "failed to ucp_init(%s)\n", ucs_status_string(status));
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+
+    memset(&worker_params, 0, sizeof(worker_params));
+    worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+    worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
+
+    status = ucp_worker_create(hc->ucp_ctx, &worker_params, &hc->ucp_worker);
+    if (status != UCS_OK) {
+        fprintf(stderr, "failed to ucp_worker_create (%s)\n", ucs_status_string(status));
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err_cleanup;
+    }
+
+    hc->worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS |
+            UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
+    hc->worker_attr.address_flags = UCP_WORKER_ADDRESS_FLAG_NET_ONLY;
+    status = ucp_worker_query (hc->ucp_worker, &hc->worker_attr);
+    if (UCS_OK != status) {
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err_worker;
+    }
+
+    return ret;
+err_worker:
+    ucp_worker_destroy(hc->ucp_worker);
+err_cleanup:
+    ucp_cleanup(hc->ucp_ctx);
+err:
+    return ret;
+}
+
+static int _dpu_ucx_fini(dpu_hc_t *hc){
+    ucp_worker_release_address(hc->ucp_worker, hc->worker_attr.address);
+    ucp_worker_destroy(hc->ucp_worker);
+    ucp_cleanup(hc->ucp_ctx);
+}
+
+
+static int _dpu_hc_buffer_alloc(dpu_hc_t *hc, dpu_mem_t *mem, size_t size)
+{
+    ucp_mem_map_params_t mem_params;
+    ucp_mem_attr_t mem_attr;
+    ucs_status_t status;
+    int ret = UCC_OK;
+
+    memset(mem, 0, sizeof(*mem));
+    mem->base = calloc(size, sizeof(char));
+    memset(&mem_params, 0, sizeof(ucp_mem_map_params_t));
+
+    mem_params.address = mem->base;
+    mem_params.length = size;
+
+    mem_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_FLAGS |
+                       UCP_MEM_MAP_PARAM_FIELD_LENGTH |
+                       UCP_MEM_MAP_PARAM_FIELD_ADDRESS;
+
+    status = ucp_mem_map(hc->ucp_ctx, &mem_params, &mem->memh);
+    if (status != UCS_OK) {
+        fprintf(stderr, "failed to ucp_mem_map (%s)\n", ucs_status_string(status));
+        ret = UCC_ERR_NO_MESSAGE;
+        goto out;
+    }
+
+    mem_attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS |
+                          UCP_MEM_ATTR_FIELD_LENGTH;
+
+    status = ucp_mem_query(mem->memh, &mem_attr);
+    if (status != UCS_OK) {
+        fprintf(stderr, "failed to ucp_mem_query (%s)\n", ucs_status_string(status));
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err_map;
+    }
+    assert(mem_attr.length == size);
+    assert(mem_attr.address == mem->base);
+
+    status = ucp_rkey_pack(hc->ucp_ctx, mem->memh,
+                           &mem->rkey.rkey_addr,
+                           &mem->rkey.rkey_addr_len);
+    if (status != UCS_OK) {
+        fprintf(stderr, "failed to ucp_rkey_pack (%s)\n", ucs_status_string(status));
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err_map;
+    }
+    
+    goto out;
+err_map:
+    ucp_mem_unmap(hc->ucp_ctx, mem->memh);
+err_calloc:
+    free(mem->base);
+out:
+    return ret;
+}
+
+static int _dpu_hc_buffer_free(dpu_hc_t *hc, dpu_mem_t *mem)
+{
+    ucp_rkey_buffer_release(mem->rkey.rkey_addr);
+    ucp_mem_unmap(hc->ucp_ctx, mem->memh);
+    free(mem->base);
+}
+
+
+static size_t _dpu_set_buffer_size(char *_env)
+{
+    char *env = getenv(_env);
+    return env != NULL ? atol(env) : DATA_BUFFER_SIZE;
+}
+ 
+int dpu_hc_init(dpu_hc_t *hc)
+{
+    int ret = UCC_OK;
+
+    memset(hc, 0, sizeof(*hc));
+
+    /* Start listening */
+    ret = _dpu_listen(hc);
+    if (ret) {
+        goto out;
+    }
+    
+    /* init ucx objects */
+    ret = _dpu_ucx_init(hc);
+    if (ret) {
+        goto err_ip;
+    }
+
+    /* set buffer size */
+    hc->data_buffer_size = _dpu_set_buffer_size("DPU_DATA_BUFFER_SIZE");
+
+    ret = _dpu_hc_buffer_alloc(hc, &hc->mem_segs.put, DATA_BUFFER_SIZE);
+    if (ret) {
+        goto err_ucx;
+    }
+    ret = _dpu_hc_buffer_alloc(hc, &hc->mem_segs.get, DATA_BUFFER_SIZE);
+    if (ret) {
+        goto err_put;
+    }
+    ret = _dpu_hc_buffer_alloc(hc, &hc->mem_segs.sync, sizeof(dpu_sync_t));
+    if (ret) {
+        goto err_get;
+    }
+
+    goto out;
+err_get:
+    _dpu_hc_buffer_free(hc, &hc->mem_segs.get);
+err_put:
+    _dpu_hc_buffer_free(hc, &hc->mem_segs.put);
+err_ucx:
+    _dpu_ucx_fini(hc);
+err_ip:
+    _dpu_listen_cleanup(hc);
+out:
+    return ret;
+}
+
+static ucs_status_t _dpu_ep_create (dpu_hc_t *hc, void *rem_worker_addr)
+{
+    ucs_status_t status;
+    ucp_ep_params_t ep_params;
+
+    ep_params.field_mask    = UCP_EP_PARAM_FIELD_FLAGS |
+                              UCP_EP_PARAM_FIELD_REMOTE_ADDRESS |
+                              UCP_EP_PARAM_FIELD_ERR_HANDLER |
+                              UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
+    ep_params.err_mode		= UCP_ERR_HANDLING_MODE_PEER;
+    ep_params.err_handler.cb    = err_cb;
+    ep_params.address = rem_worker_addr;
+
+    status = ucp_ep_create(hc->ucp_worker, &ep_params, &hc->host_ep);
+    if (status != UCS_OK) {
+        fprintf(stderr, "failed to create an endpoint on the dpu (%s)\n",
+                ucs_status_string(status));
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    return UCC_OK;
+}
+
+static int _dpu_ep_close(dpu_hc_t *hc)
+{
+    ucp_request_param_t param;
+    ucs_status_t status;
+    void *close_req;
+    int ret = UCC_OK;
+
+    param.op_attr_mask  = UCP_OP_ATTR_FIELD_FLAGS;
+    param.flags         = UCP_EP_CLOSE_FLAG_FORCE;
+    close_req           = ucp_ep_close_nbx(hc->host_ep, &param);
+    if (UCS_PTR_IS_PTR(close_req)) {
+        do {
+            ucp_worker_progress(hc->ucp_worker);
+            status = ucp_request_check_status(close_req);
+        } while (status == UCS_INPROGRESS);
+
+        ucp_request_free(close_req);
+    } else if (UCS_PTR_STATUS(close_req) != UCS_OK) {
+        fprintf(stderr, "failed to close ep %p\n", (void *)hc->host_ep);
+        ret = UCC_ERR_NO_MESSAGE;
+    }
+    return ret;
+}
+
+
+static ucs_status_t _dpu_request_wait(ucp_worker_h ucp_worker, void *request,
+                                      dpu_req_t *req_ctx)
+{
+//     printf ("%s\n", __FUNCTION__);
+    ucs_status_t status;
+
+    /* immediate completion */
+    if (request == NULL) {
+        return UCS_OK;
+    }
+
+    if (UCS_PTR_IS_ERR(request)) {
+        return UCS_PTR_STATUS(request);
+    }
+
+    while (req_ctx->complete == 0) {
+//         printf ("ucp_worker_progress()\n");
+//         sleep(1);
+        ucp_worker_progress(ucp_worker);
+    }
+    status = ucp_request_check_status(request);
+
+    ucp_request_free(request);
+
+    return status;
+}
+
+static int _dpu_request_finalize (ucp_worker_h ucp_worker, dpu_req_t *request,
+                                  dpu_req_t *req_ctx)
+{
+//     printf ("%s\n", __FUNCTION__);
+    ucs_status_t status;
+    int ret = SUCCESS;
+
+    status = _dpu_request_wait(ucp_worker, request, req_ctx);
+    if (status != UCS_OK) {
+        fprintf (stderr, "unable to recv UCX message (%s)\n", ucs_status_string(status));
+        return -1;
+    }
+
+    /* reset req_ctx */
+    req_ctx->complete = 0;
+
+    return ret;
+}
+
+static int _dpu_rmem_setup(dpu_hc_t *hc)
+{
+    int i, ret = SUCCESS;
+    ucp_request_param_t param;
+    void *request;
+    dpu_req_t req_ctx;
+    size_t rkeys_total_len = 0, rkey_lens[3];
+    uint64_t seg_base_addrs[3];
+    char *rkeys = NULL, *rkey_p;
+
+    req_ctx.complete = 0;
+
+    /* XXX */
+//     ucp_worker_print_info(hc->ucp_worker, stderr);
+
+    /* recv rkey len & address */    /* recv rkey len & address */
+    param.op_attr_mask  = UCP_OP_ATTR_FIELD_CALLBACK |
+                          UCP_OP_ATTR_FIELD_USER_DATA;
+    param.user_data     = &req_ctx;
+    param.cb.recv       = tag_recv_cb;
+    param.op_attr_mask  = UCP_OP_ATTR_FIELD_CALLBACK |
+                          UCP_OP_ATTR_FIELD_USER_DATA;
+    param.user_data     = &req_ctx;
+    param.cb.recv       = tag_recv_cb;
+    request = ucp_tag_recv_nbx(hc->ucp_worker, &hc->sync_addr, sizeof(uint64_t),
+                                      EXCHANGE_ADDR_TAG, (uint64_t)-1, &param);
+    ret = _dpu_request_finalize(hc->ucp_worker, request, &req_ctx);
+    if (ret) {
+        goto err;
+    }
+
+    request = ucp_tag_recv_nbx(hc->ucp_worker, &rkey_lens[0], sizeof(size_t),
+                                      EXCHANGE_LENGTH_TAG, (uint64_t)-1, &param);
+    ret = _dpu_request_finalize(hc->ucp_worker, request, &req_ctx);
+    if (ret) {
+        goto err;
+    }
+
+    rkeys = calloc(1, rkey_lens[0]);
+    request = ucp_tag_recv_nbx(hc->ucp_worker, rkeys, rkey_lens[0], EXCHANGE_RKEY_TAG,
+                               (uint64_t)-1, &param);
+
+    ret = _dpu_request_finalize(hc->ucp_worker, request, &req_ctx);
+    if (ret) {
+        goto err;
+    }
+
+    ucs_status_t status = ucp_ep_rkey_unpack(hc->host_ep, rkeys, &hc->sync_rkey);
+    if (UCS_OK != status) {
+        fprintf(stderr, "failed to ucp_ep_rkey_unpack (%s)\n", ucs_status_string(status));
+    }
+    free(rkeys);
+
+    /* send rkey lens & addresses */
+    param.cb.send = send_cb;
+   
+    /* compute total len */
+    for (i = 0; i < 3; i++) {
+        rkey_lens[i] = hc->mem_segs_array[i].rkey.rkey_addr_len;
+        seg_base_addrs[i] = (uint64_t)hc->mem_segs_array[i].base;
+        rkeys_total_len += rkey_lens[i];
+//         fprintf (stdout, "rkey_total_len = %lu, rkey_lens[i] = %lu\n",
+//                  rkeys_total_len, rkey_lens[i]);
+    }
+
+    rkey_p = rkeys = calloc(1, rkeys_total_len);
+
+    /* send rkey_lens */
+    request = ucp_tag_send_nbx(hc->host_ep, rkey_lens, 3*sizeof(size_t),
+                                     EXCHANGE_LENGTH_TAG, &param);
+    ret = _dpu_request_finalize(hc->ucp_worker, request, &req_ctx);
+    if (ret) {
+        goto err;
+    }
+
+    request = ucp_tag_send_nbx(hc->host_ep, seg_base_addrs, 3*sizeof(uint64_t),
+                                     EXCHANGE_ADDR_TAG, &param);
+    ret = _dpu_request_finalize(hc->ucp_worker, request, &req_ctx);
+    if (ret) {
+        goto err;
+    }
+
+    /* send rkeys */
+    for (i = 0; i < 3; i++) {
+        memcpy(rkey_p, hc->mem_segs_array[i].rkey.rkey_addr, rkey_lens[i]);
+        rkey_p+=rkey_lens[i];
+    }
+
+    request = ucp_tag_send_nbx(hc->host_ep, rkeys, rkeys_total_len, EXCHANGE_RKEY_TAG, &param);
+    ret = _dpu_request_finalize(hc->ucp_worker, request, &req_ctx);
+    if (ret) {
+        goto err;
+    }
+
+    return SUCCESS;
+
+err:
+    printf ("%s ERROR!\n", __FUNCTION__);
+    return ret;
+}
+
+
+int dpu_hc_accept(dpu_hc_t *hc)
+{
+    int ret;
+    ucs_status_t status;
+    ucp_rkey_h client_rkey_h;
+    void *rem_worker_addr;
+    size_t rem_worker_addr_len;
+
+    /* In the call to accept(), the server is put to sleep and when for an incoming
+         * client request, the three way TCP handshake* is complete, the function accept()
+         * wakes up and returns the socket descriptor representing the client socket.
+         */
+//     fprintf (stderr, "Waiting for connection...\n");
+    hc->connfd = accept(hc->listenfd, (struct sockaddr*)NULL, NULL);
+    if (-1 == hc->connfd) {
+        fprintf(stderr, "Error in accept (%s)!\n", strerror(errno));
+    }
+//     fprintf (stderr, "Connection established\n");
+
+    ret = send(hc->connfd, &hc->worker_attr.address_length, sizeof(size_t), 0);
+    if (-1 == ret) {
+        fprintf(stderr, "send worker_address_length failed!\n");
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+
+    ret = send(hc->connfd, hc->worker_attr.address,
+               hc->worker_attr.address_length, 0);
+    if (-1 == ret) {
+        fprintf(stderr, "send worker_address failed!\n");
+        fprintf(stderr, "mmap_buffer failed!\n");
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+
+    ret = recv(hc->connfd, &rem_worker_addr_len, sizeof(size_t), MSG_WAITALL);
+    if (-1 == ret) {
+        fprintf(stderr, "recv address_length failed!\n");
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+
+    rem_worker_addr = calloc(1, rem_worker_addr_len);
+
+    ret = recv(hc->connfd, rem_worker_addr, rem_worker_addr_len, MSG_WAITALL);
+    if (-1 == ret) {
+        fprintf(stderr, "recv worker address failed!\n");
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+
+    if (ret = _dpu_ep_create(hc, rem_worker_addr)) {
+        fprintf(stderr, "dpu_create_ep failed!\n");
+        ret = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+
+    ret = _dpu_rmem_setup(hc);
+    if (ret) {
+        fprintf(stderr, "exchange data failed!\n");
+        goto err;
+    }
+
+    return ret;
+
+err:
+    close(hc->connfd);
+    return ret;
+}
+
+int dpu_hc_wait(dpu_hc_t *hc, unsigned int cntr)
+{
+    dpu_sync_t *lsync = (dpu_sync_t*)hc->mem_segs.sync.base;
+    
+    while( lsync->coll_id < cntr) {
+        ucp_worker_progress(hc->ucp_worker);
+    }
+    return 0;
+}
+
+ucc_datatype_t dpu_hc_get_dtype(dpu_hc_t *hc)
+{
+    dpu_sync_t *lsync = (dpu_sync_t*)hc->mem_segs.sync.base;
+    return lsync->dtype;
+}
+
+ucc_reduction_op_t dpu_hc_get_op(dpu_hc_t *hc)
+{
+    dpu_sync_t *lsync = (dpu_sync_t*)hc->mem_segs.sync.base;
+    return lsync->op;
+}
+
+unsigned int dpu_hc_get_count_total(dpu_hc_t *hc)
+{
+    dpu_sync_t *lsync = (dpu_sync_t*)hc->mem_segs.sync.base;
+    return lsync->count_total;
+}
+
+unsigned int dpu_hc_get_count_in(dpu_hc_t *hc)
+{
+    dpu_sync_t *lsync = (dpu_sync_t*)hc->mem_segs.sync.base;
+    return lsync->count_in;
+}
+
+int dpu_hc_reply(dpu_hc_t *hc, unsigned int cntr)
+{
+    dpu_sync_t *lsync = (dpu_sync_t*)hc->mem_segs.sync.base;
+    uint32_t rsync;
+    ucp_request_param_t req_param;
+    void *request;
+    dpu_req_t req_ctx = { 0 };
+    int ret;
+
+    req_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+            UCP_OP_ATTR_FIELD_DATATYPE |
+            UCP_OP_ATTR_FIELD_USER_DATA;
+    req_param.datatype     = ucp_dt_make_contig(1);
+    req_param.cb.send      = send_cb;
+    req_param.user_data     = &req_ctx;
+
+//     static unsigned int cntr = 1;
+//     while( lsync->itt < cntr) {
+//         ucp_worker_progress(hc->ucp_worker);
+//     }
+
+    request = ucp_put_nbx(hc->host_ep, &cntr, sizeof(cntr),
+                              hc->sync_addr, hc->sync_rkey,
+                              &req_param);
+    ret = _dpu_request_finalize(hc->ucp_worker, request, &req_ctx);
+    if (ret) {
+        return -1;
+    }
+//     cntr++;
+    return 0;
+}
+
+#if 0
+{
+/* Work loop */
+/* TEST
+ * **** */
+
+free(worker_attr.address);
+free(rem_worker_addr);
+close(connfd);
+
+ep_close(ucp_worker, dpu_ep);
+
+
+printf ("END %s\n", __FUNCTION__);
+
+return ret;
+
+err:
+return ret;
+
+}
+#endif

--- a/contrib/dpu_daemon/host_channel.c
+++ b/contrib/dpu_daemon/host_channel.c
@@ -595,6 +595,12 @@ int dpu_hc_wait(dpu_hc_t *hc, unsigned int cntr)
     return 0;
 }
 
+ucc_coll_type_t dpu_hc_get_coll_type(dpu_hc_t *hc)
+{
+    dpu_sync_t *lsync = (dpu_sync_t*)hc->mem_segs.sync.base;
+    return lsync->coll_type;
+}
+
 ucc_datatype_t dpu_hc_get_dtype(dpu_hc_t *hc)
 {
     dpu_sync_t *lsync = (dpu_sync_t*)hc->mem_segs.sync.base;

--- a/contrib/dpu_daemon/host_channel.h
+++ b/contrib/dpu_daemon/host_channel.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef HOST_CHANNEL_H
+#define HOST_CHANNEL_H
+
+// #define _DEFAULT_SOURCE
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+#include <ucc/api/ucc.h>
+#include <ucp/api/ucp.h>
+
+#define IP_STRING_LEN       50
+#define PORT_STRING_LEN     8
+#define SUCCESS             0
+#define ERROR               1
+#define DEFAULT_PORT        13337
+
+#define DATA_BUFFER_SIZE     (128*1024*1024)
+
+#define EXCHANGE_LENGTH_TAG 1ull
+#define EXCHANGE_RKEY_TAG 2ull
+#define EXCHANGE_ADDR_TAG 3ull
+
+extern size_t dpu_ucc_dt_sizes[UCC_DT_USERDEFINED];
+
+typedef struct dpu_req_s {
+    int complete;
+} dpu_req_t;
+
+/* sync struct type
+ * use it for counter, dtype, ar op, length */
+typedef struct dpu_sync_s {
+    unsigned int        coll_id;
+    ucc_datatype_t      dtype;
+    ucc_reduction_op_t  op;
+    unsigned int        count_total;
+    unsigned int        count_in;
+    ucc_coll_type_t     coll_type;
+} dpu_sync_t;
+
+typedef struct dpu_rkey_s {
+    void *rkey_addr;
+    size_t rkey_addr_len;
+} dpu_rkey_t;
+
+typedef struct dpu_mem_s {
+    void *base;
+    ucp_mem_h memh;
+    dpu_rkey_t rkey;
+} dpu_mem_t;
+
+typedef struct dpu_mem_segs_s {
+    dpu_mem_t sync;
+    dpu_mem_t put;
+    dpu_mem_t get;
+} dpu_mem_segs_t;
+
+typedef struct dpu_hc_s {
+    /* TCP/IP stuff */
+    char *hname;
+    char *ip;
+    int connfd, listenfd;
+    uint16_t port;
+    /* Local UCX stuff */
+    ucp_context_h ucp_ctx;
+    ucp_worker_h ucp_worker;
+    ucp_worker_attr_t worker_attr;
+    union {
+        dpu_mem_segs_t mem_segs;
+        dpu_mem_t mem_segs_array[3];
+    };
+    /* Remote UCX stuff */
+    ucp_ep_h host_ep;
+    uint64_t sync_addr;
+    ucp_rkey_h sync_rkey;
+
+    /* bufer size*/
+    size_t data_buffer_size;
+} dpu_hc_t;
+
+int dpu_hc_init(dpu_hc_t *dpu_hc);
+int dpu_hc_accept(dpu_hc_t *hc);
+int dpu_hc_reply(dpu_hc_t *hc, unsigned int itt);
+int dpu_hc_wait(dpu_hc_t *hc, unsigned int itt);
+unsigned int        dpu_hc_get_count_total(dpu_hc_t *hc);
+unsigned int        dpu_hc_get_count_in(dpu_hc_t *hc);
+ucc_datatype_t      dpu_hc_get_dtype(dpu_hc_t *hc);
+ucc_reduction_op_t  dpu_hc_get_op(dpu_hc_t *hc);
+
+size_t dpu_ucc_dt_size(ucc_datatype_t dt);
+
+#endif

--- a/contrib/dpu_daemon/host_channel.h
+++ b/contrib/dpu_daemon/host_channel.h
@@ -97,6 +97,7 @@ int dpu_hc_reply(dpu_hc_t *hc, unsigned int itt);
 int dpu_hc_wait(dpu_hc_t *hc, unsigned int itt);
 unsigned int        dpu_hc_get_count_total(dpu_hc_t *hc);
 unsigned int        dpu_hc_get_count_in(dpu_hc_t *hc);
+ucc_coll_type_t     dpu_hc_get_coll_type(dpu_hc_t *hc);
 ucc_datatype_t      dpu_hc_get_dtype(dpu_hc_t *hc);
 ucc_reduction_op_t  dpu_hc_get_op(dpu_hc_t *hc);
 

--- a/contrib/dpu_daemon/server_ucc.c
+++ b/contrib/dpu_daemon/server_ucc.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "server_ucc.h"
+#include <assert.h>
+
+// typedef struct ucc_test_oob_allgather_req {
+//     ucc_ep_range_t range;
+//     void *sbuf;
+//     void *rbuf;
+//     void *oob_coll_ctx;
+//     int my_rank;
+//     size_t msglen;
+//     int iter;
+//     MPI_Request reqs[2];
+// } ucc_test_oob_allgather_req_t;
+
+static ucc_status_t oob_allgather_test(void *req)
+{
+    MPI_Request request = (MPI_Request)req;
+    int         completed;
+    MPI_Test(&request, &completed, MPI_STATUS_IGNORE);
+    return completed ? UCC_OK : UCC_INPROGRESS;
+}
+
+static ucc_status_t oob_allgather_free(void *req)
+{
+    return UCC_OK;
+}
+
+static ucc_status_t oob_allgather(void *sbuf, void *rbuf, size_t msglen,
+                                   void *oob_coll_ctx, void **req)
+{
+    MPI_Comm    comm = (MPI_Comm)oob_coll_ctx;
+    MPI_Request request;
+    MPI_Iallgather(sbuf, msglen, MPI_BYTE, rbuf, msglen, MPI_BYTE, comm,
+                   &request);
+    *req = (void *)request;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_mpi_create_team_nb(dpu_ucc_comm_t *comm)
+{
+    ucc_status_t status = UCC_OK;
+    /* Create UCC TEAM for comm world */
+    ucc_team_params_t team_params = {
+        .mask   = UCC_TEAM_PARAM_FIELD_EP |
+                  UCC_TEAM_PARAM_FIELD_EP_RANGE |
+                  UCC_TEAM_PARAM_FIELD_OOB,
+        .ep     = comm->g->rank,
+        .ep_range = UCC_COLLECTIVE_EP_RANGE_CONTIG,
+        .oob   = {
+            .allgather      = oob_allgather,
+            .req_test       = oob_allgather_test,
+            .req_free       = oob_allgather_free,
+            .coll_info      = (void*)MPI_COMM_WORLD,
+            .participants   = comm->g->size
+        }
+    };
+
+    status = ucc_team_create_post(&comm->ctx, 1, &team_params, &comm->team);
+
+    return status;
+}
+
+ucc_status_t ucc_mpi_create_team(dpu_ucc_comm_t *comm) {
+    ucc_status_t status;
+    
+    status = ucc_mpi_create_team_nb(comm);
+    while (UCC_INPROGRESS == (status = ucc_team_create_test(comm->team))) {
+    };
+    
+    return status;
+}
+
+int dpu_ucc_init(int argc, char **argv, dpu_ucc_global_t *g)
+{
+    ucc_status_t status;
+    char *var;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &g->rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &g->size);
+
+    UCCCHECK_GOTO(ucc_lib_config_read("DPU_DAEMON", NULL, &g->lib_config),
+                    exit_err, status);
+
+    ucc_lib_params_t lib_params = {
+        .mask = UCC_LIB_PARAM_FIELD_THREAD_MODE |
+                UCC_LIB_PARAM_FIELD_COLL_TYPES,
+        .thread_mode = UCC_THREAD_SINGLE,
+                /* TODO: support more collectives */
+        .coll_types  = UCC_COLL_TYPE_ALLREDUCE,
+    };
+
+    UCCCHECK_GOTO(ucc_init(&lib_params, g->lib_config, &g->lib),
+                    free_lib_config, status);
+
+free_lib_config:
+    ucc_lib_config_release(g->lib_config);
+exit_err:
+    return status;
+}
+
+int dpu_ucc_alloc_team(dpu_ucc_global_t *g, dpu_ucc_comm_t *comm)
+{
+    ucc_status_t status = UCC_OK;
+
+    /* Init ucc context for a specified UCC_TEST_TLS */
+    ucc_context_params_t ctx_params = {
+        .mask   = UCC_CONTEXT_PARAM_FIELD_TYPE |
+                  UCC_CONTEXT_PARAM_FIELD_OOB,
+        .type   = UCC_CONTEXT_SHARED,
+        .oob = {
+            .allgather    = oob_allgather,
+            .req_test     = oob_allgather_test,
+            .req_free     = oob_allgather_free,
+            .coll_info = (void*)MPI_COMM_WORLD,
+            .participants = g->size
+        },
+    };
+    ucc_context_config_h ctx_config;
+    UCCCHECK_GOTO(ucc_context_config_read(g->lib, NULL, &ctx_config), free_ctx_config, status);
+    UCCCHECK_GOTO(ucc_context_create(g->lib, &ctx_params, ctx_config, &comm->ctx), free_ctx, status);
+
+    comm->g = g;
+    UCCCHECK_GOTO(ucc_mpi_create_team(comm), free_ctx, status);
+
+    return status;
+free_ctx:
+    ucc_context_destroy(comm->ctx);
+free_ctx_config:
+    ucc_context_config_release(ctx_config);
+
+    return status;
+}
+
+int dpu_ucc_free_team(dpu_ucc_global_t *g, dpu_ucc_comm_t *team)
+{
+    ucc_team_destroy(team->team);
+    ucc_context_destroy(team->ctx);
+}
+
+void dpu_ucc_finalize(dpu_ucc_global_t *g) {
+    ucc_finalize(g->lib);
+    MPI_Finalize();
+}
+
+void dpu_ucc_progress(dpu_ucc_comm_t *comm)
+{
+    ucc_context_progress(comm->ctx);
+}

--- a/contrib/dpu_daemon/server_ucc.h
+++ b/contrib/dpu_daemon/server_ucc.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef TEST_MPI_H
+#define TEST_MPI_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <mpi.h>
+
+#include <ucc/api/ucc.h>
+
+#define STR(x) #x
+
+#define UCC_CHECK(_call) if (UCC_OK != (_call)) {              \
+        fprintf(stderr, "*** UCC TEST FAIL: %s\n", STR(_call)); \
+        MPI_Abort(MPI_COMM_WORLD, -1);                           \
+    }
+
+#define UCCCHECK_GOTO(_call, _label, _status)                                  \
+    do {                                                                       \
+        _status = (_call);                                                     \
+        if (UCC_OK != _status) {                                               \
+            fprintf(stderr, "UCC DPU DAEMON error: %s\n", STR(_call));         \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
+
+typedef struct {
+    ucc_team_h          ucc_world_team;
+    ucc_lib_h           lib;
+    ucc_lib_config_h    lib_config;
+    int rank;
+    int size;
+} dpu_ucc_global_t;
+
+typedef struct {
+    dpu_ucc_global_t *g;
+    ucc_context_h ctx;
+    ucc_team_h team;
+} dpu_ucc_comm_t;
+
+int dpu_ucc_init(int argc, char **argv, dpu_ucc_global_t *g);
+int dpu_ucc_alloc_team(dpu_ucc_global_t *g, dpu_ucc_comm_t *team);
+int dpu_ucc_free_team(dpu_ucc_global_t *g, dpu_ucc_comm_t *ctx);
+void dpu_ucc_finalize(dpu_ucc_global_t *g);
+void dpu_ucc_progress(dpu_ucc_comm_t *team);
+
+#endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,6 +18,10 @@ if HAVE_NCCL
 tl_dirs += components/tl/nccl
 endif
 
+if HAVE_DPU
+tl_dirs += components/tl/dpu
+endif
+
 SUBDIRS = . $(cl_dirs) $(tl_dirs) $(mc_dirs)
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =

--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -91,6 +91,7 @@ ucc_status_t ucc_cl_basic_team_destroy(ucc_base_team_t *cl_team)
             status = team->team_create_req->descs[i].status;
         }
     }
+
     ucc_team_multiple_req_free(team->team_create_req);
     ucc_coll_score_free_map(team->score_map);
     ucc_free(team->tl_teams);

--- a/src/components/tl/dpu/Makefile.am
+++ b/src/components/tl/dpu/Makefile.am
@@ -1,0 +1,21 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+
+sources =				\
+	tl_dpu.c			\
+	tl_dpu.h			\
+	tl_dpu_lib.c		\
+	tl_dpu_context.c	\
+	tl_dpu_team.c		\
+	tl_dpu_coll.c		\
+	tl_dpu_coll.h
+
+module_LTLIBRARIES = libucc_tl_dpu.la
+libucc_tl_dpu_la_SOURCES	= $(sources)
+libucc_tl_dpu_la_CPPFLAGS	= $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(UCX_CPPFLAGS) $(DPU_CPPFLAGS) 
+libucc_tl_dpu_la_CFLAGS		= $(BASE_CFLAGS)
+libucc_tl_dpu_la_LDFLAGS	= -version-info $(SOVERSION) --as-needed $(UCX_LDFLAGS) $(DPU_LDFLAGS)
+libucc_tl_dpu_la_LIBADD		= $(UCX_LIBADD) $(DPU_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
+
+include $(top_srcdir)/config/module.am

--- a/src/components/tl/dpu/tl_dpu.c
+++ b/src/components/tl/dpu/tl_dpu.c
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_dpu.h"
+
+ucc_status_t ucc_tl_dpu_get_lib_attr(const ucc_base_lib_t *lib,
+                                     ucc_base_lib_attr_t  *base_attr);
+ucc_status_t ucc_tl_dpu_get_context_attr(const ucc_base_context_t *context,
+                                         ucc_base_ctx_attr_t      *base_attr);
+
+static ucc_config_field_t ucc_tl_dpu_lib_config_table[] = {
+    {   "",
+        "",
+        NULL,
+        ucc_offsetof(ucc_tl_dpu_lib_config_t, super),
+        UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)
+    },
+    {NULL}};
+
+static ucs_config_field_t ucc_tl_dpu_context_config_table[] = {
+    {   "",
+        "",
+        NULL,
+        ucc_offsetof(ucc_tl_dpu_context_config_t, super),
+        UCC_CONFIG_TYPE_TABLE(ucc_tl_context_config_table)
+    },
+
+    {"SERVER_HOSTNAME", "",
+     "Bluefield IP address",
+     ucc_offsetof(ucc_tl_dpu_context_config_t, server_hname),
+     UCC_CONFIG_TYPE_STRING
+    },
+
+    {"SERVER_PORT", "13337",
+     "Bluefield DPU port",
+     ucc_offsetof(ucc_tl_dpu_context_config_t, server_port),
+     UCC_CONFIG_TYPE_UINT
+    },
+
+    {"ENABLE", "0",
+     "Assume server is running on BF",
+     ucc_offsetof(ucc_tl_dpu_context_config_t, use_dpu),
+     UCC_CONFIG_TYPE_UINT
+    },
+
+    {"HOST_DPU_LIST", "",
+     "A host-dpu list used to identify the DPU IP",
+     ucc_offsetof(ucc_tl_dpu_context_config_t, host_dpu_list),
+     UCC_CONFIG_TYPE_STRING
+    },
+    {NULL}};
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_dpu_lib_t, ucc_base_lib_t,
+                          const ucc_base_lib_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_dpu_lib_t, ucc_base_lib_t);
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_dpu_context_t, ucc_base_context_t,
+                          const ucc_base_context_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_dpu_context_t, ucc_base_context_t);
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_dpu_team_t, ucc_base_team_t,
+                          ucc_base_context_t *, const ucc_base_team_params_t *);
+
+ucc_status_t ucc_tl_dpu_team_create_test(ucc_base_team_t *tl_team);
+
+ucc_status_t ucc_tl_dpu_team_destroy(ucc_base_team_t *tl_team);
+
+ucc_status_t ucc_tl_dpu_coll_init(ucc_base_coll_args_t *coll_args,
+                                   ucc_base_team_t *team,
+                                   ucc_coll_task_t **task);
+
+ucc_status_t ucc_tl_dpu_team_get_scores(ucc_base_team_t   *tl_team,
+                                         ucc_coll_score_t **score_p);
+
+UCC_TL_IFACE_DECLARE(dpu, DPU);

--- a/src/components/tl/dpu/tl_dpu.h
+++ b/src/components/tl/dpu/tl_dpu.h
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_DPU_H_
+#define UCC_TL_DPU_H_
+
+#include "components/tl/ucc_tl.h"
+#include "components/tl/ucc_tl_log.h"
+#include <ucp/api/ucp.h>
+
+#ifndef UCC_TL_DPU_DEFAULT_SCORE
+#define UCC_TL_DPU_DEFAULT_SCORE 30
+#endif
+
+#define UCC_TL_DPU_TC_POLL 10
+
+#define UCC_TL_DPU_EXCHANGE_LENGTH_TAG 1ull
+#define UCC_TL_DPU_EXCHANGE_RKEY_TAG 2ull
+#define UCC_TL_DPU_EXCHANGE_ADDR_TAG 3ull
+
+#define MAX_DPU_HOST_NAME 256
+
+typedef enum {
+    UCC_TL_DPU_UCP_REQUEST_ACTIVE,
+    UCC_TL_DPU_UCP_REQUEST_DONE,
+} ucc_tl_dpu_request_status_t;
+
+typedef struct ucc_tl_dpu_request {
+  ucc_tl_dpu_request_status_t status;
+} ucc_tl_dpu_request_t;
+
+typedef struct ucc_tl_dpu_iface {
+    ucc_tl_iface_t super;
+} ucc_tl_dpu_iface_t;
+extern ucc_tl_dpu_iface_t ucc_tl_dpu;
+
+typedef struct ucc_tl_dpu_lib_config {
+    ucc_tl_lib_config_t super;
+} ucc_tl_dpu_lib_config_t;
+
+typedef struct ucc_tl_dpu_context_config {
+    ucc_tl_context_config_t super;
+    uint32_t                use_dpu;
+    uint32_t                server_port;
+    char                    *server_hname;
+    char                    *host_dpu_list;
+} ucc_tl_dpu_context_config_t;
+
+typedef struct ucc_tl_dpu_lib {
+    ucc_tl_lib_t            super;
+    ucc_tl_dpu_lib_config_t cfg;
+} ucc_tl_dpu_lib_t;
+UCC_CLASS_DECLARE(ucc_tl_dpu_lib_t, const ucc_base_lib_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_dpu_context {
+    ucc_tl_context_t            super;
+    ucc_tl_dpu_context_config_t cfg;
+    ucp_context_h               ucp_context;
+    ucp_worker_h                ucp_worker;
+    ucp_ep_h                    ucp_ep;
+} ucc_tl_dpu_context_t;
+UCC_CLASS_DECLARE(ucc_tl_dpu_context_t, const ucc_base_context_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_dpu_connect_s {
+    ucp_mem_map_params_t    mmap_params;
+    void                    *ctrl_seg_rkey_buf;
+    size_t                  ctrl_seg_rkey_buf_size;
+    size_t                  rem_rkeys_lengths[3];
+    void                    *rem_rkeys;
+    uint64_t                rem_addresses[3];
+} ucc_tl_dpu_conn_buf_t;
+
+typedef struct ucc_tl_dpu_team {
+    ucc_tl_team_t        super;
+    ucc_status_t         status;
+    ucc_rank_t           size;
+    ucc_rank_t           rank;
+    uint32_t             coll_id;
+    uint32_t             ctrl_seg[1];
+    ucp_mem_h            ctrl_seg_memh;
+    uint64_t             rem_ctrl_seg;
+    ucp_rkey_h           rem_ctrl_seg_key;
+    uint64_t             rem_data_in;
+    ucp_rkey_h           rem_data_in_key;
+    uint64_t             rem_data_out;
+    ucp_rkey_h           rem_data_out_key;
+    ucc_tl_dpu_request_t *send_req[3];
+    ucc_tl_dpu_request_t *recv_req[2];
+    ucc_tl_dpu_conn_buf_t    *conn_buf;
+} ucc_tl_dpu_team_t;
+UCC_CLASS_DECLARE(ucc_tl_dpu_team_t, ucc_base_context_t *,
+                  const ucc_base_team_params_t *);
+
+typedef struct ucc_tl_dpu_sync_t {
+    unsigned int             coll_id;
+    ucc_datatype_t           dtype;
+    ucc_reduction_op_t       op;
+    unsigned int             count_total;
+    unsigned int             count_in;
+    ucc_coll_type_t          coll_type;
+} ucc_tl_dpu_sync_t;
+
+typedef struct ucc_tl_dpu_task {
+    ucc_coll_task_t          super;
+    ucc_coll_args_t          args;
+    ucc_tl_dpu_team_t       *team;
+    ucc_tl_dpu_sync_t        sync;
+    ucc_tl_dpu_request_t    *reqs[3];
+} ucc_tl_dpu_task_t;
+
+typedef struct ucc_tl_dpu_config {
+    ucc_tl_lib_config_t super;
+} ucc_tl_dpu_config_t;
+
+typedef struct ucc_tl_dpu {
+    ucc_tl_lib_t        super;
+    ucc_tl_dpu_config_t config;
+} ucc_tl_dpu_t;
+
+#define UCC_TL_DPU_SUPPORTED_COLLS  UCC_COLL_TYPE_ALLREDUCE
+
+#define UCC_TL_DPU_TEAM_LIB(_team)                                          \
+    (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_dpu_lib_t))
+
+#define UCC_TL_DPU_TEAM_CTX(_team)                                          \
+    (ucc_derived_of((_team)->super.super.context, ucc_tl_dpu_context_t))
+
+#define UCC_TL_DPU_TEAM_CORE_CTX(_team)                                     \
+    ((_team)->super.super.context->ucc_context)
+
+void ucc_tl_dpu_req_init(void *request);
+void ucc_tl_dpu_req_cleanup(void * request);
+
+ucc_status_t ucc_tl_dpu_req_test(ucc_tl_dpu_request_t **req, ucp_worker_h worker);
+ucc_status_t ucc_tl_dpu_req_check(ucc_tl_dpu_team_t *team,
+                                      ucc_tl_dpu_request_t *req);
+
+void ucc_tl_dpu_send_handler_nbx(void *request, ucs_status_t status, void *user_data);
+void ucc_tl_dpu_recv_handler_nbx(void *request, ucs_status_t status,
+                      const ucp_tag_recv_info_t *tag_info,
+                      void *user_data);
+
+#endif

--- a/src/components/tl/dpu/tl_dpu.h
+++ b/src/components/tl/dpu/tl_dpu.h
@@ -122,7 +122,8 @@ typedef struct ucc_tl_dpu {
     ucc_tl_dpu_config_t config;
 } ucc_tl_dpu_t;
 
-#define UCC_TL_DPU_SUPPORTED_COLLS  UCC_COLL_TYPE_ALLREDUCE
+#define UCC_TL_DPU_SUPPORTED_COLLS \
+    (UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_ALLTOALL)
 
 #define UCC_TL_DPU_TEAM_LIB(_team)                                          \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_dpu_lib_t))

--- a/src/components/tl/dpu/tl_dpu_coll.c
+++ b/src/components/tl/dpu/tl_dpu_coll.c
@@ -1,0 +1,275 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_dpu.h"
+#include "tl_dpu_coll.h"
+
+#include "core/ucc_mc.h"
+#include "core/ucc_ee.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
+
+void ucc_tl_dpu_send_handler_nbx(void *request, ucs_status_t status, void *user_data)
+{
+    ucc_tl_dpu_request_t *req = (ucc_tl_dpu_request_t *)request;
+    req->status = UCC_TL_DPU_UCP_REQUEST_DONE;
+}
+
+void ucc_tl_dpu_recv_handler_nbx(void *request, ucs_status_t status,
+                      const ucp_tag_recv_info_t *tag_info,
+                      void *user_data)
+{
+  ucc_tl_dpu_request_t *req = (ucc_tl_dpu_request_t *)request;
+  req->status = UCC_TL_DPU_UCP_REQUEST_DONE;
+}
+
+static ucc_tl_dpu_task_t * ucc_tl_dpu_alloc_task(void)
+{
+    ucc_tl_dpu_task_t *task = (ucc_tl_dpu_task_t *) ucc_calloc(1, sizeof(ucc_tl_dpu_task_t), "Allocate task");
+    return task;
+}
+
+static ucc_status_t ucc_tl_dpu_free_task(ucc_tl_dpu_task_t *task)
+{
+    ucc_free(task);
+    return UCC_OK;
+}
+
+void ucc_tl_dpu_req_init(void* request)
+{
+    ucc_tl_dpu_request_t *req = (ucc_tl_dpu_request_t *)request;
+    req->status = UCC_TL_DPU_UCP_REQUEST_ACTIVE;
+}
+
+void ucc_tl_dpu_req_cleanup(void* request){ 
+    return;
+}
+
+ucc_status_t ucc_tl_dpu_req_test(ucc_tl_dpu_request_t **req, ucp_worker_h worker) {
+    if (*req == NULL) {
+        return UCC_OK;
+    }
+
+    if ((*req)->status == UCC_TL_DPU_UCP_REQUEST_DONE) {
+        (*req)->status = UCC_TL_DPU_UCP_REQUEST_ACTIVE;
+        ucp_request_free(*req);
+        (*req) = NULL;
+        return UCC_OK;
+    }
+    ucp_worker_progress(worker);
+    return UCC_INPROGRESS;
+}
+
+inline
+ucc_status_t ucc_tl_dpu_req_check(ucc_tl_dpu_team_t *team,
+                                      ucc_tl_dpu_request_t *req) {
+    if (UCS_PTR_IS_ERR(req)) {
+        tl_error(team->super.super.context->lib,
+                 "failed to send/recv msg");
+        return UCC_ERR_NO_MESSAGE;
+    }
+    return UCC_OK;
+}
+
+
+ucc_status_t ucc_tl_dpu_allreduce_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_dpu_task_t       *task       = ucc_derived_of(coll_task, ucc_tl_dpu_task_t);
+    ucc_tl_dpu_team_t       *team       = task->team;
+    ucc_tl_dpu_context_t    *ctx        = UCC_TL_DPU_TEAM_CTX(team);
+    volatile uint32_t       *check_flag = team->ctrl_seg;
+    ucc_status_t            status      = UCC_INPROGRESS;
+    int                     coll_poll   = UCC_TL_DPU_COLL_POLL;
+    int                     i;
+    ucp_request_param_t req_param;
+
+    /* Are we still in start phase? */
+    if (NULL != task->reqs[0] ||
+        NULL != task->reqs[1]) {
+        for (i = 0; i < coll_poll; i++) {
+            ucp_worker_progress(ctx->ucp_worker);
+            if ((ucc_tl_dpu_req_test(&(task->reqs[0]), ctx->ucp_worker) == UCC_OK) &&
+                (ucc_tl_dpu_req_test(&(task->reqs[1]), ctx->ucp_worker) == UCC_OK)) {
+                status = UCC_OK;
+                break;
+            }
+        }
+        if (UCC_INPROGRESS == status) {
+            return UCC_INPROGRESS;
+        }
+    }
+
+    /* check coll_id (return message from dpu server) */
+    if (team->coll_id != (*check_flag + 1)) {
+        return UCC_INPROGRESS;
+    }
+
+    if (NULL == task->reqs[2]) {
+        req_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                                UCP_OP_ATTR_FIELD_DATATYPE;
+        req_param.datatype     = ucp_dt_make_contig(1);
+        req_param.cb.recv      = ucc_tl_dpu_recv_handler_nbx;
+
+        task->reqs[2] = ucp_get_nbx(ctx->ucp_ep, task->args.dst.info.buffer,
+                            task->args.src.info.count * ucc_dt_size(task->args.src.info.datatype),
+                            team->rem_data_out, team->rem_data_out_key,
+                            &req_param);
+        if (ucc_tl_dpu_req_check(team, task->reqs[2]) != UCC_OK) {
+            return UCC_ERR_NO_MESSAGE;
+        }
+    }
+    
+    for (i = 0; i < coll_poll; i++) {
+        ucp_worker_progress(ctx->ucp_worker);
+        if ((ucc_tl_dpu_req_test(&task->reqs[2], ctx->ucp_worker) == UCC_OK)) {
+            task->super.super.status = UCC_OK;
+            return task->super.super.status;
+        }
+    }
+
+    return UCC_INPROGRESS;
+}
+
+ucc_status_t ucc_tl_dpu_allreduce_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_dpu_task_t           *task       = ucs_derived_of(coll_task, ucc_tl_dpu_task_t);
+    ucc_tl_dpu_team_t           *team       = task->team;
+    ucc_tl_dpu_context_t        *ctx        = UCC_TL_DPU_TEAM_CTX(team);
+    void                        *sbuf       = task->args.src.info.buffer;
+    void                        *rbuf       = task->args.dst.info.buffer;
+    size_t                      count       = task->args.src.info.count;
+    ucc_datatype_t              dt          = task->args.src.info.datatype;
+    size_t                      data_size   = count * ucc_dt_size(dt);
+    int                         i           = 0;
+    int                         coll_poll   = UCC_TL_DPU_COLL_POLL;
+    ucp_request_param_t         req_param;
+    ucc_status_t                status;
+
+    task->reqs[0] = NULL;
+    task->reqs[1] = NULL;
+    task->reqs[2] = NULL;
+
+    tl_info(team->super.super.context->lib, "Collective post");
+
+    req_param.op_attr_mask  = UCP_OP_ATTR_FIELD_CALLBACK |
+                              UCP_OP_ATTR_FIELD_DATATYPE;
+    req_param.datatype      = ucp_dt_make_contig(1);
+    req_param.cb.send       = ucc_tl_dpu_send_handler_nbx;
+
+    /* XXX set memory
+    req_param.mask          = 0;
+    req_param.mem_type      = task->args.src.info.mem_type;
+    req_param.memory_type   = ucc_memtype_to_ucs[mtype];
+    */
+
+    if (UCC_IS_INPLACE(task->args)) {
+        sbuf = rbuf;
+    }
+    task->reqs[0] = ucp_put_nbx(ctx->ucp_ep, sbuf, data_size,
+                             team->rem_data_in, team->rem_data_in_key, &req_param);
+    if (ucc_tl_dpu_req_check(team, task->reqs[0]) != UCC_OK) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    ucp_worker_fence(ctx->ucp_worker);
+
+    task->reqs[1] = ucp_put_nbx(ctx->ucp_ep, &task->sync, sizeof(task->sync),
+                              team->rem_ctrl_seg, team->rem_ctrl_seg_key,
+                              &req_param);
+    if (ucc_tl_dpu_req_check(team, task->reqs[1]) != UCC_OK) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    status = UCC_INPROGRESS;
+    for (i = 0; i < coll_poll; i++) {
+        ucp_worker_progress(ctx->ucp_worker);
+        if ((ucc_tl_dpu_req_test(&(task->reqs[0]), ctx->ucp_worker) == UCC_OK) &&
+            (ucc_tl_dpu_req_test(&(task->reqs[1]), ctx->ucp_worker) == UCC_OK)) {
+            status = UCC_OK;
+            break;
+        }
+    }
+
+    task->super.super.status = UCC_INPROGRESS;
+    if (UCC_INPROGRESS == status) {
+        ucc_progress_enqueue(UCC_TL_DPU_TEAM_CORE_CTX(team)->pq, &task->super);
+        return UCC_OK;
+    }
+
+    status = ucc_tl_dpu_allreduce_progress(&task->super);
+    if (UCC_INPROGRESS == status) {
+        ucc_progress_enqueue(UCC_TL_DPU_TEAM_CORE_CTX(team)->pq, &task->super);
+        return UCC_OK;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_dpu_allreduce_init(ucc_tl_dpu_task_t *task)
+{
+    if (task->args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) {
+        tl_error(UCC_TL_TEAM_LIB(task->team),
+                 "userdefined reductions are not supported yet");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    if (!UCC_IS_INPLACE(task->args) && (task->args.src.info.mem_type !=
+                                        task->args.dst.info.mem_type)) {
+        tl_error(UCC_TL_TEAM_LIB(task->team),
+                 "assymetric src/dst memory types are not supported yetpp");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    task->super.post     = ucc_tl_dpu_allreduce_start;
+    task->super.progress = ucc_tl_dpu_allreduce_progress;
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_tl_dpu_coll_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_dpu_task_t *task = ucc_derived_of(coll_task, ucc_tl_dpu_task_t);
+    tl_info(task->team->super.super.context->lib, "finalizing task %p", task);
+    ucc_tl_dpu_free_task(task);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_dpu_coll_init(ucc_base_coll_args_t *coll_args,
+                                         ucc_base_team_t      *team,
+                                         ucc_coll_task_t     **task_h)
+{
+    ucc_tl_dpu_team_t    *tl_team = ucc_derived_of(team, ucc_tl_dpu_team_t);
+    ucc_tl_dpu_task_t    *task    = ucc_tl_dpu_alloc_task();
+    ucc_status_t          status  = UCC_OK;
+
+    ucc_coll_task_init(&task->super);
+    tl_info(team->context->lib, "task %p initialized", task);
+
+    memcpy(&task->args, &coll_args->args, sizeof(ucc_coll_args_t));
+
+    task->sync.coll_id          = tl_team->coll_id;
+    task->sync.dtype            = coll_args->args.src.info.datatype;
+    task->sync.count_total      = coll_args->args.src.info.count;
+    task->sync.count_in         = coll_args->args.src.info.count;
+    task->sync.op               = coll_args->args.reduce.predefined_op;
+    task->team                  = tl_team;
+    task->super.finalize        = ucc_tl_dpu_coll_finalize;
+    task->super.triggered_post  = NULL;
+    tl_team->coll_id++;
+
+    switch (coll_args->args.coll_type) {
+    case UCC_COLL_TYPE_ALLREDUCE:
+        status = ucc_tl_dpu_allreduce_init(task);
+        break;
+    default:
+        status = UCC_ERR_NOT_SUPPORTED;
+    }
+    if (status != UCC_OK) {
+        ucc_tl_dpu_free_task(task);
+        return status;
+    }
+
+    tl_info(team->context->lib, "init coll req %p", task);
+    *task_h = &task->super;
+    return status;
+}

--- a/src/components/tl/dpu/tl_dpu_coll.h
+++ b/src/components/tl/dpu/tl_dpu_coll.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_DPU_COLL_H_
+#define UCC_TL_DPU_COLL_H_
+
+#include "components/tl/ucc_tl.h"
+#include "tl_dpu.h"
+
+#define UCC_TL_DPU_COLL_POLL 100
+
+ucc_status_t ucc_tl_dpu_allreduce_progress(ucc_coll_task_t *coll_task);
+ucc_status_t ucc_tl_dpu_allreduce_start(ucc_coll_task_t *coll_task);
+ucc_status_t ucc_tl_dpu_allreduce_init(ucc_tl_dpu_task_t *coll_task);
+ucc_status_t ucc_tl_dpu_coll_init(ucc_base_coll_args_t  *coll_args,
+                                  ucc_base_team_t       *team,
+                                  ucc_coll_task_t      **task_h);
+#endif

--- a/src/components/tl/dpu/tl_dpu_coll.h
+++ b/src/components/tl/dpu/tl_dpu_coll.h
@@ -15,6 +15,11 @@
 ucc_status_t ucc_tl_dpu_allreduce_progress(ucc_coll_task_t *coll_task);
 ucc_status_t ucc_tl_dpu_allreduce_start(ucc_coll_task_t *coll_task);
 ucc_status_t ucc_tl_dpu_allreduce_init(ucc_tl_dpu_task_t *coll_task);
+
+ucc_status_t ucc_tl_dpu_alltoall_progress(ucc_coll_task_t *coll_task);
+ucc_status_t ucc_tl_dpu_alltoall_start(ucc_coll_task_t *coll_task);
+ucc_status_t ucc_tl_dpu_alltoall_init(ucc_tl_dpu_task_t *coll_task);
+
 ucc_status_t ucc_tl_dpu_coll_init(ucc_base_coll_args_t  *coll_args,
                                   ucc_base_team_t       *team,
                                   ucc_coll_task_t      **task_h);

--- a/src/components/tl/dpu/tl_dpu_context.c
+++ b/src/components/tl/dpu/tl_dpu_context.c
@@ -1,0 +1,266 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_dpu.h"
+#include "tl_dpu_coll.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include <netdb.h>
+#include <poll.h>
+#include <errno.h>
+#include <unistd.h>
+
+static void err_cb(void *arg, ucp_ep_h ep, ucs_status_t status)
+{
+    ucc_error("error handling callback was invoked with status %d (%s)\n",
+                    status, ucs_status_string(status));
+}
+
+static int _server_connect(ucc_tl_dpu_context_t *ctx, char *hname, uint16_t port)
+{
+    int sock = 0, n;
+    struct addrinfo *res, *t;
+    struct addrinfo hints = { 0 };
+    char service[64];
+
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    sprintf(service, "%d", port);
+    n = getaddrinfo(hname, service, &hints, &res);
+
+    if (n < 0) {
+        tl_error(ctx->super.super.lib, "%s:%d: getaddrinfo(): %s for %s:%s\n", __FILE__,__LINE__, gai_strerror(n), hname, service);
+        return -1;
+    }
+
+    for (t = res; t; t = t->ai_next) {
+        sock = socket(t->ai_family, t->ai_socktype, t->ai_protocol);
+        if (sock >= 0) {
+            if (!connect(sock, t->ai_addr, t->ai_addrlen))
+                break;
+            close(sock);
+            sock = -1;
+        }
+    }
+
+    freeaddrinfo(res);
+    return sock;
+}
+
+UCC_CLASS_INIT_FUNC(ucc_tl_dpu_context_t,
+                    const ucc_base_context_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    /* TODO: Need handshake with daemon for detection */
+    ucc_tl_dpu_context_config_t *tl_dpu_config =
+        ucc_derived_of(config, ucc_tl_dpu_context_config_t);
+
+    ucc_status_t        ucc_status = UCC_OK;
+    int sockfd = 0, dpu_found = 0;
+    ucp_worker_params_t worker_params;
+    ucp_worker_attr_t   worker_attr;
+    ucp_params_t        ucp_params;
+    ucp_ep_params_t     ep_params;
+    ucp_ep_h            ucp_ep;
+    ucp_context_h       ucp_context;
+    ucp_worker_h        ucp_worker;
+    int ret;
+
+    /* Identify DPU */
+    char hname[MAX_DPU_HOST_NAME];
+    void *rem_worker_addr;
+    size_t rem_worker_addr_size;
+    
+
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_dpu_config->super.tl_lib,
+                              params->context);
+    memcpy(&self->cfg, tl_dpu_config, sizeof(*tl_dpu_config));
+
+    /* Find  DPU based on the host-dpu list */
+    gethostname(hname, sizeof(hname) - 1);
+
+    char *h = calloc(1, 256);
+    FILE *fp = NULL;
+
+    if (strcmp(tl_dpu_config->host_dpu_list,"") != 0) {
+
+        fp = fopen(tl_dpu_config->host_dpu_list, "r");
+        if (fp == NULL) {
+            tl_error(self->super.super.lib,
+                "Unable to open host_dpu_list \"%s\", disabling dpu team\n", tl_dpu_config->host_dpu_list);
+            ucc_status = UCC_ERR_NO_MESSAGE;
+        }
+        else {
+            while (fscanf(fp,"%s", h) != EOF) {
+                if (strcmp(h, hname) == 0) {
+                    dpu_found = 1;
+                    fscanf(fp, "%s", hname);
+                    tl_info(self->super.super.lib, "DPU <%s> found!\n", hname);
+                    break;
+                }
+                memset(h, 0, 256);
+            }
+        }
+        if (!dpu_found) {
+            ucc_status = UCC_ERR_NO_MESSAGE;
+        }
+    }
+    else {
+        tl_error(self->super.super.lib,
+            "DPU_ENABLE set, but HOST_LIST not specified. Disabling DPU team!\n");
+        ucc_status = UCC_ERR_NO_MESSAGE;
+    }
+    free(h);
+
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+
+    tl_info(self->super.super.lib, "Connecting to %s", hname);
+    sockfd = _server_connect(self, hname, tl_dpu_config->server_port);
+
+    memset(&ucp_params, 0, sizeof(ucp_params));
+    ucp_params.field_mask      = UCP_PARAM_FIELD_FEATURES |
+                                 UCP_PARAM_FIELD_REQUEST_SIZE |
+                                 UCP_PARAM_FIELD_REQUEST_INIT |
+                                 UCP_PARAM_FIELD_REQUEST_CLEANUP;
+    ucp_params.features        = UCP_FEATURE_TAG |
+                                 UCP_FEATURE_RMA;
+    ucp_params.request_size    = sizeof(ucc_tl_dpu_request_t);
+    ucp_params.request_init    = ucc_tl_dpu_req_init;
+    ucp_params.request_cleanup = ucc_tl_dpu_req_cleanup;
+
+    ucc_status = ucs_status_to_ucc_status(
+                    ucp_init(&ucp_params, NULL, &ucp_context));
+    if (ucc_status != UCC_OK) {
+        tl_error(self->super.super.lib,
+            "failed ucp_init(%s)\n", ucc_status_string(ucc_status));
+        goto err;
+    }
+
+    memset(&worker_params, 0, sizeof(worker_params));
+    worker_params.field_mask    = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+    worker_params.thread_mode   = UCS_THREAD_MODE_SINGLE;
+
+    ucc_status = ucs_status_to_ucc_status(
+                    ucp_worker_create(ucp_context, &worker_params, &ucp_worker));
+    if (ucc_status != UCC_OK) {
+        tl_error(self->super.super.lib,
+            "failed ucp_worker_create (%s)\n", ucc_status_string(ucc_status));
+        goto err_cleanup_context;
+    }
+
+    worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS |
+                             UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
+    worker_attr.address_flags = UCP_WORKER_ADDRESS_FLAG_NET_ONLY;
+    ucp_worker_query(ucp_worker, &worker_attr);
+
+    ret = send(sockfd, &worker_attr.address_length,
+            sizeof(&worker_attr.address_length), 0);
+    if (ret < 0) {
+        tl_error(self->super.super.lib, "send length failed");
+        ucc_status = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+    ret = send(sockfd, worker_attr.address, worker_attr.address_length, 0);
+    if (ret < 0) {
+        tl_error(self->super.super.lib, "send address failed");
+        ucc_status = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+    ret = recv(sockfd, &rem_worker_addr_size, sizeof(rem_worker_addr_size), MSG_WAITALL);
+    if (ret < 0) {
+        tl_error(self->super.super.lib, "recv address length failed");
+        ucc_status = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+    rem_worker_addr = ucc_malloc(rem_worker_addr_size, "rem_worker_addr");
+    if (NULL == rem_worker_addr) {
+        tl_error(self->super.super.lib, "failed to allocate rem_worker_addr");
+        ucc_status = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+    ret = recv(sockfd, rem_worker_addr, rem_worker_addr_size, MSG_WAITALL);
+    if (ret < 0) {
+        tl_error(self->super.super.lib, "recv address failed");
+        ucc_status = UCC_ERR_NO_MESSAGE;
+        goto err;
+    }
+
+    ep_params.field_mask       = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS      |
+                                 UCP_EP_PARAM_FIELD_ERR_HANDLER         |
+                                 UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
+
+    ep_params.address          = rem_worker_addr;
+    ep_params.err_mode         = UCP_ERR_HANDLING_MODE_PEER;
+    ep_params.err_handler.cb   = err_cb;
+
+    ucc_status = ucs_status_to_ucc_status(
+                    ucp_ep_create(ucp_worker, &ep_params, &ucp_ep));
+    free(worker_attr.address);
+    ucc_free(rem_worker_addr);
+    close(sockfd);
+    if (ucc_status != UCC_OK) {
+        tl_error(self->super.super.lib, "failed to connect to %s (%s)\n",
+                       hname, ucc_status_string(ucc_status));
+        goto err_cleanup_worker;
+    }
+
+    self->ucp_context   = ucp_context;
+    self->ucp_worker    = ucp_worker;
+    self->ucp_ep        = ucp_ep;
+
+    tl_info(self->super.super.lib, "context created");
+    return ucc_status;
+
+err_cleanup_worker:
+    ucp_worker_destroy(self->ucp_worker);
+err_cleanup_context:
+    ucp_cleanup(self->ucp_context);
+err:
+    return ucc_status;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_dpu_context_t)
+{
+    ucp_request_param_t param;
+    ucc_status_t ucc_status;
+    void *close_req;
+
+    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+
+    param.op_attr_mask  = UCP_OP_ATTR_FIELD_FLAGS;
+    param.flags         = UCP_EP_CLOSE_FLAG_FORCE;
+    close_req           = ucp_ep_close_nbx(self->ucp_ep, &param);
+    if (UCS_PTR_IS_PTR(close_req)) {
+        do {
+            ucp_worker_progress(self->ucp_worker);
+            ucc_status = ucs_status_to_ucc_status(
+                ucp_request_check_status(close_req));
+        } while (ucc_status == UCC_INPROGRESS);
+        ucp_request_free (close_req);
+    } else if (UCS_PTR_STATUS(close_req) != UCS_OK) {
+        tl_error(self->super.super.lib, "failed to close ep %p\n", (void *)self->ucp_ep);
+    }
+    ucp_worker_destroy(self->ucp_worker);
+    ucp_cleanup(self->ucp_context);
+}
+
+UCC_CLASS_DEFINE(ucc_tl_dpu_context_t, ucc_tl_context_t);
+
+ucc_status_t ucc_tl_dpu_get_context_attr(const ucc_base_context_t *context,
+                                         ucc_base_ctx_attr_t      *attr)
+{
+    /* TODO */
+    return UCC_ERR_NOT_IMPLEMENTED;
+}

--- a/src/components/tl/dpu/tl_dpu_lib.c
+++ b/src/components/tl/dpu/tl_dpu_lib.c
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_dpu.h"
+
+/* NOLINTNEXTLINE  params is not used*/
+UCC_CLASS_INIT_FUNC(ucc_tl_dpu_lib_t, const ucc_base_lib_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    const ucc_tl_dpu_lib_config_t *tl_dpu_config =
+        ucc_derived_of(config, ucc_tl_dpu_lib_config_t);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_dpu.super, &tl_dpu_config->super);
+    tl_info(&self->super, "initialized lib object: %p", self);
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_dpu_lib_t)
+{
+    tl_info(&self->super, "finalizing lib object: %p", self);
+}
+
+UCC_CLASS_DEFINE(ucc_tl_dpu_lib_t, ucc_tl_lib_t);
+
+ucc_status_t ucc_tl_dpu_get_lib_attr(const ucc_base_lib_t *lib,
+                                     ucc_base_lib_attr_t *base_attr)
+{
+    ucc_tl_lib_attr_t *attr = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
+
+    attr->super.attr.thread_mode    = UCC_THREAD_MULTIPLE;
+    attr->super.attr.coll_types     = UCC_TL_DPU_SUPPORTED_COLLS;
+    return UCC_OK;
+}

--- a/src/components/tl/dpu/tl_dpu_team.c
+++ b/src/components/tl/dpu/tl_dpu_team.c
@@ -1,0 +1,423 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_dpu.h"
+#include "tl_dpu_coll.h"
+#include "coll_score/ucc_coll_score.h"
+
+UCC_CLASS_INIT_FUNC(ucc_tl_dpu_team_t, ucc_base_context_t *tl_context,
+                    const ucc_base_team_params_t *params)
+{
+    
+
+    ucc_status_t ucc_status = UCC_OK; 
+    ucc_tl_dpu_context_t *ctx =
+        ucc_derived_of(tl_context, ucc_tl_dpu_context_t);
+
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super);
+
+    tl_info(ctx->super.super.lib, "starting: %p team_create", self);
+
+    ucp_request_param_t     send_req_param,
+                            recv_req_param;
+    int tc_poll = UCC_TL_DPU_TC_POLL, i;
+    size_t total_rkey_size = 0;
+    
+    self->coll_id   = 1;
+    self->size      = params->params.oob.participants;
+    self->rank      = params->rank;
+    self->status    = UCC_OPERATION_INITIALIZED;
+    self->conn_buf  = ucc_malloc(sizeof(ucc_tl_dpu_conn_buf_t),
+                        "Allocate connection buffer");
+
+    self->conn_buf->mmap_params.field_mask =
+                                UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                                UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    self->conn_buf->mmap_params.address = (void*)&self->ctrl_seg;
+    self->conn_buf->mmap_params.length = sizeof(self->ctrl_seg);
+
+    ucc_status = ucs_status_to_ucc_status(
+            ucp_mem_map(ctx->ucp_context, &self->conn_buf->mmap_params,
+                        &self->ctrl_seg_memh));
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+
+    ucc_status = ucs_status_to_ucc_status(
+        ucp_rkey_pack(ctx->ucp_context, self->ctrl_seg_memh,
+                      &self->conn_buf->ctrl_seg_rkey_buf,
+                      &self->conn_buf->ctrl_seg_rkey_buf_size));
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+
+    send_req_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                                  UCP_OP_ATTR_FIELD_DATATYPE;
+    send_req_param.datatype     = ucp_dt_make_contig(1);
+    send_req_param.cb.send      = ucc_tl_dpu_send_handler_nbx;
+
+    recv_req_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                                  UCP_OP_ATTR_FIELD_DATATYPE;
+    recv_req_param.datatype     = ucp_dt_make_contig(1);
+    recv_req_param.cb.recv      = ucc_tl_dpu_recv_handler_nbx;
+
+    self->send_req[0] = ucp_tag_send_nbx(ctx->ucp_ep,
+                                    &self->conn_buf->mmap_params.address,
+                                    sizeof(uint64_t),
+                                    UCC_TL_DPU_EXCHANGE_ADDR_TAG,
+                                    &send_req_param);
+    ucc_status = ucc_tl_dpu_req_check(self, self->send_req[0]);
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+
+    self->send_req[1] = ucp_tag_send_nbx(ctx->ucp_ep,
+                                    &self->conn_buf->ctrl_seg_rkey_buf_size,
+                                    sizeof(size_t),
+                                    UCC_TL_DPU_EXCHANGE_LENGTH_TAG,
+                                    &send_req_param);
+    ucc_status = ucc_tl_dpu_req_check(self, self->send_req[1]);
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+
+    self->send_req[2] = ucp_tag_send_nbx(ctx->ucp_ep,
+                                    self->conn_buf->ctrl_seg_rkey_buf,
+                                    self->conn_buf->ctrl_seg_rkey_buf_size,
+                                    UCC_TL_DPU_EXCHANGE_RKEY_TAG,
+                                    &send_req_param);
+    ucc_status = ucc_tl_dpu_req_check(self, self->send_req[2]);
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+
+    self->recv_req[0] = ucp_tag_recv_nbx(ctx->ucp_worker,
+                                self->conn_buf->rem_rkeys_lengths,
+                                sizeof(self->conn_buf->rem_rkeys_lengths),
+                                UCC_TL_DPU_EXCHANGE_LENGTH_TAG, (uint64_t)-1,
+                                &recv_req_param);
+    ucc_status = ucc_tl_dpu_req_check(self, self->recv_req[0]);
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+
+    for (i = 0; i < tc_poll; i++) {
+        ucp_worker_progress(ctx->ucp_worker);
+        if ((ucc_tl_dpu_req_test(&(self->send_req[0]), ctx->ucp_worker) == UCC_OK) &&
+            (ucc_tl_dpu_req_test(&(self->send_req[1]), ctx->ucp_worker) == UCC_OK) &&
+            (ucc_tl_dpu_req_test(&(self->send_req[2]), ctx->ucp_worker) == UCC_OK) &&
+            (ucc_tl_dpu_req_test(&(self->recv_req[0]), ctx->ucp_worker) == UCC_OK))
+        {
+            self->status = UCC_INPROGRESS; /* Advance connection establishment */
+            break;
+        }
+    }
+
+    if (UCC_INPROGRESS != self->status) {
+        return UCC_OK;
+    }
+
+    ucp_rkey_buffer_release(self->conn_buf->ctrl_seg_rkey_buf);
+    self->conn_buf->ctrl_seg_rkey_buf = NULL;
+
+    total_rkey_size     = self->conn_buf->rem_rkeys_lengths[0] +
+                          self->conn_buf->rem_rkeys_lengths[1] +
+                          self->conn_buf->rem_rkeys_lengths[2];
+    self->conn_buf->rem_rkeys = ucc_malloc(total_rkey_size, "rem_rkeys alloc");
+    self->recv_req[0]   = ucp_tag_recv_nbx(ctx->ucp_worker,
+                                    &self->conn_buf->rem_addresses,
+                                    sizeof(self->conn_buf->rem_addresses),
+                                    UCC_TL_DPU_EXCHANGE_ADDR_TAG, (uint64_t)-1,
+                                    &recv_req_param);
+    if (ucc_tl_dpu_req_check(self, self->recv_req[0]) != UCC_OK) {
+        goto err;
+    }
+
+    self->recv_req[1] = ucp_tag_recv_nbx(ctx->ucp_worker, self->conn_buf->rem_rkeys,
+                                total_rkey_size,
+                                UCC_TL_DPU_EXCHANGE_RKEY_TAG, (uint64_t)-1,
+                                &recv_req_param);
+    if (ucc_tl_dpu_req_check(self, self->recv_req[1]) != UCC_OK) {
+        goto err;
+    }
+
+    for (i = 0; i < tc_poll; i++) {
+        ucp_worker_progress(ctx->ucp_worker);
+        if ((ucc_tl_dpu_req_test(&(self->recv_req[0]), ctx->ucp_worker) == UCC_OK) &&
+            (ucc_tl_dpu_req_test(&(self->recv_req[1]), ctx->ucp_worker) == UCC_OK))
+        {
+            self->status = UCC_OK;
+            break;
+        }
+    }
+    if (UCC_OK != self->status) {
+        return UCC_OK;
+    }
+
+    self->rem_ctrl_seg = self->conn_buf->rem_addresses[0];
+    ucc_status = ucs_status_to_ucc_status(
+        ucp_ep_rkey_unpack(ctx->ucp_ep, self->conn_buf->rem_rkeys,
+                            &self->rem_ctrl_seg_key));
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+    self->rem_data_in = self->conn_buf->rem_addresses[1];
+
+    ucc_status = ucs_status_to_ucc_status(
+        ucp_ep_rkey_unpack(ctx->ucp_ep,
+                    (void*)((ptrdiff_t)self->conn_buf->rem_rkeys +
+                    self->conn_buf->rem_rkeys_lengths[0]),
+                    &self->rem_data_in_key));
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+    self->rem_data_out = self->conn_buf->rem_addresses[2];
+
+    ucc_status = ucs_status_to_ucc_status(
+        ucp_ep_rkey_unpack(ctx->ucp_ep,
+                            (void*)((ptrdiff_t)self->conn_buf->rem_rkeys +
+                            self->conn_buf->rem_rkeys_lengths[1] +
+                            self->conn_buf->rem_rkeys_lengths[0]),
+                       &self->rem_data_out_key));
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+
+    ucc_free(self->conn_buf->rem_rkeys);
+    self->conn_buf->rem_rkeys = NULL;
+    ucc_free(self->conn_buf);
+
+    return self->status;
+err:
+    if (self->conn_buf->rem_rkeys) {
+        ucc_free(self->conn_buf->rem_rkeys);
+    }
+    if (self->conn_buf->ctrl_seg_rkey_buf) {
+        ucp_rkey_buffer_release(self->conn_buf->ctrl_seg_rkey_buf);
+        self->conn_buf->ctrl_seg_rkey_buf = NULL;
+    }
+    ucc_free(self->conn_buf);
+
+    return ucc_status;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_dpu_team_t)
+{
+    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+}
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_dpu_team_t, ucc_base_team_t);
+UCC_CLASS_DEFINE(ucc_tl_dpu_team_t, ucc_tl_team_t);
+
+ucc_status_t ucc_tl_dpu_team_destroy(ucc_base_team_t *tl_team)
+{
+    ucc_tl_dpu_team_t           *team = ucc_derived_of(tl_team, ucc_tl_dpu_team_t);
+    ucc_tl_dpu_context_t        *ctx = UCC_TL_DPU_TEAM_CTX(team);
+    ucc_tl_dpu_sync_t           hangup;
+    ucc_tl_dpu_request_t        *hangup_req;
+    ucp_request_param_t         req_param;
+ 
+    hangup.coll_id  = team->coll_id;
+    hangup.dtype    = UCC_DT_USERDEFINED;
+    hangup.op       = UCC_OP_USERDEFINED;
+    hangup.count_in      = 0;
+ 
+    req_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                             UCP_OP_ATTR_FIELD_DATATYPE;
+    req_param.datatype     = ucp_dt_make_contig(1);
+    req_param.cb.send      = ucc_tl_dpu_send_handler_nbx;
+ 
+    hangup_req = ucp_put_nbx(ctx->ucp_ep, &hangup, sizeof(hangup),
+                             team->rem_ctrl_seg, team->rem_ctrl_seg_key,
+                             &req_param);
+    if (ucc_tl_dpu_req_check(team, hangup_req) != UCC_OK) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    do {
+        ucp_worker_progress(ctx->ucp_worker);
+    } while((ucc_tl_dpu_req_test(&(hangup_req), ctx->ucp_worker) != UCC_OK));
+ 
+    ucp_rkey_destroy(team->rem_ctrl_seg_key);
+    ucp_rkey_destroy(team->rem_data_in_key);
+    ucp_rkey_destroy(team->rem_data_out_key);
+    ucp_mem_unmap(ctx->ucp_context, team->ctrl_seg_memh);
+
+    UCC_CLASS_DELETE_FUNC_NAME(ucc_tl_dpu_team_t)(tl_team);
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_dpu_team_create_test(ucc_base_team_t *tl_team)
+{
+    ucc_tl_dpu_team_t       *team = ucc_derived_of(tl_team, ucc_tl_dpu_team_t);
+    ucc_tl_dpu_context_t    *ctx = UCC_TL_DPU_TEAM_CTX(team);
+    ucc_status_t            ucc_status = UCC_OK;
+    int                     tc_poll = UCC_TL_DPU_TC_POLL, i = 0;
+    size_t                  total_rkey_size;
+    ucp_request_param_t     recv_req_param;
+
+    if (UCC_OK == team->status) {
+        return UCC_OK;
+    }
+
+    recv_req_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                                  UCP_OP_ATTR_FIELD_DATATYPE;
+    recv_req_param.datatype     = ucp_dt_make_contig(1);
+    recv_req_param.cb.recv      = ucc_tl_dpu_recv_handler_nbx;
+
+    if (UCC_OPERATION_INITIALIZED == team->status) {
+        for (i = 0; i < tc_poll; i++) {
+            ucp_worker_progress(ctx->ucp_worker);
+            if ((ucc_tl_dpu_req_test(&(team->send_req[0]), ctx->ucp_worker) == UCC_OK) &&
+                (ucc_tl_dpu_req_test(&(team->send_req[1]), ctx->ucp_worker) == UCC_OK) &&
+                (ucc_tl_dpu_req_test(&(team->send_req[2]), ctx->ucp_worker) == UCC_OK) &&
+                (ucc_tl_dpu_req_test(&(team->recv_req[0]), ctx->ucp_worker) == UCC_OK))
+            {
+                team->status = UCC_INPROGRESS; /* Advance connection establishment */
+                break;
+            }
+        }
+
+        if (UCC_INPROGRESS != team->status) {
+            return UCC_INPROGRESS;
+        }
+
+        /* Continue connection establishment */
+        ucp_rkey_buffer_release(team->conn_buf->ctrl_seg_rkey_buf);
+        team->conn_buf->ctrl_seg_rkey_buf = NULL;
+
+        total_rkey_size = team->conn_buf->rem_rkeys_lengths[0] +
+                          team->conn_buf->rem_rkeys_lengths[1] +
+                          team->conn_buf->rem_rkeys_lengths[2];
+        team->conn_buf->rem_rkeys = ucc_malloc(total_rkey_size, "rem_rkeys alloc");
+
+        team->recv_req[0] = ucp_tag_recv_nbx(ctx->ucp_worker,
+                            &team->conn_buf->rem_addresses,
+                            sizeof(team->conn_buf->rem_addresses),
+                            UCC_TL_DPU_EXCHANGE_ADDR_TAG, (uint64_t)-1,
+                            &recv_req_param);
+        if (ucc_tl_dpu_req_check(team, team->recv_req[0]) != UCC_OK) {
+            goto err;
+        }
+
+        team->recv_req[1] = ucp_tag_recv_nbx(ctx->ucp_worker,
+                            team->conn_buf->rem_rkeys,
+                            total_rkey_size,
+                            UCC_TL_DPU_EXCHANGE_RKEY_TAG, (uint64_t)-1,
+                            &recv_req_param);
+        if (ucc_tl_dpu_req_check(team, team->recv_req[1]) != UCC_OK) {
+            goto err;
+        }
+
+        for (i = 0; i < tc_poll; i++) {
+            ucp_worker_progress(ctx->ucp_worker);
+            if ((ucc_tl_dpu_req_test(&(team->recv_req[0]), ctx->ucp_worker) == UCC_OK) &&
+                (ucc_tl_dpu_req_test(&(team->recv_req[1]), ctx->ucp_worker) == UCC_OK))
+            {
+                team->status = UCC_OK;
+                break;
+            }
+        }
+        if (UCC_OK != team->status) {
+            return UCC_INPROGRESS;
+        }
+    }
+
+    if (UCC_INPROGRESS == team->status) {
+        for (i = 0; i < tc_poll; i++) {
+            ucp_worker_progress(ctx->ucp_worker);
+            if ((ucc_tl_dpu_req_test(&(team->recv_req[0]), ctx->ucp_worker) == UCC_OK) &&
+                (ucc_tl_dpu_req_test(&(team->recv_req[1]), ctx->ucp_worker) == UCC_OK))
+            {
+                team->status = UCC_OK;
+                break;
+            }
+        }
+        if (UCC_OK != team->status) {
+            return UCC_INPROGRESS;
+        }
+    }
+
+    team->rem_ctrl_seg = team->conn_buf->rem_addresses[0];
+    ucc_status = ucs_status_to_ucc_status(
+        ucp_ep_rkey_unpack(ctx->ucp_ep, team->conn_buf->rem_rkeys,
+                            &team->rem_ctrl_seg_key));
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+    team->rem_data_in = team->conn_buf->rem_addresses[1];
+
+    ucc_status = ucs_status_to_ucc_status(
+        ucp_ep_rkey_unpack(ctx->ucp_ep,
+                    (void*)((ptrdiff_t)team->conn_buf->rem_rkeys +
+                    team->conn_buf->rem_rkeys_lengths[0]),
+                    &team->rem_data_in_key));
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+    team->rem_data_out = team->conn_buf->rem_addresses[2];
+
+    ucc_status = ucs_status_to_ucc_status(
+        ucp_ep_rkey_unpack(ctx->ucp_ep,
+                            (void*)((ptrdiff_t)team->conn_buf->rem_rkeys +
+                            team->conn_buf->rem_rkeys_lengths[1] +
+                            team->conn_buf->rem_rkeys_lengths[0]),
+                       &team->rem_data_out_key));
+    if (UCC_OK != ucc_status) {
+        goto err;
+    }
+
+    ucc_free(team->conn_buf->rem_rkeys);
+    team->conn_buf->rem_rkeys = NULL;
+    ucc_free(team->conn_buf);
+
+    return team->status;
+err:
+    if (team->conn_buf->rem_rkeys) {
+        ucc_free(team->conn_buf->rem_rkeys);
+    }
+    if (team->conn_buf->ctrl_seg_rkey_buf) {
+        ucp_rkey_buffer_release(team->conn_buf->ctrl_seg_rkey_buf);
+        team->conn_buf->ctrl_seg_rkey_buf = NULL;
+    }
+    ucc_free(team->conn_buf);
+
+    return ucc_status;
+}
+
+ucc_status_t ucc_tl_dpu_team_get_scores(ucc_base_team_t   *tl_team,
+                                         ucc_coll_score_t **score_p)
+{
+    ucc_tl_dpu_team_t  *team = ucc_derived_of(tl_team, ucc_tl_dpu_team_t);
+    ucc_tl_dpu_lib_t   *lib  = UCC_TL_DPU_TEAM_LIB(team);
+    ucc_coll_score_t   *score;
+    ucc_status_t        status;
+
+    /* There can be a different logic for different coll_type/mem_type.
+       Right now just init everything the same way. */
+    status = ucc_coll_score_build_default(tl_team, UCC_TL_DPU_DEFAULT_SCORE,
+                           ucc_tl_dpu_coll_init, UCC_TL_DPU_SUPPORTED_COLLS,
+                           NULL, 0, &score);
+    if (UCC_OK != status) {
+        return status;
+    }
+    if (strlen(lib->super.super.score_str) > 0) {
+        status = ucc_coll_score_update_from_str(lib->super.super.score_str,
+                                                score, team->size,
+                                                ucc_tl_dpu_coll_init, &team->super.super,
+                                                UCC_TL_DPU_DEFAULT_SCORE,
+                                                NULL);
+        if (status == UCC_ERR_INVALID_PARAM) {
+            /* User provided incorrect input - try to proceed */
+            goto err;
+        }
+    }
+    *score_p = score;
+    return status;
+err:
+    ucc_coll_score_free(score);
+    return status;
+}

--- a/src/components/tl/dpu/tl_dpu_team.c
+++ b/src/components/tl/dpu/tl_dpu_team.c
@@ -221,6 +221,7 @@ ucc_status_t ucc_tl_dpu_team_destroy(ucc_base_team_t *tl_team)
     ucp_request_param_t         req_param;
  
     hangup.coll_id  = team->coll_id;
+    hangup.coll_type = UCC_COLL_TYPE_LAST;
     hangup.dtype    = UCC_DT_USERDEFINED;
     hangup.op       = UCC_OP_USERDEFINED;
     hangup.count_in      = 0;


### PR DESCRIPTION
Adds DPU TL support for UCC and the accompanying DPU daemon.
The Daemon is currently non-persistent and a very early POC, it uses UCP for collectives but can be extended as needed.

TO-DO:
Multi context support
Add other collectives (alltoall)
DPU detection (some kind of handshake the determined dpu availability).

Data-check tested, as well as using param/comms via pytorch.