### PR TITLE
Topic/topo subgrouping

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,6 +40,8 @@ noinst_HEADERS =                      \
 	core/ucc_team.h                   \
 	core/ucc_ee.h                     \
 	core/ucc_progress_queue.h         \
+	core/ucc_topo.h                   \
+	core/ucc_sbgp.h                   \
 	schedule/ucc_schedule.h           \
 	coll_score/ucc_coll_score.h       \
 	utils/ucc_compiler_def.h          \
@@ -83,6 +85,8 @@ libucc_la_SOURCES =                  \
 	core/ucc_progress_queue.c        \
 	core/ucc_progress_queue_st.c     \
 	core/ucc_progress_queue_mt.c     \
+	core/ucc_topo.c                  \
+	core/ucc_sbgp.c                  \
 	schedule/ucc_schedule.c          \
 	coll_score/ucc_coll_score.c      \
 	coll_score/ucc_coll_score_map.c  \

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -63,6 +63,7 @@ typedef struct ucc_base_context {
 
 typedef struct ucc_base_ctx_attr_t {
     ucc_context_attr_t attr;
+    uint32_t           topo_required;
 } ucc_base_ctx_attr_t;
 
 typedef struct ucc_base_context_iface {

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -156,5 +156,6 @@ ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
     if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
         attr->attr.ctx_addr_len = 0;
     }
+    attr->topo_required = 0;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -252,6 +252,6 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
     if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR) {
         memcpy(attr->attr.ctx_addr, ctx->worker_address, ctx->ucp_addrlen);
     }
-
+    attr->topo_required = 0;
     return UCC_OK;
 }

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -10,6 +10,7 @@
 #include "ucc_progress_queue.h"
 #include "utils/ucc_list.h"
 #include "utils/ucc_proc_info.h"
+#include "ucc_topo.h"
 
 typedef struct ucc_lib_info          ucc_lib_info_t;
 typedef struct ucc_cl_context        ucc_cl_context_t;
@@ -62,6 +63,7 @@ typedef struct ucc_context {
     ucc_addr_storage_t       addr_storage;
     ucc_rank_t               rank; /*< rank of a process in the "global" (with
                                      OOB) context */
+    ucc_topo_t              *topo;
 } ucc_context_t;
 
 typedef struct ucc_context_config {

--- a/src/core/ucc_sbgp.c
+++ b/src/core/ucc_sbgp.c
@@ -1,0 +1,413 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_sbgp.h"
+#include "ucc_topo.h"
+#include "ucc_team.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_compiler_def.h"
+#include <limits.h>
+
+static char *ucc_sbgp_type_str[UCC_SBGP_LAST] = {
+    "numa", "socket", "node", "node_leaders",
+    "net", "socket_leaders", "numa_leaders", "flat"};
+
+const char*  ucc_sbgp_str(ucc_sbgp_type_t type)
+{
+    return ucc_sbgp_type_str[type];
+}
+
+static inline ucc_status_t sbgp_create_socket(ucc_team_topo_t *topo,
+                                              ucc_sbgp_t *     sbgp)
+{
+    ucc_team_t *team       = sbgp->team;
+    ucc_sbgp_t *node_sbgp  = &topo->sbgps[UCC_SBGP_NODE];
+    ucc_rank_t  group_rank = team->rank;
+    ucc_rank_t  nlr        = topo->node_leader_rank;
+    ucc_rank_t  sock_rank = 0, sock_size = 0;
+    int         i, r, nlr_pos;
+    ucc_rank_t *local_ranks;
+
+    ucc_assert(node_sbgp->status == UCC_SBGP_ENABLED);
+    local_ranks =
+        ucc_malloc(node_sbgp->group_size * sizeof(ucc_rank_t), "local_ranks");
+    if (!local_ranks) {
+        ucc_error("failed to allocate %zd bytes for local_ranks array",
+                  node_sbgp->group_size * sizeof(ucc_rank_t));
+        return UCC_ERR_NO_MEMORY;
+    }
+    for (i = 0; i < node_sbgp->group_size; i++) {
+        r = ucc_ep_map_eval(node_sbgp->map, i);
+        if (ucc_rank_on_local_socket(r, team)) {
+            local_ranks[sock_size] = r;
+            if (r == group_rank) {
+                sock_rank = sock_size;
+            }
+            sock_size++;
+        }
+    }
+    sbgp->group_size = sock_size;
+    sbgp->group_rank = sock_rank;
+    sbgp->rank_map   = local_ranks;
+    nlr_pos          = -1;
+    for (i = 0; i < sock_size; i++) {
+        if (nlr == local_ranks[i]) {
+            nlr_pos = i;
+            break;
+        }
+    }
+    if (nlr_pos > 0) {
+        if (sock_rank == 0)
+            sbgp->group_rank = nlr_pos;
+        if (sock_rank == nlr_pos)
+            sbgp->group_rank = 0;
+        SWAP(local_ranks[nlr_pos], local_ranks[0]);
+    }
+    if (sock_size > 1) {
+        sbgp->status = UCC_SBGP_ENABLED;
+    } else {
+        sbgp->status = UCC_SBGP_NOT_EXISTS;
+    }
+    return UCC_OK;
+}
+
+static inline ucc_status_t sbgp_create_node(ucc_team_topo_t *topo,
+                                            ucc_sbgp_t *     sbgp)
+{
+    ucc_team_t *team           = sbgp->team;
+    ucc_rank_t  group_size     = team->size;
+    ucc_rank_t  group_rank     = team->rank;
+    ucc_rank_t  max_local_size = 256;
+    ucc_rank_t  ctx_nlr        = topo->node_leader_rank_id;
+    ucc_rank_t  node_rank = 0, node_size = 0;
+    int         i;
+    ucc_rank_t *local_ranks, *tmp;
+    local_ranks =
+        ucc_malloc(max_local_size * sizeof(ucc_rank_t), "local_ranks");
+    if (!local_ranks) {
+        ucc_error("failed to allocate %zd bytes for local_ranks array",
+                  max_local_size * sizeof(ucc_rank_t));
+        return UCC_ERR_NO_MEMORY;
+    }
+    for (i = 0; i < group_size; i++) {
+        if (ucc_rank_on_local_node(i, team)) {
+            if (node_size == max_local_size) {
+                max_local_size *= 2;
+                tmp = ucc_realloc(local_ranks,
+                                  max_local_size * sizeof(ucc_rank_t));
+                if (!tmp) {
+                    ucc_error(
+                        "failed to allocate %zd bytes for local_ranks array",
+                        max_local_size * sizeof(ucc_rank_t));
+                    ucc_free(local_ranks);
+                    return UCC_ERR_NO_MEMORY;
+                }
+                local_ranks = tmp;
+            }
+            local_ranks[node_size] = i;
+
+            if (i == group_rank) {
+                node_rank = node_size;
+            }
+            node_size++;
+        }
+    }
+    if (0 == node_size) {
+        /* We should always have at least 1 local rank */
+        ucc_free(local_ranks);
+        return UCC_ERR_NO_MESSAGE;
+    }
+    sbgp->group_size = node_size;
+    sbgp->group_rank = node_rank;
+    sbgp->rank_map   = local_ranks;
+    if (0 < ctx_nlr && ctx_nlr < node_size) {
+        /* Rotate local_ranks array so that node_leader_rank_id becomes first
+           in that array */
+        sbgp->rank_map = ucc_malloc(node_size * sizeof(ucc_rank_t), "rank_map");
+        if (!sbgp->rank_map) {
+            ucc_error("failed to allocate %zd bytes for rank_map array",
+                      node_size * sizeof(ucc_rank_t));
+            ucc_free(local_ranks);
+            return UCC_ERR_NO_MEMORY;
+        }
+        for (i = ctx_nlr; i < node_size; i++) {
+            sbgp->rank_map[i - ctx_nlr] = local_ranks[i];
+        }
+
+        for (i = 0; i < ctx_nlr; i++) {
+            sbgp->rank_map[node_size - ctx_nlr + i] = local_ranks[i];
+        }
+        sbgp->group_rank = (node_rank + node_size - ctx_nlr) % node_size;
+        ucc_free(local_ranks);
+    }
+    topo->node_leader_rank = sbgp->rank_map[0];
+    if (node_size > 1) {
+        sbgp->status = UCC_SBGP_ENABLED;
+    } else {
+        sbgp->status = UCC_SBGP_NOT_EXISTS;
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t sbgp_create_node_leaders(ucc_team_topo_t *topo,
+                                             ucc_sbgp_t *sbgp, int ctx_nlr)
+{
+    ucc_team_t *team             = sbgp->team;
+    ucc_rank_t  comm_size        = team->size;
+    ucc_rank_t  comm_rank        = team->rank;
+    int         i_am_node_leader = 0;
+    ucc_rank_t  nnodes           = topo->topo->nnodes;
+    ucc_rank_t  n_node_leaders;
+    ucc_rank_t *nl_array_1, *nl_array_2;
+    int         i;
+
+    if (topo->min_ppn != UCC_RANK_MAX && ctx_nlr >= topo->min_ppn) {
+        sbgp->status = UCC_SBGP_NOT_EXISTS;
+        return UCC_OK;
+    }
+    nl_array_1 = ucc_malloc(nnodes * sizeof(ucc_rank_t), "nl_array_1");
+    if (!nl_array_1) {
+        ucc_error("failed to allocate %zd bytes for nl_array_1",
+                  nnodes * sizeof(ucc_rank_t));
+        return UCC_ERR_NO_MEMORY;
+    }
+    nl_array_2 = ucc_malloc(nnodes * sizeof(ucc_rank_t), "nl_array_2");
+    if (!nl_array_2) {
+        ucc_error("failed to allocate %zd bytes for nl_array_2",
+                  nnodes * sizeof(ucc_rank_t));
+        ucc_free(nl_array_1);
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    for (i = 0; i < nnodes; i++) {
+        nl_array_1[i] = 0;
+        nl_array_2[i] = UCC_RANK_MAX;
+    }
+
+    for (i = 0; i < comm_size; i++) {
+        ucc_rank_t    ctx_rank = ucc_ep_map_eval(team->ctx_map, i);
+        ucc_host_id_t host_id  = topo->topo->procs[ctx_rank].host_id;
+        if (nl_array_1[host_id] == 0 || nl_array_1[host_id] == ctx_nlr) {
+            nl_array_2[host_id] = i;
+        }
+        nl_array_1[host_id]++;
+    }
+    for (i = 0; i < nnodes; i++) {
+        if (nl_array_1[i] > topo->max_ppn) {
+            topo->max_ppn = nl_array_1[i];
+        }
+        if (nl_array_1[i] < topo->min_ppn) {
+            topo->min_ppn = nl_array_1[i];
+        }
+    }
+    n_node_leaders = 0;
+    if (ctx_nlr >= topo->min_ppn) {
+        /* at least one node has less number of local ranks than
+           ctx_nlr - can't build NET sbgp */
+        goto skip;
+    }
+
+    for (i = 0; i < nnodes; i++) {
+        if (nl_array_2[i] != INT_MAX) {
+            if (comm_rank == nl_array_2[i]) {
+                i_am_node_leader = 1;
+                sbgp->group_rank = n_node_leaders;
+            }
+            nl_array_1[n_node_leaders++] = nl_array_2[i];
+        }
+    }
+skip:
+    ucc_free(nl_array_2);
+
+    if (n_node_leaders > 1) {
+        if (i_am_node_leader) {
+            sbgp->group_size = n_node_leaders;
+            sbgp->rank_map   = nl_array_1;
+            sbgp->status     = UCC_SBGP_ENABLED;
+        } else {
+            ucc_free(nl_array_1);
+            sbgp->status = UCC_SBGP_DISABLED;
+        }
+    } else {
+        ucc_free(nl_array_1);
+        sbgp->status = UCC_SBGP_NOT_EXISTS;
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t sbgp_create_socket_leaders(ucc_team_topo_t *topo,
+                                               ucc_sbgp_t *     sbgp)
+{
+    ucc_team_t *team               = sbgp->team;
+    ucc_sbgp_t *node_sbgp          = &topo->sbgps[UCC_SBGP_NODE];
+    ucc_rank_t  comm_rank          = team->rank;
+    ucc_rank_t  nlr                = topo->node_leader_rank;
+    int         i_am_socket_leader = (nlr == comm_rank);
+    int         max_n_sockets      = topo->topo->max_n_sockets;
+    ucc_rank_t *sl_array =
+        ucc_malloc(max_n_sockets * sizeof(ucc_rank_t), "sl_array");
+    ucc_rank_t      n_socket_leaders = 1;
+    ucc_socket_id_t nlr_sock_id;
+    int             i;
+
+    if (!sl_array) {
+        ucc_error("failed to allocate %zd bytes for sl_array",
+                  max_n_sockets * sizeof(ucc_rank_t));
+        return UCC_ERR_NO_MEMORY;
+    }
+    for (i = 0; i < max_n_sockets; i++) {
+        sl_array[i] = INT_MAX;
+    }
+    nlr_sock_id =
+        topo->topo->procs[ucc_ep_map_eval(team->ctx_map, nlr)].socket_id;
+    sl_array[nlr_sock_id] = nlr;
+
+    for (i = 0; i < node_sbgp->group_size; i++) {
+        ucc_rank_t      r         = ucc_ep_map_eval(node_sbgp->map, i);
+        ucc_rank_t      ctx_rank  = ucc_ep_map_eval(team->ctx_map, r);
+        ucc_socket_id_t socket_id = topo->topo->procs[ctx_rank].socket_id;
+        if (sl_array[socket_id] == INT_MAX) {
+            n_socket_leaders++;
+            sl_array[socket_id] = r;
+            if (r == comm_rank) {
+                i_am_socket_leader = 1;
+            }
+        }
+    }
+
+    if (n_socket_leaders > 1) {
+        if (i_am_socket_leader) {
+            ucc_rank_t sl_rank = -1;
+            sbgp->rank_map =
+                ucc_malloc(sizeof(ucc_rank_t) * n_socket_leaders, "rank_map");
+            if (!sbgp->rank_map) {
+                ucc_error("failed to allocate %zd bytes for rank_map",
+                          n_socket_leaders * sizeof(ucc_rank_t));
+                ucc_free(sl_array);
+                return UCC_ERR_NO_MEMORY;
+            }
+            n_socket_leaders = 0;
+            for (i = 0; i < max_n_sockets; i++) {
+                if (sl_array[i] != INT_MAX) {
+                    sbgp->rank_map[n_socket_leaders] = sl_array[i];
+                    if (comm_rank == sl_array[i]) {
+                        sl_rank = n_socket_leaders;
+                    }
+                    n_socket_leaders++;
+                }
+            }
+            int nlr_pos = -1;
+            for (i = 0; i < n_socket_leaders; i++) {
+                if (sbgp->rank_map[i] == nlr) {
+                    nlr_pos = i;
+                    break;
+                }
+            }
+            ucc_assert(sl_rank >= 0);
+            ucc_assert(nlr_pos >= 0);
+            sbgp->group_rank = sl_rank;
+            if (nlr_pos > 0) {
+                if (sl_rank == 0)
+                    sbgp->group_rank = nlr_pos;
+                if (sl_rank == nlr_pos)
+                    sbgp->group_rank = 0;
+                SWAP(sbgp->rank_map[nlr_pos], sbgp->rank_map[0]);
+            }
+
+            sbgp->group_size = n_socket_leaders;
+            sbgp->status     = UCC_SBGP_ENABLED;
+        } else {
+            sbgp->status = UCC_SBGP_DISABLED;
+        }
+    } else {
+        sbgp->status = UCC_SBGP_NOT_EXISTS;
+    }
+    ucc_free(sl_array);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_sbgp_create(ucc_team_topo_t *topo, ucc_sbgp_type_t type)
+{
+    ucc_status_t status = UCC_OK;
+    ucc_team_t * team   = topo->team;
+    ucc_sbgp_t * sbgp   = &topo->sbgps[type];
+
+    sbgp->team   = team;
+    sbgp->type   = type;
+    sbgp->status = UCC_SBGP_NOT_EXISTS;
+
+    switch (type) {
+    case UCC_SBGP_NODE:
+        status = sbgp_create_node(topo, sbgp);
+        break;
+    case UCC_SBGP_SOCKET:
+        if (!topo->topo->sock_bound) {
+            break;
+        }
+        if (topo->sbgps[UCC_SBGP_NODE].status == UCC_SBGP_NOT_INIT) {
+            ucc_sbgp_create(topo, UCC_SBGP_NODE);
+        }
+        if (topo->sbgps[UCC_SBGP_NODE].status == UCC_SBGP_ENABLED) {
+            status = sbgp_create_socket(topo, sbgp);
+        }
+        break;
+    case UCC_SBGP_NODE_LEADERS:
+        ucc_assert(UCC_SBGP_DISABLED != topo->sbgps[UCC_SBGP_NODE].status);
+        status =
+            sbgp_create_node_leaders(topo, sbgp, topo->node_leader_rank_id);
+        break;
+    case UCC_SBGP_NET:
+        if (topo->sbgps[UCC_SBGP_NODE].status == UCC_SBGP_NOT_INIT) {
+            ucc_sbgp_create(topo, UCC_SBGP_NODE);
+        }
+        ucc_assert(UCC_SBGP_DISABLED != topo->sbgps[UCC_SBGP_NODE].status);
+        /* if (topo->sbgps[UCC_SBGP_NODE].group_rank) */
+        status = sbgp_create_node_leaders(
+            topo, sbgp, topo->sbgps[UCC_SBGP_NODE].group_rank);
+        break;
+    case UCC_SBGP_SOCKET_LEADERS:
+        if (!topo->topo->sock_bound) {
+            break;
+        }
+        if (topo->sbgps[UCC_SBGP_NODE].status == UCC_SBGP_NOT_INIT) {
+            ucc_sbgp_create(topo, UCC_SBGP_NODE);
+        }
+        if (topo->sbgps[UCC_SBGP_NODE].status == UCC_SBGP_ENABLED) {
+            status = sbgp_create_socket_leaders(topo, sbgp);
+        }
+        break;
+    default:
+        status = UCC_ERR_NOT_IMPLEMENTED;
+        break;
+    };
+    if (UCC_SBGP_ENABLED == sbgp->status && sbgp->rank_map) {
+        sbgp->map = ucc_ep_map_from_array(&sbgp->rank_map, sbgp->group_size,
+                                          topo->team->size, 1);
+    }
+    return status;
+}
+
+ucc_status_t ucc_sbgp_cleanup(ucc_sbgp_t *sbgp)
+{
+    if (sbgp->rank_map) {
+        ucc_free(sbgp->rank_map);
+    }
+    return UCC_OK;
+}
+
+void ucc_sbgp_print(ucc_sbgp_t *sbgp)
+{
+    int i;
+    if (sbgp->group_rank == 0 && sbgp->status == UCC_SBGP_ENABLED) {
+        printf("sbgp: %15s: group_size %4d, team_ranks=[ ",
+               ucc_sbgp_str(sbgp->type), sbgp->group_size);
+        for (i = 0; i < sbgp->group_size; i++) {
+            printf("%d ", sbgp->rank_map[i]);
+        }
+        printf("]");
+        printf("\n");
+    }
+}

--- a/src/core/ucc_sbgp.h
+++ b/src/core/ucc_sbgp.h
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#ifndef UCC_SBGP_H_
+#define UCC_SBGP_H_
+#include "ucc/api/ucc.h"
+#include "utils/ucc_datastruct.h"
+#include "utils/ucc_coll_utils.h"
+
+typedef enum ucc_sbgp_type_t {
+    UCC_SBGP_NUMA,
+    UCC_SBGP_SOCKET,
+    UCC_SBGP_NODE,
+    UCC_SBGP_NODE_LEADERS,
+    UCC_SBGP_NET,
+    UCC_SBGP_SOCKET_LEADERS,
+    UCC_SBGP_NUMA_LEADERS,
+    UCC_SBGP_FLAT,
+    UCC_SBGP_LAST
+} ucc_sbgp_type_t;
+
+typedef enum ucc_sbgp_status_t {
+    UCC_SBGP_NOT_INIT,
+    UCC_SBGP_DISABLED,
+    UCC_SBGP_ENABLED,
+    UCC_SBGP_NOT_EXISTS,
+} ucc_sbgp_status_t;
+
+typedef struct ucc_team      ucc_team_t;
+typedef struct ucc_team_topo ucc_team_topo_t;
+typedef struct ucc_sbgp_t {
+    ucc_sbgp_type_t   type;
+    ucc_sbgp_status_t status;
+    ucc_rank_t        group_size;
+    ucc_rank_t        group_rank;
+    ucc_rank_t       *rank_map;
+    ucc_team_t       *team;
+    ucc_ep_map_t      map;
+} ucc_sbgp_t;
+
+const char*  ucc_sbgp_str(ucc_sbgp_type_t type);
+ucc_status_t ucc_sbgp_create(ucc_team_topo_t *topo, ucc_sbgp_type_t type);
+ucc_status_t ucc_sbgp_cleanup(ucc_sbgp_t *sbgp);
+
+static inline int ucc_sbgp_rank2team(ucc_sbgp_t *sbgp, int rank)
+{
+    return ucc_ep_map_eval(sbgp->map, rank);
+}
+
+void ucc_sbgp_print(ucc_sbgp_t *sbgp);
+
+#endif

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -178,6 +178,15 @@ ucc_team_create_cls(ucc_context_t *context, ucc_team_t *team)
     ucc_status_t           status;
     ucc_base_team_params_t b_params;
 
+    if (context->topo && !team->topo) {
+        /* Context->topo is not NULL if any of the enabled CLs
+           reported topo_required through the lib_attr */
+        status = ucc_team_topo_init(team, context->topo, &team->topo);
+        if (UCC_OK != status) {
+            ucc_warn("failed to init team topo");
+        }
+    }
+
     if (team->last_team_create_posted >= 0) {
         cl_iface = UCC_CL_CTX_IFACE(context->cl_ctx[team->last_team_create_posted]);
         b_team   = &team->cl_teams[team->last_team_create_posted]->super;
@@ -346,7 +355,7 @@ static ucc_status_t ucc_team_destroy_single(ucc_team_h team)
         }
         team->cl_teams[i] = NULL;
     }
-    /* ucc_topo_cleanup(team->topo); */
+    ucc_team_topo_cleanup(team->topo);
     ucc_free(team->addr_storage.storage);
     ucc_free(team->ctx_ranks);
     ucc_team_relase_id(team);

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -42,6 +42,7 @@ typedef struct ucc_team {
     void *             oob_req;
     ucc_ep_map_t       ctx_map; /*< map to the ctx ranks, defined if CTX
                                   type is global (oob provided) */
+    ucc_team_topo_t   *topo;
 } ucc_team_t;
 
 /* If the bit is set then team_id is provided by the user */
@@ -96,6 +97,29 @@ static inline void *ucc_get_team_ep_addr(ucc_context_t *context,
 static inline ucc_rank_t ucc_get_ctx_rank(ucc_team_t *team, ucc_rank_t team_rank)
 {
     return ucc_ep_map_eval(team->ctx_map, team_rank);
+}
+
+static inline int ucc_rank_on_local_node(int team_rank, ucc_team_t *team)
+{
+    ucc_proc_info_t *procs       = team->topo->topo->procs;
+    ucc_rank_t       ctx_rank    = ucc_ep_map_eval(team->ctx_map, team_rank);
+    ucc_rank_t       my_ctx_rank = ucc_ep_map_eval(team->ctx_map, team->rank);
+
+    return procs[ctx_rank].host_hash == procs[my_ctx_rank].host_hash;
+}
+
+static inline int ucc_rank_on_local_socket(int team_rank, ucc_team_t *team)
+{
+    ucc_rank_t       ctx_rank    = ucc_ep_map_eval(team->ctx_map, team_rank);
+    ucc_rank_t       my_ctx_rank = ucc_ep_map_eval(team->ctx_map, team->rank);
+    ucc_proc_info_t *proc        = &team->topo->topo->procs[ctx_rank];
+    ucc_proc_info_t *my_proc     = &team->topo->topo->procs[my_ctx_rank];
+
+    if (my_proc->socket_id == -1) {
+        return 0;
+    }
+    return proc->host_hash == my_proc->host_hash &&
+           proc->socket_id == my_proc->socket_id;
 }
 
 #endif

--- a/src/core/ucc_topo.c
+++ b/src/core/ucc_topo.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "ucc_topo.h"
+#include "ucc_context.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_math.h"
+#include <string.h>
+#include <limits.h>
+
+static int ucc_topo_compare_proc_info(const void *a, const void *b)
+{
+    const ucc_proc_info_t *d1 = (const ucc_proc_info_t *)a;
+    const ucc_proc_info_t *d2 = (const ucc_proc_info_t *)b;
+
+    if (d1->host_hash != d2->host_hash) {
+        return d1->host_hash > d2->host_hash ? 1 : -1;
+    } else if (d1->socket_id != d2->socket_id) {
+        return d1->socket_id - d2->socket_id;
+    } else {
+        return d1->pid - d2->pid;
+    }
+}
+
+static ucc_status_t ucc_topo_compute_layout(ucc_topo_t *topo, ucc_rank_t size)
+{
+    ucc_rank_t       current_ppn  = 1;
+    ucc_rank_t       min_ppn      = UCC_RANK_MAX;
+    ucc_rank_t       max_ppn      = 0;
+    ucc_rank_t       nnodes       = 1;
+    int              max_sockid   = 0;
+    ucc_proc_info_t *sorted;
+    ucc_host_id_t    current_hash, hash;
+    int              i, j;
+
+    sorted = (ucc_proc_info_t *)ucc_malloc(size * sizeof(ucc_proc_info_t),
+                                           "proc_sorted");
+    if (!sorted) {
+        ucc_error("failed to allocate %zd bytes for proc sorted",
+                  size * sizeof(ucc_proc_info_t));
+        return UCC_ERR_NO_MEMORY;
+    }
+    memcpy(sorted, topo->procs, size * sizeof(ucc_proc_info_t));
+    qsort(sorted, size, sizeof(ucc_proc_info_t), ucc_topo_compare_proc_info);
+    current_hash = sorted[0].host_hash;
+
+    for (i = 1; i < size; i++) {
+        hash = sorted[i].host_hash;
+        if (hash != current_hash) {
+            for (j = 0; j < size; j++) {
+                if (topo->procs[j].host_hash == current_hash) {
+                    topo->procs[j].host_id = nnodes - 1;
+                }
+            }
+            if (current_ppn > max_ppn)
+                max_ppn = current_ppn;
+            if (current_ppn < min_ppn)
+                min_ppn = current_ppn;
+            nnodes++;
+            current_hash = hash;
+            current_ppn  = 1;
+        } else {
+            current_ppn++;
+        }
+    }
+    for (j = 0; j < size; j++) {
+        if (topo->procs[j].socket_id > max_sockid) {
+            max_sockid = topo->procs[j].socket_id;
+        }
+        if (topo->procs[j].host_hash == current_hash) {
+            topo->procs[j].host_id = nnodes - 1;
+        }
+    }
+
+    if (current_ppn > max_ppn) {
+        max_ppn = current_ppn;
+    }
+    if (current_ppn < min_ppn) {
+        min_ppn = current_ppn;
+    }
+
+    ucc_free(sorted);
+
+    topo->nnodes        = nnodes;
+    topo->min_ppn       = min_ppn;
+    topo->max_ppn       = max_ppn;
+    topo->max_n_sockets = max_sockid + 1;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_topo_init(ucc_addr_storage_t *storage, ucc_topo_t **_topo)
+{
+    ucc_context_addr_header_t *h;
+    ucc_topo_t                *topo;
+    int                        i;
+    ucc_status_t               status;
+
+    if (storage->size < 2) {
+        /* We should always expect at least 2 ranks data in the storage */
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    topo = ucc_malloc(sizeof(*topo), "topo");
+    if (!topo) {
+        ucc_error("failed to allocate %zd bytes for topo", sizeof(*topo));
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    topo->sock_bound = 1;
+    topo->n_procs    = storage->size;
+    topo->procs =
+        (ucc_proc_info_t *)ucc_malloc(storage->size * sizeof(ucc_proc_info_t),
+            "topo_procs");
+    if (!topo->procs) {
+        ucc_error("failed to allocate %zd bytes for topo_procs",
+                  storage->size * sizeof(ucc_proc_info_t));
+        ucc_free(topo);
+        return UCC_ERR_NO_MEMORY;
+    }
+    for (i = 0; i < storage->size; i++) {
+        h = (ucc_context_addr_header_t *)PTR_OFFSET(storage->storage,
+                                                    storage->addr_len * i);
+        topo->procs[i] = h->ctx_id.pi;
+        if (h->ctx_id.pi.socket_id == -1) {
+            topo->sock_bound = 0;
+        }
+    }
+    status = ucc_topo_compute_layout(topo, storage->size);
+    if (UCC_OK != status) {
+        ucc_free(topo->procs);
+        ucc_free(topo);
+        return status;
+    }
+
+    *_topo = topo;
+    return UCC_OK;
+}
+
+void ucc_topo_cleanup(ucc_topo_t *topo)
+{
+    if (topo) {
+        ucc_free(topo->procs);
+        ucc_free(topo);
+    }
+}
+
+ucc_status_t ucc_team_topo_init(ucc_team_t *team, ucc_topo_t *topo,
+                                ucc_team_topo_t **_team_topo)
+{
+    ucc_team_topo_t *team_topo = malloc(sizeof(*team_topo));
+    int              i;
+    if (!team_topo) {
+        return UCC_ERR_NO_MEMORY;
+    }
+    team_topo->topo = topo;
+    for (i = 0; i < UCC_SBGP_LAST; i++) {
+        team_topo->sbgps[i].status = UCC_SBGP_NOT_INIT;
+    }
+    team_topo->no_socket           = 0;
+    team_topo->node_leader_rank    = -1;
+    team_topo->node_leader_rank_id = 0;
+    team_topo->team                = team;
+    team_topo->min_ppn             = UCC_RANK_MAX;
+    team_topo->max_ppn             = 0;
+    *_team_topo                    = team_topo;
+    return UCC_OK;
+}
+
+void ucc_team_topo_cleanup(ucc_team_topo_t *team_topo)
+{
+    int i;
+    if (team_topo) {
+        for (i = 0; i < UCC_SBGP_LAST; i++) {
+            if (team_topo->sbgps[i].status == UCC_SBGP_ENABLED) {
+                ucc_sbgp_cleanup(&team_topo->sbgps[i]);
+            }
+        }
+        free(team_topo);
+    }
+}
+
+ucc_sbgp_t *ucc_team_topo_get_sbgp(ucc_team_topo_t *topo, ucc_sbgp_type_t type)
+{
+    if (topo->sbgps[type].status == UCC_SBGP_NOT_INIT) {
+        if (UCC_OK != ucc_sbgp_create(topo, type)) {
+            ucc_error("failed to create sbgp %s", ucc_sbgp_str(type));
+            /* sbgps[type]->status is set accordingly */
+        }
+    }
+    return &topo->sbgps[type];
+}

--- a/src/core/ucc_topo.h
+++ b/src/core/ucc_topo.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#ifndef UCC_TOPO_H_
+#define UCC_TOPO_H_
+#include "ucc_sbgp.h"
+#include "utils/ucc_proc_info.h"
+
+typedef struct ucc_topo {
+    ucc_proc_info_t *procs;
+    ucc_rank_t       n_procs;
+    ucc_rank_t       nnodes;
+    ucc_rank_t       min_ppn;
+    ucc_rank_t       max_ppn;
+    ucc_rank_t       max_n_sockets;
+    uint32_t         sock_bound;
+} ucc_topo_t;
+
+typedef struct ucc_team         ucc_team_t;
+typedef struct ucc_addr_storage ucc_addr_storage_t;
+typedef struct ucc_team_topo {
+    ucc_topo_t *topo;
+    ucc_sbgp_t  sbgps[UCC_SBGP_LAST];
+    ucc_rank_t  node_leader_rank;
+    ucc_rank_t  node_leader_rank_id;
+    int         no_socket;
+    ucc_team_t *team;
+    ucc_rank_t  min_ppn;
+    ucc_rank_t  max_ppn;
+} ucc_team_topo_t;
+
+ucc_status_t ucc_topo_init(ucc_addr_storage_t *storage, ucc_topo_t **topo);
+void         ucc_topo_cleanup(ucc_topo_t *topo);
+
+ucc_status_t ucc_team_topo_init(ucc_team_t *team, ucc_topo_t *topo,
+                                ucc_team_topo_t **team_topo);
+void         ucc_team_topo_cleanup(ucc_team_topo_t *team_topo);
+ucc_sbgp_t *ucc_team_topo_get_sbgp(ucc_team_topo_t *topo, ucc_sbgp_type_t type);
+
+#endif

--- a/src/utils/ucc_math.c
+++ b/src/utils/ucc_math.c
@@ -21,3 +21,34 @@ size_t ucc_dt_sizes[UCC_DT_USERDEFINED] = {
     [UCC_DT_INT128]  = 16,
     [UCC_DT_UINT128] = 16,
 };
+
+static int _compare(const void *a, const void *b)
+{
+    return (*(int *)a - *(int *)b);
+}
+
+static int _compare_inv(const void *a, const void *b)
+{
+    return (*(int *)b - *(int *)a);
+}
+
+static inline int _unique(int *first, int *last)
+{
+    int *begin  = first;
+    int *result = first;
+    if (first == last) {
+        return 1;
+    }
+    while (++first != last) {
+        if (!(*result == *first)) {
+            *(++result) = *first;
+        }
+    }
+    return (++result - begin);
+}
+
+int ucc_sort_uniq(int *array, int len, int inverse)
+{
+    qsort(array, len, sizeof(int), inverse ? _compare_inv : _compare);
+    return _unique(array, array + len);
+}

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -53,4 +53,15 @@ static inline unsigned long ucc_str_hash_djb2(const char *str)
     return hash;
 }
 
+/* Sorts the input integer array in-place keeping only
+   unique elements */
+int ucc_sort_uniq(int *array, int len, int inverse);
+
+#define SWAP(_x, _y)                                                           \
+    do {                                                                       \
+        int _tmp = (_x);                                                       \
+        (_x)     = (_y);                                                       \
+        (_y)     = _tmp;                                                       \
+    } while (0)
+
 #endif

--- a/src/utils/ucc_proc_info.c
+++ b/src/utils/ucc_proc_info.c
@@ -1,12 +1,21 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+
 #include "ucc_proc_info.h"
-#include "ucc_math.h"
 #include "ucc_log.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_math.h"
+#include <errno.h>
+#include <sched.h>
 #include <limits.h>
 #include <stdint.h>
 #include "config.h"
 #ifdef HAVE_UCS_GET_SYSTEM_ID
 #include <ucs/sys/uid.h>
 #endif
+
 
 ucc_proc_info_t ucc_local_proc;
 static char ucc_local_hostname[HOST_NAME_MAX];
@@ -16,12 +25,165 @@ const char*  ucc_hostname()
     return ucc_local_hostname;
 }
 
-uint64_t ucc_get_system_id(){
+
+uint64_t ucc_get_system_id()
+{
 #ifdef HAVE_UCS_GET_SYSTEM_ID
     return ucs_get_system_id();
 #else
     return ucc_str_hash_djb2(ucc_local_hostname);
 #endif
+}
+
+typedef unsigned long int cpu_mask_t;
+#define NCPUBITS (8 * sizeof(cpu_mask_t))
+
+#define CPUELT(cpu) ((cpu) / NCPUBITS)
+#define CPUMASK(cpu) ((cpu_mask_t)1 << ((cpu) % NCPUBITS))
+
+#define SBGP_CPU_ISSET(cpu, setsize, cpusetp)                                  \
+    ({                                                                         \
+        size_t __cpu = (cpu);                                                  \
+        __cpu < 8 * (setsize)                                                  \
+            ? ((((const cpu_mask_t *)((cpusetp)->__bits))[__CPUELT(__cpu)] &   \
+                CPUMASK(__cpu))) != 0                                          \
+            : 0;                                                               \
+    })
+
+static int parse_cpuset_file(FILE *file, int *nr_psbl_cpus)
+{
+    unsigned long start, stop;
+    while (fscanf(file, "%lu", &start) == 1) {
+        int c = fgetc(file);
+        stop  = start;
+        if (c == '-') {
+            if (fscanf(file, "%lu", &stop) != 1) {
+                /* Range is usually <int>-<int> */
+                errno = EINVAL;
+                return -1;
+            }
+            c = fgetc(file);
+        }
+
+        if (c == EOF || c == '\n') {
+            *nr_psbl_cpus = (int)stop + 1;
+            break;
+        }
+
+        if (c != ',') {
+            /* Wrong terminating char */
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+ucc_status_t ucc_get_bound_socket_id(int *socketid)
+{
+    cpu_set_t *cpuset = NULL;
+    int        sockid = -1, sockid2 = -1;
+    int        try, i, n_sockets, cpu, nr_cpus, nr_psbl_cpus = 0;
+    size_t     setsize;
+    FILE *     fptr, *possible;
+    char       str[1024];
+    int *      socket_ids, tmpid;
+
+    /* Get the number of total procs and online procs */
+    nr_cpus = sysconf(_SC_NPROCESSORS_CONF);
+
+    /* Need to make sure nr_cpus !< possible_cpus+1 */
+    possible = fopen("/sys/devices/system/cpu/possible", "r");
+    if (possible) {
+        if (parse_cpuset_file(possible, &nr_psbl_cpus) == 0) {
+            if (nr_cpus < nr_psbl_cpus + 1)
+                nr_cpus = nr_psbl_cpus;
+        }
+        fclose(possible);
+    }
+
+    if (!nr_cpus) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    /* The cpuset size on some kernels needs to be bigger than
+     * the number of nr_cpus, hwloc gets around this
+     * by blocking on a loop and increasing nr_cpus.
+     * We will try 1000 (arbitrary) attempts, and revert to hwloc
+     * if all fail */
+    setsize = ((nr_cpus + NCPUBITS - 1) / NCPUBITS) * sizeof(cpu_mask_t);
+    cpuset  = __sched_cpualloc(nr_cpus);
+    if (NULL == cpuset) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    try = 1000;
+    while (0 < sched_getaffinity(0, setsize, cpuset) && try > 0) {
+        __sched_cpufree(cpuset);
+        try--;
+        nr_cpus *= 2;
+        cpuset = __sched_cpualloc(nr_cpus);
+        if (NULL == cpuset) {
+            try = 0;
+            break;
+        }
+        setsize = ((nr_cpus + NCPUBITS - 1) / NCPUBITS) * sizeof(cpu_mask_t);
+    }
+
+    /* If after all tries we're still not getting it, error out
+     * let hwloc take over */
+    if (try == 0) {
+        ucc_error("Error when manually trying to discover socket_id using "
+                  "sched_getaffinity()");
+        __sched_cpufree(cpuset);
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    socket_ids = ucc_malloc(nr_cpus * sizeof(int), "socket_ids");
+    if (!socket_ids) {
+        ucc_error("failed to allocate %zd bytes for socket_ids array",
+                  nr_cpus * sizeof(int));
+        return UCC_ERR_NO_MEMORY;
+    }
+    /* Loop through all cpus, and check if I'm bound to the socket */
+    for (cpu = 0; cpu < nr_cpus; cpu++) {
+        socket_ids[cpu] = -1;
+        sprintf(str, "/sys/bus/cpu/devices/cpu%d/topology/physical_package_id",
+                cpu);
+        fptr = fopen(str, "r");
+        if (!fptr) {
+            /* Do nothing just skip */
+            continue;
+        }
+        /* Read socket id from file */
+        if ((1 == fscanf(fptr, "%d", &tmpid)) && (tmpid >= 0)) {
+            socket_ids[cpu] = tmpid;
+            if (SBGP_CPU_ISSET(cpu, setsize, cpuset)) {
+                if (sockid == -1) {
+                    sockid = tmpid;
+                } else if (tmpid != sockid && sockid2 == -1) {
+                    sockid2 = tmpid;
+                }
+            }
+        }
+        fclose(fptr);
+    }
+
+    /* Check that a process is bound to 1 and only 1 socket */
+    if ((sockid != -1) && (sockid2 == -1)) {
+        /* Some archs (eg. POWER) seem to have non-linear socket_ids.
+          * Convert to logical index by findig first occurence of tmpid in
+          * the global socket_ids array. */
+        n_sockets = ucc_sort_uniq(socket_ids, nr_cpus, 0);
+        for (i = 0; i < n_sockets; i++) {
+            if (socket_ids[i] == sockid) {
+                *socketid = i;
+                break;
+            }
+        }
+        ucc_assert(((*socketid) >= 0) && ((*socketid) < nr_cpus));
+    }
+    ucc_free(socket_ids);
+    return UCC_OK;
 }
 
 ucc_status_t ucc_local_proc_info_init()
@@ -40,5 +202,10 @@ ucc_status_t ucc_local_proc_info_init()
 
     ucc_debug("proc pid %d, host %s, host_hash %lu",
               ucc_local_proc.pid, ucc_local_hostname, ucc_local_proc.host_hash);
+
+    if (UCC_OK != ucc_get_bound_socket_id(&ucc_local_proc.socket_id)) {
+        ucc_debug("failed to get bound socket id");
+    }
+
     return UCC_OK;
 }

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -83,6 +83,7 @@ gtest_SOURCES =                     \
 	core/test_bcast.cc              \
 	core/test_allreduce.cc          \
 	core/test_schedule.cc           \
+	core/test_topo.cc               \
 	utils/test_string.cc            \
 	utils/test_ep_map.cc            \
 	utils/test_lock_free_queue.cc   \

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -396,10 +396,10 @@ UccJob::~UccJob()
     if (this == UccJob::staticUccJob) {
         staticTeams.clear();
     }
-    for (int i = 0; i < n_procs; i++){
+    for (int i = 0; i < n_procs; i++) {
         workers.push_back(std::thread(thread_proc_destruct, &procs, i));
     }
-    for (int i = 0; i < n_procs; i++){
+    for (int i = 0; i < n_procs; i++) {
         workers[i].join();
     }
 }

--- a/test/gtest/core/test_topo.cc
+++ b/test/gtest/core/test_topo.cc
@@ -1,0 +1,289 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+extern "C" {
+#include <core/ucc_context.h>
+#include <core/ucc_team.h>
+#include <core/ucc_global_opts.h>
+}
+
+#include <common/test.h>
+#include <vector>
+#include <algorithm>
+#include <random>
+
+class addr_storage {
+  public:
+    ucc_addr_storage_t                     storage;
+    std::vector<ucc_context_addr_header_t> h;
+    addr_storage(int size)
+    {
+        h.resize(size);
+        storage.storage  = h.data();
+        storage.size     = size;
+        storage.addr_len = sizeof(ucc_context_addr_header_t);
+    }
+};
+
+class test_topo : public ucc::test {
+  public:
+    ucc_topo_t *topo;
+    ucc_team_t  team;
+    test_topo()
+    {
+        ucc_constructor();
+    }
+    ~test_topo()
+    {
+        ucc_team_topo_cleanup(team.topo);
+        ucc_topo_cleanup(topo);
+    }
+};
+
+#define SET_PI(_s, _i, _host, _sock, _pid)                                     \
+    _s.h[_i].ctx_id.pi.host_hash = _host;                                      \
+    _s.h[_i].ctx_id.pi.socket_id = _sock;                                      \
+    _s.h[_i].ctx_id.pi.pid       = _pid;
+
+UCC_TEST_F(test_topo, single_node)
+{
+    const ucc_rank_t ctx_size = 4;
+    addr_storage     s(ctx_size);
+    ucc_sbgp_t *     sbgp;
+
+    /* simulates world proc array */
+    SET_PI(s, 0, 0xabcd, 0, 0);
+    SET_PI(s, 1, 0xabcd, 0, 1);
+    SET_PI(s, 2, 0xabcd, 0, 2);
+    SET_PI(s, 3, 0xabcd, 0, 3);
+
+    /* team from the world */
+    team.size         = ctx_size;
+    team.rank         = 0;
+    team.ctx_map.type = UCC_EP_MAP_FULL;
+
+    /* Init topo for such team */
+    EXPECT_EQ(UCC_OK, ucc_topo_init(&s.storage, &topo));
+    EXPECT_EQ(UCC_OK, ucc_team_topo_init(&team, topo, &team.topo));
+
+    /* Check subgroups */
+
+    /* NODE subgroup  - ALL on the same node*/
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NODE);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(sbgp->group_size, ctx_size);
+    EXPECT_EQ(sbgp->group_rank, 0);
+    EXPECT_EQ(sbgp->map.type, UCC_EP_MAP_FULL);
+
+    /* NODE_LEADERS subgroup */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NODE_LEADERS);
+    EXPECT_EQ(UCC_SBGP_NOT_EXISTS, sbgp->status);
+
+    /* SOCKET subgroup - ALL on the same socket */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_SOCKET);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(sbgp->group_size, ctx_size);
+    EXPECT_EQ(sbgp->group_rank, 0);
+    EXPECT_EQ(sbgp->map.type, UCC_EP_MAP_FULL);
+
+    /* SOCKET_LEADERS subgroup - just 1 socket - no socket_leaders group*/
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_SOCKET_LEADERS);
+    EXPECT_EQ(UCC_SBGP_NOT_EXISTS, sbgp->status);
+}
+
+UCC_TEST_F(test_topo, node_reordered)
+{
+    const ucc_rank_t ctx_size              = 4;
+    const ucc_rank_t team_size             = 3;
+    ucc_rank_t       team_ranks[team_size] = {2, 3, 1};
+    addr_storage     s(ctx_size);
+    ucc_sbgp_t *     sbgp;
+
+    /* simulates world proc array */
+    SET_PI(s, 0, 0xabcd, 0, 0);
+    SET_PI(s, 1, 0xabcd, 0, 1);
+    SET_PI(s, 2, 0xabcd, 0, 2);
+    SET_PI(s, 3, 0xabcd, 0, 3);
+
+    /* team from the world */
+    team.size              = team_size;
+    team.rank              = 2; //will build subgroups from rank 2 perspective
+    team.ctx_map.type      = UCC_EP_MAP_ARRAY;
+    team.ctx_map.ep_num    = team_size;
+    team.ctx_map.array.map = team_ranks;
+    team.ctx_map.array.elem_size = sizeof(ucc_rank_t);
+
+    /* Init topo for such team */
+    EXPECT_EQ(UCC_OK, ucc_topo_init(&s.storage, &topo));
+    EXPECT_EQ(UCC_OK, ucc_team_topo_init(&team, topo, &team.topo));
+
+    /* Check subgroups */
+
+    /* NODE subgroup  - ALL on the same node*/
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NODE);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(team_size, sbgp->group_size);
+    EXPECT_EQ(2, sbgp->group_rank);
+}
+
+UCC_TEST_F(test_topo, 1node_2sockets)
+{
+    const ucc_rank_t ctx_size  = 6;
+    const ucc_rank_t team_size = 6;
+    addr_storage     s(ctx_size);
+    ucc_sbgp_t *     sbgp;
+
+    /* simulates world proc array */
+    SET_PI(s, 0, 0xabcd, 0, 0);
+    SET_PI(s, 1, 0xabcd, 1, 1);
+    SET_PI(s, 2, 0xabcd, 0, 2);
+    SET_PI(s, 3, 0xabcd, 1, 3);
+    SET_PI(s, 4, 0xabcd, 0, 4);
+    SET_PI(s, 5, 0xabcd, 1, 5);
+
+    /* team from the world */
+    team.size         = team_size;
+    team.rank         = 3; // from rank 1 perspective
+    team.ctx_map.type = UCC_EP_MAP_FULL;
+
+    /* Init topo for such team */
+    EXPECT_EQ(UCC_OK, ucc_topo_init(&s.storage, &topo));
+    EXPECT_EQ(UCC_OK, ucc_team_topo_init(&team, topo, &team.topo));
+
+    /* Check subgroups */
+
+    /* NODE subgroup  - ALL on the same node*/
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NODE);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(team_size, sbgp->group_size);
+    EXPECT_EQ(3, sbgp->group_rank);
+
+    /* SOCKET subgroup - must contain ranks 1, 3, 5 */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_SOCKET);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(sbgp->group_size, ctx_size / 2);
+    EXPECT_EQ(sbgp->group_rank, 1); //rank 3 is rank 1 in subgroup 1, 3, 5
+    EXPECT_EQ(sbgp->map.type, UCC_EP_MAP_STRIDED);
+    EXPECT_EQ(sbgp->map.strided.start, 1);
+    EXPECT_EQ(sbgp->map.strided.stride, 2);
+
+    /* SOCKET_LEADERS subgroup - ranks 0 and 1. Rank 3 does not participate, so
+       the SBGP is disabled for him */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_SOCKET_LEADERS);
+    EXPECT_EQ(UCC_SBGP_DISABLED, sbgp->status);
+
+    ucc_team_topo_cleanup(team.topo);
+    team.rank = 1;
+    EXPECT_EQ(UCC_OK, ucc_team_topo_init(&team, topo, &team.topo));
+    /* SOCKET_LEADERS subgroup - ranks 0 and 1. Rank 1 is also rank 1
+       in the SBGP*/
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_SOCKET_LEADERS);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(sbgp->group_size, 2);
+    EXPECT_EQ(sbgp->group_rank, 1);
+    EXPECT_EQ(sbgp->map.type, UCC_EP_MAP_STRIDED);
+    EXPECT_EQ(sbgp->map.strided.start, 0);
+    EXPECT_EQ(sbgp->map.strided.stride, 1);
+}
+
+UCC_TEST_F(test_topo, 2nodes)
+{
+    const ucc_rank_t ctx_size  = 8;
+    const ucc_rank_t team_size = 8;
+    addr_storage     s(ctx_size);
+    ucc_sbgp_t *     sbgp;
+
+    /* simulates world proc array : 2 nodes, 5 ranks on 1st node and
+       3 on 2nd*/
+    SET_PI(s, 0, 0xaaa, 0, 0);
+    SET_PI(s, 1, 0xaaa, 1, 1);
+    SET_PI(s, 2, 0xaaa, 0, 2);
+    SET_PI(s, 3, 0xaaa, 1, 3);
+    SET_PI(s, 4, 0xaaa, 0, 4);
+
+    SET_PI(s, 5, 0xbbb, 0, 5);
+    SET_PI(s, 6, 0xbbb, 1, 6);
+    SET_PI(s, 7, 0xbbb, 0, 7);
+
+    /* team from the world */
+    team.size         = team_size;
+    team.ctx_map.type = UCC_EP_MAP_FULL;
+
+    team.rank = 3; // from rank 1 perspective
+    /* Init topo for such team */
+    EXPECT_EQ(UCC_OK, ucc_topo_init(&s.storage, &topo));
+    EXPECT_EQ(UCC_OK, ucc_team_topo_init(&team, topo, &team.topo));
+
+    /* NODE subgroup  - ALL on the same node*/
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NODE);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(5, sbgp->group_size);
+    EXPECT_EQ(3, sbgp->group_rank);
+    EXPECT_EQ(sbgp->map.type, UCC_EP_MAP_STRIDED);
+    EXPECT_EQ(sbgp->map.strided.start, 0);
+    EXPECT_EQ(sbgp->map.strided.stride, 1);
+
+    /* SOCKET subgroup - must contain ranks 1, 3, 5 */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_SOCKET);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(sbgp->group_size, 2);
+    EXPECT_EQ(sbgp->group_rank, 1); //rank 3 is rank 1 in subgroup 1, 3, 5
+    EXPECT_EQ(sbgp->map.type, UCC_EP_MAP_STRIDED);
+    EXPECT_EQ(sbgp->map.strided.start, 1);
+    EXPECT_EQ(sbgp->map.strided.stride, 2);
+
+    /* SOCKET_LEADERS subgroup - ranks 0 and 1. Rank 3 does not participate, so
+       the SBGP is disabled for him */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_SOCKET_LEADERS);
+    EXPECT_EQ(UCC_SBGP_DISABLED, sbgp->status);
+
+    /* NODE LEADERS subgroup - ranks 0 and 5. Rank 3 does not participate, so
+       the SBGP is disabled for him */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NODE_LEADERS);
+    EXPECT_EQ(UCC_SBGP_DISABLED, sbgp->status);
+
+    /* NET subgroup - there is no process with local rank 3 on 2nd node */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NET);
+    EXPECT_EQ(UCC_SBGP_NOT_EXISTS, sbgp->status);
+
+    /* RANK 6 perspective */
+    ucc_team_topo_cleanup(team.topo);
+    team.rank = 6;
+    EXPECT_EQ(UCC_OK, ucc_team_topo_init(&team, topo, &team.topo));
+    /* NODE subgroup  - ALL on the same node*/
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NODE);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(3, sbgp->group_size);
+    EXPECT_EQ(1, sbgp->group_rank);
+    EXPECT_EQ(sbgp->map.type, UCC_EP_MAP_STRIDED);
+    EXPECT_EQ(sbgp->map.strided.start, 5);
+    EXPECT_EQ(sbgp->map.strided.stride, 1);
+
+    /* SOCKET subgroup - has only 1 rank on socket 1, so SBGP NOT EXISTS */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_SOCKET);
+    EXPECT_EQ(UCC_SBGP_NOT_EXISTS, sbgp->status);
+
+    /* SOCKET_LEADERS subgroup - ranks 5 and 6*/
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_SOCKET_LEADERS);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(2, sbgp->group_size);
+    EXPECT_EQ(1, sbgp->group_rank);
+    EXPECT_EQ(sbgp->map.type, UCC_EP_MAP_STRIDED);
+    EXPECT_EQ(sbgp->map.strided.start, 5);
+    EXPECT_EQ(sbgp->map.strided.stride, 1);
+
+    /* NODE LEADERS subgroup - ranks 0 and 5. Rank 6 does not participate, so
+       the SBGP is disabled for him */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NODE_LEADERS);
+    EXPECT_EQ(UCC_SBGP_DISABLED, sbgp->status);
+
+    /* NET subgroup - ranks 1 and 6 (local ranks 0 on nodes) */
+    sbgp = ucc_team_topo_get_sbgp(team.topo, UCC_SBGP_NET);
+    EXPECT_EQ(UCC_SBGP_ENABLED, sbgp->status);
+    EXPECT_EQ(2, sbgp->group_size);
+    EXPECT_EQ(1, sbgp->group_rank);
+    EXPECT_EQ(sbgp->map.type, UCC_EP_MAP_STRIDED);
+    EXPECT_EQ(sbgp->map.strided.start, 1);
+    EXPECT_EQ(sbgp->map.strided.stride, 5);
+}


### PR DESCRIPTION
## What
Adds basic subgrouping functionality to UCC. Ranks participating in a team can now be partitioned into groups (1) belonging to same node, (2) socket, (3) nodeleaders, etc.

## Why ?
These groupings are used to build hierarchical collective schedules

## How ?
1. Each rank encodes local process information (currently host_hash, socket_id, pid) into ctx address header. 
2. This info is exchanged at ucc_context_create (with OOB) as part of address_exchange flow.
3. CTX level topo datastructure is initialized: it stores the global view of processes data (global with respect to context)
4. When team is created the ucc_team_topo_t is initialized from global ucc_topo_t -> this gives the team level subgrouping information.
5. Subgroups (SBGPS) are created "locally" (w/o communication) and on-demand.
6. The whole topo flow is only enabled if any CL/TL reports that it needs it.
