### PR TITLE
MC: cleanup interface

### DIFF
--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -46,7 +46,9 @@ typedef struct ucc_mem_attr {
     void              *base_address;
 
     /**
-     * Length of the whole allocation to which the provided buffer belongs to.
+     * If UCC_MEM_ATTR_FIELD_ALLOC_LENGTH is set this parameter should be equal
+     * to known allocation length. On output length of the whole allocation
+     * to which the provided buffer belongs to is returned.
      * If the md not support querying allocation length, then the length passed
      * to ucc_mc_cuda_mem_query is returned as is.
      */
@@ -71,8 +73,7 @@ typedef struct ucc_mc_config {
 extern ucc_config_field_t ucc_mc_config_table[];
 
 typedef struct ucc_mc_ops {
-    ucc_status_t (*mem_query)(const void *ptr, size_t length,
-                              ucc_mem_attr_t *mem_attr);
+    ucc_status_t (*mem_query)(const void *ptr, ucc_mem_attr_t *mem_attr);
     ucc_status_t (*mem_alloc)(void **ptr, size_t size);
     ucc_status_t (*mem_free)(void *ptr);
     ucc_status_t (*reduce)(const void *src1, const void *src2, void *dst,

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -119,16 +119,9 @@ static ucc_status_t ucc_mc_cpu_memcpy(void *dst, const void *src, size_t len,
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_cpu_mem_query(const void *ptr, size_t length,
-                                        ucc_mem_attr_t *mem_attr)
+static ucc_status_t ucc_mc_cpu_mem_query(const void *ptr, //NOLINT
+                                         ucc_mem_attr_t *mem_attr) //NOLINT
 {
-    if (ptr == NULL || length == 0) {
-        mem_attr->mem_type     = UCC_MEMORY_TYPE_HOST;
-        mem_attr->base_address = NULL;
-        mem_attr->alloc_length = 0;
-        return UCC_OK;
-    }
-
     /* not supposed to be used */
     mc_error(&ucc_mc_cpu.super, "host memory component shouldn't be used for"
                                 "mem type detection");

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -156,13 +156,14 @@ void ucc_tl_ucp_pre_register_mem(ucc_tl_ucp_team_t *team, void *addr,
     ucc_mem_attr_t mem_attr;
     ucc_status_t status;
 
-    if (addr == NULL|| length == 0) {
+    if ((addr == NULL) || (length == 0)) {
         return;
     }
 
-    mem_attr.field_mask = UCC_MEM_ATTR_FIELD_BASE_ADDRESS |
-                          UCC_MEM_ATTR_FIELD_ALLOC_LENGTH;
-    status = ucc_mc_query(addr, length, &mem_attr);
+    mem_attr.field_mask   = UCC_MEM_ATTR_FIELD_BASE_ADDRESS |
+                            UCC_MEM_ATTR_FIELD_ALLOC_LENGTH;
+    mem_attr.alloc_length = length;
+    status = ucc_mc_get_mem_attr(addr, &mem_attr);
     if (ucc_likely(status == UCC_OK)) {
         base_address = mem_attr.base_address;
         alloc_length = mem_attr.alloc_length;

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -23,16 +23,18 @@ static ucc_cl_team_t *ucc_select_cl_team(ucc_coll_args_t *coll_args,
     return team->cl_teams[0];
 }
 
-#define UCC_BUFFER_INFO_CHECK_MEM_TYPE(_info)                                  \
-    do {                                                                       \
-        if ((_info).mem_type == UCC_MEMORY_TYPE_UNKNOWN) {                     \
-            ucc_status_t st =                                                  \
-                ucc_mc_type((_info).buffer, &((_info).mem_type));              \
-            if (ucc_unlikely(st != UCC_OK)) {                                  \
-                return st;                                                     \
-            }                                                                  \
+#define UCC_BUFFER_INFO_CHECK_MEM_TYPE(_info) do {                             \
+    if ((_info).mem_type == UCC_MEMORY_TYPE_UNKNOWN) {                         \
+        ucc_mem_attr_t mem_attr;                                               \
+        ucc_status_t st;                                                       \
+        mem_attr.field_mask = UCC_MEM_ATTR_FIELD_MEM_TYPE;                     \
+        st = ucc_mc_get_mem_attr((_info).buffer, &mem_attr);                   \
+        if (ucc_unlikely(st != UCC_OK)) {                                      \
+            return st;                                                         \
         }                                                                      \
-    } while (0)
+        (_info).mem_type = mem_attr.mem_type;                                  \
+    }                                                                          \
+} while(0)
 
 #define UCC_IS_ROOT(_args, _myrank) ((_args).root == (_myrank))
 

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -13,10 +13,12 @@ ucc_status_t ucc_mc_init();
 
 ucc_status_t ucc_mc_available(ucc_memory_type_t mem_type);
 
-ucc_status_t ucc_mc_type(const void *ptr, ucc_memory_type_t *mem_type);
-
-ucc_status_t ucc_mc_query(const void *ptr, size_t length,
-                          ucc_mem_attr_t *mem_attr);
+/**
+ * Query for memory attributes.
+ * @param [in]        ptr       Memory pointer to query.
+ * @param [in,out]    mem_attr  Memory attributes.
+ */
+ucc_status_t ucc_mc_get_mem_attr(const void *ptr, ucc_mem_attr_t *mem_attr);
 
 ucc_status_t ucc_mc_alloc(void **ptr, size_t len, ucc_memory_type_t mem_type);
 
@@ -24,7 +26,8 @@ ucc_status_t ucc_mc_free(void *ptr, ucc_memory_type_t mem_type);
 
 ucc_status_t ucc_mc_finalize();
 
-ucc_status_t ucc_mc_ee_task_post(void *ee_context, ucc_ee_type_t ee_type, void **ee_task);
+ucc_status_t ucc_mc_ee_task_post(void *ee_context, ucc_ee_type_t ee_type,
+                                 void **ee_task);
 
 ucc_status_t ucc_mc_ee_task_query(void *ee_task, ucc_ee_type_t ee_type);
 
@@ -34,18 +37,43 @@ ucc_status_t ucc_mc_ee_create_event(void **event, ucc_ee_type_t ee_type);
 
 ucc_status_t ucc_mc_ee_destroy_event(void *event, ucc_ee_type_t ee_type);
 
-ucc_status_t ucc_mc_ee_event_post(void *ee_context, void *event, ucc_ee_type_t ee_type);
+ucc_status_t ucc_mc_ee_event_post(void *ee_context, void *event,
+                                  ucc_ee_type_t ee_type);
 
 ucc_status_t ucc_mc_ee_event_test(void *event, ucc_ee_type_t ee_type);
 
-ucc_status_t ucc_mc_reduce(const void *src1, const void *src2, void *dst,
-                           size_t count, ucc_datatype_t dt,
-                           ucc_reduction_op_t op, ucc_memory_type_t mem_type);
 
 ucc_status_t ucc_mc_memcpy(void *dst, const void *src, size_t len,
                            ucc_memory_type_t dst_mem,
                            ucc_memory_type_t src_mem);
 
+/**
+ * Performs reduction of two vectors and stores result to dst
+ * @param [in]  src1     First vector reduction operand
+ * @param [in]  src2     Second vector reduction operand
+ * @param [out] dst      dst = src1 (op) src2{0}
+ * @param [in]  count    Number of elements in dst
+ * @param [in]  dtype    Vectors elements datatype
+ * @param [in]  op       Reduction operation
+ * @param [in]  mem_type Vectors memory type
+ */
+ucc_status_t ucc_mc_reduce(const void *src1, const void *src2, void *dst,
+                           size_t count, ucc_datatype_t dtype,
+                           ucc_reduction_op_t op, ucc_memory_type_t mem_type);
+
+/**
+ * Performs reduction of multiple vectors and stores result to dst
+ * @param [in]  src1     First vector reduction operand
+ * @param [in]  src2     Array of vector reduction operands
+ * @param [out] dst      dst = src1 (op) src2{0} (op) src2{1} (op) ...
+ *                                               (op) src2{size-1}
+ * @param [in]  count    Number of elements in dst
+ * @param [in]  size     Number of vectors in src2
+ * @param [in]  stride   Offset between vectors in src2
+ * @param [in]  dtype    Vectors elements datatype
+ * @param [in]  op       Reduction operation
+ * @param [in]  mem_type Vectors memory type
+ */
 ucc_status_t ucc_mc_reduce_multi(void *src1, void *src2, void *dst,
                                  size_t count, size_t size, size_t stride,
                                  ucc_datatype_t dtype, ucc_reduction_op_t op,


### PR DESCRIPTION
## What

- Removed ucc_mc_type function since it is a duplication of ucc_mem_query
- Added docs for some functions in mc
- Changed log level for cuMemGetAddressRange to make it less verbose. It was producing following output for cpu alltoall
```
tc=Alltoall team=world mtype=host msgsize=8
[1622199941.339627] [swx-dgx04:67160:0]         mc_cuda.c:353  cuda mc ERROR cuMemGetAddressRange(0x8abb730) error: 500(no error)
[1622199941.340636] [swx-dgx04:67160:0]         mc_cuda.c:353  cuda mc ERROR cuMemGetAddressRange(0x9276110) error: 500(no error)
[1622199941.340665] [swx-dgx04:67161:0]         mc_cuda.c:353  cuda mc ERROR cuMemGetAddressRange(0x91046c0) error: 500(no error)
tc=Alltoall team=world mtype=host msgsize=64
[1622199941.342563] [swx-dgx04:67160:0]         mc_cuda.c:353  cuda mc ERROR cuMemGetAddressRange(0x8fac250) error: 500(no error)
[1622199941.342555] [swx-dgx04:67161:0]         mc_cuda.c:353  cuda mc ERROR cuMemGetAddressRange(0x8c47220) error: 500(no error)
[1622199941.343361] [swx-dgx04:67161:0]         mc_cuda.c:353  cuda mc ERROR cuMemGetAddressRange(0x8d12a20) error: 500(no error)
[1622199941.343389] [swx-dgx04:67160:0]         mc_cuda.c:353  cuda mc ERROR cuMemGetAddressRange(0x9005e90) error: 500(no error)
tc=Alltoall team=world mtype=host msgsize=512
```