### PR TITLE
TL/NCCL: use memops to check completion

### DIFF
--- a/src/components/tl/nccl/tl_nccl.c
+++ b/src/components/tl/nccl/tl_nccl.c
@@ -19,9 +19,22 @@ static ucc_config_field_t ucc_tl_nccl_lib_config_table[] = {
 
     {NULL}};
 
+const char* ucc_tl_nccl_completion_sync_names[] = {
+    [UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT]  = "event",
+    [UCC_TL_NCCL_COMPLETION_SYNC_TYPE_MEMOPS] = "driver",
+    [UCC_TL_NCCL_COMPLETION_SYNC_TYPE_AUTO]   = "auto",
+    [UCC_TL_NCCL_COMPLETION_SYNC_TYPE_LAST]   = NULL
+};
+
 static ucs_config_field_t ucc_tl_nccl_context_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_nccl_context_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_tl_context_config_table)},
+
+    {"SYNC", "auto",
+     "Determines how UCC tests completion of NCCL collective",
+     ucs_offsetof(ucc_tl_nccl_context_config_t, sync_type),
+     UCS_CONFIG_TYPE_ENUM(ucc_tl_nccl_completion_sync_names)
+    },
 
     {NULL}};
 

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -28,8 +28,16 @@ typedef struct ucc_tl_nccl_lib_config {
     ucc_tl_lib_config_t super;
 } ucc_tl_nccl_lib_config_t;
 
+typedef enum ucc_tl_nccl_completion_sync_type {
+    UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT,
+    UCC_TL_NCCL_COMPLETION_SYNC_TYPE_MEMOPS,
+    UCC_TL_NCCL_COMPLETION_SYNC_TYPE_AUTO,
+    UCC_TL_NCCL_COMPLETION_SYNC_TYPE_LAST
+} ucc_tl_nccl_completion_sync_type_t;
+
 typedef struct ucc_tl_nccl_context_config {
-    ucc_tl_context_config_t super;
+    ucc_tl_context_config_t            super;
+    ucc_tl_nccl_completion_sync_type_t sync_type;
 } ucc_tl_nccl_context_config_t;
 
 typedef struct ucc_tl_nccl_lib {
@@ -59,6 +67,7 @@ typedef struct ucc_tl_nccl_team {
 
 typedef struct ucc_tl_nccl_task {
     ucc_coll_task_t     super;
+    ucc_status_t       *dev_status;
     ucc_tl_nccl_team_t *team;
     ucc_coll_args_t     args;
     cudaEvent_t         completed;

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -5,11 +5,71 @@
  */
 
 #include "tl_nccl.h"
+#include "core/ucc_mc.h"
+#include "core/ucc_ee.h"
+
+ucc_status_t ucc_tl_nccl_collective_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_status_t status;
+
+    status = ucc_mc_ee_event_test(task->completed, UCC_EE_CUDA_STREAM);
+    coll_task->super.status = status;
+    return status;
+}
+
+static void ucc_tl_nccl_req_mpool_obj_init(ucc_mpool_t *mp, void *obj,
+                                           void *chunk)
+{
+    ucc_tl_nccl_task_t *req = (ucc_tl_nccl_task_t*) obj;
+    req->super.progress = ucc_tl_nccl_collective_progress;
+}
+
 
 static ucc_mpool_ops_t ucc_tl_nccl_req_mpool_ops = {
     .chunk_alloc   = ucc_mpool_hugetlb_malloc,
     .chunk_release = ucc_mpool_hugetlb_free,
-    .obj_init      = NULL,
+    .obj_init      = ucc_tl_nccl_req_mpool_obj_init,
+    .obj_cleanup   = NULL
+};
+
+static ucc_status_t ucc_tl_nccl_req_mapped_mpool_chunk_malloc(ucc_mpool_t *mp,
+                                                              size_t *size_p,
+                                                              void ** chunk_p)
+{
+    cudaError_t cu_st;
+
+    cu_st = cudaHostAlloc((void**)chunk_p, *size_p, cudaHostAllocMapped);
+    if (cu_st != cudaSuccess) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    return UCC_OK;
+}
+
+static void ucc_tl_nccl_req_mapped_mpool_chunk_free(ucc_mpool_t *mp,
+                                                    void *chunk)
+{
+    cudaFreeHost(chunk);
+}
+
+static void ucc_tl_nccl_req_mapped_mpool_obj_init(ucc_mpool_t *mp, void *obj,
+                                                  void *chunk)
+{
+    ucc_tl_nccl_task_t *req = (ucc_tl_nccl_task_t*) obj;
+    cudaError_t st;
+    st = cudaHostGetDevicePointer((void**)(&req->dev_status),
+                                  (void *)&req->super.super.status, 0);
+    if (st != cudaSuccess) {
+        req->super.super.status = UCC_ERR_NO_MESSAGE;
+    }
+    req->super.progress = NULL;
+}
+
+static ucc_mpool_ops_t ucc_tl_nccl_req_mapped_mpool_ops = {
+    .chunk_alloc   = ucc_tl_nccl_req_mapped_mpool_chunk_malloc,
+    .chunk_release = ucc_tl_nccl_req_mapped_mpool_chunk_free,
+    .obj_init      = ucc_tl_nccl_req_mapped_mpool_obj_init,
     .obj_cleanup   = NULL
 };
 
@@ -19,15 +79,50 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
 {
     ucc_tl_nccl_context_config_t *tl_nccl_config =
         ucc_derived_of(config, ucc_tl_nccl_context_config_t);
+    int mem_ops_attr = 0;
     ucc_status_t status;
+    CUresult cu_st;
+    CUdevice cu_dev;
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_nccl_config->super.tl_lib,
                               params->context);
     memcpy(&self->cfg, tl_nccl_config, sizeof(*tl_nccl_config));
-    status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_nccl_task_t), 0,
-                            UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
-                            &ucc_tl_nccl_req_mpool_ops, params->thread_mode,
-                            "tl_nccl_req_mp");
+    if (self->cfg.sync_type != UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT) {
+        cu_st = cuCtxGetDevice(&cu_dev);
+        if (cu_st == CUDA_SUCCESS) {
+            cu_st = cuDeviceGetAttribute(&mem_ops_attr,
+                                        CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS,
+                                        cu_dev);
+        } else {
+            tl_info(self->super.super.lib, "failed to get cuda device");
+        }
+        if (mem_ops_attr == 0) {
+            if (self->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_MEMOPS) {
+                tl_error(self->super.super.lib, "memops not supported");
+                return UCC_ERR_NOT_SUPPORTED;
+            }
+            tl_info(self->super.super.lib, "fallback to event completion sync");
+            self->cfg.sync_type = UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT;
+        } else {
+            self->cfg.sync_type = UCC_TL_NCCL_COMPLETION_SYNC_TYPE_MEMOPS;
+        }
+    }
+    ucc_assert(self->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_MEMOPS ||
+               self->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT);
+    if (self->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_MEMOPS) {
+        tl_info(self->super.super.lib, "using memops completion sync");
+        status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_nccl_task_t), 0,
+                                UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
+                                &ucc_tl_nccl_req_mapped_mpool_ops,
+                                params->thread_mode, "tl_nccl_req_mp");
+    } else {
+        tl_info(self->super.super.lib, "using event completion sync");
+        status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_nccl_task_t), 0,
+                                UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
+                                &ucc_tl_nccl_req_mpool_ops, params->thread_mode,
+                                "tl_nccl_req_mp");
+    }
+
     if (status != UCC_OK) {
         tl_error(self->super.super.lib,
                  "failed to initialize tl_nccl_req mpool");

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -124,7 +124,9 @@ static ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
     ucc_status_t       status = UCC_OK ;
 
     tl_info(UCC_TL_TEAM_LIB(task->team), "finalizing coll task %p", task);
-    ucc_mc_ee_destroy_event(task->completed, UCC_EE_CUDA_STREAM);
+    if (task->completed) {
+        ucc_mc_ee_destroy_event(task->completed, UCC_EE_CUDA_STREAM);
+    }
     ucc_mpool_put(task);
     return status;
 }
@@ -170,8 +172,8 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
     task = ucc_mpool_get(&nccl_ctx->req_mp);
     ucc_coll_task_init(&task->super);
     memcpy(&task->args, &coll_args->args, sizeof(ucc_coll_args_t));
-    task->team = nccl_team;
-    task->super.finalize = ucc_tl_nccl_coll_finalize;
+    task->team                 = nccl_team;
+    task->super.finalize       = ucc_tl_nccl_coll_finalize;
     task->super.triggered_post = ucc_tl_nccl_triggered_post;
     status = ucc_mc_ee_create_event((void **)&task->completed, UCC_EE_CUDA_STREAM);
     if (ucc_unlikely(status != UCC_OK)) {


### PR DESCRIPTION
## What
Use cudastreamwritevalue to signal completion of nccl collective. If it's enabled to progress is needed for TL NCCL

