### PR TITLE
TL/NCCL: change task status from progress only

### DIFF
--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -67,6 +67,7 @@ typedef struct ucc_tl_nccl_team {
 
 typedef struct ucc_tl_nccl_task {
     ucc_coll_task_t     super;
+    ucc_status_t        host_status;
     ucc_status_t       *dev_status;
     ucc_tl_nccl_team_t *team;
     ucc_coll_args_t     args;


### PR DESCRIPTION
## What
In case of  memops sync task status need to be changed only during collective progress. Otherwise task might never be dequeued from progress queue