### PR TITLE
MC: check provided thread mode

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -59,6 +59,9 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                [CUDA_MAJOR_VERSION=`nvcc  --version | grep release | sed 's/.*release //' | sed 's/\,.*//' |  cut -d "." -f 1`
                 AS_IF([test $CUDA_MAJOR_VERSION -lt 8],
                       [cuda_happy=no])])
+         AS_IF([test "x$enable_debug" = xyes],
+               [NVCC_CFLAGS="$NVCC_CFLAGS -O0 -g"],
+               [NVCC_CFLAGS="$NVCC_CFLAGS -O3 -g -DNDEBUG"])
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AS_IF([test $CUDA_MAJOR_VERSION -eq 8],
                       [NVCC_ARCH="${ARCH5} ${ARCH6} ${ARCH8}"])
@@ -77,6 +80,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                [AC_SUBST([CUDA_CPPFLAGS], ["$CUDA_CPPFLAGS"])
                 AC_SUBST([CUDA_LDFLAGS], ["$CUDA_LDFLAGS"])
                 AC_SUBST([CUDA_LIBS], ["$CUDA_LIBS"])
+                AC_SUBST([NVCC_CFLAGS], ["$NVCC_CFLAGS"])
                 AC_DEFINE([HAVE_CUDA], 1, [Enable CUDA support])],
                [AS_IF([test "x$with_cuda" != "xguess"],
                       [AC_MSG_ERROR([CUDA support is requested but cuda packages cannot be found])],

--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -13,11 +13,16 @@
 #include "utils/ucc_parser.h"
 #include "utils/ucc_mpool.h"
 #include "core/ucc_global_opts.h"
-#include "core/ucc_mc.h"
 
-typedef struct ucc_mc_buffer_header ucc_mc_buffer_header_t;
+typedef struct ucc_mc_params {
+    ucc_thread_mode_t thread_mode;
+} ucc_mc_params_t;
 
-typedef struct ucc_mc_params ucc_mc_params_t;
+typedef struct ucc_mc_buffer_header {
+    ucc_memory_type_t mt;
+    int               from_pool;
+    void             *addr;
+} ucc_mc_buffer_header_t;
 
 /**
  * UCC memory attributes field mask
@@ -62,6 +67,21 @@ typedef struct ucc_mem_attr {
 
 } ucc_mem_attr_t;
 
+/**
+ * UCC memory component attributes field mask
+ */
+typedef enum ucc_mc_attr_field {
+    UCC_MC_ATTR_FIELD_THREAD_MODE = UCC_BIT(0)
+}  ucc_mc_attr_field_t;
+
+typedef struct ucc_mc_attr {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucc_mc_attr_field_t.
+     */
+    uint64_t          field_mask;
+    ucc_thread_mode_t thread_mode;
+} ucc_mc_attr_t;
 
 /**
  * Array of string names for each memory type
@@ -111,6 +131,7 @@ typedef struct ucc_mc_base {
     ucc_mc_config_t                *config;
     ucc_config_global_list_entry_t  config_table;
     ucc_status_t                   (*init)(const ucc_mc_params_t *mc_params);
+    ucc_status_t                   (*get_attr)(ucc_mc_attr_t *mc_attr);
     ucc_status_t                   (*finalize)();
     ucc_mc_ops_t                    ops;
     const ucc_ee_ops_t              ee_ops;

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -36,6 +36,14 @@ static ucc_status_t ucc_mc_cpu_init(const ucc_mc_params_t *mc_params)
     return UCC_OK;
 }
 
+static ucc_status_t ucc_mc_cpu_get_attr(ucc_mc_attr_t *mc_attr)
+{
+    if (mc_attr->field_mask & UCC_MC_ATTR_FIELD_THREAD_MODE) {
+        mc_attr->thread_mode = ucc_mc_cpu.thread_mode;
+    }
+    return UCC_OK;
+}
+
 static ucc_status_t ucc_mc_cpu_mem_alloc(ucc_mc_buffer_header_t **h_ptr,
                                          size_t                   size)
 {
@@ -276,6 +284,7 @@ ucc_mc_cpu_t ucc_mc_cpu = {
     .super.type             = UCC_MEMORY_TYPE_HOST,
     .super.ee_type          = UCC_EE_CPU_THREAD,
     .super.init             = ucc_mc_cpu_init,
+    .super.get_attr         = ucc_mc_cpu_get_attr,
     .super.finalize         = ucc_mc_cpu_finalize,
     .super.ops.mem_query    = ucc_mc_cpu_mem_query,
     .super.ops.mem_alloc    = ucc_mc_cpu_mem_pool_alloc_with_init,

--- a/src/components/mc/cuda/kernel/Makefile.am
+++ b/src/components/mc/cuda/kernel/Makefile.am
@@ -3,7 +3,7 @@
 #
 
 NVCC = nvcc
-NVCCFLAGS = ${AM_CPPFLAGS} ${UCS_CPPFLAGS} -I${UCC_TOP_BUILDDIR} -I${UCC_TOP_SRCDIR}/src -I${UCC_TOP_BUILDDIR}/src --compiler-options -fno-rtti,-fno-exceptions
+NVCCFLAGS = ${AM_CPPFLAGS} ${UCS_CPPFLAGS} ${NVCC_CFLAGS} -I${UCC_TOP_BUILDDIR} -I${UCC_TOP_SRCDIR}/src -I${UCC_TOP_BUILDDIR}/src --compiler-options -fno-rtti,-fno-exceptions
 
 LINK = $(LIBTOOL) --mode=link $(CC) -o $@
 

--- a/src/components/mc/cuda/kernel/mc_cuda_reduce.cu
+++ b/src/components/mc/cuda/kernel/mc_cuda_reduce.cu
@@ -161,6 +161,7 @@ ucc_status_t ucc_mc_cuda_reduce(const void *src1, const void *src2, void *dst,
         case UCC_DT_FLOAT16:
             ucc_assert(2 == sizeof(__half));
             DT_REDUCE_FLOAT(__half, op, src1, src2, dst, count, stream, bk, th);
+            break;
         case UCC_DT_FLOAT32:
             ucc_assert(4 == sizeof(float));
             DT_REDUCE_FLOAT(float, op, src1, src2, dst, count, stream, bk, th);

--- a/src/components/mc/cuda/kernel/mc_cuda_reduce_multi.cu
+++ b/src/components/mc/cuda/kernel/mc_cuda_reduce_multi.cu
@@ -30,7 +30,7 @@ __global__ void UCC_REDUCE_CUDA_ ## NAME (const T *s1, const T *s2, T *d,      \
                 d[i] = OP(d[i], s2[i + j * ld]);                               \
             }                                                                  \
         }                                                                      \
-}                                                                              \
+}
 
 #define CUDA_REDUCE_WITH_OP_SPECIALIZED(NAME, OP, TYPE)                        \
 template <>                                                                    \
@@ -46,7 +46,7 @@ __global__ void UCC_REDUCE_CUDA_ ## NAME (const TYPE *s1, const TYPE *s2,      \
                 d[i] = OP(d[i], s2[i + j * ld]);                               \
             }                                                                  \
         }                                                                      \
-}                                                                              \
+}
 
 CUDA_REDUCE_WITH_OP(MAX,  DO_OP_MAX)
 CUDA_REDUCE_WITH_OP(MIN,  DO_OP_MIN)
@@ -73,7 +73,7 @@ CUDA_REDUCE_WITH_OP_SPECIALIZED(PROD, DO_OP_PROD_HALF, __half)
 #define DT_REDUCE_INT(type, op, src1_p, src2_p, dest_p, size, count, ld, s,    \
                       b, t) do {                                               \
         const type *sbuf1 = (type *)src1_p;                                    \
-        const type *sbuf2= (type *)src2_p;                                     \
+        const type *sbuf2 = (type *)src2_p;                                    \
         type *dest = (type *)dest_p;                                           \
         switch(op) {                                                           \
         case UCC_OP_MAX:                                                       \

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -235,6 +235,14 @@ static ucc_status_t ucc_mc_cuda_init(const ucc_mc_params_t *mc_params)
     return UCC_OK;
 }
 
+static ucc_status_t ucc_mc_cuda_get_attr(ucc_mc_attr_t *mc_attr)
+{
+    if (mc_attr->field_mask & UCC_MC_ATTR_FIELD_THREAD_MODE) {
+        mc_attr->thread_mode = ucc_mc_cuda.thread_mode;
+    }
+    return UCC_OK;
+}
+
 static ucc_status_t ucc_mc_cuda_mem_alloc(ucc_mc_buffer_header_t **h_ptr,
                                           size_t                   size)
 {
@@ -633,6 +641,7 @@ ucc_mc_cuda_t ucc_mc_cuda = {
     .super.ee_type          = UCC_EE_CUDA_STREAM,
     .super.type             = UCC_MEMORY_TYPE_CUDA,
     .super.init             = ucc_mc_cuda_init,
+    .super.get_attr         = ucc_mc_cuda_get_attr,
     .super.finalize         = ucc_mc_cuda_finalize,
     .super.ops.mem_query    = ucc_mc_cuda_mem_query,
     .super.ops.mem_alloc    = ucc_mc_cuda_mem_pool_alloc_with_init,

--- a/src/core/ucc_mc.c
+++ b/src/core/ucc_mc.c
@@ -42,6 +42,7 @@ ucc_status_t ucc_mc_init(const ucc_mc_params_t *mc_params)
     int            i, n_mcs;
     ucc_mc_base_t *mc;
     ucc_status_t   status;
+    ucc_mc_attr_t attr;
 
     memset(mc_ops, 0, UCC_MEMORY_TYPE_LAST * sizeof(ucc_mc_ops_t *));
     memset(ee_ops, 0, UCC_EE_LAST * sizeof(ucc_ee_ops_t *));
@@ -75,6 +76,18 @@ ucc_status_t ucc_mc_init(const ucc_mc_params_t *mc_params)
                 continue;
             }
             ucc_debug("%s initialized", mc->super.name);
+        } else {
+            attr.field_mask = UCC_MC_ATTR_FIELD_THREAD_MODE;
+            status = mc->get_attr(&attr);
+            if (status != UCC_OK) {
+                return status;
+            }
+            if (attr.thread_mode < mc_params->thread_mode) {
+                ucc_warn("memory component %s was allready initilized with "
+                         "different thread mode: current tm %d, provided tm %d",
+                         mc->super.name, attr.thread_mode,
+                         mc_params->thread_mode);
+            }
         }
         mc->ref_cnt++;
         mc_ops[mc->type] = &mc->ops;

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -9,18 +9,6 @@
 #include "ucc/api/ucc.h"
 #include "components/mc/base/ucc_mc_base.h"
 
-typedef struct ucc_mem_attr ucc_mem_attr_t;
-
-typedef struct ucc_mc_buffer_header {
-    ucc_memory_type_t mt;
-    int               from_pool;
-    void             *addr;
-} ucc_mc_buffer_header_t;
-
-typedef struct ucc_mc_params {
-    ucc_thread_mode_t thread_mode;
-} ucc_mc_params_t;
-
 ucc_status_t ucc_mc_init(const ucc_mc_params_t *mc_params);
 
 ucc_status_t ucc_mc_available(ucc_memory_type_t mem_type);

--- a/test/gtest/core/test_mc.cc
+++ b/test/gtest/core/test_mc.cc
@@ -82,7 +82,8 @@ UCC_TEST_F(test_mc, can_alloc_and_free_host_mem)
     ucc_mc_finalize();
 }
 
-UCC_TEST_F(test_mc, can_alloc_and_free_host_mem_mt)
+// Disabled because can't reinit mc with different thread mode
+UCC_TEST_F(test_mc, DISABLED_can_alloc_and_free_host_mem_mt)
 {
     // mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1MB and is configurable at runtime.
     int                    num_of_threads = 10;

--- a/test/gtest/core/test_mc_cuda.cc
+++ b/test/gtest/core/test_mc_cuda.cc
@@ -93,7 +93,8 @@ UCC_TEST_F(test_mc_cuda, can_alloc_and_free_mem)
     EXPECT_EQ(UCC_OK, ucc_mc_free(mc_header));
 }
 
-UCC_TEST_F(test_mc_cuda_mt, can_alloc_and_free_mem_mt)
+// Disabled because can't reinit mc with different thread mode
+UCC_TEST_F(test_mc_cuda_mt, DISABLED_can_alloc_and_free_mem_mt)
 {
     // mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1MB and is configurable at runtime.
     int                    num_of_threads = 10;


### PR DESCRIPTION
## What
Fixing multiple bugs in MC:
- checking provided thread mode in ucc_mc_init, print warning if requested thread_mode is not consistent with previously used
- disabled 2 test cases in gtest because they depend on the order in which memory components were initialized
- fix fp16 switch exit
- added debug flags for nvcc host code if --enable-debug is set

