### PR TITLE
Add config file for cmake to find UCC on system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,8 @@
 if !DOCS_ONLY
 SUBDIRS =      \
 	src        \
-	tools/info
+	tools/info \
+	cmake
 
 if HAVE_MPICXX
 SUBDIRS +=     \

--- a/cmake/Makefile.am
+++ b/cmake/Makefile.am
@@ -1,0 +1,11 @@
+#
+# Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+#
+
+cmakedir = $(libdir)/cmake/ucc
+cmake_DATA =                       \
+    ucc-targets.cmake              \
+    ucc-config.cmake               \
+    ucc-config-version.cmake
+
+EXTRA_DIST = $(cmake_DATA)

--- a/cmake/ucc-config-version.cmake.in
+++ b/cmake/ucc-config-version.cmake.in
@@ -1,0 +1,31 @@
+#
+# Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+#
+
+# This is a basic version file for the Config-mode of find_package().
+#
+# This file sets PACKAGE_VERSION_EXACT if the current version string and
+# the requested version string are exactly the same and it sets
+# PACKAGE_VERSION_COMPATIBLE if the current version is >= requested version.
+
+set(PACKAGE_VERSION @VERSION@)
+
+if (PACKAGE_FIND_VERSION_RANGE)
+  # Package version must be in the requested version range
+  if ((PACKAGE_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MIN)
+      OR (PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_GREATER PACKAGE_FIND_VERSION_MAX)
+      OR (PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE" AND PACKAGE_VERSION VERSION_GREATER_EQUAL PACKAGE_FIND_VERSION_MAX))
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  endif()
+else()
+  if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+  endif()
+endif()

--- a/cmake/ucc-config.cmake.in
+++ b/cmake/ucc-config.cmake.in
@@ -1,0 +1,8 @@
+#
+# Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+#
+
+set(UCC_LIBRARIES "@prefix@/lib")
+set(UCC_INCLUDE_DIRS "@prefix@/include")
+
+include("${CMAKE_CURRENT_LIST_DIR}/ucc-targets.cmake")

--- a/cmake/ucc-targets.cmake.in
+++ b/cmake/ucc-targets.cmake.in
@@ -1,0 +1,10 @@
+#
+# Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+#
+
+add_library(ucc::ucc SHARED IMPORTED)
+
+set_target_properties(ucc::ucc PROPERTIES
+  IMPORTED_LOCATION "@prefix@/lib/libucc.so"
+  INTERFACE_INCLUDE_DIRECTORIES "@prefix@/include"
+)

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,10 @@ AC_CONFIG_FILES([
                  test/mpi/Makefile
                  tools/info/Makefile
                  tools/perf/Makefile
+                 cmake/Makefile
+                 cmake/ucc-config-version.cmake
+                 cmake/ucc-config.cmake
+                 cmake/ucc-targets.cmake
                  ])
 AC_OUTPUT
 


### PR DESCRIPTION
This PR makes the installation script writes cmake config files to `${prefix}/lib/cmake/ucc` so that cmake projects can easily find UCC installed on the system. PyTorch uses cmake, so this will be helpful for PyTorch to integrate the ucc backend to upstream.

I will add the same thing for UCX later. This PR is tested by: https://github.com/zasdfgbnm/cmake-ucx-ucc, please let me know if you want cmake testes to be included in this repository as well.