### PR TITLE
MC/CPU: openmp reduction

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,8 @@ AC_MSG_RESULT([git sha: $ucc_git_sha])
 CFLAGS_save="$CFLAGS"
 AC_PROG_CC
 AC_PROG_CXX
+: ${enable_openmp=no}
+AC_OPENMP
 AM_PROG_AS
 AC_PROG_LN_S
 AC_PROG_MKDIR_P
@@ -76,6 +78,7 @@ AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_HEADER_STDC
 CFLAGS="$CFLAGS_save"
+AC_MSG_RESULT([OMP: $enable_openmp])
 
 #
 # Check if 'ln' supports creating relative links

--- a/src/components/mc/cpu/Makefile.am
+++ b/src/components/mc/cpu/Makefile.am
@@ -21,7 +21,7 @@ sources =                         \
 module_LTLIBRARIES        = libucc_mc_cpu.la
 libucc_mc_cpu_la_SOURCES  = $(sources)
 libucc_mc_cpu_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS)
-libucc_mc_cpu_la_CFLAGS   = $(BASE_CFLAGS)
+libucc_mc_cpu_la_CFLAGS   = $(BASE_CFLAGS) $(OPENMP_CFLAGS)
 libucc_mc_cpu_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
 libucc_mc_cpu_la_LIBADD   = $(UCC_TOP_BUILDDIR)/src/libucc.la
 

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -20,6 +20,10 @@ static ucc_config_field_t ucc_mc_cpu_config_table[] = {
     {"MPOOL_MAX_ELEMS", "8", "The max amount of elements in mc cpu mpool",
      ucc_offsetof(ucc_mc_cpu_config_t, mpool_max_elems), UCC_CONFIG_TYPE_UINT},
 
+    {"REDUCE_NUM_THREADS", "1", "Number of OMP threads used for reduction",
+     ucc_offsetof(ucc_mc_cpu_config_t, reduce_num_threads),
+     UCC_CONFIG_TYPE_UINT},
+
     {NULL}
 
 };

--- a/src/components/mc/cpu/mc_cpu.h
+++ b/src/components/mc/cpu/mc_cpu.h
@@ -14,6 +14,7 @@ typedef struct ucc_mc_cpu_config {
     ucc_mc_config_t super;
     size_t          mpool_elem_size;
     int             mpool_max_elems;
+    int             reduce_num_threads;
 } ucc_mc_cpu_config_t;
 
 typedef struct ucc_mc_cpu {


### PR DESCRIPTION
## What
Use openmp to do reduction in parallel.

## How ?
During configure time user can add --enable-openmp option ( by default disabled) to use parallel reduction. Number of threads controlled by UCC_MC_CPU_REDUCE_NUM_THREADS variable