### PR TITLE
Adjust AllGather, AlltoAll count

### DIFF
--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -23,7 +23,7 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
     ucc_memory_type_t  rmem       = coll_task->args.dst.info.mem_type;
     size_t             count      = coll_task->args.dst.info.count;
     ucc_datatype_t     dt         = coll_task->args.dst.info.datatype;
-    size_t             data_size  = count * ucc_dt_size(dt);
+    size_t             data_size  = (count / team->size) * ucc_dt_size(dt);
     ucc_rank_t         sendto     = (group_rank + 1) % group_size;
     ucc_rank_t         recvfrom   = (group_rank - 1 + group_size) % group_size;
     int                step;
@@ -67,7 +67,7 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
     ucc_memory_type_t  smem      = coll_task->args.src.info.mem_type;
     ucc_memory_type_t  rmem      = coll_task->args.dst.info.mem_type;
     ucc_datatype_t     dt        = coll_task->args.dst.info.datatype;
-    size_t             data_size = count * ucc_dt_size(dt);
+    size_t             data_size = (count / team->size) * ucc_dt_size(dt);
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_ring_start", 0);

--- a/src/components/tl/ucp/alltoall/alltoall_pairwise.c
+++ b/src/components/tl/ucp/alltoall/alltoall_pairwise.c
@@ -40,7 +40,7 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *coll_task)
 
     posts     = UCC_TL_UCP_TEAM_LIB(team)->cfg.alltoall_pairwise_num_posts;
     nreqs     = (posts > gsize || posts == 0) ? gsize : posts;
-    data_size = (size_t)coll_task->args.src.info.count *
+    data_size = (size_t)(coll_task->args.src.info.count / gsize) *
                 ucc_dt_size(coll_task->args.src.info.datatype);
     while ((task->send_posted < gsize || task->recv_posted < gsize) &&
            (polls++ < task->n_polls)) {

--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -15,7 +15,7 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     TestCase(_team, _mt, _msgsize, _inplace, _max_size)
 {
     size_t dt_size = ucc_dt_size(TEST_DT);
-    size_t count = _msgsize/dt_size;
+    size_t single_rank_count = _msgsize / dt_size;
     int rank, size;
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
@@ -34,25 +34,27 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     if (TEST_NO_INPLACE == inplace) {
         UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
         sbuf = sbuf_mc_header->addr;
-        init_buffer(sbuf, count, TEST_DT, _mt, rank);
+        init_buffer(sbuf, single_rank_count, TEST_DT, _mt, rank);
         UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
                            _mt, _msgsize);
         check_sbuf = check_sbuf_mc_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
-        init_buffer((void*)((ptrdiff_t)rbuf + rank*count*dt_size),
-                    count, TEST_DT, _mt, rank);
-        init_buffer((void*)((ptrdiff_t)check_rbuf + rank*count*dt_size),
-                    count, TEST_DT, UCC_MEMORY_TYPE_HOST, rank);
+        init_buffer(
+            (void *)((ptrdiff_t)rbuf + rank * single_rank_count * dt_size),
+            single_rank_count, TEST_DT, _mt, rank);
+        init_buffer((void *)((ptrdiff_t)check_rbuf +
+                             rank * single_rank_count * dt_size),
+                    single_rank_count, TEST_DT, UCC_MEMORY_TYPE_HOST, rank);
     }
 
     args.src.info.buffer   = sbuf;
-    args.src.info.count    = count;
+    args.src.info.count    = single_rank_count;
     args.src.info.datatype = TEST_DT;
     args.src.info.mem_type = _mt;
     args.dst.info.buffer   = rbuf;
-    args.dst.info.count    = count;
+    args.dst.info.count    = single_rank_count * size;
     args.dst.info.datatype = TEST_DT;
     args.dst.info.mem_type = _mt;
     UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
@@ -60,18 +62,19 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 
 ucc_status_t TestAllgather::check()
 {
-    size_t       count = args.dst.info.count;
+    int size, completed;
+    MPI_Comm_size(team.comm, &size);
+    size_t       single_rank_count = args.dst.info.count / size;
     MPI_Datatype dt    = ucc_dt_to_mpi(TEST_DT);
-    int          size, completed;
     MPI_Request  req;
 
-    MPI_Comm_size(team.comm, &size);
-    MPI_Iallgather(inplace ? MPI_IN_PLACE : check_sbuf, count, dt,
-                   check_rbuf, count, dt, team.comm, &req);
+    MPI_Iallgather(inplace ? MPI_IN_PLACE : check_sbuf, single_rank_count, dt,
+                   check_rbuf, single_rank_count, dt, team.comm, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
     } while(!completed);
 
-    return compare_buffers(rbuf, check_rbuf, count*size, TEST_DT, mem_type);
+    return compare_buffers(rbuf, check_rbuf, single_rank_count * size, TEST_DT,
+                           mem_type);
 }

--- a/test/mpi/test_alltoall.cc
+++ b/test/mpi/test_alltoall.cc
@@ -15,7 +15,7 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     TestCase(_team, _mt, _msgsize, _inplace, _max_size)
 {
     size_t dt_size = ucc_dt_size(TEST_DT);
-    size_t count = _msgsize/dt_size;
+    size_t single_rank_count = _msgsize / dt_size;
     int rank;
     int nprocs;
 
@@ -36,24 +36,25 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     if (TEST_NO_INPLACE == inplace) {
         UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize * nprocs, _mt));
         sbuf = sbuf_mc_header->addr;
-        init_buffer(sbuf, count * nprocs, TEST_DT, _mt, rank);
+        init_buffer(sbuf, single_rank_count * nprocs, TEST_DT, _mt, rank);
         UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
                            _mt, _msgsize * nprocs);
         check_sbuf = check_sbuf_mc_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
-        init_buffer(rbuf, count * nprocs, TEST_DT, _mt, rank);
-        init_buffer(check_rbuf, count * nprocs, TEST_DT, UCC_MEMORY_TYPE_HOST, rank);
+        init_buffer(rbuf, single_rank_count * nprocs, TEST_DT, _mt, rank);
+        init_buffer(check_rbuf, single_rank_count * nprocs, TEST_DT,
+                    UCC_MEMORY_TYPE_HOST, rank);
     }
 
     args.src.info.buffer      = sbuf;
-    args.src.info.count       = count;
+    args.src.info.count       = single_rank_count * nprocs;
     args.src.info.datatype    = TEST_DT;
     args.src.info.mem_type    = _mt;
 
     args.dst.info.buffer      = rbuf;
-    args.dst.info.count       = count;
+    args.dst.info.count       = single_rank_count * nprocs;
     args.dst.info.datatype    = TEST_DT;
     args.dst.info.mem_type    = _mt;
     UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
@@ -61,16 +62,19 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 
 ucc_status_t TestAlltoall::check()
 {
-    size_t      count = args.src.info.count;
+    int size, completed;
+    MPI_Comm_size(team.comm, &size);
+    size_t      single_rank_count = args.src.info.count / size;
     MPI_Request req;
-    int         completed;
 
-    MPI_Ialltoall(inplace ? MPI_IN_PLACE : check_sbuf, count, ucc_dt_to_mpi(TEST_DT),
-                  check_rbuf, count, ucc_dt_to_mpi(TEST_DT), team.comm, &req);
+    MPI_Ialltoall(inplace ? MPI_IN_PLACE : check_sbuf, single_rank_count,
+                  ucc_dt_to_mpi(TEST_DT), check_rbuf, single_rank_count,
+                  ucc_dt_to_mpi(TEST_DT), team.comm, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
     } while(!completed);
 
-    return compare_buffers(rbuf, check_rbuf, count, TEST_DT, mem_type);
+    return compare_buffers(rbuf, check_rbuf, single_rank_count * size, TEST_DT,
+                           mem_type);
 }

--- a/tools/perf/ucc_pt_coll_allgather.cc
+++ b/tools/perf/ucc_pt_coll_allgather.cc
@@ -26,21 +26,21 @@ ucc_pt_coll_allgather::ucc_pt_coll_allgather(int size, ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_allgather::init_coll_args(size_t count,
-                                                  ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_allgather::init_coll_args(size_t single_rank_count,
+                                                   ucc_coll_args_t &args)
 {
     size_t dt_size  = ucc_dt_size(coll_args.src.info.datatype);
-    size_t size_src = count * dt_size;
-    size_t size_dst = comm_size * count * dt_size;
+    size_t       size_src = single_rank_count * dt_size;
+    size_t       size_dst = comm_size * single_rank_count * dt_size;
     ucc_status_t st;
 
     args = coll_args;
-    args.dst.info.count = count;
+    args.dst.info.count = single_rank_count * comm_size;
     UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size_dst, args.dst.info.mem_type),
                   exit, st);
     args.dst.info.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
-        args.src.info.count = count;
+        args.src.info.count = single_rank_count;
         UCCCHECK_GOTO(
             ucc_mc_alloc(&src_header, size_src, args.src.info.mem_type),
             free_dst, st);

--- a/tools/perf/ucc_pt_coll_alltoall.cc
+++ b/tools/perf/ucc_pt_coll_alltoall.cc
@@ -25,20 +25,20 @@ ucc_pt_coll_alltoall::ucc_pt_coll_alltoall(int size, ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_alltoall::init_coll_args(size_t count,
+ucc_status_t ucc_pt_coll_alltoall::init_coll_args(size_t single_rank_count,
                                                   ucc_coll_args_t &args)
 {
     size_t       dt_size = ucc_dt_size(coll_args.src.info.datatype);
-    size_t       size    = comm_size * count * dt_size;
+    size_t       size    = comm_size * single_rank_count * dt_size;
     ucc_status_t st      = UCC_OK;
 
     args = coll_args;
-    args.dst.info.count = count;
+    args.dst.info.count = single_rank_count * comm_size;
     UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size, args.dst.info.mem_type), exit,
                   st);
     args.dst.info.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
-        args.src.info.count = count;
+        args.src.info.count = single_rank_count * comm_size;
         UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size, args.src.info.mem_type),
                       free_dst, st);
         args.src.info.buffer = src_header->addr;
@@ -62,7 +62,7 @@ float ucc_pt_coll_alltoall::get_bw(float time_ms, int grsize,
                                    ucc_coll_args_t args)
 {
     float N = grsize;
-    float S = N * args.src.info.count * ucc_dt_size(args.src.info.datatype);
+    float S = args.src.info.count * ucc_dt_size(args.src.info.datatype);
 
     return (S / time_ms) * ((N - 1) / N) / 1000.0;
 }


### PR DESCRIPTION
## What
Changes AllGather dst.count for the number of elements in the entire dst buffer, for all ranks combined.
Changes AlltoAll dst.count & src.count for the number of elements in the entire src & dst buffers, for all ranks combined.

## Why ?
API Change in PR #225 

## How ?
Change implementation in TL and use cases in tests.
