### PR TITLE
MC/CUDA: uninit warn build fix

### DIFF
--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -138,7 +138,7 @@ extern ucc_mc_cuda_t ucc_mc_cuda;
 
 #define UCC_MC_CUDA_INIT_STREAM() do {                                         \
     if (ucc_mc_cuda.stream == NULL) {                                          \
-        cudaError_t cuda_st;                                                   \
+        cudaError_t cuda_st = cudaSuccess;                                     \
         ucc_spin_lock(&ucc_mc_cuda.init_spinlock);                             \
         if (ucc_mc_cuda.stream == NULL) {                                      \
             cuda_st = cudaStreamCreateWithFlags(&ucc_mc_cuda.stream,           \


### PR DESCRIPTION
## What
Fixes build on CentOS 8 + GCC8.3.1

## Why ?
In file included from /global/home/users/valentinp/workspace/ucc/src/utils/ucc_compiler_def.h:15,
                 from /global/home/users/valentinp/workspace/ucc/src/utils/ucc_component.h:11,
                 from /global/home/users/valentinp/workspace/ucc/src/components/mc/base/ucc_mc_base.h:11,
                 from mc_cuda.h:10,
                 from mc_cuda.c:7:
mc_cuda.c: In function ‘ucc_mc_cuda_memcpy’:
/global/home/users/valentinp/workspace/ucx/build_rel/install/include/ucs/debug/log_def.h:34:13: error: ‘cuda_st’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
             ucs_log_dispatch(__FILE__, __LINE__, __func__, \
             ^~~~~~~~~~~~~~~~
In file included from mc_cuda.c:7:
mc_cuda.h:141:21: note: ‘cuda_st’ was declared here
         cudaError_t cuda_st; 


