### PR TITLE
TOOLS: added option to print bw in perftest

### DIFF
--- a/tools/perf/ucc_pt_benchmark.h
+++ b/tools/perf/ucc_pt_benchmark.h
@@ -20,7 +20,8 @@ class ucc_pt_benchmark {
 
     ucc_status_t barrier();
     void print_header();
-    void print_time(size_t count, std::chrono::nanoseconds time);
+    void print_time(size_t count, ucc_coll_args_t args,
+                    std::chrono::nanoseconds time);
 public:
     ucc_pt_benchmark(ucc_pt_benchmark_config cfg, ucc_pt_comm *communcator);
     ucc_status_t run_bench() noexcept;

--- a/tools/perf/ucc_pt_coll.cc
+++ b/tools/perf/ucc_pt_coll.cc
@@ -4,11 +4,18 @@ bool ucc_pt_coll::has_reduction()
 {
     return has_reduction_;
 }
+
 bool ucc_pt_coll::has_inplace()
 {
     return has_inplace_;
 }
+
 bool ucc_pt_coll::has_range()
 {
     return has_range_;
+}
+
+bool ucc_pt_coll::has_bw()
+{
+    return has_bw_;
 }

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -17,6 +17,7 @@ protected:
     bool has_inplace_;
     bool has_reduction_;
     bool has_range_;
+    bool has_bw_;
     ucc_coll_args_t coll_args;
     ucc_mc_buffer_header_t *dst_header;
     ucc_mc_buffer_header_t *src_header;
@@ -24,10 +25,14 @@ public:
     virtual ucc_status_t init_coll_args(size_t count,
                                         ucc_coll_args_t &args) = 0;
     virtual void free_coll_args(ucc_coll_args_t &args) = 0;
-    virtual double get_bus_bw(double time_us) = 0;
+    virtual float get_bw(float time_ms, int grsize, ucc_coll_args_t args)
+    {
+        return 0.0;
+    }
     bool has_reduction();
     bool has_inplace();
     bool has_range();
+    bool has_bw();
     virtual ~ucc_pt_coll() {};
 };
 
@@ -39,7 +44,7 @@ public:
                           bool is_inplace);
     ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
     void free_coll_args(ucc_coll_args_t &args) override;
-    double get_bus_bw(double time_us) override;
+    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
 };
 
 class ucc_pt_coll_allgatherv: public ucc_pt_coll {
@@ -50,7 +55,6 @@ public:
                            bool is_inplace);
     ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
     void free_coll_args(ucc_coll_args_t &args) override;
-    double get_bus_bw(double time_us) override;
 };
 
 class ucc_pt_coll_allreduce: public ucc_pt_coll {
@@ -59,7 +63,7 @@ public:
                           ucc_reduction_op_t op, bool is_inplace);
     ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
     void free_coll_args(ucc_coll_args_t &args) override;
-    double get_bus_bw(double time_us) override;
+    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
 };
 
 class ucc_pt_coll_alltoall: public ucc_pt_coll {
@@ -70,7 +74,7 @@ public:
                          bool is_inplace);
     ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
     void free_coll_args(ucc_coll_args_t &args) override;
-    double get_bus_bw(double time_us) override;
+    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
 };
 
 class ucc_pt_coll_alltoallv: public ucc_pt_coll {
@@ -81,7 +85,6 @@ public:
                           bool is_inplace);
     ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
     void free_coll_args(ucc_coll_args_t &args) override;
-    double get_bus_bw(double time_us) override;
 };
 
 class ucc_pt_coll_barrier: public ucc_pt_coll {
@@ -89,7 +92,6 @@ public:
     ucc_pt_coll_barrier();
     ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
     void free_coll_args(ucc_coll_args_t &args) override;
-    double get_bus_bw(double time_us) override;
 };
 
 class ucc_pt_coll_bcast: public ucc_pt_coll {
@@ -97,7 +99,7 @@ public:
     ucc_pt_coll_bcast(ucc_datatype_t dt, ucc_memory_type mt);
     ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
     void free_coll_args(ucc_coll_args_t &args) override;
-    double get_bus_bw(double time_us) override;
+    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
 };
 
 #endif

--- a/tools/perf/ucc_pt_coll_allgather.cc
+++ b/tools/perf/ucc_pt_coll_allgather.cc
@@ -9,9 +9,10 @@ ucc_pt_coll_allgather::ucc_pt_coll_allgather(int size, ucc_datatype_t dt,
                                              bool is_inplace):
     comm_size(size)
 {
-    has_inplace_= true;
+    has_inplace_  = true;
     has_reduction_= false;
-    has_range_ = true;
+    has_range_    = true;
+    has_bw_       = true;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_ALLGATHER;
@@ -52,16 +53,19 @@ exit:
     return st;
 }
 
+float ucc_pt_coll_allgather::get_bw(float time_ms, int grsize,
+                                    ucc_coll_args_t args)
+{
+    float N = grsize;
+    float S = N * args.dst.info.count * ucc_dt_size(args.dst.info.datatype);
+
+    return (S / time_ms) * ((N - 1) / N) / 1000.0;
+}
+
 void ucc_pt_coll_allgather::free_coll_args(ucc_coll_args_t &args)
 {
     if (!UCC_IS_INPLACE(args)) {
         ucc_mc_free(src_header);
     }
     ucc_mc_free(dst_header);
-}
-
-double ucc_pt_coll_allgather::get_bus_bw(double time_us)
-{
-    //TODO
-    return 0.0;
 }

--- a/tools/perf/ucc_pt_coll_allgatherv.cc
+++ b/tools/perf/ucc_pt_coll_allgatherv.cc
@@ -12,6 +12,7 @@ ucc_pt_coll_allgatherv::ucc_pt_coll_allgatherv(int size, ucc_datatype_t dt,
     has_inplace_= true;
     has_reduction_= false;
     has_range_ = true;
+    has_bw_ = false;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_ALLGATHERV;
@@ -71,10 +72,4 @@ void ucc_pt_coll_allgatherv::free_coll_args(ucc_coll_args_t &args)
     ucc_mc_free(dst_header);
     ucc_free(args.dst.info_v.counts);
     ucc_free(args.dst.info_v.displacements);
-}
-
-double ucc_pt_coll_allgatherv::get_bus_bw(double time_us)
-{
-    //TODO
-    return 0.0;
 }

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -9,9 +9,10 @@ ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
                                              ucc_reduction_op_t op,
                                              bool is_inplace)
 {
-    has_inplace_= true;
-    has_reduction_= true;
-    has_range_ = true;
+    has_inplace_   = true;
+    has_reduction_ = true;
+    has_range_     = true;
+    has_bw_        = true;
 
     coll_args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
     coll_args.mask = 0;
@@ -58,8 +59,11 @@ void ucc_pt_coll_allreduce::free_coll_args(ucc_coll_args_t &args)
     ucc_mc_free(dst_header);
 }
 
-double ucc_pt_coll_allreduce::get_bus_bw(double time_us)
+float ucc_pt_coll_allreduce::get_bw(float time_ms, int grsize,
+                                    ucc_coll_args_t args)
 {
-    //TODO
-    return 0.0;
+    float N = grsize;
+    float S = args.src.info.count * ucc_dt_size(args.src.info.datatype);
+
+    return (S / time_ms) * (2 * (N - 1) / N) / 1000.0;
 }

--- a/tools/perf/ucc_pt_coll_alltoall.cc
+++ b/tools/perf/ucc_pt_coll_alltoall.cc
@@ -8,9 +8,10 @@ ucc_pt_coll_alltoall::ucc_pt_coll_alltoall(int size, ucc_datatype_t dt,
                                            ucc_memory_type mt, bool is_inplace):
     comm_size(size)
 {
-    has_inplace_= true;
+    has_inplace_  = true;
     has_reduction_= false;
-    has_range_ = true;
+    has_range_    = true;
+    has_bw_       = true;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_ALLTOALL;
@@ -57,8 +58,11 @@ void ucc_pt_coll_alltoall::free_coll_args(ucc_coll_args_t &args)
     ucc_mc_free(dst_header);
 }
 
-double ucc_pt_coll_alltoall::get_bus_bw(double time_us)
+float ucc_pt_coll_alltoall::get_bw(float time_ms, int grsize,
+                                   ucc_coll_args_t args)
 {
-    //TODO
-    return 0.0;
+    float N = grsize;
+    float S = N * args.src.info.count * ucc_dt_size(args.src.info.datatype);
+
+    return (S / time_ms) * ((N - 1) / N) / 1000.0;
 }

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -11,6 +11,7 @@ ucc_pt_coll_alltoallv::ucc_pt_coll_alltoallv(int size, ucc_datatype_t dt,
     has_inplace_= true;
     has_reduction_= false;
     has_range_ = true;
+    has_bw_ = false;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_ALLTOALLV;
@@ -79,10 +80,4 @@ void ucc_pt_coll_alltoallv::free_coll_args(ucc_coll_args_t &args)
     ucc_free(args.dst.info_v.displacements);
     ucc_free(args.src.info_v.counts);
     ucc_free(args.src.info_v.displacements);
-}
-
-double ucc_pt_coll_alltoallv::get_bus_bw(double time_us)
-{
-    //TODO
-    return 0.0;
 }

--- a/tools/perf/ucc_pt_coll_barrier.cc
+++ b/tools/perf/ucc_pt_coll_barrier.cc
@@ -9,6 +9,7 @@ ucc_pt_coll_barrier::ucc_pt_coll_barrier()
     has_inplace_= false;
     has_reduction_ = false;
     has_range_ = false;
+    has_bw_ = false;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_BARRIER;
@@ -24,10 +25,4 @@ ucc_status_t ucc_pt_coll_barrier::init_coll_args(size_t count,
 void ucc_pt_coll_barrier::free_coll_args(ucc_coll_args_t &args)
 {
     return;
-}
-
-double ucc_pt_coll_barrier::get_bus_bw(double time_us)
-{
-    //TODO
-    return 0.0;
 }

--- a/tools/perf/ucc_pt_coll_bcast.cc
+++ b/tools/perf/ucc_pt_coll_bcast.cc
@@ -7,9 +7,10 @@
 ucc_pt_coll_bcast::ucc_pt_coll_bcast(ucc_datatype_t dt,
                                              ucc_memory_type mt)
 {
-    has_inplace_ = false;
+    has_inplace_   = false;
     has_reduction_ = false;
-    has_range_ = true;
+    has_range_     = true;
+    has_bw_        = true;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_BCAST;
@@ -39,8 +40,9 @@ void ucc_pt_coll_bcast::free_coll_args(ucc_coll_args_t &args)
     ucc_mc_free(src_header);
 }
 
-double ucc_pt_coll_bcast::get_bus_bw(double time_us)
+float ucc_pt_coll_bcast::get_bw(float time_ms, int grsize, ucc_coll_args_t args)
 {
-    //TODO
-    return 0.0;
+    float S = args.src.info.count * ucc_dt_size(args.src.info.datatype);
+
+    return S / time_ms / 1000.0;
 }

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -14,6 +14,7 @@ ucc_pt_config::ucc_pt_config() {
     bench.n_iter_large   = 200;
     bench.n_warmup_large = 20;
     bench.large_thresh   = 64 * 1024;
+    bench.full_print     = false;
 }
 
 const std::map<std::string, ucc_reduction_op_t> ucc_pt_op_map = {
@@ -57,7 +58,7 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
 {
     int c;
 
-    while ((c = getopt(argc, argv, "c:b:e:d:m:n:w:o:ih")) != -1) {
+    while ((c = getopt(argc, argv, "c:b:e:d:m:n:w:o:ihF")) != -1) {
         switch (c) {
             case 'c':
                 if (ucc_pt_coll_map.count(optarg) == 0) {
@@ -105,6 +106,9 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
             case 'i':
                 bench.inplace = true;
                 break;
+            case 'F':
+                bench.full_print = true;
+                break;
             case 'h':
             default:
                 print_help();
@@ -126,6 +130,7 @@ void ucc_pt_config::print_help()
     std::cout << "  -m <mtype name>: memory type"<<std::endl;
     std::cout << "  -n <number>: number of iterations"<<std::endl;
     std::cout << "  -w <number>: number of warmup iterations"<<std::endl;
+    std::cout << "  -F: enable full print"<<std::endl;
     std::cout << "  -h: show this help message"<<std::endl;
     std::cout << std::endl;
 }

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -40,6 +40,7 @@ struct ucc_pt_benchmark_config {
     int                n_warmup_small;
     int                n_iter_large;
     int                n_warmup_large;
+    bool               full_print;
 };
 
 struct ucc_pt_config {


### PR DESCRIPTION
## What
Extending perftest performance results output with BW information. By default disabled and can be enabled using -F cmd line option.
Example output:
```bash
Collective:             Alltoall
Memory type:            cuda
Datatype:               float32
Reduction:              N/A
Inplace:                0
Warmup:
  small                 10
  large                 10
Iterations:
  small                 1
  large                 1

       Count        Size                Time, us                           Bandwidth, GB/s
                                 avg         min         max         avg         min         max
       65536      262144       76.46       72.62       82.30       24.00       25.27       22.30
      131072      524288      121.82      118.44      125.04       30.13       30.99       29.35
      262144     1048576      211.42      203.83      222.87       34.72       36.01       32.93
      524288     2097152      359.76      345.17      380.07       40.80       42.53       38.62
     1048576     4194304      682.48      649.85      719.07       43.02       45.18       40.83
     2097152     8388608     1315.94     1279.99     1376.54       44.62       45.88       42.66
     4194304    16777216     2555.02     2507.76     2616.37       45.96       46.83       44.89
     8388608    33554432     5020.71     4955.89     5088.03       46.78       47.39       46.16
    16777216    67108864    10150.63     9972.56    10292.35       46.28       47.11       45.64
    33554432   134217728    20192.23    19797.02    20401.44       46.53       47.46       46.05
    67108864   268435456    40651.33    39398.89    41318.54       46.22       47.69       45.48
```

## Why ?
Bandwidth characteristic allows to determine if network is a bottleneck for collective.
Ref. https://github.com/NVIDIA/nccl-tests/blob/master/doc/PERFORMANCE.md#bandwidth
