### PR TITLE
MC: fixed mc reduce multi parameters order

### DIFF
--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -106,7 +106,7 @@ typedef struct ucc_mc_ops {
                            size_t count, ucc_datatype_t dt,
                            ucc_reduction_op_t op);
     ucc_status_t (*reduce_multi)(const void *src1, const void *src2, void *dst,
-                                 size_t count, size_t size, size_t stride,
+                                 size_t n_vectors, size_t count, size_t stride,
                                  ucc_datatype_t dt, ucc_reduction_op_t op);
     ucc_status_t (*memcpy)(void *dst, const void *src, size_t len,
                            ucc_memory_type_t dst_mem,

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -157,44 +157,44 @@ ucc_mc_cpu_mem_pool_alloc_with_init(ucc_mc_buffer_header_t **h_ptr, size_t size)
 }
 
 static ucc_status_t ucc_mc_cpu_reduce_multi(const void *src1, const void *src2,
-                                            void *dst, size_t size,
+                                            void *dst, size_t n_vectors,
                                             size_t count, size_t stride,
                                             ucc_datatype_t     dt,
                                             ucc_reduction_op_t op)
 {
     switch(dt) {
     case UCC_DT_INT8:
-        return ucc_mc_cpu_reduce_multi_int8(src1, src2, dst, size, count,
+        return ucc_mc_cpu_reduce_multi_int8(src1, src2, dst, n_vectors, count,
                                             stride, op);
     case UCC_DT_INT16:
-        return ucc_mc_cpu_reduce_multi_int16(src1, src2, dst, size, count,
-                                             stride, op);
+        return ucc_mc_cpu_reduce_multi_int16(src1, src2, dst, n_vectors,
+                                             count, stride, op);
     case UCC_DT_INT32:
-        return ucc_mc_cpu_reduce_multi_int32(src1, src2, dst, size, count,
-                                             stride, op);
+        return ucc_mc_cpu_reduce_multi_int32(src1, src2, dst, n_vectors,
+                                             count, stride, op);
     case UCC_DT_INT64:
-        return ucc_mc_cpu_reduce_multi_int64(src1, src2, dst, size, count,
-                                             stride, op);
+        return ucc_mc_cpu_reduce_multi_int64(src1, src2, dst, n_vectors,
+                                             count, stride, op);
     case UCC_DT_UINT8:
-        return ucc_mc_cpu_reduce_multi_uint8(src1, src2, dst, size, count,
-                                             stride, op);
+        return ucc_mc_cpu_reduce_multi_uint8(src1, src2, dst, n_vectors,
+                                             count, stride, op);
     case UCC_DT_UINT16:
-        return ucc_mc_cpu_reduce_multi_uint16(src1, src2, dst, size, count,
-                                              stride, op);
+        return ucc_mc_cpu_reduce_multi_uint16(src1, src2, dst, n_vectors,
+                                              count, stride, op);
     case UCC_DT_UINT32:
-        return ucc_mc_cpu_reduce_multi_uint32(src1, src2, dst, size, count,
-                                              stride, op);
+        return ucc_mc_cpu_reduce_multi_uint32(src1, src2, dst, n_vectors,
+                                              count, stride, op);
     case UCC_DT_UINT64:
-        return ucc_mc_cpu_reduce_multi_uint64(src1, src2, dst, size, count,
-                                              stride, op);
+        return ucc_mc_cpu_reduce_multi_uint64(src1, src2, dst, n_vectors,
+                                              count, stride, op);
     case UCC_DT_FLOAT32:
         ucc_assert(4 == sizeof(float));
-        return ucc_mc_cpu_reduce_multi_float(src1, src2, dst, size, count,
-                                             stride, op);
+        return ucc_mc_cpu_reduce_multi_float(src1, src2, dst, n_vectors,
+                                             count, stride, op);
     case UCC_DT_FLOAT64:
         ucc_assert(8 == sizeof(double));
-        return ucc_mc_cpu_reduce_multi_double(src1, src2, dst, size, count,
-                                              stride, op);
+        return ucc_mc_cpu_reduce_multi_double(src1, src2, dst, n_vectors,
+                                              count, stride, op);
     default:
         mc_error(&ucc_mc_cpu.super, "unsupported reduction type (%d)", dt);
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce.h
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce.h
@@ -164,7 +164,7 @@
 
 #define REDUCE_FN_DECLARE(_type)                                               \
     ucc_status_t ucc_mc_cpu_reduce_multi_##_type(                              \
-        const void *src1, const void *src2, void *dst, size_t size,            \
+        const void *src1, const void *src2, void *dst, size_t n_vectors,       \
         size_t count, size_t stride, ucc_reduction_op_t op)
 REDUCE_FN_DECLARE(int8);
 REDUCE_FN_DECLARE(int16);

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_double.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_double.c
@@ -7,10 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_double(const void *src1, const void *src2,
-                                            void *dst, size_t size,
+                                            void *dst, size_t n_vectors,
                                             size_t count, size_t stride,
                                             ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_FLOAT(double, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_FLOAT(double, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_float.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_float.c
@@ -7,9 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_float(const void *src1, const void *src2,
-                                           void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_reduction_op_t op)
+                                           void *dst, size_t n_vectors,
+                                           size_t count, size_t stride,
+                                           ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_FLOAT(float, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_FLOAT(float, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_int16.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_int16.c
@@ -7,9 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_int16(const void *src1, const void *src2,
-                                           void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_reduction_op_t op)
+                                           void *dst, size_t n_vectors,
+                                           size_t count, size_t stride,
+                                           ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_INT(int16_t, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_INT(int16_t, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_int32.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_int32.c
@@ -7,9 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_int32(const void *src1, const void *src2,
-                                           void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_reduction_op_t op)
+                                           void *dst, size_t n_vectors,
+                                           size_t count, size_t stride,
+                                           ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_INT(int32_t, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_INT(int32_t, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_int64.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_int64.c
@@ -7,9 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_int64(const void *src1, const void *src2,
-                                           void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_reduction_op_t op)
+                                           void *dst, size_t n_vectors,
+                                           size_t count, size_t stride,
+                                           ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_INT(int64_t, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_INT(int64_t, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_int8.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_int8.c
@@ -7,9 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_int8(const void *src1, const void *src2,
-                                          void *dst, size_t size, size_t count,
-                                          size_t stride, ucc_reduction_op_t op)
+                                          void *dst, size_t n_vectors,
+                                          size_t count, size_t stride,
+                                          ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_INT(int8_t, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_INT(int8_t, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_uint16.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_uint16.c
@@ -7,10 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_uint16(const void *src1, const void *src2,
-                                            void *dst, size_t size,
+                                            void *dst, size_t n_vectors,
                                             size_t count, size_t stride,
                                             ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_INT(uint16_t, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_INT(uint16_t, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_uint32.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_uint32.c
@@ -7,10 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_uint32(const void *src1, const void *src2,
-                                            void *dst, size_t size,
+                                            void *dst, size_t n_vectors,
                                             size_t count, size_t stride,
                                             ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_INT(uint32_t, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_INT(uint32_t, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_uint64.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_uint64.c
@@ -7,10 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_uint64(const void *src1, const void *src2,
-                                            void *dst, size_t size,
+                                            void *dst, size_t n_vectors,
                                             size_t count, size_t stride,
                                             ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_INT(uint64_t, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_INT(uint64_t, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce_uint8.c
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce_uint8.c
@@ -7,9 +7,10 @@
 #include "reduce/mc_cpu_reduce.h"
 
 ucc_status_t ucc_mc_cpu_reduce_multi_uint8(const void *src1, const void *src2,
-                                           void *dst, size_t size, size_t count,
-                                           size_t stride, ucc_reduction_op_t op)
+                                           void *dst, size_t n_vectors,
+                                           size_t count, size_t stride,
+                                           ucc_reduction_op_t op)
 {
-    DO_DT_REDUCE_INT(uint8_t, op, src1, src2, dst, size, count, stride);
+    DO_DT_REDUCE_INT(uint8_t, op, src1, src2, dst, n_vectors, count, stride);
     return UCC_OK;
 }

--- a/src/components/mc/cuda/kernel/mc_cuda_reduce_multi.cu
+++ b/src/components/mc/cuda/kernel/mc_cuda_reduce_multi.cu
@@ -158,8 +158,9 @@ extern "C" {
 #endif
 
 ucc_status_t ucc_mc_cuda_reduce_multi(const void *src1, const void *src2,
-                                      void *dst, size_t size, size_t count,
-                                      size_t stride, ucc_datatype_t dt,
+                                      void *dst, size_t n_vectors,
+                                      size_t count, size_t stride,
+                                      ucc_datatype_t dt,
                                       ucc_reduction_op_t op)
 {
     size_t        ld     = stride / ucc_dt_size(dt);
@@ -175,30 +176,30 @@ ucc_status_t ucc_mc_cuda_reduce_multi(const void *src1, const void *src2,
     switch (dt)
     {
         case UCC_DT_INT16:
-            DT_REDUCE_INT(int16_t, op, src1, src2, dst, size, count, ld, stream,
-                          bk, th);
+            DT_REDUCE_INT(int16_t, op, src1, src2, dst, n_vectors, count, ld,
+                          stream, bk, th);
             break;
         case UCC_DT_INT32:
-            DT_REDUCE_INT(int32_t, op, src1, src2, dst, size, count, ld, stream,
-                          bk, th);
+            DT_REDUCE_INT(int32_t, op, src1, src2, dst, n_vectors, count, ld,
+                          stream, bk, th);
             break;
         case UCC_DT_INT64:
-            DT_REDUCE_INT(int64_t, op, src1, src2, dst, size, count, ld, stream,
-                         bk, th);
+            DT_REDUCE_INT(int64_t, op, src1, src2, dst, n_vectors, count, ld,
+                          stream, bk, th);
             break;
         case UCC_DT_FLOAT16:
             ucc_assert(2 == sizeof(__half));
-            DT_REDUCE_FLOAT(__half, op, src1, src2, dst, size, count, ld,
+            DT_REDUCE_FLOAT(__half, op, src1, src2, dst, n_vectors, count, ld,
                             stream, bk, th);
             break;
         case UCC_DT_FLOAT32:
             ucc_assert(4 == sizeof(float));
-            DT_REDUCE_FLOAT(float, op, src1, src2, dst, size, count, ld, stream,
-                            bk, th);
+            DT_REDUCE_FLOAT(float, op, src1, src2, dst, n_vectors, count, ld,
+                            stream, bk, th);
             break;
         case UCC_DT_FLOAT64:
             ucc_assert(8 == sizeof(double));
-            DT_REDUCE_FLOAT(double, op, src1, src2, dst, size, count, ld,
+            DT_REDUCE_FLOAT(double, op, src1, src2, dst, n_vectors, count, ld,
                             stream, bk, th);
             break;
         default:

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -89,8 +89,9 @@ ucc_status_t ucc_mc_cuda_reduce(const void *src1, const void *src2,
                                 ucc_reduction_op_t op);
 
 ucc_status_t ucc_mc_cuda_reduce_multi(const void *src1, const void *src2,
-                                      void *dst, size_t size, size_t count,
-                                      size_t stride, ucc_datatype_t dt,
+                                      void *dst, size_t n_vectors,
+                                      size_t count, size_t stride,
+                                      ucc_datatype_t dt,
                                       ucc_reduction_op_t op);
 
 extern ucc_mc_cuda_t ucc_mc_cuda;

--- a/src/core/ucc_mc.c
+++ b/src/core/ucc_mc.c
@@ -154,7 +154,7 @@ UCC_MC_PROFILE_FUNC(ucc_status_t, ucc_mc_reduce,
 
 UCC_MC_PROFILE_FUNC(ucc_status_t, ucc_mc_reduce_multi,
                     (src1, src2, dst, size, count, stride, dtype, op, mem_type),
-                    void *src1, void *src2, void *dst, size_t size,
+                    void *src1, void *src2, void *dst, size_t n_vectors,
                     size_t count, size_t stride, ucc_datatype_t dtype,
                     ucc_reduction_op_t op, ucc_memory_type_t mem_type)
 {
@@ -162,7 +162,7 @@ UCC_MC_PROFILE_FUNC(ucc_status_t, ucc_mc_reduce_multi,
         return UCC_OK;
     }
     UCC_CHECK_MC_AVAILABLE(mem_type);
-    return mc_ops[mem_type]->reduce_multi(src1, src2, dst, size, count, stride,
+    return mc_ops[mem_type]->reduce_multi(src1, src2, dst, n_vectors, count, stride,
                                           dtype, op);
 }
 

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -64,19 +64,19 @@ ucc_status_t ucc_mc_reduce(const void *src1, const void *src2, void *dst,
 
 /**
  * Performs reduction of multiple vectors and stores result to dst
- * @param [in]  src1     First vector reduction operand
- * @param [in]  src2     Array of vector reduction operands
- * @param [out] dst      dst = src1 (op) src2{0} (op) src2{1} (op) ...
+ * @param [in]  src1      First vector reduction operand
+ * @param [in]  src2      Array of vector reduction operands
+ * @param [out] dst       dst = src1 (op) src2{0} (op) src2{1} (op) ...
  *                                               (op) src2{size-1}
- * @param [in]  count    Number of elements in dst
- * @param [in]  size     Number of vectors in src2
- * @param [in]  stride   Offset between vectors in src2
- * @param [in]  dtype    Vectors elements datatype
- * @param [in]  op       Reduction operation
- * @param [in]  mem_type Vectors memory type
+ * @param [in]  n_vectors Number of vectors in src2
+ * @param [in]  count     Number of elements in dst
+ * @param [in]  stride    Offset between vectors in src2
+ * @param [in]  dtype     Vectors elements datatype
+ * @param [in]  op        Reduction operation
+ * @param [in]  mem_type  Vectors memory type
  */
 ucc_status_t ucc_mc_reduce_multi(void *src1, void *src2, void *dst,
-                                 size_t count, size_t size, size_t stride,
+                                 size_t n_vectors, size_t count, size_t stride,
                                  ucc_datatype_t dtype, ucc_reduction_op_t op,
                                  ucc_memory_type_t mem_type);
 
@@ -95,7 +95,7 @@ static inline ucc_status_t ucc_dt_reduce(const void *src1, const void *src2,
 }
 
 static inline ucc_status_t ucc_dt_reduce_multi(void *src1, void *src2,
-                                               void *dst, size_t size,
+                                               void *dst, size_t n_vectors,
                                                size_t count, size_t stride,
                                                ucc_datatype_t dt,
                                                ucc_memory_type_t mem_type,
@@ -104,7 +104,7 @@ static inline ucc_status_t ucc_dt_reduce_multi(void *src1, void *src2,
     if (args->mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) {
         return UCC_ERR_NOT_SUPPORTED; //TODO
     } else {
-        return ucc_mc_reduce_multi(src1, src2, dst, size, count, stride,
+        return ucc_mc_reduce_multi(src1, src2, dst, n_vectors, count, stride,
                                    dt, args->reduce.predefined_op, mem_type);
     }
 }


### PR DESCRIPTION
## What
Switch the order between size and count parameters in ucc_mc_reduce_multi function decleration in ucc_mc.h

## Why ?
To fit to the order in which the function is implemeted in ucc_mc.c and in which it is called from ucc_dt_reduce_multi. 

## How ?
Switched size and count.
