### PR TITLE
UCP: Implementing Allreduce SRA KN offload

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -36,7 +36,7 @@ jobs:
               return 1
             fi
           fi
-          if ! echo $msg | grep -qP '^Merge |^((CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC)|(CL/|TL/|MC/|UCP|UCG|NCCL|BASIC|CUDA|CPU|EE))+: \w'
+          if ! echo $msg | grep -qP '^Merge |^((CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC|SCHEDULE)|(CL/|TL/|MC/|UCP|UCG|NCCL|BASIC|CUDA|CPU|EE))+: \w'
           then
             echo "Wrong header"
             return 1

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce.h
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce.h
@@ -89,7 +89,7 @@
         const type *restrict s2 = (const type *restrict)src2_p;                \
         type *restrict       d  = (type * restrict) dest_p;                    \
         ucc_assert((ptrdiff_t)d <= (ptrdiff_t)src2_p ||                        \
-                   (ptrdiff_t)d > (ptrdiff_t)src2_p + (size - 1) * stride +    \
+                   (ptrdiff_t)d >= (ptrdiff_t)src2_p + (size - 1) * stride +   \
                                       count * sizeof(type));                   \
         switch (op) {                                                          \
         case UCC_OP_MAX:                                                       \
@@ -138,7 +138,7 @@
         const type *restrict s2 = (const type *restrict)src2_p;                \
         type *restrict       d  = (type * restrict) dest_p;                    \
         ucc_assert((ptrdiff_t)d <= (ptrdiff_t)src2_p ||                        \
-                   (ptrdiff_t)d > (ptrdiff_t)src2_p + (size - 1) * stride +    \
+                   (ptrdiff_t)d >= (ptrdiff_t)src2_p + (size - 1) * stride +   \
                                       count * sizeof(type));                   \
         switch (op) {                                                          \
         case UCC_OP_MAX:                                                       \

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -64,7 +64,7 @@ UCC_KN_PHASE_EXTRA:
         local_seg_offset = ucc_sra_kn_compute_seg_offset(
             block_count, step_radix, local_seg_index);
 
-        sbuf = task->args.src.info.buffer;
+        sbuf = task->allgather_kn.sbuf;
         rbuf = PTR_OFFSET(sbuf, -local_seg_offset * dt_size);
         for (loop_step = 1; loop_step < radix; loop_step++) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, size, loop_step);
@@ -75,7 +75,7 @@ UCC_KN_PHASE_EXTRA:
                                              mem_type, peer, team, task),
                           task, out);
         }
-        task->args.src.info.buffer = rbuf;
+        task->allgather_kn.sbuf = rbuf;
 
         for (loop_step = 1; loop_step < radix; loop_step++) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, size, loop_step);
@@ -123,20 +123,24 @@ out:
 
 ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t *team = task->team;
-    ucc_rank_t         size = team->size;
-    ucc_rank_t         rank = team->rank;
+    ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team  = task->team;
+    ucc_rank_t         size  = team->size;
+    ucc_rank_t         rank  = team->rank;
+    ucc_kn_radix_t     radix = task->allgather_kn.p.radix;
     ucc_status_t       status;
     ptrdiff_t          offset;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_kn_start", 0);
+    ucc_tl_ucp_task_reset(task);
+
     task->allgather_kn.phase = UCC_KN_PHASE_INIT;
     ucc_assert(task->args.src.info.mem_type == task->args.dst.info.mem_type);
 
+    ucc_knomial_pattern_init_backward(size, rank, radix, &task->allgather_kn.p);
     offset = ucc_sra_kn_get_offset(task->args.src.info.count,
                                    ucc_dt_size(task->args.src.info.datatype),
-                                   rank, size, task->allgather_kn.p.radix);
+                                   rank, size, radix);
     if (!UCC_IS_INPLACE(task->args)) {
         status = ucc_mc_memcpy(PTR_OFFSET(task->args.dst.info.buffer, offset),
                                task->args.src.info.buffer,
@@ -148,8 +152,7 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
             return status;
         }
     }
-    task->args.src.info.buffer = PTR_OFFSET(task->args.dst.info.buffer, offset);
-    task->super.super.status   = UCC_INPROGRESS;
+    task->allgather_kn.sbuf = PTR_OFFSET(task->args.dst.info.buffer, offset);
 
     status = ucc_tl_ucp_allgather_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {
@@ -168,11 +171,10 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_init_r(
     ucc_rank_t         rank    = tl_team->rank;
     ucc_tl_ucp_task_t *task;
     task = ucc_tl_ucp_init_task(coll_args, team);
-
-    ucc_knomial_pattern_init_backward(size, rank, radix, &task->allgather_kn.p);
-
     task->super.post     = ucc_tl_ucp_allgather_knomial_start;
     task->super.progress = ucc_tl_ucp_allgather_knomial_progress;
+    ucc_knomial_pattern_init_backward(size, rank, radix, &task->allgather_kn.p);
+
     *task_h              = &task->super;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -71,7 +71,8 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_ring_start", 0);
-    task->super.super.status     = UCC_INPROGRESS;
+    ucc_tl_ucp_task_reset(task);
+
     if (!UCC_IS_INPLACE(task->args)) {
         status = ucc_mc_memcpy((void*)((ptrdiff_t)rbuf + data_size * team->rank),
                                sbuf, data_size, rmem, smem);

--- a/src/components/tl/ucp/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv_ring.c
@@ -70,7 +70,8 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *coll_task)
     size_t             data_size, data_displ, rdt_size;
     ucc_status_t       status;
 
-    task->super.super.status     = UCC_INPROGRESS;
+    ucc_tl_ucp_task_reset(task);
+
     if (!UCC_IS_INPLACE(task->args)) {
         /* TODO replace local sendrecv with memcpy? */
         rdt_size   = ucc_dt_size(task->args.dst.info_v.datatype);

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -178,6 +178,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
                              ucc_min(UCC_TL_UCP_TEAM_LIB(team)->
                                      cfg.allreduce_kn_radix, size),
                              &task->allreduce_kn.p);
+    ucc_tl_ucp_task_reset(task);
     task->super.super.status = UCC_INPROGRESS;
     status = ucc_tl_ucp_allreduce_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -106,11 +106,11 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
     ucc_event_manager_subscribe(&rs_task->em, UCC_EVENT_COMPLETED, task,
                                 ucc_task_start_handler);
 
-    schedule->super.post     = ucc_tl_ucp_allreduce_sra_knomial_start;
-    schedule->super.progress = NULL;
-    schedule->super.finalize = ucc_tl_ucp_allreduce_sra_knomial_finalize;
+    schedule->super.post           = ucc_tl_ucp_allreduce_sra_knomial_start;
+    schedule->super.progress       = NULL;
+    schedule->super.finalize       = ucc_tl_ucp_allreduce_sra_knomial_finalize;
     schedule->super.triggered_post = ucc_tl_ucp_triggered_post;
-    *task_h                  = &schedule->super;
+    *task_h                        = &schedule->super;
     return UCC_OK;
 out:
     ucc_tl_ucp_put_schedule(schedule);

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -88,9 +88,8 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
     }
     ucc_schedule_add_task(schedule, task);
     ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
-                                task);
-    task->handlers[UCC_EVENT_SCHEDULE_STARTED] = ucc_task_start_handler;
-    rs_task                                    = task;
+                                task, ucc_task_start_handler);
+    rs_task = task;
 
     /* 2nd step of allreduce: knomial allgather. 2nd task subscribes
      to completion event of reduce_scatter task. */
@@ -104,8 +103,8 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
     }
 
     ucc_schedule_add_task(schedule, task);
-    ucc_event_manager_subscribe(&rs_task->em, UCC_EVENT_COMPLETED, task);
-    task->handlers[UCC_EVENT_COMPLETED] = ucc_task_start_handler;
+    ucc_event_manager_subscribe(&rs_task->em, UCC_EVENT_COMPLETED, task,
+                                ucc_task_start_handler);
 
     schedule->super.post     = ucc_tl_ucp_allreduce_sra_knomial_start;
     schedule->super.progress = NULL;

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -109,6 +109,7 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
     schedule->super.post     = ucc_tl_ucp_allreduce_sra_knomial_start;
     schedule->super.progress = NULL;
     schedule->super.finalize = ucc_tl_ucp_allreduce_sra_knomial_finalize;
+    schedule->super.triggered_post = ucc_tl_ucp_triggered_post;
     *task_h                  = &schedule->super;
     return UCC_OK;
 out:

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -50,10 +50,12 @@ ucc_status_t
 ucc_tl_ucp_allreduce_sra_knomial_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
-
+    ucc_status_t    status;
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(schedule, "ucp_allreduce_sra_kn_done", 0);
+
+    status = ucc_schedule_finalize(coll_task);
     ucc_tl_ucp_put_schedule(schedule);
-    return UCC_OK;
+    return status;
 }
 
 ucc_status_t
@@ -84,7 +86,6 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
                  "failed to init reduce_scatter_knomial task");
         goto out;
     }
-    task->flags = UCC_COLL_TASK_FLAG_INTERNAL;
     ucc_schedule_add_task(schedule, task);
     ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
                                 task);
@@ -101,7 +102,7 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
                  "failed to init allgather_knomial task");
         goto out;
     }
-    task->flags = UCC_COLL_TASK_FLAG_INTERNAL;
+
     ucc_schedule_add_task(schedule, task);
     ucc_event_manager_subscribe(&rs_task->em, UCC_EVENT_COMPLETED, task);
     task->handlers[UCC_EVENT_COMPLETED] = ucc_task_start_handler;

--- a/src/components/tl/ucp/alltoall/alltoall.c
+++ b/src/components/tl/ucp/alltoall/alltoall.c
@@ -13,19 +13,26 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_alltoall_init(ucc_tl_ucp_task_t *task)
 {
-    if ((task->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
-        (task->args.flags & UCC_COLL_ARGS_FLAG_IN_PLACE)) {
-        tl_debug(UCC_TL_TEAM_LIB(task->team),
-                 "inplace alltoall is not supported");
-        return UCC_ERR_NOT_SUPPORTED;
-    }
-    if ((task->args.src.info.datatype == UCC_DT_USERDEFINED) ||
-        (task->args.dst.info.datatype == UCC_DT_USERDEFINED)) {
-        tl_debug(UCC_TL_TEAM_LIB(task->team),
-                 "user defined datatype is not supported");
-        return UCC_ERR_NOT_SUPPORTED;
-    }
-    task->super.post     = ucc_tl_ucp_alltoall_pairwise_start;
-    task->super.progress = ucc_tl_ucp_alltoall_pairwise_progress;
-    return UCC_OK;
+    ucc_status_t status;
+
+    ALLTOALL_TASK_CHECK(task->args, task->team);
+    status = ucc_tl_ucp_alltoall_pairwise_init_common(task);
+out:
+    return status;
+}
+
+ucc_status_t ucc_tl_ucp_alltoall_pairwise_init(ucc_base_coll_args_t *coll_args,
+                                                ucc_base_team_t      *team,
+                                                ucc_coll_task_t     **task_h)
+{
+    ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_tl_ucp_task_t *task;
+    ucc_status_t       status;
+
+    ALLTOALL_TASK_CHECK(coll_args->args, tl_team);
+    task                 = ucc_tl_ucp_init_task(coll_args, team);
+    *task_h              = &task->super;
+    status = ucc_tl_ucp_alltoall_pairwise_init_common(task);
+out:
+    return status;
 }

--- a/src/components/tl/ucp/alltoall/alltoall.h
+++ b/src/components/tl/ucp/alltoall/alltoall.h
@@ -12,4 +12,35 @@
 
 ucc_status_t ucc_tl_ucp_alltoall_init(ucc_tl_ucp_task_t *task);
 
+ucc_status_t ucc_tl_ucp_alltoall_pairwise_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t      *team,
+                                               ucc_coll_task_t     **task_h);
+
+ucc_status_t ucc_tl_ucp_alltoall_pairwise_init_common(ucc_tl_ucp_task_t *task);
+
+#define ALLTOALL_CHECK_INPLACE(_args, _team)                \
+    do {                                                    \
+        if (UCC_IS_INPLACE(_args)) {                        \
+            tl_error(UCC_TL_TEAM_LIB(_team),                \
+                     "inplace alltoall is not supported");  \
+            status = UCC_ERR_NOT_SUPPORTED;                 \
+            goto out;                                       \
+        }                                                   \
+    } while (0)
+
+#define ALLTOALL_CHECK_USERDEFINED_DT(_args, _team)             \
+    do {                                                        \
+        if ((_args.src.info.datatype == UCC_DT_USERDEFINED) ||  \
+            (_args.dst.info.datatype == UCC_DT_USERDEFINED)) {  \
+            tl_error(UCC_TL_TEAM_LIB(_team),                    \
+                     "user defined datatype is not supported"); \
+            status = UCC_ERR_NOT_SUPPORTED;                     \
+            goto out;                                           \
+        }                                                       \
+    } while (0)
+
+#define ALLTOALL_TASK_CHECK(_args, _team)              \
+    ALLTOALL_CHECK_INPLACE((_args), (_team));          \
+    ALLTOALL_CHECK_USERDEFINED_DT((_args), (_team));
+
 #endif

--- a/src/components/tl/ucp/alltoall/alltoall_pairwise.c
+++ b/src/components/tl/ucp/alltoall/alltoall_pairwise.c
@@ -79,12 +79,27 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team = task->team;
-    size_t data_size;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_alltoall_pairwise_start", 0);
-    task->super.super.status = UCC_INPROGRESS;
-    task->n_polls            = ucc_min(1, task->n_polls);
+    ucc_tl_ucp_task_reset(task);
 
+    ucc_tl_ucp_alltoall_pairwise_progress(&task->super);
+    if (UCC_INPROGRESS == task->super.super.status) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+        return UCC_OK;
+    }
+    return ucc_task_complete(coll_task);
+}
+
+ucc_status_t ucc_tl_ucp_alltoall_pairwise_init_common(ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t *team = task->team;
+    size_t data_size;
+
+    task->super.post     = ucc_tl_ucp_alltoall_pairwise_start;
+    task->super.progress = ucc_tl_ucp_alltoall_pairwise_progress;
+
+    task->n_polls = ucc_min(1, task->n_polls);
     if (UCC_TL_UCP_TEAM_CTX(team)->cfg.pre_reg_mem) {
         data_size = (size_t)task->args.src.info.count *
                     ucc_dt_size(task->args.src.info.datatype);
@@ -94,10 +109,5 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_start(ucc_coll_task_t *coll_task)
                                     task->args.dst.info.mem_type);
     }
 
-    ucc_tl_ucp_alltoall_pairwise_progress(&task->super);
-    if (UCC_INPROGRESS == task->super.super.status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return UCC_OK;
 }

--- a/src/components/tl/ucp/alltoallv/alltoallv.h
+++ b/src/components/tl/ucp/alltoallv/alltoallv.h
@@ -12,4 +12,35 @@
 
 ucc_status_t ucc_tl_ucp_alltoallv_init(ucc_tl_ucp_task_t *task);
 
+ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init(ucc_base_coll_args_t *coll_args,
+                                                ucc_base_team_t      *team,
+                                                ucc_coll_task_t     **task_h);
+
+ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task);
+
+#define ALLTOALLV_CHECK_INPLACE(_args, _team)               \
+    do {                                                    \
+        if (UCC_IS_INPLACE(_args)) {                        \
+            tl_error(UCC_TL_TEAM_LIB(_team),                \
+                     "inplace alltoallv is not supported"); \
+            status = UCC_ERR_NOT_SUPPORTED;                 \
+            goto out;                                       \
+        }                                                   \
+    } while (0)
+
+#define ALLTOALLV_CHECK_USERDEFINED_DT(_args, _team)                \
+    do {                                                            \
+        if ((_args.src.info_v.datatype == UCC_DT_USERDEFINED) ||    \
+            (_args.dst.info_v.datatype == UCC_DT_USERDEFINED)) {    \
+            tl_error(UCC_TL_TEAM_LIB(_team),                        \
+                     "user defined datatype is not supported");     \
+            status = UCC_ERR_NOT_SUPPORTED;                         \
+            goto out;                                               \
+        }                                                           \
+    } while (0)
+
+#define ALLTOALLV_TASK_CHECK(_args, _team)              \
+    ALLTOALLV_CHECK_INPLACE((_args), (_team));          \
+    ALLTOALLV_CHECK_USERDEFINED_DT((_args), (_team));
+
 #endif

--- a/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
@@ -93,9 +93,24 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_start(ucc_coll_task_t *coll_task)
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_alltoallv_pairwise_start",
                                      0);
-    task->super.super.status = UCC_INPROGRESS;
-    task->n_polls            = ucc_min(1, task->n_polls);
+    ucc_tl_ucp_task_reset(task);
 
+    ucc_tl_ucp_alltoallv_pairwise_progress(&task->super);
+    if (UCC_INPROGRESS == task->super.super.status) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+        return UCC_OK;
+    }
+    return ucc_task_complete(coll_task);
+}
+
+ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t *team = task->team;
+
+    task->super.post     = ucc_tl_ucp_alltoallv_pairwise_start;
+    task->super.progress = ucc_tl_ucp_alltoallv_pairwise_progress;
+
+    task->n_polls = ucc_min(1, task->n_polls);
     if (UCC_TL_UCP_TEAM_CTX(team)->cfg.pre_reg_mem) {
         if (task->args.flags & UCC_COLL_ARGS_FLAG_CONTIG_SRC_BUFFER) {
             ucc_tl_ucp_pre_register_mem(team, task->args.src.info_v.buffer,
@@ -113,11 +128,5 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_start(ucc_coll_task_t *coll_task)
                                         task->args.dst.info_v.mem_type);
         }
     }
-
-    ucc_tl_ucp_alltoallv_pairwise_progress(&task->super);
-    if (UCC_INPROGRESS == task->super.super.status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return UCC_OK;
 }

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -82,11 +82,13 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *coll_task)
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_bcast_kn_start", 0);
+    ucc_tl_ucp_task_reset(task);
+
     task->bcast_kn.radix =
         ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.bcast_kn_radix, team->size);
     CALC_DIST(team->size, task->bcast_kn.radix, task->bcast_kn.dist);
-    task->super.super.status = UCC_INPROGRESS;
-    status                   = ucc_tl_ucp_bcast_knomial_progress(&task->super);
+
+    status = ucc_tl_ucp_bcast_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {
         ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
         return UCC_OK;

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -22,9 +22,9 @@
 ucc_status_t
 ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t     *team  = task->team;
-    ucc_kn_radix_t         radix = task->reduce_scatter_kn.p.radix;
+    ucc_tl_ucp_task_t     *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t     *team = task->team;
+    ucc_kn_radix_t         radix     = task->reduce_scatter_kn.p.radix;
     uint8_t                node_type = task->reduce_scatter_kn.p.node_type;
     ucc_knomial_pattern_t *p         = &task->reduce_scatter_kn.p;
     void                  *scratch   = task->reduce_scatter_kn.scratch;
@@ -42,8 +42,14 @@ ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_status_t           status;
     ucc_kn_radix_t         loop_step;
     size_t                 block_count, peer_seg_count, local_seg_count;
-    void                  *reduce_data, *local_data;
+    void                  *reduce_data, *local_data, *scratch_offset;
+    int                    sra_offload;
+    ucc_memory_type_t      sra_mem_type;
 
+    sra_offload     = (mem_type == UCC_MEMORY_TYPE_CUDA &&
+                      UCC_TL_UCP_TEAM_LIB(team)->cfg.allreduce_sra_kn_offload);
+    sra_mem_type    = (sra_offload) ? UCC_MEMORY_TYPE_HOST : mem_type;
+    scratch_offset  = PTR_OFFSET(scratch, data_size);
     local_seg_count = 0;
     block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
     UCC_KN_GOTO_PHASE(task->reduce_scatter_kn.phase);
@@ -58,8 +64,8 @@ ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     if (KN_NODE_PROXY == node_type) {
         peer = ucc_knomial_pattern_get_extra(p, rank);
         UCPCHECK_GOTO(
-            ucc_tl_ucp_recv_nb(scratch, data_size, mem_type, peer, team, task),
-            task, out);
+            ucc_tl_ucp_recv_nb(scratch, data_size, sra_mem_type, peer, team,
+            		           task), task, out);
     }
 
 UCC_KN_PHASE_EXTRA:
@@ -71,10 +77,19 @@ UCC_KN_PHASE_EXTRA:
         if (KN_NODE_EXTRA == node_type) {
             goto out;
         } else {
-            if (UCC_OK != (status = ucc_dt_reduce(sbuf, scratch, rbuf, count,
-                                                  dt, mem_type, &task->args))) {
+        	if (sra_offload) {
+                status = ucc_mc_memcpy(scratch_offset, sbuf, data_size,
+                                   sra_mem_type, mem_type);
+                if (ucc_unlikely(UCC_OK != status)) {
+                    return status;
+                }
+                sbuf = rbuf = scratch_offset;
+            }
+            status = ucc_dt_reduce(sbuf, scratch, rbuf, count, dt, sra_mem_type,
+        		                                               &task->args);
+            if (ucc_unlikely(UCC_OK != status)) {
                 tl_error(UCC_TL_TEAM_LIB(task->team),
-                         "failed to perform dt reduction");
+                     "failed to perform dt reduction");
                 task->super.super.status = status;
                 return status;
             }
@@ -84,9 +99,9 @@ UCC_KN_PHASE_EXTRA:
         step_radix  = ucc_sra_kn_compute_step_radix(rank, size, p);
         block_count = ucc_sra_kn_compute_block_count(count, rank, p);
         sbuf        = (p->iteration == 0)
-                          ? ((KN_NODE_PROXY == node_type) ? task->args.dst.info.buffer
-                                                          : task->args.src.info.buffer)
-                          : task->reduce_scatter_kn.scratch;
+                          ? ((KN_NODE_PROXY == node_type) ? rbuf
+                                                          : sbuf)
+                          : scratch;
         for (loop_step = 1; loop_step < radix; loop_step++) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, size, loop_step);
             if (peer == UCC_KN_PEER_NULL)
@@ -100,16 +115,15 @@ UCC_KN_PHASE_EXTRA:
                 block_count, step_radix, peer_seg_index);
             UCPCHECK_GOTO(
                 ucc_tl_ucp_send_nb(PTR_OFFSET(sbuf, peer_seg_offset * dt_size),
-                                   peer_seg_count * dt_size, mem_type, peer,
-                                   team, task),
-                task, out);
+                    peer_seg_count * dt_size,
+                    (p->iteration == 0 && node_type != KN_NODE_PROXY)
+                    ? mem_type : sra_mem_type, peer, team, task), task, out);
         }
 
         local_seg_index = ucc_sra_kn_compute_seg_index(rank, p->radix_pow, p);
         local_seg_count = ucc_sra_kn_compute_seg_size(block_count, step_radix,
                                                       local_seg_index);
-
-        rbuf = task->reduce_scatter_kn.scratch;
+        rbuf = scratch; // if sra_offload - rbuf will be HOST scratch
         if (p->iteration != 0) {
             rbuf = PTR_OFFSET(rbuf, block_count * dt_size);
         }
@@ -118,7 +132,7 @@ UCC_KN_PHASE_EXTRA:
             if (peer == UCC_KN_PEER_NULL)
                 continue;
             UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(rbuf, local_seg_count * dt_size,
-                                             mem_type, peer, team, task),
+                                             sra_mem_type, peer, team, task),
                           task, out);
             rbuf = PTR_OFFSET(rbuf, local_seg_count * dt_size);
         }
@@ -128,14 +142,23 @@ UCC_KN_PHASE_EXTRA:
             return task->super.super.status;
         }
         if (task->send_posted > p->iteration * (radix - 1)) {
-            sbuf       = (p->iteration == 0) ? ((KN_NODE_PROXY == node_type)
-                                                    ? task->args.dst.info.buffer
-                                                    : task->args.src.info.buffer)
-                                             : task->reduce_scatter_kn.scratch;
+        	if (p->iteration==0){
+        		if (KN_NODE_PROXY == node_type) {
+        			if (sra_offload) {
+        				sbuf = scratch_offset;
+        			} else {
+        				sbuf = task->args.dst.info.buffer;
+        			}
+        		} else {
+        			sbuf = task->args.src.info.buffer;
+        		}
+        	} else {
+        		sbuf = scratch;
+        	}
             rbuf       = (p->iteration != 0)
-                             ? PTR_OFFSET(task->reduce_scatter_kn.scratch,
+                             ? PTR_OFFSET(scratch,
                                     block_count * dt_size)
-                             : task->reduce_scatter_kn.scratch;
+                             : scratch;
             step_radix = ucc_sra_kn_compute_step_radix(rank, size, p);
             local_seg_index =
                 ucc_sra_kn_compute_seg_index(rank, p->radix_pow, p);
@@ -144,12 +167,21 @@ UCC_KN_PHASE_EXTRA:
             local_seg_offset = ucc_sra_kn_compute_seg_offset(
                 block_count, step_radix, local_seg_index);
             local_data  = PTR_OFFSET(sbuf, local_seg_offset * dt_size);
-            reduce_data = task->reduce_scatter_kn.scratch;
+            if (sra_offload && p->iteration == 0 &&
+                               node_type != KN_NODE_PROXY) {
+                status = ucc_mc_memcpy(scratch_offset, local_data,
+                            local_seg_count * dt_size, sra_mem_type, mem_type);
+                if (ucc_unlikely(status != UCC_OK)) {
+                	return status;
+                }
+                local_data = scratch_offset;
+            }
+            reduce_data = scratch;
             if (UCC_OK != (status = ucc_dt_reduce_multi(
                                local_data, rbuf, reduce_data,
                                task->send_posted - p->iteration * (radix - 1),
                                local_seg_count, local_seg_count * dt_size, dt,
-                               mem_type, &task->args))) {
+                               sra_mem_type, &task->args))) {
                 tl_error(UCC_TL_TEAM_LIB(task->team),
                          "failed to perform dt reduction");
                 task->super.super.status = status;
@@ -158,12 +190,9 @@ UCC_KN_PHASE_EXTRA:
         }
         ucc_knomial_pattern_next_iteration(p);
     }
-
     offset = ucc_sra_kn_get_offset(count, dt_size, rank, size, radix);
     status = ucc_mc_memcpy(PTR_OFFSET(task->args.dst.info.buffer, offset),
-                           task->reduce_scatter_kn.scratch,
-                           local_seg_count * dt_size, mem_type, mem_type);
-
+                 scratch, local_seg_count * dt_size, mem_type, sra_mem_type);
     if (UCC_OK != status) {
         return status;
     }
@@ -189,11 +218,13 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
                              task->reduce_scatter_kn.p.radix,
                              &task->reduce_scatter_kn.p);
     node_type = task->reduce_scatter_kn.p.node_type;
-    if (!(UCC_IS_INPLACE(task->args) || (KN_NODE_PROXY == node_type))) {
+    if (!(UCC_IS_INPLACE(task->args) || KN_NODE_PROXY == node_type) && !(task->args.src.info.mem_type == UCC_MEMORY_TYPE_CUDA &&
+            UCC_TL_UCP_TEAM_LIB(team)->cfg.allreduce_sra_kn_offload &&
+            (task->reduce_scatter_kn.p.n_extra == 0 || node_type != KN_NODE_EXTRA ||
+                                        UCC_IS_INPLACE(task->args)))) {
         task->reduce_scatter_kn.scratch = task->args.dst.info.buffer;
     }
     task->reduce_scatter_kn.phase = UCC_KN_PHASE_INIT;
-
     status = ucc_tl_ucp_reduce_scatter_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {
         ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
@@ -205,10 +236,15 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
 ucc_status_t
 ucc_tl_ucp_reduce_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    uint8_t            node_type = task->reduce_scatter_kn.p.node_type;
-
-    if (UCC_IS_INPLACE(task->args) || (KN_NODE_PROXY == node_type)) {
+    ucc_tl_ucp_task_t     *task        = ucc_derived_of(coll_task,
+                                                        ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t     *team        = task->team;
+    ucc_knomial_pattern_t *p           = &task->reduce_scatter_kn.p;
+    ucc_memory_type_t      mem_type    = task->args.src.info.mem_type;
+    if ((mem_type == UCC_MEMORY_TYPE_CUDA &&
+           UCC_TL_UCP_TEAM_LIB(team)->cfg.allreduce_sra_kn_offload &&
+           (p->n_extra == 0 || p->node_type != KN_NODE_EXTRA)) ||
+           (UCC_IS_INPLACE(task->args) || KN_NODE_PROXY == p->node_type)) {
         ucc_mc_free(task->reduce_scatter_kn.scratch_mc_header);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);
@@ -218,16 +254,17 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
     ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
     ucc_coll_task_t **task_h, ucc_kn_radix_t radix)
 {
-    ucc_tl_ucp_team_t *tl_team   = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_rank_t         size      = tl_team->size;
-    ucc_rank_t         rank      = tl_team->rank;
-    size_t             count     = coll_args->args.src.info.count;
-    ucc_datatype_t     dt        = coll_args->args.src.info.datatype;
-    size_t             dt_size   = ucc_dt_size(dt);
-    size_t             data_size = count * dt_size;
-    ucc_memory_type_t  mem_type  = coll_args->args.src.info.mem_type;
-    ucc_tl_ucp_task_t *task;
-    ucc_status_t       status;
+    ucc_tl_ucp_team_t     *tl_team   = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_rank_t             size      = tl_team->size;
+    ucc_rank_t             rank      = tl_team->rank;
+    size_t                 count     = coll_args->args.src.info.count;
+    ucc_datatype_t         dt        = coll_args->args.src.info.datatype;
+    size_t                 dt_size   = ucc_dt_size(dt);
+    size_t                 data_size = count * dt_size;
+    ucc_memory_type_t      mem_type  = coll_args->args.src.info.mem_type;
+    ucc_knomial_pattern_t *p;
+    ucc_tl_ucp_task_t     *task;
+    ucc_status_t           status;
 
     task                 = ucc_tl_ucp_init_task(coll_args, team);
     task->super.post     = ucc_tl_ucp_reduce_scatter_knomial_start;
@@ -236,21 +273,33 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
 
     ucc_assert(task->args.src.info.mem_type == task->args.dst.info.mem_type);
     ucc_knomial_pattern_init(size, rank, radix, &task->reduce_scatter_kn.p);
+    p = &task->reduce_scatter_kn.p;
 
-    if (UCC_IS_INPLACE(task->args) ||
-        (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type)) {
+    if (mem_type == UCC_MEMORY_TYPE_CUDA &&
+        UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_offload &&
+        (p->n_extra == 0 || p->node_type != KN_NODE_EXTRA ||
+                                    UCC_IS_INPLACE(task->args))) {
+        status = ucc_mc_alloc(&task->reduce_scatter_kn.scratch_mc_header,
+                              data_size * 2, UCC_MEMORY_TYPE_HOST);
+        task->reduce_scatter_kn.scratch = task->reduce_scatter_kn.
+                                                scratch_mc_header->addr;
+        if (UCC_OK != status) {
+            return status;
+    	}
+    }
+    else if (UCC_IS_INPLACE(task->args) ||
+        (KN_NODE_PROXY == p->node_type)) {
         status = ucc_mc_alloc(&task->reduce_scatter_kn.scratch_mc_header,
                               data_size, mem_type);
-        task->reduce_scatter_kn.scratch =
-            task->reduce_scatter_kn.scratch_mc_header->addr;
+        task->reduce_scatter_kn.scratch = task->reduce_scatter_kn.
+                                                scratch_mc_header->addr;
         if (UCC_OK != status) {
             return status;
         }
-        if (UCC_IS_INPLACE(task->args)) {
-            task->args.src.info.buffer = task->args.dst.info.buffer;
-        }
     }
-
+    if (UCC_IS_INPLACE(task->args)) {
+        task->args.src.info.buffer = task->args.dst.info.buffer;
+    }
     *task_h = &task->super;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -52,6 +52,12 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
+    {"ALLREDUCE_SRA_KN_OFFLOAD", "0",
+     "SRA offload, 0 - off, 1 - offload from cuda to host or vise versa,"
+     "depending on the program's memory type at run time",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_offload),
+     UCC_CONFIG_TYPE_UINT},
+
     {"REDUCE_SCATTER_KN_RADIX", "4",
      "Radix of the knomial reduce-scatter algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_scatter_kn_radix),

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -41,6 +41,7 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t            barrier_kn_radix;
     uint32_t            allreduce_kn_radix;
     uint32_t            allreduce_sra_kn_radix;
+    uint32_t            allreduce_sra_kn_offload;
     uint32_t            reduce_scatter_kn_radix;
     uint32_t            allgather_kn_radix;
     uint32_t            bcast_kn_radix;

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -90,8 +90,8 @@ ucc_tl_ucp_event_trigger_complete(ucc_coll_task_t *parent_task,
         ucc_assert(coll_task->super.status == UCC_INPROGRESS);
         if (coll_task->ee_task) {
             ucc_event_manager_init(&coll_task->em);
-            coll_task->handlers[UCC_EVENT_COMPLETED] = ucc_tl_ucp_triggered_coll_complete;
-            ucc_event_manager_subscribe(&coll_task->em, UCC_EVENT_COMPLETED, coll_task);
+            ucc_event_manager_subscribe(&coll_task->em, UCC_EVENT_COMPLETED, coll_task,
+                                        ucc_tl_ucp_triggered_coll_complete);
         }
     }
 
@@ -173,8 +173,8 @@ ucc_status_t ucc_tl_ucp_triggered_post(ucc_ee_h ee, ucc_ev_t *ev, //NOLINT
             "triggered post. ev_task:%p coll_task:%p", &ev_task->super, coll_task);
     ev_task->super.progress = ucc_tl_ucp_ee_wait_for_event_trigger;
     ucc_event_manager_init(&ev_task->super.em);
-    coll_task->handlers[UCC_EVENT_COMPLETED] = ucc_tl_ucp_event_trigger_complete;
-    ucc_event_manager_subscribe(&ev_task->super.em, UCC_EVENT_COMPLETED, coll_task);
+    ucc_event_manager_subscribe(&ev_task->super.em, UCC_EVENT_COMPLETED, coll_task,
+                                ucc_tl_ucp_event_trigger_complete);
 
     status = ucc_tl_ucp_ee_wait_for_event_trigger(&ev_task->super);
     if (ucc_unlikely(status != UCC_OK)) {

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -48,6 +48,7 @@ typedef struct ucc_tl_ucp_task {
         struct {
             int                     phase;
             ucc_knomial_pattern_t   p;
+            void                   *sbuf;
         } allgather_kn;
         struct {
             ucc_rank_t              dist;
@@ -55,6 +56,15 @@ typedef struct ucc_tl_ucp_task {
         } bcast_kn;
     };
 } ucc_tl_ucp_task_t;
+
+static inline void ucc_tl_ucp_task_reset(ucc_tl_ucp_task_t *task)
+{
+    task->send_posted        = 0;
+    task->send_completed     = 0;
+    task->recv_posted        = 0;
+    task->recv_completed     = 0;
+    task->super.super.status = UCC_INPROGRESS;
+}
 
 static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_team_t *team)
 {
@@ -64,16 +74,12 @@ static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_team_t *team)
     UCC_TL_UCP_PROFILE_REQUEST_NEW(task, "tl_ucp_task", 0);
     task->super.super.status = UCC_OPERATION_INITIALIZED;
     task->super.flags        = 0;
-    task->send_posted        = 0;
-    task->send_completed     = 0;
-    task->recv_posted        = 0;
-    task->recv_completed     = 0;
     task->n_polls            = ctx->cfg.n_polls;
     task->team               = team;
     task->subset.map.type    = UCC_EP_MAP_FULL;
     task->subset.map.ep_num  = team->size;
     task->subset.myrank      = team->rank;
-
+    ucc_tl_ucp_task_reset(task);
     return task;
 }
 

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -75,7 +75,6 @@ ucc_schedule_completed_handler(ucc_coll_task_t *parent_task, //NOLINT
 ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx)
 {
     ucc_status_t status;
-
     status             = ucc_coll_task_init(&schedule->super);
     schedule->ctx      = ctx;
     schedule->n_tasks  = 0;

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -60,11 +60,15 @@ typedef struct ucc_coll_task {
 } ucc_coll_task_t;
 
 typedef struct ucc_context ucc_context_t;
+
+#define UCC_SCHEDULE_MAX_TASKS 8
+
 typedef struct ucc_schedule {
-    ucc_coll_task_t super;
-    int             n_completed_tasks;
-    int             n_tasks;
-    ucc_context_t  *ctx;
+    ucc_coll_task_t  super;
+    int              n_completed_tasks;
+    int              n_tasks;
+    ucc_context_t   *ctx;
+    ucc_coll_task_t *tasks[UCC_SCHEDULE_MAX_TASKS];
 } ucc_schedule_t;
 
 ucc_status_t ucc_event_manager_init(ucc_event_manager_t *em);
@@ -78,6 +82,7 @@ void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
 ucc_status_t ucc_schedule_start(ucc_schedule_t *schedule);
 ucc_status_t ucc_task_start_handler(ucc_coll_task_t *parent,
                                     ucc_coll_task_t *task);
+ucc_status_t ucc_schedule_finalize(ucc_coll_task_t *task);
 
 static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
 {

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -26,9 +26,14 @@ typedef ucc_status_t (*ucc_coll_post_fn_t)(ucc_coll_task_t *task);
 typedef ucc_status_t (*ucc_coll_triggered_post_fn_t)(ucc_ee_h ee, ucc_ev_t *ev, ucc_coll_task_t *task);
 typedef ucc_status_t (*ucc_coll_finalize_fn_t)(ucc_coll_task_t *task);
 
+typedef struct ucc_em_listener {
+    ucc_coll_task_t          *task;
+    ucc_task_event_handler_p  handler;
+    ucc_event_t               event;
+} ucc_em_listener_t;
+
 typedef struct ucc_event_manager {
-    ucc_coll_task_t *listeners[UCC_EVENT_LAST][MAX_LISTENERS];
-    int              listeners_size[UCC_EVENT_LAST];
+    ucc_em_listener_t listeners[MAX_LISTENERS];
 } ucc_event_manager_t;
 
 enum {
@@ -44,7 +49,6 @@ typedef struct ucc_coll_task {
     ucc_coll_finalize_fn_t       finalize;
     ucc_coll_callback_t          cb;
     ucc_event_manager_t          em;
-    ucc_task_event_handler_p     handlers[UCC_EVENT_LAST];
     ucc_status_t               (*progress)(struct ucc_coll_task *self);
     struct ucc_schedule         *schedule;
     ucc_ee_h                     ee;
@@ -72,14 +76,22 @@ typedef struct ucc_schedule {
 } ucc_schedule_t;
 
 ucc_status_t ucc_event_manager_init(ucc_event_manager_t *em);
+
 ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task);
+
 void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
-                                 ucc_coll_task_t *task);
+                                 ucc_coll_task_t *task,
+                                 ucc_task_event_handler_p handler);
+
 ucc_status_t ucc_event_manager_notify(ucc_coll_task_t *parent_task,
                                       ucc_event_t event);
+
 ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx);
+
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
+
 ucc_status_t ucc_schedule_start(ucc_schedule_t *schedule);
+
 ucc_status_t ucc_task_start_handler(ucc_coll_task_t *parent,
                                     ucc_coll_task_t *task);
 ucc_status_t ucc_schedule_finalize(ucc_coll_task_t *task);

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -82,6 +82,7 @@ gtest_SOURCES =                     \
 	core/test_allgatherv.cc         \
 	core/test_bcast.cc              \
 	core/test_allreduce.cc          \
+	core/test_schedule.cc           \
 	utils/test_string.cc            \
 	utils/test_ep_map.cc            \
 	utils/test_lock_free_queue.cc   \

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -548,3 +548,17 @@ void UccCollArgs::set_inplace(gtest_ucc_inplace_t _inplace)
 {
     inplace = _inplace;
 }
+
+void clear_buffer(void *_buf, size_t size, ucc_memory_type_t mt, uint8_t value)
+{
+    void *buf = _buf;
+    if (mt != UCC_MEMORY_TYPE_HOST) {
+        buf = ucc_malloc(size, "buf");
+        ASSERT_NE(0, (uintptr_t)buf);
+    }
+    memset(buf, value, size);
+    if (UCC_MEMORY_TYPE_HOST != mt) {
+        UCC_CHECK(ucc_mc_memcpy(_buf, buf, size, mt, UCC_MEMORY_TYPE_HOST));
+        ucc_free(buf);
+    }
+}

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -226,4 +226,6 @@ public:
     static void startall(std::vector<UccReq> &reqs);
 };
 
+void clear_buffer(void *_buf, size_t size, ucc_memory_type_t mt, uint8_t value);
+
 #endif

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -80,6 +80,14 @@ public:
             coll->dst.info_v.buffer = ctxs[r]->dst_mc_header->addr;
         }
     }
+    void reset(UccCollCtxVec ctxs)
+    {
+        for (auto r = 0; r < ctxs.size(); r++) {
+            ucc_coll_args_t *coll = ctxs[r]->args;
+            clear_buffer(coll->dst.info_v.buffer, ctxs[r]->rbuf_size, mem_type,
+                         0);
+        }
+    }
     bool  data_validate(UccCollCtxVec ctxs)
     {
         bool                   ret = true;
@@ -165,6 +173,34 @@ UCC_TEST_P(test_alltoallv_0, single)
     data_fini(ctxs);
 }
 
+UCC_TEST_P(test_alltoallv_0, single_persistent)
+{
+    const int            team_id  = std::get<0>(GetParam());
+    ucc_memory_type_t    mem_type = std::get<1>(GetParam());
+    gtest_ucc_inplace_t  inplace  = std::get<2>(GetParam());
+    const ucc_datatype_t dtype    = (ucc_datatype_t)std::get<3>(GetParam());
+    UccTeam_h            team     = UccJob::getStaticTeams()[team_id];
+    int                  size     = team->procs.size();
+    const int            n_calls  = 3;
+    UccCollCtxVec        ctxs;
+
+    coll_mask = UCC_COLL_ARGS_FIELD_FLAGS;
+    coll_flags =
+        UCC_COLL_ARGS_FLAG_COUNT_64BIT | UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+    set_inplace(inplace);
+    set_mem_type(mem_type);
+
+    data_init(size, (ucc_datatype_t)dtype, 1, ctxs);
+    UccReq req(team, ctxs);
+
+    for (auto i = 0; i < n_calls; i++) {
+        req.start();
+        req.wait();
+        EXPECT_EQ(true, data_validate(ctxs));
+        reset(ctxs);
+    }
+    data_fini(ctxs);
+}
 
 class test_alltoallv_1 : public test_alltoallv <uint32_t>,
         public ::testing::WithParamInterface<Param_0> {};

--- a/test/gtest/core/test_schedule.cc
+++ b/test/gtest/core/test_schedule.cc
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+extern "C" {
+#include "schedule/ucc_schedule.h"
+}
+typedef std::tuple<ucc_coll_task_t*, int> rst_t;
+class test_schedule : public ucc_coll_task_t, public ucc::test
+{
+public:
+    std::vector<rst_t> rst;
+    static ucc_status_t handler_1(ucc_coll_task_t *parent,
+                                  ucc_coll_task_t *task) {
+        test_schedule *ts = (test_schedule*)task;
+        ts->rst.push_back(rst_t(parent, 1));
+        return UCC_OK;
+    }
+    static ucc_status_t handler_2(ucc_coll_task_t *parent,
+                                  ucc_coll_task_t *task) {
+        test_schedule *ts = (test_schedule*)task;
+        ts->rst.push_back(rst_t(parent, 2));
+        return UCC_OK;
+    }
+};
+
+/* Tasks subscribes on 2 tasks to EVENT_COMPLETED with the same
+   handler */
+UCC_TEST_F(test_schedule, single_handler)
+{
+    std::vector<ucc_coll_task_t> tasks(2);
+
+    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t*)this));
+    for (auto &t :  tasks) {
+        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t));
+        ucc_event_manager_subscribe(&t.em, UCC_EVENT_COMPLETED,
+                                    (ucc_coll_task_t*)this,
+                                    test_schedule::handler_1);
+    }
+
+    for (auto &t :  tasks) {
+        EXPECT_EQ(UCC_OK, ucc_event_manager_notify(&t, UCC_EVENT_COMPLETED));
+    }
+    EXPECT_EQ(2, rst.size());
+    EXPECT_EQ(true, (std::get<0>(rst[0]) == &tasks[0]) &&
+              (std::get<1>(rst[0]) == 1));
+    EXPECT_EQ(true, (std::get<0>(rst[1]) == &tasks[1]) &&
+              (std::get<1>(rst[1]) == 1));
+}
+
+/* Tasks subscribes on 2 tasks to EVENT_COMPLETED with 2 different
+   handlers */
+UCC_TEST_F(test_schedule, different_handlers)
+{
+    std::vector<ucc_coll_task_t> tasks(2);
+
+    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t*)this));
+    for (auto &t :  tasks) {
+        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t));
+    }
+    ucc_event_manager_subscribe(&tasks[0].em, UCC_EVENT_COMPLETED,
+                                (ucc_coll_task_t*)this,
+                                test_schedule::handler_1);
+    ucc_event_manager_subscribe(&tasks[1].em, UCC_EVENT_COMPLETED,
+                                (ucc_coll_task_t*)this,
+                                test_schedule::handler_2);
+
+    for (auto &t :  tasks) {
+        EXPECT_EQ(UCC_OK, ucc_event_manager_notify(&t, UCC_EVENT_COMPLETED));
+    }
+
+    EXPECT_EQ(2, rst.size());
+    EXPECT_EQ(true, (std::get<0>(rst[0]) == &tasks[0]) &&
+              (std::get<1>(rst[0]) == 1));
+    EXPECT_EQ(true, (std::get<0>(rst[1]) == &tasks[1]) &&
+              (std::get<1>(rst[1]) == 2));
+}


### PR DESCRIPTION
## What
Allreduce SRA KN offload scratch buffers and reduce_scatter compute from cuda to host.

## Why ?
To reduce compute traffic on cuda during Allreduce_sra_knomial runtime.

## How ?
Allocating HOST scratch buffers and choosing relevant mc component to run reduce_scatter with. Then writing the data back into cuda recieve buffer.
