### PR TITLE
TL/UCP: skip 0 count in alltoallv

### DIFF
--- a/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
@@ -54,7 +54,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
             data_displ = ucc_coll_args_get_displacement(&task->args,
                             task->args.dst.info_v.displacements,
                             peer) * rdt_size;
-            UCPCHECK_GOTO(ucc_tl_ucp_recv_nb((void *)(rbuf + data_displ),
+            UCPCHECK_GOTO(ucc_tl_ucp_recv_nz((void *)(rbuf + data_displ),
                                              data_size, rmem, peer, team, task),
                           task, out);
             polls = 0;
@@ -67,7 +67,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
             data_displ = ucc_coll_args_get_displacement(&task->args,
                             task->args.src.info_v.displacements,
                             peer) * sdt_size;
-            UCPCHECK_GOTO(ucc_tl_ucp_send_nb((void *)(sbuf + data_displ),
+            UCPCHECK_GOTO(ucc_tl_ucp_send_nz((void *)(sbuf + data_displ),
                                              data_size, smem, peer, team, task),
                           task, out);
             polls = 0;

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -119,6 +119,39 @@ static inline ucc_status_t ucc_tl_ucp_recv_nb(void *buffer, size_t msglen,
     return UCC_OK;
 }
 
+/* Non-Zero recv: if msglen == 0 then it is a no-op */
+static inline ucc_status_t ucc_tl_ucp_recv_nz(void *buffer, size_t msglen,
+                                              ucc_memory_type_t mtype,
+                                              ucc_rank_t dest_group_rank,
+                                              ucc_tl_ucp_team_t *team,
+                                              ucc_tl_ucp_task_t *task)
+{
+    if (msglen == 0) {
+        task->recv_posted++;
+        task->recv_completed++;
+        return UCC_OK;
+    }
+    return ucc_tl_ucp_recv_nb(buffer, msglen, mtype,
+                              dest_group_rank, team, task);
+}
+
+/* Non-Zero send: if msglen == 0 then it is a no-op */
+static inline ucc_status_t ucc_tl_ucp_send_nz(void *buffer, size_t msglen,
+                                              ucc_memory_type_t mtype,
+                                              ucc_rank_t dest_group_rank,
+                                              ucc_tl_ucp_team_t *team,
+                                              ucc_tl_ucp_task_t *task)
+{
+    if (msglen == 0) {
+        task->send_posted++;
+        task->send_completed++;
+        return UCC_OK;
+    }
+    return ucc_tl_ucp_send_nb(buffer, msglen, mtype,
+                              dest_group_rank, team, task);
+}
+
+
 #define UCPCHECK_GOTO(_cmd, _task, _label)                                     \
     do {                                                                       \
         ucc_status_t _status = (_cmd);                                         \

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -50,7 +50,8 @@ public:
                 ((T*)coll->src.info_v.displacements)[i] = buf_count;
                 buf_count += rank_count;
             }
-
+            /* Force at least 1 zero count for bigger coverage of corner cases */
+            ((T*)coll->src.info_v.counts)[(r + 1) % nprocs] = 0;
             ctxs[r]->init_buf = ucc_malloc(buf_count * ucc_dt_size(dtype), "init buf");
             EXPECT_NE(ctxs[r]->init_buf, nullptr);
             for (int i = 0; i < nprocs; i++) {
@@ -74,6 +75,7 @@ public:
                 ((T*)coll->dst.info_v.displacements)[i] = buf_count;
                 buf_count += rank_count;
             }
+            ((T*)coll->dst.info_v.counts)[(r - 1 + nprocs) % nprocs] = 0;
             ctxs[r]->rbuf_size = buf_count * ucc_dt_size(dtype);
             UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_mc_header,
                                    buf_count * ucc_dt_size(dtype), mem_type));


### PR DESCRIPTION
## What
Don't start actual p2p operation in alltoallv if send/recv count is 0

## Why ?
Small perf optimization
