### PR TITLE
SCHEDULE: rework listeners

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -36,7 +36,7 @@ jobs:
               return 1
             fi
           fi
-          if ! echo $msg | grep -qP '^Merge |^((CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC)|(CL/|TL/|MC/|UCP|UCG|NCCL|BASIC|CUDA|CPU|EE))+: \w'
+          if ! echo $msg | grep -qP '^Merge |^((CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC|SCHEDULE)|(CL/|TL/|MC/|UCP|UCG|NCCL|BASIC|CUDA|CPU|EE))+: \w'
           then
             echo "Wrong header"
             return 1

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -79,10 +79,8 @@ ucc_status_t ucc_tl_nccl_collective_sync(ucc_tl_nccl_task_t *task,
             return UCC_ERR_NO_MESSAGE;
         }
     }
+
     status = task->super.progress(&task->super);
-    if (ucc_unlikely(status < 0)) {
-        return ucc_task_error(&task->super);
-    }
     if (status == UCC_INPROGRESS) {
         ucc_progress_enqueue(UCC_TL_CORE_CTX(task->team)->pq, &task->super);
         return UCC_OK;

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -88,9 +88,8 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
     }
     ucc_schedule_add_task(schedule, task);
     ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
-                                task);
-    task->handlers[UCC_EVENT_SCHEDULE_STARTED] = ucc_task_start_handler;
-    rs_task                                    = task;
+                                task, ucc_task_start_handler);
+    rs_task = task;
 
     /* 2nd step of allreduce: knomial allgather. 2nd task subscribes
      to completion event of reduce_scatter task. */
@@ -104,8 +103,8 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
     }
 
     ucc_schedule_add_task(schedule, task);
-    ucc_event_manager_subscribe(&rs_task->em, UCC_EVENT_COMPLETED, task);
-    task->handlers[UCC_EVENT_COMPLETED] = ucc_task_start_handler;
+    ucc_event_manager_subscribe(&rs_task->em, UCC_EVENT_COMPLETED, task,
+                                ucc_task_start_handler);
 
     schedule->super.post     = ucc_tl_ucp_allreduce_sra_knomial_start;
     schedule->super.progress = NULL;

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -90,8 +90,8 @@ ucc_tl_ucp_event_trigger_complete(ucc_coll_task_t *parent_task,
         ucc_assert(coll_task->super.status == UCC_INPROGRESS);
         if (coll_task->ee_task) {
             ucc_event_manager_init(&coll_task->em);
-            coll_task->handlers[UCC_EVENT_COMPLETED] = ucc_tl_ucp_triggered_coll_complete;
-            ucc_event_manager_subscribe(&coll_task->em, UCC_EVENT_COMPLETED, coll_task);
+            ucc_event_manager_subscribe(&coll_task->em, UCC_EVENT_COMPLETED, coll_task,
+                                        ucc_tl_ucp_triggered_coll_complete);
         }
     }
 
@@ -173,8 +173,8 @@ ucc_status_t ucc_tl_ucp_triggered_post(ucc_ee_h ee, ucc_ev_t *ev, //NOLINT
             "triggered post. ev_task:%p coll_task:%p", &ev_task->super, coll_task);
     ev_task->super.progress = ucc_tl_ucp_ee_wait_for_event_trigger;
     ucc_event_manager_init(&ev_task->super.em);
-    coll_task->handlers[UCC_EVENT_COMPLETED] = ucc_tl_ucp_event_trigger_complete;
-    ucc_event_manager_subscribe(&ev_task->super.em, UCC_EVENT_COMPLETED, coll_task);
+    ucc_event_manager_subscribe(&ev_task->super.em, UCC_EVENT_COMPLETED, coll_task,
+                                ucc_tl_ucp_event_trigger_complete);
 
     status = ucc_tl_ucp_ee_wait_for_event_trigger(&ev_task->super);
     if (ucc_unlikely(status != UCC_OK)) {

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -69,10 +69,7 @@ static int ucc_pq_mt_progress(ucc_progress_queue_t *pq)
     pq->dequeue(pq, &task);
     if (task) {
         if (task->progress) {
-            status = task->progress(task);
-            if (ucc_unlikely(status < 0)) {
-                return ucc_task_error(task);
-            }
+            task->progress(task);
         }
         if (UCC_INPROGRESS == task->super.status) {
             pq->enqueue(pq, task);

--- a/src/core/ucc_progress_queue_st.c
+++ b/src/core/ucc_progress_queue_st.c
@@ -21,12 +21,9 @@ static int ucc_pq_st_progress(ucc_progress_queue_t *pq)
     ucc_status_t     status;
 
     ucc_list_for_each_safe(task, tmp, &pq_st->list, list_elem) {
-        if (task->progress) { //TODO maybe dummy empty progress fn is better than branch?
+        if (task->progress) {
             ucc_assert(task->super.status != UCC_OK);
-            status = task->progress(task);
-            if (ucc_unlikely(status < 0)) {
-                return ucc_task_error(task);
-            }
+            task->progress(task);
         }
         if (UCC_INPROGRESS == task->super.status) {
             continue;

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -8,18 +8,26 @@
 ucc_status_t ucc_event_manager_init(ucc_event_manager_t *em)
 {
     int i;
-    for (i = 0; i < UCC_EVENT_LAST; i++) {
-        em->listeners_size[i] = 0;
+    for (i = 0; i < MAX_LISTENERS; i++) {
+        em->listeners[i].task = NULL;
     }
     return UCC_OK;
 }
 
 void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
-                                 ucc_coll_task_t *task)
+                                 ucc_coll_task_t *task,
+                                 ucc_task_event_handler_p handler)
 {
-    ucc_assert(em->listeners_size[event] < MAX_LISTENERS);
-    em->listeners[event][em->listeners_size[event]] = task;
-    em->listeners_size[event]++;
+    int i;
+    for (i = 0; i < MAX_LISTENERS; i++) {
+        if (!em->listeners[i].task) {
+            em->listeners[i].task    = task;
+            em->listeners[i].event   = event;
+            em->listeners[i].handler = handler;
+            break;
+        }
+    }
+    ucc_assert(i < MAX_LISTENERS);
 }
 
 ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task)
@@ -31,6 +39,26 @@ ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task)
     return ucc_event_manager_init(&task->em);
 }
 
+static ucc_status_t
+ucc_task_error_handler(ucc_coll_task_t *parent_task,
+                       ucc_coll_task_t *task)
+{
+    ucc_event_manager_t *em = &parent_task->em;
+    ucc_coll_task_t     *listener;
+    int                 i;
+
+    task->super.status = parent_task->super.status;
+    for (i = 0; i < MAX_LISTENERS; i++) {
+        listener = em->listeners[i].task;
+        if (listener &&
+            listener->super.status != parent_task->super.status) {
+            /* status has not been propagated yet */
+            ucc_task_error_handler(task, listener);
+        }
+    }
+    return UCC_OK;
+}
+
 ucc_status_t ucc_event_manager_notify(ucc_coll_task_t *parent_task,
                                       ucc_event_t event)
 {
@@ -39,11 +67,17 @@ ucc_status_t ucc_event_manager_notify(ucc_coll_task_t *parent_task,
     ucc_status_t        status;
     int                 i;
 
-    for (i = 0; i < em->listeners_size[event]; i++) {
-        task   = em->listeners[event][i];
-        status = task->handlers[event](parent_task, task);
-        if (ucc_unlikely(status != UCC_OK)) {
-            return status;
+    for (i = 0; i < MAX_LISTENERS; i++) {
+        task = em->listeners[i].task;
+        if (task) {
+            if (UCC_EVENT_ERROR == event) {
+                ucc_task_error_handler(parent_task, task);
+            } else if (em->listeners[i].event == event) {
+                status = em->listeners[i].handler(parent_task, task);
+                if (ucc_unlikely(status != UCC_OK)) {
+                    return status;
+                }
+            }
         }
     }
     return UCC_OK;
@@ -62,34 +96,20 @@ ucc_schedule_completed_handler(ucc_coll_task_t *parent_task, //NOLINT
     return UCC_OK;
 }
 
-static ucc_status_t
-ucc_schedule_error_handler(ucc_coll_task_t *parent_task, //NOLINT
-                           ucc_coll_task_t *task)
-{
-    task->super.status = parent_task->super.status;
-    return ucc_event_manager_notify(task, UCC_EVENT_ERROR);
-}
-
 ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx)
 {
     ucc_status_t status;
-    status = ucc_coll_task_init(&schedule->super);
-    schedule->super.handlers[UCC_EVENT_COMPLETED] =
-        ucc_schedule_completed_handler;
-    schedule->super.handlers[UCC_EVENT_ERROR] =
-        ucc_schedule_error_handler;
-    schedule->n_completed_tasks = 0;
-    schedule->ctx               = ctx;
-    schedule->n_tasks           = 0;
+
+    status             = ucc_coll_task_init(&schedule->super);
+    schedule->ctx      = ctx;
+    schedule->n_tasks  = 0;
     return status;
 }
 
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task)
 {
     ucc_event_manager_subscribe(&task->em, UCC_EVENT_COMPLETED,
-                                &schedule->super);
-    ucc_event_manager_subscribe(&task->em, UCC_EVENT_ERROR,
-                                &schedule->super);
+                            &schedule->super, ucc_schedule_completed_handler);
     task->schedule                       = schedule;
     schedule->tasks[schedule->n_tasks++] = task;
 }

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -82,6 +82,7 @@ gtest_SOURCES =                     \
 	core/test_allgatherv.cc         \
 	core/test_bcast.cc              \
 	core/test_allreduce.cc          \
+	core/test_schedule.cc           \
 	utils/test_string.cc            \
 	utils/test_ep_map.cc            \
 	utils/test_lock_free_queue.cc   \

--- a/test/gtest/core/test_schedule.cc
+++ b/test/gtest/core/test_schedule.cc
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+extern "C" {
+#include "schedule/ucc_schedule.h"
+}
+typedef std::tuple<ucc_coll_task_t*, int> rst_t;
+class test_schedule : public ucc_coll_task_t, public ucc::test
+{
+public:
+    std::vector<rst_t> rst;
+    static ucc_status_t handler_1(ucc_coll_task_t *parent,
+                                  ucc_coll_task_t *task) {
+        test_schedule *ts = (test_schedule*)task;
+        ts->rst.push_back(rst_t(parent, 1));
+        return UCC_OK;
+    }
+    static ucc_status_t handler_2(ucc_coll_task_t *parent,
+                                  ucc_coll_task_t *task) {
+        test_schedule *ts = (test_schedule*)task;
+        ts->rst.push_back(rst_t(parent, 2));
+        return UCC_OK;
+    }
+};
+
+/* Tasks subscribes on 2 tasks to EVENT_COMPLETED with the same
+   handler */
+UCC_TEST_F(test_schedule, single_handler)
+{
+    std::vector<ucc_coll_task_t> tasks(2);
+
+    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t*)this));
+    for (auto &t :  tasks) {
+        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t));
+        ucc_event_manager_subscribe(&t.em, UCC_EVENT_COMPLETED,
+                                    (ucc_coll_task_t*)this,
+                                    test_schedule::handler_1);
+    }
+
+    for (auto &t :  tasks) {
+        EXPECT_EQ(UCC_OK, ucc_event_manager_notify(&t, UCC_EVENT_COMPLETED));
+    }
+    EXPECT_EQ(2, rst.size());
+    EXPECT_EQ(true, (std::get<0>(rst[0]) == &tasks[0]) &&
+              (std::get<1>(rst[0]) == 1));
+    EXPECT_EQ(true, (std::get<0>(rst[1]) == &tasks[1]) &&
+              (std::get<1>(rst[1]) == 1));
+}
+
+/* Tasks subscribes on 2 tasks to EVENT_COMPLETED with 2 different
+   handlers */
+UCC_TEST_F(test_schedule, different_handlers)
+{
+    std::vector<ucc_coll_task_t> tasks(2);
+
+    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t*)this));
+    for (auto &t :  tasks) {
+        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t));
+    }
+    ucc_event_manager_subscribe(&tasks[0].em, UCC_EVENT_COMPLETED,
+                                (ucc_coll_task_t*)this,
+                                test_schedule::handler_1);
+    ucc_event_manager_subscribe(&tasks[1].em, UCC_EVENT_COMPLETED,
+                                (ucc_coll_task_t*)this,
+                                test_schedule::handler_2);
+
+    for (auto &t :  tasks) {
+        EXPECT_EQ(UCC_OK, ucc_event_manager_notify(&t, UCC_EVENT_COMPLETED));
+    }
+
+    EXPECT_EQ(2, rst.size());
+    EXPECT_EQ(true, (std::get<0>(rst[0]) == &tasks[0]) &&
+              (std::get<1>(rst[0]) == 1));
+    EXPECT_EQ(true, (std::get<0>(rst[1]) == &tasks[1]) &&
+              (std::get<1>(rst[1]) == 2));
+}


### PR DESCRIPTION
## What
Change the implementation of event manager to support subscription on the same event with different handlers for different parent tasks

## Why ?
When we will build more complex algorithms (upcoming PRs in CL/HIER, 2 lvl allreduce alg) we will have e.g. schedule of schedules: e.g., 1 sra schedule launched after another task_T. The SRA schedule subscribes to its tasks on EVENT completed but also needs to subscribe with different handler to the task_T.
