### PR TITLE
CORE: call task complete for schedule

### DIFF
--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -57,6 +57,7 @@ ucc_schedule_completed_handler(ucc_coll_task_t *parent_task, //NOLINT
     self->n_completed_tasks += 1;
     if (self->n_completed_tasks == self->n_tasks) {
         self->super.super.status = UCC_OK;
+        ucc_task_complete(&self->super);
     }
     return UCC_OK;
 }


### PR DESCRIPTION
## What
Since schedule is a task need to call task_complete function for it.

## Why ?
Fixing bug when callback function is not called after collective complete
