### PR TITLE
Blocking a2a self copy

### DIFF
--- a/src/components/tl/ucp/alltoall/alltoall_pairwise.c
+++ b/src/components/tl/ucp/alltoall/alltoall_pairwise.c
@@ -75,6 +75,11 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team = task->team;
+    ptrdiff_t          sbuf = (ptrdiff_t)task->args.src.info.buffer;
+    ptrdiff_t          rbuf = (ptrdiff_t)task->args.dst.info.buffer;
+    ucc_memory_type_t  smem = task->args.src.info.mem_type;
+    ucc_memory_type_t  rmem = task->args.dst.info.mem_type;
+    ucc_rank_t        grank = team->rank;
     size_t data_size;
 
     task->super.super.status = UCC_INPROGRESS;
@@ -89,10 +94,25 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_start(ucc_coll_task_t *coll_task)
                                     task->args.dst.info.mem_type);
     }
 
+    /* blocking self send/recv */
+    if ((UCC_TL_UCP_TEAM_CTX(team)->cfg.blocking_a2a_self_copy)) {
+        data_size = (size_t)task->args.src.info.count *
+                    ucc_dt_size(task->args.src.info.datatype);
+        UCPCHECK_GOTO(ucc_tl_ucp_recv_nb((void *)(rbuf + grank * data_size),
+                                          data_size, rmem, grank, team, task),
+                                          task, error);
+        UCPCHECK_GOTO(ucc_tl_ucp_send_nb((void *)(sbuf + grank * data_size),
+                                          data_size, smem, grank, team, task),
+                                          task, error);
+        while (UCC_OK == ucc_tl_ucp_test(task));
+    }
+
     ucc_tl_ucp_alltoall_pairwise_progress(&task->super);
     if (UCC_INPROGRESS == task->super.super.status) {
         ucc_progress_enqueue(UCC_TL_UCP_TEAM_CORE_CTX(team)->pq, &task->super);
         return UCC_OK;
     }
     return ucc_task_complete(coll_task);
+error:
+    return task->super.super.status;
 }

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -71,6 +71,11 @@ static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_context_config_t, pre_reg_mem),
      UCC_CONFIG_TYPE_UINT},
 
+    {"BLOCKING_A2A_SELF_COPY", "0",
+     "Pre Register collective memory region with UCX",
+     ucc_offsetof(ucc_tl_ucp_context_config_t, blocking_a2a_self_copy),
+     UCC_CONFIG_TYPE_UINT},
+
     {NULL}};
 
 UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_ucp_lib_t, ucc_base_lib_t,

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -39,6 +39,7 @@ typedef struct ucc_tl_ucp_context_config {
     uint32_t                n_polls;
     uint32_t                oob_npolls;
     uint32_t                pre_reg_mem;
+    uint32_t                blocking_a2a_self_copy;
 } ucc_tl_ucp_context_config_t;
 
 typedef struct ucc_tl_ucp_lib {


### PR DESCRIPTION
`UCC_TL_UCP_BLOCKING_A2A_SELF_COPY=1` to do blocking self copy in alltoall and alltoallv before send/recv from remote peers
