### PR TITLE
BUILD: improve cmake support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,3 +30,10 @@ jobs:
     - name: Run ucc_info
       run: |
         /tmp/ucc/install/bin/ucc_info -vc
+    - name: Run CMake tests
+      run: |
+        set -e
+        cmake -S test/cmake -B /tmp/cmake-ucc -DCMAKE_PREFIX_PATH=/tmp/ucc/install
+        cd /tmp/cmake-ucc
+        cmake --build .
+        ./test_ucc

--- a/cmake/ucc-config.cmake.in
+++ b/cmake/ucc-config.cmake.in
@@ -2,7 +2,7 @@
 # Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
 #
 
-set(UCC_LIBRARIES "@prefix@/lib")
-set(UCC_INCLUDE_DIRS "@prefix@/include")
-
 include("${CMAKE_CURRENT_LIST_DIR}/ucc-targets.cmake")
+
+set(UCC_LIBRARIES "@libdir@")
+set(UCC_INCLUDE_DIRS "@includedir@")

--- a/cmake/ucc-targets.cmake.in
+++ b/cmake/ucc-targets.cmake.in
@@ -2,9 +2,12 @@
 # Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
 #
 
+set(prefix "@prefix@")
+set(exec_prefix "@exec_prefix@")
+
 add_library(ucc::ucc SHARED IMPORTED)
 
 set_target_properties(ucc::ucc PROPERTIES
-  IMPORTED_LOCATION "@prefix@/lib/libucc.so"
-  INTERFACE_INCLUDE_DIRECTORIES "@prefix@/include"
+  IMPORTED_LOCATION "@libdir@/libucc.so"
+  INTERFACE_INCLUDE_DIRECTORIES "@includedir@"
 )

--- a/test/cmake/CMakeLists.txt
+++ b/test/cmake/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(test_ucc)
+find_package(UCC REQUIRED)
+add_executable(test_ucc main.cpp)
+target_link_libraries(test_ucc ucc::ucc)

--- a/test/cmake/main.cpp
+++ b/test/cmake/main.cpp
@@ -1,0 +1,22 @@
+#include <ucc/api/ucc.h>
+#include <cassert>
+
+int main(int argc, char *argv[]) {
+  ucc_status_t st;
+
+  ucc_lib_config_h lib_config;
+  st = ucc_lib_config_read(nullptr, nullptr, &lib_config);
+  assert(st == UCC_OK);
+
+  ucc_lib_params_t lib_params = {};
+  lib_params.mask = UCC_LIB_PARAM_FIELD_THREAD_MODE;
+  lib_params.thread_mode = UCC_THREAD_MULTIPLE;
+
+  ucc_lib_h lib;
+  st = ucc_init(&lib_params, lib_config, &lib);
+  assert(st == UCC_OK);
+
+  ucc_lib_config_release(lib_config);
+  ucc_finalize(lib);
+  return 0;
+}


### PR DESCRIPTION
Make improvements based on reviews from https://github.com/openucx/ucx/pull/7096
- Use `@libdir@` and `@includedir@` instead of `@prefix@/lib` and `@prefix@/include`.
- Add tests.