### PR TITLE
CORE: Change mt pq default value

### DIFF
--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -18,7 +18,7 @@ static ucc_config_field_t ucc_context_config_table[] = {
      "An optimization hint of how many endpoints will be created on this context",
      ucc_offsetof(ucc_context_config_t, estimated_num_eps), UCC_CONFIG_TYPE_UINT},
 
-    {"LOCK_FREE_PROGRESS_Q", "0",
+    {"LOCK_FREE_PROGRESS_Q", "1",
      "Enable lock free progress queue optimization",
      ucc_offsetof(ucc_context_config_t, lock_free_progress_q), UCC_CONFIG_TYPE_UINT},
 

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -15,26 +15,32 @@
 static uint32_t ucc_context_seq_num = 0;
 static ucc_config_field_t ucc_context_config_table[] = {
     {"ESTIMATED_NUM_EPS", "0",
-     "An optimization hint of how many endpoints will be created on this context",
-     ucc_offsetof(ucc_context_config_t, estimated_num_eps), UCC_CONFIG_TYPE_UINT},
+     "An optimization hint of how many endpoints will be created on this "
+     "context",
+     ucc_offsetof(ucc_context_config_t, estimated_num_eps),
+     UCC_CONFIG_TYPE_UINT},
 
     {"LOCK_FREE_PROGRESS_Q", "1",
      "Enable lock free progress queue optimization",
-     ucc_offsetof(ucc_context_config_t, lock_free_progress_q), UCC_CONFIG_TYPE_UINT},
+     ucc_offsetof(ucc_context_config_t, lock_free_progress_q),
+     UCC_CONFIG_TYPE_UINT},
 
     {"ESTIMATED_NUM_PPN", "0",
      "An optimization hint of how many endpoints created on this context reside"
      " on the same node",
-     ucc_offsetof(ucc_context_config_t, estimated_num_ppn), UCC_CONFIG_TYPE_UINT},
+     ucc_offsetof(ucc_context_config_t, estimated_num_ppn),
+     UCC_CONFIG_TYPE_UINT},
 
     {"TEAM_IDS_POOL_SIZE", "32",
-     "Defines the size of the team_id_pool. The number of coexisting unique team ids "
-     "for a single process is team_ids_pool_size*64. This parameter is relevant when "
-     "internal team id allocation takes place.",
-     ucc_offsetof(ucc_context_config_t, team_ids_pool_size), UCC_CONFIG_TYPE_UINT},
+     "Defines the size of the team_id_pool. The number of coexisting unique "
+     "team ids for a single process is team_ids_pool_size*64. This parameter"
+     " is relevant when internal team id allocation takes place.",
+     ucc_offsetof(ucc_context_config_t, team_ids_pool_size),
+     UCC_CONFIG_TYPE_UINT},
 
     {NULL}
 };
+
 UCC_CONFIG_REGISTER_TABLE(ucc_context_config_table, "UCC context", NULL,
                           ucc_context_config_t, &ucc_config_global_list);
 

--- a/tools/perf/ucc_perftest.cc
+++ b/tools/perf/ucc_perftest.cc
@@ -18,7 +18,7 @@ int main(int argc, char *argv[])
         std::cerr << e.what() << std::endl;
         std::exit(1);
     }
-    st = comm->init();
+    st = comm->init(pt_config.bench.n_threads);
     if (st != UCC_OK) {
         delete comm;
         std::exit(1);

--- a/tools/perf/ucc_pt_benchmark.h
+++ b/tools/perf/ucc_pt_benchmark.h
@@ -12,6 +12,7 @@
 #include "ucc_pt_comm.h"
 #include <ucc/api/ucc.h>
 #include <chrono>
+#include <vector>
 
 class ucc_pt_benchmark {
     ucc_pt_benchmark_config config;
@@ -24,9 +25,6 @@ class ucc_pt_benchmark {
 public:
     ucc_pt_benchmark(ucc_pt_benchmark_config cfg, ucc_pt_comm *communcator);
     ucc_status_t run_bench() noexcept;
-    ucc_status_t run_single_test(ucc_coll_args_t args,
-                                 int nwarmup, int niter,
-                                 std::chrono::nanoseconds &time) noexcept;
     ~ucc_pt_benchmark();
 };
 

--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -36,14 +36,19 @@ int ucc_pt_comm::get_rank()
     return bootstrap->get_rank();
 }
 
+int ucc_pt_comm::get_n_threads()
+{
+    return n_threads;
+}
+
 int ucc_pt_comm::get_size()
 {
     return bootstrap->get_size();
 }
 
-ucc_team_h ucc_pt_comm::get_team()
+ucc_team_h ucc_pt_comm::get_team(int thread_id)
 {
-    return team;
+    return teams[thread_id];
 }
 
 ucc_context_h ucc_pt_comm::get_context()
@@ -51,7 +56,7 @@ ucc_context_h ucc_pt_comm::get_context()
     return context;
 }
 
-ucc_status_t ucc_pt_comm::init()
+ucc_status_t ucc_pt_comm::init(int number_of_threads)
 {
     ucc_lib_config_h lib_config;
     ucc_context_config_h ctx_config;
@@ -60,6 +65,8 @@ ucc_status_t ucc_pt_comm::init()
     ucc_team_params_t team_params;
     ucc_status_t st;
     std::string cfg_mod;
+    n_threads = number_of_threads;
+    int i;
 
     if (cfg.mt != UCC_MEMORY_TYPE_HOST) {
         set_gpu_device();
@@ -68,7 +75,8 @@ ucc_status_t ucc_pt_comm::init()
                   exit_err, st);
     std::memset(&lib_params, 0, sizeof(ucc_lib_params_t));
     lib_params.mask = UCC_LIB_PARAM_FIELD_THREAD_MODE;
-    lib_params.thread_mode = UCC_THREAD_SINGLE;
+    lib_params.thread_mode =
+        (n_threads > 1) ? UCC_THREAD_MULTIPLE : UCC_THREAD_SINGLE;
     UCCCHECK_GOTO(ucc_init(&lib_params, lib_config, &lib), free_lib_config, st);
     UCCCHECK_GOTO(ucc_context_config_read(lib, NULL, &ctx_config),
                   free_lib, st);
@@ -85,21 +93,41 @@ ucc_status_t ucc_pt_comm::init()
     ctx_params.oob  = bootstrap->get_context_oob();
     UCCCHECK_GOTO(ucc_context_create(lib, &ctx_params, ctx_config, &context),
                   free_ctx_config, st);
+    teams = (ucc_team_h *)ucc_malloc(sizeof(ucc_team_h) * n_threads);
+    if (!teams) {
+        std::cerr << "UCC perftest error: teams malloc failed"
+                  << "\n";
+        st = UCC_ERR_NO_MEMORY;
+        goto free_ctx;
+    }
     team_params.mask     = UCC_TEAM_PARAM_FIELD_EP |
                            UCC_TEAM_PARAM_FIELD_EP_RANGE |
                            UCC_TEAM_PARAM_FIELD_OOB;
     team_params.oob      = bootstrap->get_team_oob();
     team_params.ep       = bootstrap->get_rank();
     team_params.ep_range = UCC_COLLECTIVE_EP_RANGE_CONTIG;
-    UCCCHECK_GOTO(ucc_team_create_post(&context, 1, &team_params, &team),
-                  free_ctx, st);
-    do {
-        st = ucc_team_create_test(team);
-    } while(st == UCC_INPROGRESS);
-    UCCCHECK_GOTO(st, free_ctx, st);
+    for (i = 0; i < n_threads; i++) {
+        UCCCHECK_GOTO(
+            ucc_team_create_post(&context, 1, &team_params, &teams[i]),
+            free_teams, st);
+        do {
+            st = ucc_team_create_test(teams[i]);
+        } while (st == UCC_INPROGRESS);
+        UCCCHECK_GOTO(st, free_teams, st);
+    }
     ucc_context_config_release(ctx_config);
     ucc_lib_config_release(lib_config);
     return UCC_OK;
+free_teams:
+    for (i = i - 1; i >= 0; i--) {
+        do {
+            st = ucc_team_destroy(teams[i]);
+        } while (st == UCC_INPROGRESS);
+        if (st != UCC_OK) {
+            std::cerr << "ucc team destroy error: " << ucc_status_string(st);
+        }
+    }
+    ucc_free(teams);
 free_ctx:
     ucc_context_destroy(context);
 free_ctx_config:
@@ -115,26 +143,30 @@ exit_err:
 ucc_status_t ucc_pt_comm::finalize()
 {
     ucc_status_t status;
-
-    do {
-        status = ucc_team_destroy(team);
-    } while (status == UCC_INPROGRESS);
-    if (status != UCC_OK) {
-        std::cerr << "ucc team destroy error: " << ucc_status_string(status);
+    int          i;
+    for (i = 0; i < n_threads; i++) {
+        do {
+            status = ucc_team_destroy(teams[i]);
+        } while (status == UCC_INPROGRESS);
+        if (status != UCC_OK) {
+            std::cerr << "ucc team destroy error: "
+                      << ucc_status_string(status);
+        }
     }
+    ucc_free(teams);
     ucc_context_destroy(context);
     ucc_finalize(lib);
     return UCC_OK;
 }
 
-ucc_status_t ucc_pt_comm::barrier()
+ucc_status_t ucc_pt_comm::barrier(int thread_id)
 {
     ucc_coll_args_t args;
     ucc_coll_req_h req;
 
     args.mask = 0;
     args.coll_type = UCC_COLL_TYPE_BARRIER;
-    ucc_collective_init(&args, &req, team);
+    ucc_collective_init(&args, &req, teams[thread_id]);
     ucc_collective_post(req);
     do {
         ucc_context_progress(context);
@@ -160,7 +192,7 @@ ucc_status_t ucc_pt_comm::allreduce(float* in, float* out, size_t size,
     args.dst.info.count       = size;
     args.dst.info.datatype    = UCC_DT_FLOAT32;
     args.dst.info.mem_type    = UCC_MEMORY_TYPE_HOST;
-    ucc_collective_init(&args, &req, team);
+    ucc_collective_init(&args, &req, teams[0]);
     ucc_collective_post(req);
     do {
         ucc_context_progress(context);

--- a/tools/perf/ucc_pt_comm.h
+++ b/tools/perf/ucc_pt_comm.h
@@ -16,18 +16,20 @@ class ucc_pt_comm {
     ucc_pt_comm_config cfg;
     ucc_lib_h lib;
     ucc_context_h context;
-    ucc_team_h team;
+    int                n_threads;
+    ucc_team_h *       teams;
     ucc_pt_bootstrap *bootstrap;
     void set_gpu_device();
 public:
     ucc_pt_comm(ucc_pt_comm_config config);
     int get_rank();
     int get_size();
-    ucc_team_h get_team();
+    int           get_n_threads();
+    ucc_team_h    get_team(int thread_id);
     ucc_context_h get_context();
     ~ucc_pt_comm();
-    ucc_status_t init();
-    ucc_status_t barrier();
+    ucc_status_t init(int n_threads);
+    ucc_status_t barrier(int thread_id);
     ucc_status_t allreduce(float* in, float *out, size_t size,
                            ucc_reduction_op_t op);
     ucc_status_t finalize();

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -14,6 +14,7 @@ ucc_pt_config::ucc_pt_config() {
     bench.n_iter_large   = 200;
     bench.n_warmup_large = 20;
     bench.large_thresh   = 64 * 1024;
+    bench.n_threads      = 1;
 }
 
 const std::map<std::string, ucc_reduction_op_t> ucc_pt_op_map = {
@@ -57,7 +58,7 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
 {
     int c;
 
-    while ((c = getopt(argc, argv, "c:b:e:d:m:n:w:o:ih")) != -1) {
+    while ((c = getopt(argc, argv, "c:b:e:d:m:t:n:w:o:ih")) != -1) {
         switch (c) {
             case 'c':
                 if (ucc_pt_coll_map.count(optarg) == 0) {
@@ -105,6 +106,13 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
             case 'i':
                 bench.inplace = true;
                 break;
+            case 't':
+                std::stringstream(optarg) >> bench.n_threads;
+                if (bench.n_threads < 1) {
+                    std::cerr << "invalid thread num" << std::endl;
+                    return UCC_ERR_INVALID_PARAM;
+                }
+                break;
             case 'h':
             default:
                 print_help();
@@ -126,6 +134,7 @@ void ucc_pt_config::print_help()
     std::cout << "  -m <mtype name>: memory type"<<std::endl;
     std::cout << "  -n <number>: number of iterations"<<std::endl;
     std::cout << "  -w <number>: number of warmup iterations"<<std::endl;
+    std::cout << "  -t <number>: number of threads" << std::endl;
     std::cout << "  -h: show this help message"<<std::endl;
     std::cout << std::endl;
 }

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -40,6 +40,7 @@ struct ucc_pt_benchmark_config {
     int                n_warmup_small;
     int                n_iter_large;
     int                n_warmup_large;
+    int                n_threads;
 };
 
 struct ucc_pt_config {


### PR DESCRIPTION
## What
Change mt progress queue default value to lock-free queue. In addition, add a multithreaded option to perf test. 

## Why ?
Better optimization for the multi-threaded environment, tests were added in order to check mt progress queue performance.

## How ?
Simply change the default value. Change infrastructure of perf tests.
