### PR TITLE
MC/CUDA: init stream on demand

### DIFF
--- a/src/components/mc/cuda/kernel/mc_cuda_reduce.cu
+++ b/src/components/mc/cuda/kernel/mc_cuda_reduce.cu
@@ -138,10 +138,12 @@ ucc_status_t ucc_mc_cuda_reduce(const void *src1, const void *src2, void *dst,
                                 size_t count, ucc_datatype_t dt,
                                 ucc_reduction_op_t op)
 {
-    cudaStream_t  stream = ucc_mc_cuda.stream;
     int           th     = MC_CUDA_CONFIG->reduce_num_threads;;
     unsigned long bk     = (count + th - 1)/th;;
+    cudaStream_t  stream;
 
+    UCC_MC_CUDA_INIT_STREAM();
+    stream = ucc_mc_cuda.stream;
     if (MC_CUDA_CONFIG->reduce_num_blocks != UCC_ULUNITS_AUTO) {
         bk = ucc_min(bk, MC_CUDA_CONFIG->reduce_num_blocks);
     }

--- a/src/components/mc/cuda/kernel/mc_cuda_reduce_multi.cu
+++ b/src/components/mc/cuda/kernel/mc_cuda_reduce_multi.cu
@@ -162,11 +162,13 @@ ucc_status_t ucc_mc_cuda_reduce_multi(const void *src1, const void *src2,
                                       size_t stride, ucc_datatype_t dt,
                                       ucc_reduction_op_t op)
 {
-    cudaStream_t  stream = ucc_mc_cuda.stream;
     size_t        ld     = stride / ucc_dt_size(dt);
     int           th     = MC_CUDA_CONFIG->reduce_num_threads;;
     unsigned long bk     = (count + th - 1)/th;;
+    cudaStream_t  stream;
 
+    UCC_MC_CUDA_INIT_STREAM();
+    stream = ucc_mc_cuda.stream;
     if (MC_CUDA_CONFIG->reduce_num_blocks != UCC_ULUNITS_AUTO) {
         bk = ucc_min(bk, MC_CUDA_CONFIG->reduce_num_blocks);
     }

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -71,7 +71,7 @@ static int ucc_pq_mt_progress(ucc_progress_queue_t *pq)
         if (task->progress) {
             status = task->progress(task);
             if (ucc_unlikely(status < 0)) {
-                return status;
+                return ucc_task_error(task);
             }
         }
         if (UCC_INPROGRESS == task->super.status) {

--- a/src/core/ucc_progress_queue_st.c
+++ b/src/core/ucc_progress_queue_st.c
@@ -25,7 +25,7 @@ static int ucc_pq_st_progress(ucc_progress_queue_t *pq)
             ucc_assert(task->super.status != UCC_OK);
             status = task->progress(task);
             if (ucc_unlikely(status < 0)) {
-                return status;
+                return ucc_task_error(task);
             }
         }
         if (UCC_INPROGRESS == task->super.status) {

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -15,6 +15,7 @@
 typedef enum {
     UCC_EVENT_COMPLETED = 0,
     UCC_EVENT_SCHEDULE_STARTED,
+    UCC_EVENT_ERROR,
     UCC_EVENT_LAST
 } ucc_event_t;
 
@@ -78,6 +79,15 @@ void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
 ucc_status_t ucc_schedule_start(ucc_schedule_t *schedule);
 ucc_status_t ucc_task_start_handler(ucc_coll_task_t *parent,
                                     ucc_coll_task_t *task);
+
+static inline ucc_status_t ucc_task_error(ucc_coll_task_t *task)
+{
+    ucc_status_t status = task->super.status;
+
+    ucc_assert(status < 0);
+    ucc_error("failure in task %p, %s", task, ucc_status_string(status));
+    return ucc_event_manager_notify(task, UCC_EVENT_ERROR);
+}
 
 static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
 {


### PR DESCRIPTION
## What
Fix for #234

1. Initialize cuda stream only when it's needed for the first time, that way we guarantee that we pick correct device for stream (fixing cuda error)

2. Introduce error event handler and UCC_EVENT_ERROR to propagate error from individual task to schedule (fixing infinity progress after error)

