### PR TITLE
CORE: coll_init log

### DIFF
--- a/config/m4/configure.m4
+++ b/config/m4/configure.m4
@@ -70,5 +70,5 @@ AS_IF([test "x$enable_debug" = xyes],
     AC_DEFINE([UCS_MAX_LOG_LEVEL], [UCS_LOG_LEVEL_TRACE_POLL], [Highest log level])],
     [CFLAGS="$CFLAGS -O3 -g -DNDEBUG"
     CXXFLAGS="$CXXFLAGS -O3 -g -DNDEBUG"
-    AC_DEFINE([UCS_MAX_LOG_LEVEL], [UCS_LOG_LEVEL_INFO], [Highest log level])
+    AC_DEFINE([UCS_MAX_LOG_LEVEL], [UCS_LOG_LEVEL_DEBUG], [Highest log level])
     ])

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -59,7 +59,7 @@ static ucc_status_t ucc_mc_cpu_mem_alloc(ucc_mc_buffer_header_t **h_ptr,
     h->addr      = PTR_OFFSET(h, sizeof(ucc_mc_buffer_header_t));
     h->mt        = UCC_MEMORY_TYPE_HOST;
     *h_ptr       = h;
-    mc_debug(&ucc_mc_cpu.super, "MC allocated %ld bytes with ucc_malloc", size);
+    mc_trace(&ucc_mc_cpu.super, "allocated %ld bytes with ucc_malloc", size);
     return UCC_OK;
 }
 
@@ -74,7 +74,7 @@ static ucc_status_t ucc_mc_cpu_mem_pool_alloc(ucc_mc_buffer_header_t **h_ptr,
         // Slow path
         return ucc_mc_cpu_mem_alloc(h_ptr, size);
     }
-    mc_debug(&ucc_mc_cpu.super, "MC allocated %ld bytes from cpu mpool", size);
+    mc_trace(&ucc_mc_cpu.super, "allocated %ld bytes from cpu mpool", size);
     *h_ptr = h;
     return UCC_OK;
 }

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -267,7 +267,7 @@ static ucc_status_t ucc_mc_cuda_mem_alloc(ucc_mc_buffer_header_t **h_ptr,
     h->from_pool = 0;
     h->mt        = UCC_MEMORY_TYPE_CUDA;
     *h_ptr       = h;
-    mc_debug(&ucc_mc_cuda.super, "MC allocated %ld bytes with cudaMalloc", size);
+    mc_trace(&ucc_mc_cuda.super, "allocated %ld bytes with cudaMalloc", size);
     return UCC_OK;
 }
 
@@ -286,7 +286,7 @@ static ucc_status_t ucc_mc_cuda_mem_pool_alloc(ucc_mc_buffer_header_t **h_ptr,
         return UCC_ERR_NO_MEMORY;
     }
     *h_ptr = h;
-    mc_debug(&ucc_mc_cuda.super, "MC allocated %ld bytes from cuda mpool", size);
+    mc_trace(&ucc_mc_cuda.super, "allocated %ld bytes from cuda mpool", size);
     return UCC_OK;
 }
 

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -49,7 +49,8 @@ void ucc_tl_ucp_recv_completion_cb(void *request, ucs_status_t status,
 ucc_status_t ucc_tl_ucp_coll_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    tl_info(UCC_TASK_LIB(task), "finalizing ev_task %p", task);
+
+    tl_trace(UCC_TASK_LIB(task), "finalizing task %p", task);
     ucc_tl_ucp_put_task(task);
     return UCC_OK;
 }
@@ -60,8 +61,8 @@ ucc_tl_ucp_triggered_coll_complete(ucc_coll_task_t *parent_task, //NOLINT
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
 
-    tl_info(UCC_TASK_LIB(task), "triggered collective complete. task:%p",
-            coll_task);
+    tl_trace(UCC_TASK_LIB(task), "triggered collective complete. task:%p",
+             coll_task);
     return ucc_mc_ee_task_end(coll_task->ee_task, coll_task->ee->ee_type);
 }
 
@@ -72,8 +73,8 @@ ucc_tl_ucp_event_trigger_complete(ucc_coll_task_t *parent_task,
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_status_t status;
 
-    tl_info(UCC_TASK_LIB(task), "event triggered. ev_task:%p coll_task:%p",
-            parent_task, coll_task);
+    tl_trace(UCC_TASK_LIB(task), "event triggered. ev_task:%p coll_task:%p",
+             parent_task, coll_task);
 
     coll_task->ee_task = parent_task->ee_task;
     status = coll_task->post(coll_task);
@@ -112,8 +113,8 @@ static ucc_status_t ucc_tl_ucp_ee_wait_for_event_trigger(ucc_coll_task_t *coll_t
             task->super.ee_task = NULL;
         } else if (UCC_OK == ucc_ee_get_event_internal(task->super.ee, &ev,
                                                 &task->super.ee->event_in_queue)) {
-            tl_info(UCC_TASK_LIB(task), "triggered event arrived. ev_task:%p",
-                    coll_task);
+            tl_trace(UCC_TASK_LIB(task), "triggered event arrived. ev_task:%p",
+                     coll_task);
             task->super.ev = ev;
             task->super.ee_task = NULL;
         } else {
@@ -167,7 +168,7 @@ ucc_status_t ucc_tl_ucp_triggered_post(ucc_ee_h ee, ucc_ev_t *ev, //NOLINT
     ev_task->super.finalize       = ucc_tl_ucp_coll_finalize;
     ev_task->super.super.status   = UCC_INPROGRESS;
 
-    tl_info(UCC_TASK_LIB(task), "triggered post. ev_task:%p coll_task:%p",
+    tl_trace(UCC_TASK_LIB(task), "triggered post. ev_task:%p coll_task:%p",
             &ev_task->super, coll_task);
     ev_task->super.progress = ucc_tl_ucp_ee_wait_for_event_trigger;
     ucc_event_manager_init(&ev_task->super.em);
@@ -224,7 +225,7 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_args_t *coll_args,
         ucc_tl_ucp_put_task(task);
         return status;
     }
-    tl_info(team->context->lib, "init coll req %p", task);
+    tl_trace(team->context->lib, "init coll req %p", task);
     *task_h = &task->super;
     return status;
 }

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -149,6 +149,11 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
         task->cb = coll_args->cb;
         task->flags |= UCC_COLL_TASK_FLAG_CB;
     }
+    if (ucc_global_config.log_component.log_level >= UCC_LOG_LEVEL_DEBUG) {
+        char coll_debug_str[256];
+        ucc_coll_str(&op_args, coll_debug_str, sizeof(coll_debug_str));
+        ucc_debug("coll_init: %s, req %p", coll_debug_str, task);
+    }
     *request = &task->super;
     return UCC_OK;
 }
@@ -156,12 +161,16 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
 ucc_status_t ucc_collective_post(ucc_coll_req_h request)
 {
     ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
+
+    ucc_debug("coll_post: req %p", task);
     return task->post(task);
 }
 
 ucc_status_t ucc_collective_triggered_post(ucc_ee_h ee, ucc_ev_t *ev)
 {
     ucc_coll_task_t *task = ucc_derived_of(ev->req, ucc_coll_task_t);
+
+    ucc_debug("coll_triggered_post: req %p", task);
     task->ee = ee;
     return task->triggered_post(ee, ev, task);
 }
@@ -170,5 +179,7 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_finalize, (request),
                       ucc_coll_req_h request)
 {
     ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
+
+    ucc_debug("coll_finalize: req %p", task);
     return task->finalize(task);
 }

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -116,4 +116,5 @@ static inline ucc_rank_t ucc_ep_map_eval(ucc_ep_map_t map, ucc_rank_t rank)
 ucc_ep_map_t ucc_ep_map_from_array(ucc_rank_t **array, ucc_rank_t size,
                                    ucc_rank_t full_size, int need_free);
 
+void ucc_coll_str(const ucc_base_coll_args_t *args, char *str, size_t len);
 #endif


### PR DESCRIPTION
## What
Adds better logging for collective flow at CORE. Enabled with UCC_LOG_LEVEL=debug.

## Why ?
1 Variable now clearly shows which collectives are being called. E.g:
```
[1626684901.014276] [hpchead:4878 :0]        ucc_coll.c:155  UCC  DEBUG coll_init: team id 4 size 2 rank 1 ctx_rank 2: Alltoallv Host inplace=0 sbytes=564 rbytes=744, req 0x1383f80
[1626684901.014281] [hpchead:4878 :0]        ucc_coll.c:165  UCC  DEBUG coll_post: req 0x1383f80
[1626684901.014297] [hpchead:4878 :0]        ucc_coll.c:183  UCC  DEBUG coll_finalize: req 0x1383f80
[1626684900.868189] [hpchead:4877 :0]        ucc_coll.c:155  UCC  DEBUG coll_init: team id 4 size 2 rank 0 ctx_rank 1: Bcast Host inplace=0 root=1 bytes=8, req 0x138ff80
[1626684900.868194] [hpchead:4877 :0]        ucc_coll.c:165  UCC  DEBUG coll_post: req 0x138ff80
[1626684900.868220] [hpchead:4877 :0]        ucc_coll.c:183  UCC  DEBUG coll_finalize: req 0x138ff80
```


## How ?
MIN UCC log level in release mode is increased up to debug (similarly to UCS). Logging at CORE is added with DEBUG level for collective_init/post/trig_post/finalize. Logs in other components are decreased to trace.
