### PR TITLE
TEST: build mpi tests if mpi found

### DIFF
--- a/.ci/scripts/build_ucc.sh
+++ b/.ci/scripts/build_ucc.sh
@@ -8,12 +8,8 @@ cd "${UCC_SRC_DIR}"
 mkdir -p "${UCC_SRC_DIR}/build"
 cd "${UCC_SRC_DIR}/build"
 "${UCC_SRC_DIR}/configure" --with-ucx="${UCX_INSTALL_DIR}" --with-cuda="${CUDA_HOME}" \
-    --prefix="${UCC_INSTALL_DIR}" --enable-gtest
+    --prefix="${UCC_INSTALL_DIR}" --enable-gtest --with-mpi
 make -j install
 echo "${UCC_INSTALL_DIR}/lib" > /etc/ld.so.conf.d/ucc.conf
 ldconfig
 ldconfig -p | grep -i libucc
-
-# Build MPI tests
-cd "${UCC_SRC_DIR}/build/test/mpi"
-make -j

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,12 +8,13 @@ SUBDIRS =      \
 	tools/info
 
 if HAVE_MPICXX
-SUBDIRS += tools/perf
+SUBDIRS +=     \
+	tools/perf \
+	test/mpi
 endif
 
 if HAVE_GTEST
 SUBDIRS += test/gtest
-
 gtest:
 	@make -C test/gtest test
 endif

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -23,12 +23,14 @@ ucc_test_mpi_SOURCES = \
 	test_alltoall.cc   \
 	test_alltoallv.cc
 
-CXX=mpicxx
+CXX=$(MPICXX)
+LD=$(MPICXX)
 ucc_test_mpi_CPPFLAGS=$(BASE_CPPFLAGS)
 ucc_test_mpi_CXXFLAGS=$(BASE_CXXFLAGS) -std=gnu++11
-ucc_test_mpi_LDFLAGS=-L${top_builddir}/src/.libs -lucc
+ucc_test_mpi_LDADD=$(UCC_TOP_BUILDDIR)/src/libucc.la
 
 if HAVE_CUDA
-ucc_test_mpi_CXXFLAGS+=$(CUDA_CPPFLAGS) -DUCC_TEST_WITH_CUDA
-ucc_test_mpi_LDFLAGS+=$(CUDA_LDFLAGS) $(CUDA_LIBS)
+ucc_test_mpi_CPPFLAGS+=$(CUDA_CPPFLAGS)
+ucc_test_mpi_LDFLAGS=$(CUDA_LDFLAGS)
+ucc_test_mpi_LDADD+=$(CUDA_LIBS)
 endif


### PR DESCRIPTION
## What
Currently mpi is hardcoded in mpi tests instead we can use paths found during configure steps.

