### PR TITLE
Cache args on coll_task

### DIFF
--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -69,10 +69,15 @@ typedef struct ucc_tl_nccl_task {
     ucc_coll_task_t     super;
     ucc_status_t        host_status;
     ucc_status_t       *dev_status;
-    ucc_tl_nccl_team_t *team;
-    ucc_coll_args_t     args;
     cudaEvent_t         completed;
 } ucc_tl_nccl_task_t;
+
+#define TASK_TEAM(_task)                                                       \
+    (ucc_derived_of((_task)->super.team, ucc_tl_nccl_team_t))
+#define TASK_CTX(_task)                                                        \
+    (ucc_derived_of((_task)->super.team->context, ucc_tl_nccl_context_t))
+#define TASK_LIB(_task)                                                        \
+    (ucc_derived_of((_task)->super.team->context->lib, ucc_tl_nccl_lib_t))
 
 #define UCC_TL_NCCL_SUPPORTED_COLLS                         \
     (UCC_COLL_TYPE_ALLTOALL  | UCC_COLL_TYPE_ALLTOALLV  |   \

--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -12,10 +12,9 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
 {
-    if ((task->args.src.info.datatype == UCC_DT_USERDEFINED) ||
-        (task->args.dst.info.datatype == UCC_DT_USERDEFINED)) {
-        tl_error(UCC_TL_TEAM_LIB(task->team),
-                 "user defined datatype is not supported");
+    if ((task->super.args.src.info.datatype == UCC_DT_USERDEFINED) ||
+        (task->super.args.dst.info.datatype == UCC_DT_USERDEFINED)) {
+        tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     task->super.post     = ucc_tl_ucp_allgather_ring_start;

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -22,14 +22,15 @@
 ucc_status_t ucc_tl_ucp_allgather_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t     *team  = task->team;
+    ucc_coll_args_t       *args  = &coll_task->args;
+    ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
     ucc_kn_radix_t         radix = task->allgather_kn.p.radix;
     uint8_t                node_type  = task->allgather_kn.p.node_type;
     ucc_knomial_pattern_t *p          = &task->allgather_kn.p;
-    void                  *rbuf       = task->args.dst.info.buffer;
-    ucc_memory_type_t      mem_type   = task->args.src.info.mem_type;
-    size_t                 count      = task->args.src.info.count;
-    ucc_datatype_t         dt         = task->args.src.info.datatype;
+    void                  *rbuf       = args->dst.info.buffer;
+    ucc_memory_type_t      mem_type   = args->src.info.mem_type;
+    size_t                 count      = args->src.info.count;
+    ucc_datatype_t         dt         = args->src.info.datatype;
     size_t                 dt_size    = ucc_dt_size(dt);
     size_t                 data_size  = count * dt_size;
     ucc_rank_t             size       = team->size;
@@ -103,7 +104,7 @@ UCC_KN_PHASE_EXTRA:
 
     if (KN_NODE_PROXY == node_type) {
         peer = ucc_knomial_pattern_get_extra(p, rank);
-        UCPCHECK_GOTO(ucc_tl_ucp_send_nb(task->args.dst.info.buffer, data_size,
+        UCPCHECK_GOTO(ucc_tl_ucp_send_nb(args->dst.info.buffer, data_size,
                                          mem_type, peer, team, task),
                       task, out);
     } else {
@@ -124,7 +125,8 @@ out:
 ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t *team  = task->team;
+    ucc_coll_args_t   *args  = &coll_task->args;
+    ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
     ucc_rank_t         size  = team->size;
     ucc_rank_t         rank  = team->rank;
     ucc_kn_radix_t     radix = task->allgather_kn.p.radix;
@@ -135,24 +137,22 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_reset(task);
 
     task->allgather_kn.phase = UCC_KN_PHASE_INIT;
-    ucc_assert(task->args.src.info.mem_type == task->args.dst.info.mem_type);
+    ucc_assert(args->src.info.mem_type == args->dst.info.mem_type);
 
     ucc_knomial_pattern_init_backward(size, rank, radix, &task->allgather_kn.p);
-    offset = ucc_sra_kn_get_offset(task->args.src.info.count,
-                                   ucc_dt_size(task->args.src.info.datatype),
-                                   rank, size, radix);
-    if (!UCC_IS_INPLACE(task->args)) {
-        status = ucc_mc_memcpy(PTR_OFFSET(task->args.dst.info.buffer, offset),
-                               task->args.src.info.buffer,
-                               task->args.src.info.count *
-                                   ucc_dt_size(task->args.src.info.datatype),
-                               task->args.dst.info.mem_type,
-                               task->args.src.info.mem_type);
+    offset = ucc_sra_kn_get_offset(args->src.info.count,
+                                   ucc_dt_size(args->src.info.datatype), rank,
+                                   size, radix);
+    if (!UCC_IS_INPLACE(*args)) {
+        status = ucc_mc_memcpy(
+            PTR_OFFSET(args->dst.info.buffer, offset), args->src.info.buffer,
+            args->src.info.count * ucc_dt_size(args->src.info.datatype),
+            args->dst.info.mem_type, args->src.info.mem_type);
         if (UCC_OK != status) {
             return status;
         }
     }
-    task->allgather_kn.sbuf = PTR_OFFSET(task->args.dst.info.buffer, offset);
+    task->allgather_kn.sbuf = PTR_OFFSET(args->dst.info.buffer, offset);
 
     status = ucc_tl_ucp_allgather_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -16,13 +16,13 @@
 ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t *team       = task->team;
+    ucc_tl_ucp_team_t *team       = TASK_TEAM(task);
     ucc_rank_t         group_rank = team->rank;
     ucc_rank_t         group_size = team->size;
-    void              *rbuf       = task->args.dst.info.buffer;
-    ucc_memory_type_t  rmem       = task->args.dst.info.mem_type;
-    size_t             count      = task->args.dst.info.count;
-    ucc_datatype_t     dt         = task->args.dst.info.datatype;
+    void              *rbuf       = coll_task->args.dst.info.buffer;
+    ucc_memory_type_t  rmem       = coll_task->args.dst.info.mem_type;
+    size_t             count      = coll_task->args.dst.info.count;
+    ucc_datatype_t     dt         = coll_task->args.dst.info.datatype;
     size_t             data_size  = count * ucc_dt_size(dt);
     ucc_rank_t         sendto     = (group_rank + 1) % group_size;
     ucc_rank_t         recvfrom   = (group_rank - 1 + group_size) % group_size;
@@ -60,20 +60,20 @@ out:
 ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t *team      = task->team;
-    size_t             count     = task->args.dst.info.count;
-    void              *sbuf      = task->args.src.info.buffer;
-    void              *rbuf      = task->args.dst.info.buffer;
-    ucc_memory_type_t  smem      = task->args.src.info.mem_type;
-    ucc_memory_type_t  rmem      = task->args.dst.info.mem_type;
-    ucc_datatype_t     dt        = task->args.dst.info.datatype;
+    ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
+    size_t             count     = coll_task->args.dst.info.count;
+    void              *sbuf      = coll_task->args.src.info.buffer;
+    void              *rbuf      = coll_task->args.dst.info.buffer;
+    ucc_memory_type_t  smem      = coll_task->args.src.info.mem_type;
+    ucc_memory_type_t  rmem      = coll_task->args.dst.info.mem_type;
+    ucc_datatype_t     dt        = coll_task->args.dst.info.datatype;
     size_t             data_size = count * ucc_dt_size(dt);
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_ring_start", 0);
     ucc_tl_ucp_task_reset(task);
 
-    if (!UCC_IS_INPLACE(task->args)) {
+    if (!UCC_IS_INPLACE(coll_task->args)) {
         status = ucc_mc_memcpy((void*)((ptrdiff_t)rbuf + data_size * team->rank),
                                sbuf, data_size, rmem, smem);
         if (ucc_unlikely(UCC_OK != status)) {

--- a/src/components/tl/ucp/allgatherv/allgatherv.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv.c
@@ -14,11 +14,10 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task)
 {
-    if ((task->args.dst.info_v.datatype == UCC_DT_USERDEFINED) ||
-        (!UCC_IS_INPLACE(task->args) &&
-         (task->args.src.info.datatype == UCC_DT_USERDEFINED))) {
-        tl_error(UCC_TL_TEAM_LIB(task->team),
-                 "user defined datatype is not supported");
+    if ((task->super.args.dst.info_v.datatype == UCC_DT_USERDEFINED) ||
+        (!UCC_IS_INPLACE(task->super.args) &&
+         (task->super.args.src.info.datatype == UCC_DT_USERDEFINED))) {
+        tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     task->super.post     = ucc_tl_ucp_allgatherv_ring_start;

--- a/src/components/tl/ucp/allreduce/allreduce.c
+++ b/src/components/tl/ucp/allreduce/allreduce.c
@@ -26,7 +26,7 @@ ucc_base_coll_alg_info_t
 ucc_status_t ucc_tl_ucp_allreduce_init(ucc_tl_ucp_task_t *task)
 {
     ucc_status_t status;
-    ALLREDUCE_TASK_CHECK(task->args, task->team);
+    ALLREDUCE_TASK_CHECK(task->super.args, TASK_TEAM(task));
     status = ucc_tl_ucp_allreduce_knomial_init_common(task);
 out:
     return status;

--- a/src/components/tl/ucp/alltoall/alltoall.c
+++ b/src/components/tl/ucp/alltoall/alltoall.c
@@ -15,15 +15,15 @@ ucc_status_t ucc_tl_ucp_alltoall_init(ucc_tl_ucp_task_t *task)
 {
     ucc_status_t status;
 
-    ALLTOALL_TASK_CHECK(task->args, task->team);
+    ALLTOALL_TASK_CHECK(task->super.args, TASK_TEAM(task));
     status = ucc_tl_ucp_alltoall_pairwise_init_common(task);
 out:
     return status;
 }
 
 ucc_status_t ucc_tl_ucp_alltoall_pairwise_init(ucc_base_coll_args_t *coll_args,
-                                                ucc_base_team_t      *team,
-                                                ucc_coll_task_t     **task_h)
+                                               ucc_base_team_t      *team,
+                                               ucc_coll_task_t     **task_h)
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_task_t *task;

--- a/src/components/tl/ucp/alltoallv/alltoallv.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv.c
@@ -15,7 +15,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_init(ucc_tl_ucp_task_t *task)
 {
     ucc_status_t status;
 
-    ALLTOALLV_TASK_CHECK(task->args, task->team);
+    ALLTOALLV_TASK_CHECK(task->super.args, TASK_TEAM(task));
     status = ucc_tl_ucp_alltoallv_pairwise_init_common(task);
 out:
     return status;

--- a/src/components/tl/ucp/barrier/barrier_knomial.c
+++ b/src/components/tl/ucp/barrier/barrier_knomial.c
@@ -20,7 +20,7 @@
 ucc_status_t ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t     *team       = task->team;
+    ucc_tl_ucp_team_t     *team       = TASK_TEAM(task);
     ucc_kn_radix_t         radix      = task->barrier.p.radix;
     uint8_t                node_type  = task->barrier.p.node_type;
     ucc_knomial_pattern_t *p          = &task->barrier.p;
@@ -104,7 +104,7 @@ out:
 ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t *team = task->team;
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_barrier_kn_start", 0);

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -22,17 +22,17 @@
 ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t *team      = task->team;
+    ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
     ucc_rank_t         myrank    = team->rank;
     ucc_rank_t         team_size = team->size;
-    ucc_rank_t         root      = (uint32_t)task->args.root;
+    ucc_rank_t         root      = (uint32_t)coll_task->args.root;
     uint32_t           radix     = task->bcast_kn.radix;
     ucc_rank_t         vrank     = (myrank - root + team_size) % team_size;
     ucc_rank_t         dist      = task->bcast_kn.dist;
-    void              *buffer    = task->args.src.info.buffer;
-    ucc_memory_type_t  mtype     = task->args.src.info.mem_type;
-    size_t data_size =
-        task->args.src.info.count * ucc_dt_size(task->args.src.info.datatype);
+    void              *buffer    = coll_task->args.src.info.buffer;
+    ucc_memory_type_t  mtype     = coll_task->args.src.info.mem_type;
+    size_t             data_size = coll_task->args.src.info.count *
+                       ucc_dt_size(coll_task->args.src.info.datatype);
     ucc_rank_t vpeer, peer, vroot_at_level, root_at_level, pos;
     uint32_t i;
 
@@ -78,7 +78,7 @@ out:
 ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t *team = task->team;
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_bcast_kn_start", 0);

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -23,16 +23,17 @@ ucc_status_t
 ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t     *team  = task->team;
+    ucc_coll_args_t       *args  = &coll_task->args;
+    ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
     ucc_kn_radix_t         radix = task->reduce_scatter_kn.p.radix;
     uint8_t                node_type = task->reduce_scatter_kn.p.node_type;
     ucc_knomial_pattern_t *p         = &task->reduce_scatter_kn.p;
     void                  *scratch   = task->reduce_scatter_kn.scratch;
-    void                  *sbuf      = task->args.src.info.buffer;
-    void                  *rbuf      = task->args.dst.info.buffer;
-    ucc_memory_type_t      mem_type  = task->args.src.info.mem_type;
-    size_t                 count     = task->args.src.info.count;
-    ucc_datatype_t         dt        = task->args.src.info.datatype;
+    void                  *sbuf      = args->src.info.buffer;
+    void                  *rbuf      = args->dst.info.buffer;
+    ucc_memory_type_t      mem_type  = args->src.info.mem_type;
+    size_t                 count     = args->src.info.count;
+    ucc_datatype_t         dt        = args->src.info.datatype;
     size_t                 dt_size   = ucc_dt_size(dt);
     size_t                 data_size = count * dt_size;
     ucc_rank_t             size      = team->size;
@@ -72,9 +73,8 @@ UCC_KN_PHASE_EXTRA:
             goto out;
         } else {
             if (UCC_OK != (status = ucc_dt_reduce(sbuf, scratch, rbuf, count,
-                                                  dt, mem_type, &task->args))) {
-                tl_error(UCC_TL_TEAM_LIB(task->team),
-                         "failed to perform dt reduction");
+                                                  dt, mem_type, args))) {
+                tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
                 task->super.super.status = status;
                 return status;
             }
@@ -84,8 +84,8 @@ UCC_KN_PHASE_EXTRA:
         step_radix  = ucc_sra_kn_compute_step_radix(rank, size, p);
         block_count = ucc_sra_kn_compute_block_count(count, rank, p);
         sbuf        = (p->iteration == 0)
-                          ? ((KN_NODE_PROXY == node_type) ? task->args.dst.info.buffer
-                                                          : task->args.src.info.buffer)
+                          ? ((KN_NODE_PROXY == node_type) ? args->dst.info.buffer
+                                                          : args->src.info.buffer)
                           : task->reduce_scatter_kn.scratch;
         for (loop_step = 1; loop_step < radix; loop_step++) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, size, loop_step);
@@ -128,10 +128,10 @@ UCC_KN_PHASE_EXTRA:
             return task->super.super.status;
         }
         if (task->send_posted > p->iteration * (radix - 1)) {
-            sbuf       = (p->iteration == 0) ? ((KN_NODE_PROXY == node_type)
-                                                    ? task->args.dst.info.buffer
-                                                    : task->args.src.info.buffer)
-                                             : task->reduce_scatter_kn.scratch;
+            sbuf       = (p->iteration == 0)
+                             ? ((KN_NODE_PROXY == node_type) ? args->dst.info.buffer
+                                                             : args->src.info.buffer)
+                             : task->reduce_scatter_kn.scratch;
             rbuf       = (p->iteration != 0)
                              ? PTR_OFFSET(task->reduce_scatter_kn.scratch,
                                     block_count * dt_size)
@@ -149,9 +149,8 @@ UCC_KN_PHASE_EXTRA:
                                local_data, rbuf, reduce_data,
                                task->send_posted - p->iteration * (radix - 1),
                                local_seg_count, local_seg_count * dt_size, dt,
-                               mem_type, &task->args))) {
-                tl_error(UCC_TL_TEAM_LIB(task->team),
-                         "failed to perform dt reduction");
+                               mem_type, args))) {
+                tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
                 task->super.super.status = status;
                 return status;
             }
@@ -160,7 +159,7 @@ UCC_KN_PHASE_EXTRA:
     }
 
     offset = ucc_sra_kn_get_offset(count, dt_size, rank, size, radix);
-    status = ucc_mc_memcpy(PTR_OFFSET(task->args.dst.info.buffer, offset),
+    status = ucc_mc_memcpy(PTR_OFFSET(args->dst.info.buffer, offset),
                            task->reduce_scatter_kn.scratch,
                            local_seg_count * dt_size, mem_type, mem_type);
 
@@ -178,9 +177,11 @@ out:
 ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t *team = task->team;
+    ucc_coll_args_t   *args = &coll_task->args;
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
     ucc_status_t       status;
     uint8_t            node_type;
+
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_reduce_scatter_kn_start",
                                      0);
     ucc_tl_ucp_task_reset(task);
@@ -189,8 +190,8 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
                              task->reduce_scatter_kn.p.radix,
                              &task->reduce_scatter_kn.p);
     node_type = task->reduce_scatter_kn.p.node_type;
-    if (!(UCC_IS_INPLACE(task->args) || (KN_NODE_PROXY == node_type))) {
-        task->reduce_scatter_kn.scratch = task->args.dst.info.buffer;
+    if (!(UCC_IS_INPLACE(*args) || (KN_NODE_PROXY == node_type))) {
+        task->reduce_scatter_kn.scratch = args->dst.info.buffer;
     }
     task->reduce_scatter_kn.phase = UCC_KN_PHASE_INIT;
 
@@ -208,7 +209,7 @@ ucc_tl_ucp_reduce_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     uint8_t            node_type = task->reduce_scatter_kn.p.node_type;
 
-    if (UCC_IS_INPLACE(task->args) || (KN_NODE_PROXY == node_type)) {
+    if (UCC_IS_INPLACE(coll_task->args) || (KN_NODE_PROXY == node_type)) {
         ucc_mc_free(task->reduce_scatter_kn.scratch_mc_header);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);
@@ -234,10 +235,11 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
     task->super.progress = ucc_tl_ucp_reduce_scatter_knomial_progress;
     task->super.finalize = ucc_tl_ucp_reduce_scatter_knomial_finalize;
 
-    ucc_assert(task->args.src.info.mem_type == task->args.dst.info.mem_type);
+    ucc_assert(coll_args->args.src.info.mem_type ==
+               coll_args->args.dst.info.mem_type);
     ucc_knomial_pattern_init(size, rank, radix, &task->reduce_scatter_kn.p);
 
-    if (UCC_IS_INPLACE(task->args) ||
+    if (UCC_IS_INPLACE(coll_args->args) ||
         (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type)) {
         status = ucc_mc_alloc(&task->reduce_scatter_kn.scratch_mc_header,
                               data_size, mem_type);
@@ -246,8 +248,8 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
         if (UCC_OK != status) {
             return status;
         }
-        if (UCC_IS_INPLACE(task->args)) {
-            task->args.src.info.buffer = task->args.dst.info.buffer;
+        if (UCC_IS_INPLACE(coll_args->args)) {
+            task->super.args.src.info.buffer = coll_args->args.dst.info.buffer;
         }
     }
 

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -19,8 +19,6 @@ extern const char
 
 typedef struct ucc_tl_ucp_task {
     ucc_coll_task_t      super;
-    ucc_coll_args_t      args;
-    ucc_tl_ucp_team_t *  team;
     uint32_t             send_posted;
     uint32_t             send_completed;
     uint32_t             recv_posted;
@@ -57,6 +55,13 @@ typedef struct ucc_tl_ucp_task {
     };
 } ucc_tl_ucp_task_t;
 
+#define TASK_TEAM(_task)                                                       \
+    (ucc_derived_of((_task)->super.team, ucc_tl_ucp_team_t))
+#define TASK_CTX(_task)                                                        \
+    (ucc_derived_of((_task)->super.team->context, ucc_tl_ucp_context_t))
+#define TASK_LIB(_task)                                                        \
+    (ucc_derived_of((_task)->super.team->context->lib, ucc_tl_ucp_lib_t))
+
 static inline void ucc_tl_ucp_task_reset(ucc_tl_ucp_task_t *task)
 {
     task->send_posted        = 0;
@@ -75,7 +80,7 @@ static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_team_t *team)
     task->super.super.status = UCC_OPERATION_INITIALIZED;
     task->super.flags        = 0;
     task->n_polls            = ctx->cfg.n_polls;
-    task->team               = team;
+    task->super.team         = &team->super.super;
     task->subset.map.type    = UCC_EP_MAP_FULL;
     task->subset.map.ep_num  = team->size;
     task->subset.myrank      = team->rank;
@@ -95,7 +100,7 @@ static inline ucc_schedule_t *ucc_tl_ucp_get_schedule(ucc_tl_ucp_team_t *team)
     ucc_schedule_t       *schedule = ucc_mpool_get(&ctx->req_mp);
 
     UCC_TL_UCP_PROFILE_REQUEST_NEW(schedule, "tl_ucp_task", 0);
-    ucc_schedule_init(schedule, UCC_TL_CORE_CTX(team));
+    ucc_schedule_init(schedule, NULL, &team->super.super);
     return schedule;
 }
 
@@ -120,9 +125,7 @@ ucc_tl_ucp_init_task(ucc_base_coll_args_t *coll_args, ucc_base_team_t *team)
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_task_t *task    = ucc_tl_ucp_get_task(tl_team);
 
-    ucc_coll_task_init(&task->super);
-    memcpy(&task->args, &coll_args->args, sizeof(ucc_coll_args_t));
-    task->team           = tl_team;
+    ucc_coll_task_init(&task->super, &coll_args->args, team);
     task->tag            = tl_team->seq_num;
     tl_team->seq_num     = (tl_team->seq_num + 1) % UCC_TL_UCP_MAX_COLL_TAG;
     task->super.finalize = ucc_tl_ucp_coll_finalize;
@@ -144,7 +147,7 @@ static inline ucc_status_t ucc_tl_ucp_test(ucc_tl_ucp_task_t *task)
         if (UCC_TL_UCP_TASK_P2P_COMPLETE(task)) {
             return UCC_OK;
         }
-        ucp_worker_progress(UCC_TL_UCP_TEAM_CTX(task->team)->ucp_worker);
+        ucp_worker_progress(TASK_CTX(task)->ucp_worker);
     }
     return UCC_INPROGRESS;
 }
@@ -157,4 +160,5 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
                                        ucc_coll_type_t          coll_type,
                                        ucc_memory_type_t        mem_type,
                                        ucc_base_coll_init_fn_t *init);
+
 #endif

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -35,16 +35,14 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
             .mem_type = UCC_MEMORY_TYPE_HOST
         }
     };
-    status = ucc_coll_task_init(&task->super);
+    status = ucc_coll_task_init(&task->super, &args, team);
     if (status != UCC_OK) {
         goto free_task;
     }
     task->subset = subset;
-    task->team = tl_team;
     task->tag  = UCC_TL_UCP_SERVICE_TAG;
     task->n_polls = 10; // TODO need a var ?
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
-    memcpy(&task->args, &args, sizeof(ucc_coll_args_t));
     *task_p = &task->super;
     status = ucc_tl_ucp_allreduce_knomial_init_common(task);
     if (status != UCC_OK) {

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -20,7 +20,7 @@ typedef enum {
 } ucc_event_t;
 
 typedef struct ucc_coll_task ucc_coll_task_t;
-
+typedef struct ucc_base_team ucc_base_team_t;
 typedef ucc_status_t (*ucc_task_event_handler_p)(ucc_coll_task_t *parent,
                                                  ucc_coll_task_t *task);
 typedef ucc_status_t (*ucc_coll_post_fn_t)(ucc_coll_task_t *task);
@@ -45,6 +45,8 @@ enum {
 typedef struct ucc_coll_task {
     ucc_coll_req_t               super;
     uint32_t                     flags;
+    ucc_coll_args_t              args;
+    ucc_base_team_t             *team;
     ucc_coll_post_fn_t           post;
     ucc_coll_triggered_post_fn_t triggered_post;
     ucc_coll_finalize_fn_t       finalize;
@@ -78,7 +80,8 @@ typedef struct ucc_schedule {
 
 ucc_status_t ucc_event_manager_init(ucc_event_manager_t *em);
 
-ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task);
+ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task, ucc_coll_args_t *args,
+                                ucc_base_team_t *team);
 
 void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
                                  ucc_coll_task_t *task,
@@ -87,7 +90,8 @@ void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
 ucc_status_t ucc_event_manager_notify(ucc_coll_task_t *parent_task,
                                       ucc_event_t event);
 
-ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_context_t *ctx);
+ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_coll_args_t *args,
+                               ucc_base_team_t *team);
 
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
 
@@ -121,4 +125,9 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
     }
     return status;
 }
+
+#define UCC_TASK_LIB(_task) (((ucc_coll_task_t *)_task)->team->context->lib)
+#define UCC_TASK_CORE_CTX(_task)                                               \
+    (((ucc_coll_task_t *)_task)->team->context->ucc_context)
+
 #endif

--- a/test/gtest/core/test_schedule.cc
+++ b/test/gtest/core/test_schedule.cc
@@ -32,9 +32,9 @@ UCC_TEST_F(test_schedule, single_handler)
 {
     std::vector<ucc_coll_task_t> tasks(2);
 
-    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t*)this));
+    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t *)this, NULL, NULL));
     for (auto &t :  tasks) {
-        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t));
+        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t, NULL, NULL));
         ucc_event_manager_subscribe(&t.em, UCC_EVENT_COMPLETED,
                                     (ucc_coll_task_t*)this,
                                     test_schedule::handler_1);
@@ -56,9 +56,9 @@ UCC_TEST_F(test_schedule, different_handlers)
 {
     std::vector<ucc_coll_task_t> tasks(2);
 
-    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t*)this));
+    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t *)this, NULL, NULL));
     for (auto &t :  tasks) {
-        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t));
+        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t, NULL, NULL));
     }
     ucc_event_manager_subscribe(&tasks[0].em, UCC_EVENT_COMPLETED,
                                 (ucc_coll_task_t*)this,


### PR DESCRIPTION
## What
Adds ucc_coll_args_t to ucc_coll_task_t and save the args during ucc_coll_task_init. Base (cl/tl) team is also cached on task (schedule).

## Why ?
2 reasons: 1. this logic is duplicated in every TL currently - so it is moved to the common place; 2. access to arges will be used in pipelined schedules to restart the task with custom frag settings.

