### PR TITLE
MC: save memtype in header

### DIFF
--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -49,6 +49,7 @@ static ucc_status_t ucc_mc_cpu_mem_alloc(ucc_mc_buffer_header_t **h_ptr,
     }
     h->from_pool = 0;
     h->addr      = PTR_OFFSET(h, sizeof(ucc_mc_buffer_header_t));
+    h->mt        = UCC_MEMORY_TYPE_HOST;
     *h_ptr       = h;
     mc_debug(&ucc_mc_cpu.super, "MC allocated %ld bytes with ucc_malloc", size);
     return UCC_OK;
@@ -88,6 +89,7 @@ static void ucc_mc_cpu_chunk_init(ucc_mpool_t *mp, //NOLINT
     ucc_mc_buffer_header_t *h = (ucc_mc_buffer_header_t *)obj;
     h->from_pool              = 1;
     h->addr                   = PTR_OFFSET(h, sizeof(ucc_mc_buffer_header_t));
+    h->mt                     = UCC_MEMORY_TYPE_HOST;
 }
 
 static void ucc_mc_cpu_chunk_release(ucc_mpool_t *mp, void *chunk) //NOLINT

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -250,6 +250,7 @@ static ucc_status_t ucc_mc_cuda_mem_alloc(ucc_mc_buffer_header_t **h_ptr,
         return UCC_ERR_NO_MEMORY;
     }
     h->from_pool = 0;
+    h->mt        = UCC_MEMORY_TYPE_CUDA;
     *h_ptr       = h;
     mc_debug(&ucc_mc_cuda.super, "MC allocated %ld bytes with cudaMalloc", size);
     return UCC_OK;
@@ -302,6 +303,7 @@ static void ucc_mc_cuda_chunk_init(ucc_mpool_t *mp, //NOLINT
                  MC_CUDA_CONFIG->mpool_elem_size, st, cudaGetErrorString(st));
     }
     h->from_pool = 1;
+    h->mt        = UCC_MEMORY_TYPE_CUDA;
 }
 
 static void ucc_mc_cuda_chunk_release(ucc_mpool_t *mp, void *chunk) //NOLINT

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -217,8 +217,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_finalize(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_status_t st, global_st;
 
-    global_st = ucc_mc_free(task->allreduce_kn.scratch_mc_header,
-                            task->args.src.info.mem_type);
+    global_st = ucc_mc_free(task->allreduce_kn.scratch_mc_header);
     if (ucc_unlikely(global_st != UCC_OK)) {
         tl_error(UCC_TL_TEAM_LIB(task->team),
                  "failed to free scratch buffer");

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -190,9 +190,9 @@ ucc_tl_ucp_reduce_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     uint8_t            node_type = task->reduce_scatter_kn.p.node_type;
-    ucc_memory_type_t  mem_type  = task->args.src.info.mem_type;
+
     if (UCC_IS_INPLACE(task->args) || (KN_NODE_PROXY == node_type)) {
-        ucc_mc_free(task->reduce_scatter_kn.scratch_mc_header, mem_type);
+        ucc_mc_free(task->reduce_scatter_kn.scratch_mc_header);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);
 }

--- a/src/core/ucc_mc.c
+++ b/src/core/ucc_mc.c
@@ -141,11 +141,10 @@ ucc_status_t ucc_mc_reduce_multi(void *src1, void *src2, void *dst,
                                           dtype, op);
 }
 
-ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *h_ptr,
-                         ucc_memory_type_t       mem_type)
+ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *h_ptr)
 {
-    UCC_CHECK_MC_AVAILABLE(mem_type);
-    return mc_ops[mem_type]->mem_free(h_ptr);
+    UCC_CHECK_MC_AVAILABLE(h_ptr->mt);
+    return mc_ops[h_ptr->mt]->mem_free(h_ptr);
 }
 
 ucc_status_t ucc_mc_memcpy(void *dst, const void *src, size_t len,

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -12,8 +12,9 @@
 typedef struct ucc_mem_attr ucc_mem_attr_t;
 
 typedef struct ucc_mc_buffer_header {
-    int   from_pool;
-    void *addr;
+    ucc_memory_type_t mt;
+    int               from_pool;
+    void             *addr;
 } ucc_mc_buffer_header_t;
 
 typedef struct ucc_mc_params {
@@ -34,8 +35,7 @@ ucc_status_t ucc_mc_get_mem_attr(const void *ptr, ucc_mem_attr_t *mem_attr);
 ucc_status_t ucc_mc_alloc(ucc_mc_buffer_header_t **h_ptr, size_t len,
                           ucc_memory_type_t mem_type);
 
-ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *h_ptr,
-                         ucc_memory_type_t       mem_type);
+ucc_status_t ucc_mc_free(ucc_mc_buffer_header_t *h_ptr);
 
 ucc_status_t ucc_mc_finalize();
 

--- a/test/gtest/core/test_allgather.cc
+++ b/test/gtest/core/test_allgather.cc
@@ -65,9 +65,9 @@ public:
         for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
             ucc_coll_args_t* coll = ctx->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
+                UCC_CHECK(ucc_mc_free(ctx->src_mc_header));
             }
-            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header));
             ucc_free(ctx->init_buf);
             free(coll);
             free(ctx);

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -80,9 +80,9 @@ public:
         for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
             ucc_coll_args_t* coll = ctx->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
+                UCC_CHECK(ucc_mc_free(ctx->src_mc_header));
             }
-            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header));
             free(coll->dst.info_v.displacements);
             free(coll->dst.info_v.counts);
             ucc_free(ctx->init_buf);

--- a/test/gtest/core/test_allreduce.cc
+++ b/test/gtest/core/test_allreduce.cc
@@ -71,9 +71,9 @@ class test_allreduce : public UccCollArgs, public testing::Test {
         for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
             ucc_coll_args_t* coll = ctx->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
+                UCC_CHECK(ucc_mc_free(ctx->src_mc_header));
             }
-            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header));
             ucc_free(ctx->init_buf);
             free(coll);
             free(ctx);
@@ -200,4 +200,3 @@ TYPED_TEST(test_allreduce, multiple_cuda_inplace) {
     TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE);
 }
 #endif
-

--- a/test/gtest/core/test_alltoall.cc
+++ b/test/gtest/core/test_alltoall.cc
@@ -67,9 +67,9 @@ public:
         for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
             ucc_coll_args_t* coll = ctx->args;
             if (coll->src.info.buffer) { /* no inplace */
-                UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
+                UCC_CHECK(ucc_mc_free(ctx->src_mc_header));
             }
-            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header));
             ucc_free(ctx->init_buf);
             free(coll);
             free(ctx);

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -123,10 +123,10 @@ public:
     {
         for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
             ucc_coll_args_t* coll = ctx->args;
-            UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->src_mc_header));
             free(coll->src.info_v.counts);
             free(coll->src.info_v.displacements);
-            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header));
             free(coll->dst.info_v.counts);
             free(coll->dst.info_v.displacements);
             ucc_free(ctx->init_buf);
@@ -224,7 +224,7 @@ class test_alltoallv_3 : public test_alltoallv<uint32_t>,
 
 
 UCC_TEST_P(test_alltoallv_2, multiple)
-{    
+{
     ucc_memory_type_t           mem_type = std::get<0>(GetParam());
     gtest_ucc_inplace_t         inplace  = std::get<1>(GetParam());
     const ucc_datatype_t        dtype    = (ucc_datatype_t)std::get<2>(GetParam());

--- a/test/gtest/core/test_bcast.cc
+++ b/test/gtest/core/test_bcast.cc
@@ -55,7 +55,7 @@ public:
         for (auto r = 0; r < ctxs.size(); r++) {
             gtest_ucc_coll_ctx_t *ctx = ctxs[r];
             ucc_coll_args_t* coll = ctx->args;
-            UCC_CHECK(ucc_mc_free(ctx->src_mc_header, mem_type));
+            UCC_CHECK(ucc_mc_free(ctx->src_mc_header));
             if (r == coll->root) {
                 ucc_free(ctx->init_buf);
             }

--- a/test/gtest/core/test_mc.cc
+++ b/test/gtest/core/test_mc.cc
@@ -30,7 +30,7 @@ void *mt_ucc_mc_cpu_allocs(void *args)
                   ucc_mc_alloc(&headers[i], size, UCC_MEMORY_TYPE_HOST));
         pointers[i] = headers[i]->addr;
         memset(pointers[i], 0, size);
-        EXPECT_EQ(UCC_OK, ucc_mc_free(headers[i], UCC_MEMORY_TYPE_HOST));
+        EXPECT_EQ(UCC_OK, ucc_mc_free(headers[i]));
         if (i % 2) {
             size *= quantifier;
         }
@@ -78,7 +78,7 @@ UCC_TEST_F(test_mc, can_alloc_and_free_host_mem)
     EXPECT_EQ(UCC_OK, ucc_mc_alloc(&h, size, UCC_MEMORY_TYPE_HOST));
     ptr = h->addr;
     memset(ptr, 0, size);
-    EXPECT_EQ(UCC_OK, ucc_mc_free(h, UCC_MEMORY_TYPE_HOST));
+    EXPECT_EQ(UCC_OK, ucc_mc_free(h));
     ucc_mc_finalize();
 }
 

--- a/test/gtest/core/test_mc_cuda.cc
+++ b/test/gtest/core/test_mc_cuda.cc
@@ -31,7 +31,7 @@ void *mt_ucc_mc_cuda_allocs(void *args)
                   ucc_mc_alloc(&headers[i], size, UCC_MEMORY_TYPE_CUDA));
         pointers[i] = headers[i]->addr;
         EXPECT_EQ(cudaSuccess, cudaMemset(pointers[i], 0, size));
-        EXPECT_EQ(UCC_OK, ucc_mc_free(headers[i], UCC_MEMORY_TYPE_CUDA));
+        EXPECT_EQ(UCC_OK, ucc_mc_free(headers[i]));
         if (i % 2) {
             size *= quantifier;
         }
@@ -90,7 +90,7 @@ UCC_TEST_F(test_mc_cuda, can_alloc_and_free_mem)
               ucc_mc_alloc(&mc_header, TEST_ALLOC_SIZE, UCC_MEMORY_TYPE_CUDA));
     test_ptr = mc_header->addr;
     EXPECT_EQ(cudaSuccess, cudaMemset(test_ptr, 0, TEST_ALLOC_SIZE));
-    EXPECT_EQ(UCC_OK, ucc_mc_free(mc_header, UCC_MEMORY_TYPE_CUDA));
+    EXPECT_EQ(UCC_OK, ucc_mc_free(mc_header));
 }
 
 UCC_TEST_F(test_mc_cuda_mt, can_alloc_and_free_mem_mt)

--- a/test/gtest/core/test_mc_reduce.h
+++ b/test/gtest/core/test_mc_reduce.h
@@ -234,22 +234,22 @@ class test_mc_reduce : public testing::Test {
     ucc_status_t free_bufs(ucc_memory_type_t mtype)
     {
         if (buf1_h != nullptr) {
-            ucc_mc_free(buf1_h_mc_header, UCC_MEMORY_TYPE_HOST);
+            ucc_mc_free(buf1_h_mc_header);
         }
         if (buf2_h != nullptr) {
-            ucc_mc_free(buf2_h_mc_header, UCC_MEMORY_TYPE_HOST);
+            ucc_mc_free(buf2_h_mc_header);
         }
         if (res_h != nullptr) {
-            ucc_mc_free(res_h_mc_header, UCC_MEMORY_TYPE_HOST);
+            ucc_mc_free(res_h_mc_header);
         }
         if (buf1_d != nullptr) {
-            ucc_mc_free(buf1_d_mc_header, mtype);
+            ucc_mc_free(buf1_d_mc_header);
         }
         if (buf2_d != nullptr) {
-            ucc_mc_free(buf2_d_mc_header, mtype);
+            ucc_mc_free(buf2_d_mc_header);
         }
         if (res_d != nullptr) {
-            ucc_mc_free(res_d_mc_header, mtype);
+            ucc_mc_free(res_d_mc_header);
         }
 
         return UCC_OK;

--- a/test/mpi/buffer.cc
+++ b/test/mpi/buffer.cc
@@ -125,7 +125,7 @@ ucc_status_t compare_buffers(void *_rst, void *expected, size_t count,
     }
 
     if (UCC_MEMORY_TYPE_HOST != mt) {
-        UCC_CHECK(ucc_mc_free(rst_mc_header, UCC_MEMORY_TYPE_HOST));
+        UCC_CHECK(ucc_mc_free(rst_mc_header));
     }
 
     return status;

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -159,13 +159,13 @@ TestCase::~TestCase()
         UCC_CHECK(ucc_collective_finalize(req));
     }
     if (sbuf) {
-        UCC_CHECK(ucc_mc_free(sbuf_mc_header, mem_type));
+        UCC_CHECK(ucc_mc_free(sbuf_mc_header));
     }
     if (rbuf) {
-        UCC_CHECK(ucc_mc_free(rbuf_mc_header, mem_type));
+        UCC_CHECK(ucc_mc_free(rbuf_mc_header));
     }
     if (check_sbuf) {
-        UCC_CHECK(ucc_mc_free(check_sbuf_mc_header, mem_type));
+        UCC_CHECK(ucc_mc_free(check_sbuf_mc_header));
     }
     if (check_rbuf) {
         ucc_free(check_rbuf);

--- a/tools/perf/ucc_pt_coll_allgather.cc
+++ b/tools/perf/ucc_pt_coll_allgather.cc
@@ -47,7 +47,7 @@ ucc_status_t ucc_pt_coll_allgather::init_coll_args(size_t count,
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(dst_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header);
 exit:
     return st;
 }
@@ -55,9 +55,9 @@ exit:
 void ucc_pt_coll_allgather::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(src_header, args.src.info.mem_type);
+        ucc_mc_free(src_header);
     }
-    ucc_mc_free(dst_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header);
 }
 
 double ucc_pt_coll_allgather::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_allgatherv.cc
+++ b/tools/perf/ucc_pt_coll_allgatherv.cc
@@ -54,7 +54,7 @@ ucc_status_t ucc_pt_coll_allgatherv::init_coll_args(size_t count,
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(dst_header, args.dst.info_v.mem_type);
+    ucc_mc_free(dst_header);
 free_displ:
     ucc_free(args.dst.info_v.displacements);
 free_count:
@@ -66,9 +66,9 @@ exit:
 void ucc_pt_coll_allgatherv::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(src_header, args.src.info.mem_type);
+        ucc_mc_free(src_header);
     }
-    ucc_mc_free(dst_header, args.dst.info_v.mem_type);
+    ucc_mc_free(dst_header);
     ucc_free(args.dst.info_v.counts);
     ucc_free(args.dst.info_v.displacements);
 }

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -45,7 +45,7 @@ ucc_status_t ucc_pt_coll_allreduce::init_coll_args(size_t count,
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(dst_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header);
 exit:
     return st;
 }
@@ -53,9 +53,9 @@ exit:
 void ucc_pt_coll_allreduce::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(src_header, args.src.info.mem_type);
+        ucc_mc_free(src_header);
     }
-    ucc_mc_free(dst_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header);
 }
 
 double ucc_pt_coll_allreduce::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_alltoall.cc
+++ b/tools/perf/ucc_pt_coll_alltoall.cc
@@ -44,7 +44,7 @@ ucc_status_t ucc_pt_coll_alltoall::init_coll_args(size_t count,
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(dst_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header);
 exit:
     return st;
 }
@@ -52,9 +52,9 @@ exit:
 void ucc_pt_coll_alltoall::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(src_header, args.src.info.mem_type);
+        ucc_mc_free(src_header);
     }
-    ucc_mc_free(dst_header, args.dst.info.mem_type);
+    ucc_mc_free(dst_header);
 }
 
 double ucc_pt_coll_alltoall::get_bus_bw(double time_us)

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -56,7 +56,7 @@ ucc_status_t ucc_pt_coll_alltoallv::init_coll_args(size_t count,
     }
     return UCC_OK;
 free_dst:
-    ucc_mc_free(dst_header, args.dst.info_v.mem_type);
+    ucc_mc_free(dst_header);
 free_dst_displ:
     ucc_free(args.dst.info_v.displacements);
 free_dst_count:
@@ -72,9 +72,9 @@ exit:
 void ucc_pt_coll_alltoallv::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
-        ucc_mc_free(src_header, args.src.info_v.mem_type);
+        ucc_mc_free(src_header);
     }
-    ucc_mc_free(dst_header, args.dst.info_v.mem_type);
+    ucc_mc_free(dst_header);
     ucc_free(args.dst.info_v.counts);
     ucc_free(args.dst.info_v.displacements);
     ucc_free(args.src.info_v.counts);

--- a/tools/perf/ucc_pt_coll_bcast.cc
+++ b/tools/perf/ucc_pt_coll_bcast.cc
@@ -36,7 +36,7 @@ exit:
 
 void ucc_pt_coll_bcast::free_coll_args(ucc_coll_args_t &args)
 {
-    ucc_mc_free(src_header, args.src.info.mem_type);
+    ucc_mc_free(src_header);
 }
 
 double ucc_pt_coll_bcast::get_bus_bw(double time_us)


### PR DESCRIPTION
## What
Save memory type info to ucc_mc_buffer_header_t

## Why ?
* simplify ucc_mc_free function
* fix bug in mpi tests
```
tc=Allreduce team=world msgsize=262144 inplace=0 dt=float64 op=max
tc=Allreduce team=world msgsize=2097152 inplace=0 dt=int32 op=sum
*** UCC TEST FAIL: ucc_mc_free(check_sbuf_mc_header, mem_type)
[1623745418.771668]          mc_cuda.c:340  cuda mc ERROR failed to free mem at 0x47db4b0, cuda error 1(invalid argument)
```
