### PR TITLE
TEST: fix ucc allocations

### DIFF
--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -9,6 +9,7 @@
 #include "ucc/api/ucc.h"
 extern "C" {
 #include "core/ucc_mc.h"
+#include "utils/ucc_malloc.h"
 }
 #include <vector>
 #include <tuple>

--- a/test/gtest/core/test_allgather.cc
+++ b/test/gtest/core/test_allgather.cc
@@ -35,9 +35,8 @@ public:
             coll->dst.info.count   = (ucc_count_t)count;
             coll->dst.info.datatype = dtype;
 
-            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf,
-                                   ucc_dt_size(dtype) * count,
-                                   UCC_MEMORY_TYPE_HOST));
+            ctxs[r]->init_buf = ucc_malloc(ucc_dt_size(dtype) * count, "init buf");
+            EXPECT_NE(ctxs[r]->init_buf, nullptr);
             uint8_t *sbuf = (uint8_t*)ctxs[r]->init_buf;
             for (int i = 0; i < ucc_dt_size(dtype) * count; i++) {
                 sbuf[i] = r;
@@ -70,7 +69,7 @@ public:
                 UCC_CHECK(ucc_mc_free(coll->src.info.buffer, mem_type));
             }
             UCC_CHECK(ucc_mc_free(coll->dst.info.buffer, mem_type));
-            UCC_CHECK(ucc_mc_free(ctx->init_buf, UCC_MEMORY_TYPE_HOST));
+            ucc_free(ctx->init_buf);
             free(coll);
             free(ctx);
         }
@@ -82,8 +81,8 @@ public:
         std::vector<uint8_t *> dsts(ctxs.size());
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
-                UCC_CHECK(ucc_mc_alloc((void**)&dsts[r], ctxs[r]->rbuf_size,
-                                       UCC_MEMORY_TYPE_HOST));
+                dsts[r] = (uint8_t *) ucc_malloc(ctxs[r]->rbuf_size, "dsts buf");
+                EXPECT_NE(dsts[r], nullptr);
                 UCC_CHECK(ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info.buffer,
                                         ctxs[r]->rbuf_size, UCC_MEMORY_TYPE_HOST,
                                         mem_type));
@@ -108,7 +107,7 @@ public:
         }
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
-                UCC_CHECK(ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST));
+                ucc_free(dsts[r]);
             }
         }
         return ret;

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -48,9 +48,8 @@ public:
             coll->dst.info_v.displacements = (ucc_aint_t*)displs;
             coll->dst.info_v.datatype = dtype;
 
-            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf,
-                                   ucc_dt_size(dtype) * my_count,
-                                   UCC_MEMORY_TYPE_HOST));
+            ctxs[r]->init_buf = ucc_malloc(ucc_dt_size(dtype) * my_count, "init buf");
+            EXPECT_NE(ctxs[r]->init_buf, nullptr);
             for (int i = 0; i < (ucc_dt_size(dtype) * my_count); i++) {
                 uint8_t *sbuf = (uint8_t*)ctxs[r]->init_buf;
                 sbuf[i] = r;
@@ -86,7 +85,7 @@ public:
             UCC_CHECK(ucc_mc_free(coll->dst.info.buffer, mem_type));
             free(coll->dst.info_v.displacements);
             free(coll->dst.info_v.counts);
-            UCC_CHECK(ucc_mc_free(ctx->init_buf, UCC_MEMORY_TYPE_HOST));
+            ucc_free(ctx->init_buf);
             free(coll);
             free(ctx);
         }
@@ -99,8 +98,8 @@ public:
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
-                UCC_CHECK(ucc_mc_alloc((void**)&dsts[r], ctxs[r]->rbuf_size,
-                                       UCC_MEMORY_TYPE_HOST));
+                dsts[r] = (uint8_t *) ucc_malloc(ctxs[r]->rbuf_size, "ctxs buf");
+                EXPECT_NE(dsts[r], nullptr);
                 UCC_CHECK(ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info_v.buffer,
                                         ctxs[r]->rbuf_size, UCC_MEMORY_TYPE_HOST,
                                         mem_type));
@@ -128,7 +127,7 @@ public:
         }
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
-                UCC_CHECK(ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST));
+                ucc_free (dsts[r]);
             }
         }
         return ret;

--- a/test/gtest/core/test_allreduce.cc
+++ b/test/gtest/core/test_allreduce.cc
@@ -36,8 +36,8 @@ class test_allreduce : public UccCollArgs, public testing::Test {
             coll->coll_type = UCC_COLL_TYPE_ALLREDUCE;
             coll->reduce.predefined_op = T::redop;
 
-            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf, ucc_dt_size(dt) * count,
-                                   UCC_MEMORY_TYPE_HOST));
+            ctxs[r]->init_buf = ucc_malloc(ucc_dt_size(dt) * count, "init buf");
+            EXPECT_NE(ctxs[r]->init_buf, nullptr);
             for (int i = 0; i < count; i++) {
                 typename T::type * ptr;
                 ptr = (typename T::type *)ctxs[r]->init_buf;
@@ -75,7 +75,7 @@ class test_allreduce : public UccCollArgs, public testing::Test {
                 UCC_CHECK(ucc_mc_free(coll->src.info.buffer, mem_type));
             }
             UCC_CHECK(ucc_mc_free(coll->dst.info.buffer, mem_type));
-            UCC_CHECK(ucc_mc_free(ctx->init_buf, UCC_MEMORY_TYPE_HOST));
+            ucc_free(ctx->init_buf);
             free(coll);
             free(ctx);
         }
@@ -88,9 +88,8 @@ class test_allreduce : public UccCollArgs, public testing::Test {
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
-                UCC_CHECK(ucc_mc_alloc((void**)&dsts[r],
-                                       count * sizeof(typename T::type),
-                                       UCC_MEMORY_TYPE_HOST));
+                dsts[r] = (typename T::type *) ucc_malloc(count * sizeof(typename T::type), "dsts buf");
+                EXPECT_NE(dsts[r], nullptr);
                 UCC_CHECK(ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info.buffer,
                                         count * sizeof(typename T::type), UCC_MEMORY_TYPE_HOST,
                                         mem_type));
@@ -112,7 +111,7 @@ class test_allreduce : public UccCollArgs, public testing::Test {
         }
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
             for (int r = 0; r < ctxs.size(); r++) {
-                UCC_CHECK(ucc_mc_free((void*)dsts[r], UCC_MEMORY_TYPE_HOST));
+                ucc_free(dsts[r]);
             }
         }
         return true;

--- a/test/gtest/core/test_bcast.cc
+++ b/test/gtest/core/test_bcast.cc
@@ -40,8 +40,8 @@ public:
             UCC_CHECK(ucc_mc_alloc(&coll->src.info.buffer, ctxs[r]->rbuf_size,
                                    mem_type));
             if (r == root) {
-                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->init_buf, ctxs[r]->rbuf_size,
-                                       UCC_MEMORY_TYPE_HOST));
+                ctxs[r]->init_buf = ucc_malloc(ctxs[r]->rbuf_size, "init buf");
+                EXPECT_NE(ctxs[r]->init_buf, nullptr);
                 uint8_t *sbuf = (uint8_t*)ctxs[r]->init_buf;
                 for (int i = 0; i < ctxs[r]->rbuf_size; i++) {
                     sbuf[i] = (uint8_t)i;
@@ -59,7 +59,7 @@ public:
             ucc_coll_args_t* coll = ctx->args;
             UCC_CHECK(ucc_mc_free(coll->src.info.buffer, mem_type));
             if (r == coll->root) {
-                UCC_CHECK(ucc_mc_free(ctx->init_buf, UCC_MEMORY_TYPE_HOST));
+                ucc_free(ctx->init_buf);
             }
             free(coll);
             free(ctx);
@@ -73,8 +73,8 @@ public:
         uint8_t *dsts;
 
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
-                UCC_CHECK(ucc_mc_alloc((void**)&dsts, ctxs[root]->rbuf_size,
-                                       UCC_MEMORY_TYPE_HOST));
+                dsts = (uint8_t*) ucc_malloc(ctxs[root]->rbuf_size, "dsts buf");
+                EXPECT_NE(dsts, nullptr);
                 UCC_CHECK(ucc_mc_memcpy(dsts, ctxs[root]->args->src.info.buffer,
                                         ctxs[root]->rbuf_size,
                                         UCC_MEMORY_TYPE_HOST, mem_type));
@@ -94,7 +94,7 @@ public:
             }
         }
         if (UCC_MEMORY_TYPE_HOST != mem_type) {
-            UCC_CHECK(ucc_mc_free((void*)dsts, UCC_MEMORY_TYPE_HOST));
+            ucc_free(dsts);
         }
         return ret;
     }

--- a/test/mpi/buffer.cc
+++ b/test/mpi/buffer.cc
@@ -28,8 +28,8 @@ void init_buffer(void *_buf, size_t count, ucc_datatype_t dt,
 {
     void *buf = NULL;
     if (mt == UCC_MEMORY_TYPE_CUDA) {
-        UCC_CHECK(ucc_mc_alloc(&buf, count * ucc_dt_size(dt),
-                               UCC_MEMORY_TYPE_HOST));
+        buf = ucc_malloc(count * ucc_dt_size(dt), "buf");
+        UCC_MALLOC_CHECK(buf);
     } else if (mt == UCC_MEMORY_TYPE_HOST) {
         buf = _buf;
     } else {
@@ -75,7 +75,7 @@ void init_buffer(void *_buf, size_t count, ucc_datatype_t dt,
     if (UCC_MEMORY_TYPE_HOST != mt) {
         UCC_CHECK(ucc_mc_memcpy(_buf, buf, count * ucc_dt_size(dt),
                                 mt, UCC_MEMORY_TYPE_HOST));
-        UCC_CHECK(ucc_mc_free(buf, UCC_MEMORY_TYPE_HOST));
+        ucc_free(buf);
     }
 }
 

--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -28,7 +28,8 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     }
 
     UCC_CHECK(ucc_mc_alloc(&rbuf, _msgsize*size, _mt));
-    UCC_CHECK(ucc_mc_alloc(&check_rbuf, _msgsize*size, UCC_MEMORY_TYPE_HOST));
+    check_rbuf = ucc_malloc(_msgsize*size, "check rbuf");
+    UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
         UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize, _mt));
         init_buffer(sbuf, count, TEST_DT, _mt, rank);

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -28,12 +28,13 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc((void**)&counts, size * sizeof(uint32_t),
-                           UCC_MEMORY_TYPE_HOST));
-    UCC_CHECK(ucc_mc_alloc((void**)&displacements, size * sizeof(uint32_t),
-                           UCC_MEMORY_TYPE_HOST));
+    counts = (int *) ucc_malloc(size * sizeof(uint32_t), "counts buf");
+    UCC_MALLOC_CHECK(counts);
+    displacements = (int *) ucc_malloc(size * sizeof(uint32_t), "displacements buf");
+    UCC_MALLOC_CHECK(displacements);
     UCC_CHECK(ucc_mc_alloc(&rbuf, _msgsize*size, _mt));
-    UCC_CHECK(ucc_mc_alloc(&check_rbuf, _msgsize*size, UCC_MEMORY_TYPE_HOST));
+    check_rbuf = ucc_malloc(_msgsize*size, "check rbuf");
+    UCC_MALLOC_CHECK(check_rbuf);
     for (int i = 0; i < size; i++) {
         counts[i] = count;
         displacements[i] = i * count;
@@ -67,10 +68,10 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 
 TestAllgatherv::~TestAllgatherv() {
     if (counts) {
-        ucc_mc_free(counts, UCC_MEMORY_TYPE_HOST);
+        ucc_free(counts);
     }
     if (displacements) {
-        ucc_mc_free(displacements, UCC_MEMORY_TYPE_HOST);
+        ucc_free(displacements);
     }
 }
 ucc_status_t TestAllgatherv::check()

--- a/test/mpi/test_allreduce.cc
+++ b/test/mpi/test_allreduce.cc
@@ -27,7 +27,8 @@ TestAllreduce::TestAllreduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     }
 
     UCC_CHECK(ucc_mc_alloc(&rbuf, _msgsize, _mt));
-    UCC_CHECK(ucc_mc_alloc(&check_rbuf, _msgsize, UCC_MEMORY_TYPE_HOST));
+    check_rbuf = ucc_malloc(_msgsize, "check rbuf");
+    UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
         UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize, _mt));
         init_buffer(sbuf, count, dt, _mt, rank);

--- a/test/mpi/test_alltoall.cc
+++ b/test/mpi/test_alltoall.cc
@@ -30,7 +30,8 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     }
 
     UCC_CHECK(ucc_mc_alloc(&rbuf, _msgsize * nprocs, _mt));
-    UCC_CHECK(ucc_mc_alloc(&check_rbuf, _msgsize * nprocs, UCC_MEMORY_TYPE_HOST));
+    check_rbuf = ucc_malloc(_msgsize * nprocs, "check rbuf");
+    UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
         UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize * nprocs, _mt));
         init_buffer(sbuf, count * nprocs, TEST_DT, _mt, rank);

--- a/test/mpi/test_alltoallv.cc
+++ b/test/mpi/test_alltoallv.cc
@@ -108,8 +108,8 @@ TestAlltoallv::TestAlltoallv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     UCC_ALLOC_COPY_BUF(check_sbuf, UCC_MEMORY_TYPE_HOST, sbuf, _mt,
                        sncounts * dt_size);
     UCC_CHECK(ucc_mc_alloc(&rbuf, rncounts * dt_size, _mt));
-    UCC_CHECK(ucc_mc_alloc(&check_rbuf, rncounts * dt_size,
-                           UCC_MEMORY_TYPE_HOST));
+    check_rbuf = ucc_malloc(rncounts * dt_size, "check rbuf");
+    UCC_MALLOC_CHECK(check_rbuf);
 
     args.src.info_v.buffer = sbuf;
     args.src.info_v.datatype = TEST_DT;

--- a/test/mpi/test_bcast.cc
+++ b/test/mpi/test_bcast.cc
@@ -27,9 +27,11 @@ TestBcast::TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    UCC_CHECK(ucc_mc_alloc(&check_rbuf, _msgsize*size, UCC_MEMORY_TYPE_HOST));
+    check_rbuf = ucc_malloc(_msgsize * size, "check rbuf");
+    UCC_MALLOC_CHECK(check_rbuf);
     UCC_CHECK(ucc_mc_alloc(&sbuf, _msgsize, _mt));
-    UCC_CHECK(ucc_mc_alloc(&check_sbuf, _msgsize, UCC_MEMORY_TYPE_HOST));
+    check_sbuf = ucc_malloc(_msgsize, "check sbuf");
+    UCC_MALLOC_CHECK(check_sbuf);
     if (rank == root) {
         init_buffer(sbuf, count, TEST_DT, _mt, rank);
         UCC_CHECK(ucc_mc_memcpy(check_sbuf, sbuf, _msgsize,                        \

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -165,9 +165,9 @@ TestCase::~TestCase()
         UCC_CHECK(ucc_mc_free(rbuf, mem_type));
     }
     if (check_sbuf) {
-        UCC_CHECK(ucc_mc_free(check_sbuf, UCC_MEMORY_TYPE_HOST));
+        ucc_free(check_sbuf);
     }
     if (check_rbuf) {
-        UCC_CHECK(ucc_mc_free(check_rbuf, UCC_MEMORY_TYPE_HOST));
+        ucc_free(check_rbuf);
     }
 }

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -13,6 +13,9 @@
 #include <unistd.h>
 #include <mpi.h>
 #include <ucc/api/ucc.h>
+extern "C" {
+#include "utils/ucc_malloc.h"
+}
 BEGIN_C_DECLS
 #include "core/ucc_mc.h"
 #include "utils/ucc_math.h"
@@ -26,6 +29,12 @@ END_C_DECLS
 #define UCC_CHECK(_call)                                                \
     if (UCC_OK != (_call)) {                                            \
         std::cerr << "*** UCC TEST FAIL: " << STR(_call) << "\n";       \
+        MPI_Abort(MPI_COMM_WORLD, -1);                                  \
+    }
+
+#define UCC_MALLOC_CHECK(_obj)                                          \
+    if (!(_obj)) {                                                      \
+        std::cerr << "*** UCC MALLOC FAIL \n";                          \
         MPI_Abort(MPI_COMM_WORLD, -1);                                  \
     }
 

--- a/tools/perf/ucc_perftest.h
+++ b/tools/perf/ucc_perftest.h
@@ -7,6 +7,9 @@
 #include <ucc/api/ucc.h>
 #include <iostream>
 #include "config.h"
+extern "C" {
+#include "utils/ucc_malloc.h"
+}
 
 #define STR(x) #x
 #define UCCCHECK_GOTO(_call, _label, _status)                                  \
@@ -15,6 +18,16 @@
         if (UCC_OK != _status) {                                               \
             std::cerr << "UCC perftest error: " << ucc_status_string(_status)  \
                       << " in " << STR(_call) << "\n";                         \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
+
+#define UCC_MALLOC_CHECK_GOTO(_obj, _label, _status)                           \
+    do {                                                                       \
+        if (!(_obj)) {                                                         \
+            _status = UCC_ERR_NO_MEMORY;                                       \
+            std::cerr << "UCC perftest error: " << ucc_status_string(_status)  \
+                      << "\n";                                                 \
             goto _label;                                                       \
         }                                                                      \
     } while (0)


### PR DESCRIPTION
## What
Changed unnecessary mc allocation to ucc_malloc in tests.

## Why ?
To reduce mc usage unless needed.

## How ?
Any place in tests that called ucc_mc_alloc with UCC_MEMORY_TYPE_HOST directly was changed to ucc_malloc.
