### PR TITLE
MC/CPU: remove unnecessary dt param

### DIFF
--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -157,36 +157,36 @@ static ucc_status_t ucc_mc_cpu_reduce_multi(const void *src1, const void *src2,
     switch(dt) {
     case UCC_DT_INT8:
         return ucc_mc_cpu_reduce_multi_int8(src1, src2, dst, size, count,
-                                            stride, dt, op);
+                                            stride, op);
     case UCC_DT_INT16:
         return ucc_mc_cpu_reduce_multi_int16(src1, src2, dst, size, count,
-                                             stride, dt, op);
+                                             stride, op);
     case UCC_DT_INT32:
         return ucc_mc_cpu_reduce_multi_int32(src1, src2, dst, size, count,
-                                             stride, dt, op);
+                                             stride, op);
     case UCC_DT_INT64:
         return ucc_mc_cpu_reduce_multi_int64(src1, src2, dst, size, count,
-                                             stride, dt, op);
+                                             stride, op);
     case UCC_DT_UINT8:
         return ucc_mc_cpu_reduce_multi_uint8(src1, src2, dst, size, count,
-                                             stride, dt, op);
+                                             stride, op);
     case UCC_DT_UINT16:
         return ucc_mc_cpu_reduce_multi_uint16(src1, src2, dst, size, count,
-                                              stride, dt, op);
+                                              stride, op);
     case UCC_DT_UINT32:
         return ucc_mc_cpu_reduce_multi_uint32(src1, src2, dst, size, count,
-                                              stride, dt, op);
+                                              stride, op);
     case UCC_DT_UINT64:
         return ucc_mc_cpu_reduce_multi_uint64(src1, src2, dst, size, count,
-                                              stride, dt, op);
+                                              stride, op);
     case UCC_DT_FLOAT32:
         ucc_assert(4 == sizeof(float));
         return ucc_mc_cpu_reduce_multi_float(src1, src2, dst, size, count,
-                                             stride, dt, op);
+                                             stride, op);
     case UCC_DT_FLOAT64:
         ucc_assert(8 == sizeof(double));
         return ucc_mc_cpu_reduce_multi_double(src1, src2, dst, size, count,
-                                              stride, dt, op);
+                                              stride, op);
     default:
         mc_error(&ucc_mc_cpu.super, "unsupported reduction type (%d)", dt);
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce.h
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce.h
@@ -165,7 +165,7 @@
 #define REDUCE_FN_DECLARE(_type)                                               \
     ucc_status_t ucc_mc_cpu_reduce_multi_##_type(                              \
         const void *src1, const void *src2, void *dst, size_t size,            \
-        size_t count, size_t stride, ucc_datatype_t dt, ucc_reduction_op_t op)
+        size_t count, size_t stride, ucc_reduction_op_t op)
 REDUCE_FN_DECLARE(int8);
 REDUCE_FN_DECLARE(int16);
 REDUCE_FN_DECLARE(int32);

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_double.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_double.c
@@ -9,7 +9,6 @@
 ucc_status_t ucc_mc_cpu_reduce_multi_double(const void *src1, const void *src2,
                                             void *dst, size_t size,
                                             size_t count, size_t stride,
-                                            ucc_datatype_t     dt,
                                             ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_FLOAT(double, op, src1, src2, dst, size, count, stride);

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_float.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_float.c
@@ -8,8 +8,7 @@
 
 ucc_status_t ucc_mc_cpu_reduce_multi_float(const void *src1, const void *src2,
                                            void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_datatype_t dt,
-                                           ucc_reduction_op_t op)
+                                           size_t stride, ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_FLOAT(float, op, src1, src2, dst, size, count, stride);
     return UCC_OK;

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_int16.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_int16.c
@@ -8,8 +8,7 @@
 
 ucc_status_t ucc_mc_cpu_reduce_multi_int16(const void *src1, const void *src2,
                                            void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_datatype_t dt,
-                                           ucc_reduction_op_t op)
+                                           size_t stride, ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_INT(int16_t, op, src1, src2, dst, size, count, stride);
     return UCC_OK;

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_int32.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_int32.c
@@ -8,8 +8,7 @@
 
 ucc_status_t ucc_mc_cpu_reduce_multi_int32(const void *src1, const void *src2,
                                            void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_datatype_t dt,
-                                           ucc_reduction_op_t op)
+                                           size_t stride, ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_INT(int32_t, op, src1, src2, dst, size, count, stride);
     return UCC_OK;

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_int64.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_int64.c
@@ -8,8 +8,7 @@
 
 ucc_status_t ucc_mc_cpu_reduce_multi_int64(const void *src1, const void *src2,
                                            void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_datatype_t dt,
-                                           ucc_reduction_op_t op)
+                                           size_t stride, ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_INT(int64_t, op, src1, src2, dst, size, count, stride);
     return UCC_OK;

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_int8.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_int8.c
@@ -8,8 +8,7 @@
 
 ucc_status_t ucc_mc_cpu_reduce_multi_int8(const void *src1, const void *src2,
                                           void *dst, size_t size, size_t count,
-                                          size_t stride, ucc_datatype_t dt,
-                                          ucc_reduction_op_t op)
+                                          size_t stride, ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_INT(int8_t, op, src1, src2, dst, size, count, stride);
     return UCC_OK;

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_uint16.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_uint16.c
@@ -9,7 +9,6 @@
 ucc_status_t ucc_mc_cpu_reduce_multi_uint16(const void *src1, const void *src2,
                                             void *dst, size_t size,
                                             size_t count, size_t stride,
-                                            ucc_datatype_t     dt,
                                             ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_INT(uint16_t, op, src1, src2, dst, size, count, stride);

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_uint32.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_uint32.c
@@ -9,7 +9,6 @@
 ucc_status_t ucc_mc_cpu_reduce_multi_uint32(const void *src1, const void *src2,
                                             void *dst, size_t size,
                                             size_t count, size_t stride,
-                                            ucc_datatype_t     dt,
                                             ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_INT(uint32_t, op, src1, src2, dst, size, count, stride);

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_uint64.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_uint64.c
@@ -9,7 +9,6 @@
 ucc_status_t ucc_mc_cpu_reduce_multi_uint64(const void *src1, const void *src2,
                                             void *dst, size_t size,
                                             size_t count, size_t stride,
-                                            ucc_datatype_t     dt,
                                             ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_INT(uint64_t, op, src1, src2, dst, size, count, stride);

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_uint8.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_uint8.c
@@ -8,8 +8,7 @@
 
 ucc_status_t ucc_mc_cpu_reduce_multi_uint8(const void *src1, const void *src2,
                                            void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_datatype_t dt,
-                                           ucc_reduction_op_t op)
+                                           size_t stride, ucc_reduction_op_t op)
 {
     DO_DT_REDUCE_INT(uint8_t, op, src1, src2, dst, size, count, stride);
     return UCC_OK;


### PR DESCRIPTION
## What
Remove unnecessary  dt param from ucc_mc_cpu_reduce_multi_* functions

## Why ?
Fix clang-tidy warnings
```
reduce/mc_cpu_reduce_uint16.c:12:64: warning: parameter 'dt' is unused [misc-unused-parameters]
                                            ucc_datatype_t     dt,
```
