### PR TITLE
Topic/service colls

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,6 +42,7 @@ noinst_HEADERS =                      \
 	core/ucc_progress_queue.h         \
 	core/ucc_topo.h                   \
 	core/ucc_sbgp.h                   \
+	core/ucc_service_coll.h           \
 	schedule/ucc_schedule.h           \
 	coll_score/ucc_coll_score.h       \
 	utils/ucc_compiler_def.h          \
@@ -87,6 +88,7 @@ libucc_la_SOURCES =                  \
 	core/ucc_progress_queue_mt.c     \
 	core/ucc_topo.c                  \
 	core/ucc_sbgp.c                  \
+	core/ucc_service_coll.c          \
 	schedule/ucc_schedule.c          \
 	coll_score/ucc_coll_score.c      \
 	coll_score/ucc_coll_score_map.c  \

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -30,8 +30,14 @@ typedef struct ucc_base_config {
     char                           *score_str;
 } ucc_base_config_t;
 
+enum {
+    UCC_BASE_LIB_FLAG_TEAM_ID_REQUIRED      = UCC_BIT(1),
+    UCC_BASE_LIB_FLAG_SERVICE_TEAM_REQUIRED = UCC_BIT(2)
+};
+
 typedef struct ucc_base_lib_attr_t {
     ucc_lib_attr_t attr;
+    uint64_t       flags;
 } ucc_base_lib_attr_t;
 
 typedef struct ucc_base_lib_params {

--- a/src/components/cl/basic/cl_basic_coll.c
+++ b/src/components/cl/basic/cl_basic_coll.c
@@ -17,7 +17,11 @@ ucc_status_t ucc_cl_basic_coll_init(ucc_base_coll_args_t *coll_args,
     ucc_status_t            status;
     status =
         ucc_coll_score_map_lookup(cl_team->score_map, coll_args, &init, &bteam);
-    if (UCC_OK != status) {
+    if (UCC_ERR_NOT_FOUND == status) {
+        cl_warn(UCC_CL_TEAM_LIB(cl_team),
+                "no TL supporting given coll args is available");
+        return UCC_ERR_NOT_SUPPORTED;
+    } else if (UCC_OK != status) {
         return status;
     }
     return init(coll_args, bteam, task);

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -45,6 +45,7 @@ static inline ucc_status_t check_tl_lib_attr(const ucc_base_lib_t *lib,
     attr->super.attr.thread_mode =
         ucc_min(attr->super.attr.thread_mode, tl_attr.super.attr.thread_mode);
     attr->super.attr.coll_types |= tl_attr.super.attr.coll_types;
+    attr->super.flags           |= tl_attr.super.flags;
     return UCC_OK;
 }
 
@@ -61,6 +62,7 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
     attr->tls                    = &cl_lib->tls;
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = 0;
+    attr->super.flags            = 0;
     if (tls->count == 1 && !strcmp(tls->names[0], "all")) {
         /* Check all available components, since CL_BASIC_TLS == "all" */
         for (i = 0; i < ucc_global_config.tl_framework.n_components; i++) {

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -45,7 +45,7 @@ static inline ucc_status_t check_tl_lib_attr(const ucc_base_lib_t *lib,
     attr->super.attr.thread_mode =
         ucc_min(attr->super.attr.thread_mode, tl_attr.super.attr.thread_mode);
     attr->super.attr.coll_types |= tl_attr.super.attr.coll_types;
-    attr->super.flags           |= tl_attr.super.flags;
+    attr->super.flags |= tl_attr.super.flags;
     return UCC_OK;
 }
 

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -104,4 +104,5 @@ typedef struct ucc_cl_lib_attr {
 #define UCC_CL_TEAM_IFACE(_cl_team)                                            \
     (ucc_derived_of((_cl_team)->super.context->lib, ucc_cl_lib_t))->iface
 
+#define UCC_CL_TEAM_LIB(_cl_team) (_cl_team)->super.super.context->lib
 #endif

--- a/src/components/tl/nccl/tl_nccl_lib.c
+++ b/src/components/tl/nccl/tl_nccl_lib.c
@@ -30,5 +30,6 @@ ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
     ucc_tl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = UCC_TL_NCCL_SUPPORTED_COLLS;
+    attr->super.flags            = 0;
     return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -19,7 +19,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_team_t, ucc_base_context_t *tl_context,
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params->team);
     self->oob       = params->params.oob;
-    self->size      = self->oob.participants;
+    self->size      = self->oob.n_oob_eps;
     self->rank      = params->rank;
     self->unique_id = ucc_malloc(sizeof(ncclUniqueId) * (self->size + 1),
                                  "tl_nccl_unique_id");

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -45,18 +45,13 @@ ucc_status_t ucc_tl_lib_config_read(ucc_tl_iface_t *iface,
                                     const char *full_prefix,
                                     ucc_tl_lib_config_t **cl_config);
 
-typedef struct ucc_tl_team_subset {
-    ucc_ep_map_t map;
-    ucc_rank_t   myrank;
-} ucc_tl_team_subset_t ;
-
 typedef struct ucc_tl_service_coll {
     ucc_status_t (*allreduce)(ucc_base_team_t *team, void *sbuf, void *rbuf,
                               ucc_datatype_t dt, size_t count,
                               ucc_reduction_op_t op,
-                              ucc_tl_team_subset_t subset, ucc_coll_task_t **task);
+                              ucc_team_subset_t subset, ucc_coll_task_t **task);
     ucc_status_t (*allgather)(ucc_base_team_t *team, void *sbuf, void *rbuf,
-                              size_t msgsize, ucc_tl_team_subset_t subset,
+                              size_t msgsize, ucc_team_subset_t subset,
                               ucc_coll_task_t **task);
     void         (*update_id)(ucc_base_team_t *team, uint16_t id);
 } ucc_tl_service_coll_t;

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -55,8 +55,9 @@ typedef struct ucc_tl_service_coll {
                               ucc_datatype_t dt, size_t count,
                               ucc_reduction_op_t op,
                               ucc_tl_team_subset_t subset, ucc_coll_task_t **task);
-    ucc_status_t (*test)(ucc_coll_task_t *task);
-    ucc_status_t (*cleanup)(ucc_coll_task_t *task);
+    ucc_status_t (*allgather)(ucc_base_team_t *team, void *sbuf, void *rbuf,
+                              size_t msgsize, ucc_tl_team_subset_t subset,
+                              ucc_coll_task_t **task);
     void         (*update_id)(ucc_base_team_t *team, uint16_t id);
 } ucc_tl_service_coll_t;
 

--- a/src/components/tl/ucp/allgather/allgather.h
+++ b/src/components/tl/ucp/allgather/allgather.h
@@ -9,6 +9,8 @@
 #include "../tl_ucp_coll.h"
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task);
+ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
+ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *task);
 
 /* Uses allgather_kn_radix from config */
 ucc_status_t ucc_tl_ucp_allgather_knomial_init(ucc_base_coll_args_t *coll_args,

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -77,9 +77,9 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_reset(task);
 
     if (!UCC_IS_INPLACE(coll_task->args)) {
-        status = ucc_mc_memcpy(PTR_OFFSET(rbuf, data_size *
-                                          task->subset.myrank),
-                               sbuf, data_size, rmem, smem);
+        status =
+            ucc_mc_memcpy(PTR_OFFSET(rbuf, data_size * task->subset.myrank),
+                          sbuf, data_size, rmem, smem);
         if (ucc_unlikely(UCC_OK != status)) {
             return status;
         }

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -23,7 +23,7 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
     ucc_memory_type_t  rmem       = coll_task->args.dst.info.mem_type;
     size_t             count      = coll_task->args.dst.info.count;
     ucc_datatype_t     dt         = coll_task->args.dst.info.datatype;
-    size_t             data_size  = (count / team->size) * ucc_dt_size(dt);
+    size_t             data_size  = (count / group_size) * ucc_dt_size(dt);
     ucc_rank_t         sendto     = (group_rank + 1) % group_size;
     ucc_rank_t         recvfrom   = (group_rank - 1 + group_size) % group_size;
     int                step;
@@ -70,7 +70,8 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
     ucc_memory_type_t  smem      = coll_task->args.src.info.mem_type;
     ucc_memory_type_t  rmem      = coll_task->args.dst.info.mem_type;
     ucc_datatype_t     dt        = coll_task->args.dst.info.datatype;
-    size_t             data_size = (count / team->size) * ucc_dt_size(dt);
+    size_t             data_size = (count / task->subset.map.ep_num) *
+        ucc_dt_size(dt);
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_ring_start", 0);

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -17,8 +17,8 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team       = TASK_TEAM(task);
-    ucc_rank_t         group_rank = team->rank;
-    ucc_rank_t         group_size = team->size;
+    ucc_rank_t         group_rank = task->subset.myrank;
+    ucc_rank_t         group_size = (ucc_rank_t)task->subset.map.ep_num;
     void              *rbuf       = coll_task->args.dst.info.buffer;
     ucc_memory_type_t  rmem       = coll_task->args.dst.info.mem_type;
     size_t             count      = coll_task->args.dst.info.count;
@@ -28,9 +28,12 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
     ucc_rank_t         recvfrom   = (group_rank - 1 + group_size) % group_size;
     int                step;
     void              *buf;
+
     if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
         return task->super.super.status;
     }
+    sendto   = ucc_ep_map_eval(task->subset.map, sendto);
+    recvfrom = ucc_ep_map_eval(task->subset.map, recvfrom);
 
     while (task->send_posted < group_size - 1) {
         step = task->send_posted;
@@ -74,7 +77,8 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_reset(task);
 
     if (!UCC_IS_INPLACE(coll_task->args)) {
-        status = ucc_mc_memcpy((void*)((ptrdiff_t)rbuf + data_size * team->rank),
+        status = ucc_mc_memcpy(PTR_OFFSET(rbuf, data_size *
+                                          task->subset.myrank),
                                sbuf, data_size, rmem, smem);
         if (ucc_unlikely(UCC_OK != status)) {
             return status;

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -85,9 +85,9 @@ UCC_KN_PHASE_EXTRA:
     while(!ucc_knomial_pattern_loop_done(p)) {
         for (loop_step = 1; loop_step < radix; loop_step++) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, size, loop_step);
-            peer = ucc_ep_map_eval(task->subset.map, peer);
             if (peer == UCC_KN_PEER_NULL)
                 continue;
+            peer = ucc_ep_map_eval(task->subset.map, peer);
             if ((p->iteration == 0) && (KN_NODE_PROXY != node_type) &&
                 !UCC_IS_INPLACE(*args)) {
                 send_buf = sbuf;
@@ -103,9 +103,9 @@ UCC_KN_PHASE_EXTRA:
         recv_offset = 0;
         for (loop_step = 1; loop_step < radix; loop_step++) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, size, loop_step);
-            peer = ucc_ep_map_eval(task->subset.map, peer);
             if (peer == UCC_KN_PEER_NULL)
                 continue;
+            peer = ucc_ep_map_eval(task->subset.map, peer);
             UCPCHECK_GOTO(
                 ucc_tl_ucp_recv_nb((void *)((ptrdiff_t)scratch + recv_offset),
                                    data_size, mem_type, peer, team, task),

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -84,16 +84,14 @@ static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {
 
     {"NPOLLS", "10",
      "Number of ucp progress polling cycles for p2p requests testing",
-     ucc_offsetof(ucc_tl_ucp_context_config_t, n_polls),
-     UCC_CONFIG_TYPE_UINT},
+     ucc_offsetof(ucc_tl_ucp_context_config_t, n_polls), UCC_CONFIG_TYPE_UINT},
 
     {"OOB_NPOLLS", "20",
      "Number of polling cycles for oob allgather and service coll request",
      ucc_offsetof(ucc_tl_ucp_context_config_t, oob_npolls),
      UCC_CONFIG_TYPE_UINT},
 
-    {"PRE_REG_MEM", "0",
-     "Pre Register collective memory region with UCX",
+    {"PRE_REG_MEM", "0", "Pre Register collective memory region with UCX",
      ucc_offsetof(ucc_tl_ucp_context_config_t, pre_reg_mem),
      UCC_CONFIG_TYPE_UINT},
 
@@ -132,9 +130,10 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
                                           ucc_tl_team_subset_t subset,
                                           ucc_coll_task_t **task);
 
-ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf, void *rbuf,
-                                          size_t msgsize, ucc_tl_team_subset_t subset,
-                                          ucc_coll_task_t **task_p);
+ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
+                                          void *rbuf, size_t msgsize,
+                                          ucc_tl_team_subset_t subset,
+                                          ucc_coll_task_t    **task_p);
 
 ucc_status_t ucc_tl_ucp_service_test(ucc_coll_task_t *task);
 

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -88,7 +88,7 @@ static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {
      UCC_CONFIG_TYPE_UINT},
 
     {"OOB_NPOLLS", "20",
-     "Number of polling cycles for oob allgather request",
+     "Number of polling cycles for oob allgather and service coll request",
      ucc_offsetof(ucc_tl_ucp_context_config_t, oob_npolls),
      UCC_CONFIG_TYPE_UINT},
 
@@ -131,6 +131,10 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
                                           size_t count, ucc_reduction_op_t op,
                                           ucc_tl_team_subset_t subset,
                                           ucc_coll_task_t **task);
+
+ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf, void *rbuf,
+                                          size_t msgsize, ucc_tl_team_subset_t subset,
+                                          ucc_coll_task_t **task_p);
 
 ucc_status_t ucc_tl_ucp_service_test(ucc_coll_task_t *task);
 
@@ -186,8 +190,7 @@ void ucc_tl_ucp_pre_register_mem(ucc_tl_ucp_team_t *team, void *addr,
 __attribute__((constructor)) static void tl_ucp_iface_init(void)
 {
     ucc_tl_ucp.super.scoll.allreduce = ucc_tl_ucp_service_allreduce;
-    ucc_tl_ucp.super.scoll.test      = ucc_tl_ucp_service_test;
-    ucc_tl_ucp.super.scoll.cleanup   = ucc_tl_ucp_service_cleanup;
+    ucc_tl_ucp.super.scoll.allgather = ucc_tl_ucp_service_allgather;
     ucc_tl_ucp.super.scoll.update_id = ucc_tl_ucp_service_update_id;
     ucc_tl_ucp.super.alg_info[ucc_ilog2(UCC_COLL_TYPE_ALLREDUCE)] =
         ucc_tl_ucp_allreduce_algs;

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -127,12 +127,12 @@ ucc_status_t ucc_tl_ucp_populate_rcache(void *addr, size_t length,
 ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
                                           void *rbuf, ucc_datatype_t dt,
                                           size_t count, ucc_reduction_op_t op,
-                                          ucc_tl_team_subset_t subset,
+                                          ucc_team_subset_t subset,
                                           ucc_coll_task_t **task);
 
 ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
                                           void *rbuf, size_t msgsize,
-                                          ucc_tl_team_subset_t subset,
+                                          ucc_team_subset_t subset,
                                           ucc_coll_task_t    **task_p);
 
 ucc_status_t ucc_tl_ucp_service_test(ucc_coll_task_t *task);

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -133,7 +133,7 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
 ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
                                           void *rbuf, size_t msgsize,
                                           ucc_team_subset_t subset,
-                                          ucc_coll_task_t    **task_p);
+                                          ucc_coll_task_t **task_p);
 
 ucc_status_t ucc_tl_ucp_service_test(ucc_coll_task_t *task);
 

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -26,14 +26,14 @@ extern const char
     } while (0)
 
 typedef struct ucc_tl_ucp_task {
-    ucc_coll_task_t      super;
-    uint32_t             send_posted;
-    uint32_t             send_completed;
-    uint32_t             recv_posted;
-    uint32_t             recv_completed;
-    uint32_t             tag;
-    uint32_t             n_polls;
-    ucc_tl_team_subset_t subset;
+    ucc_coll_task_t   super;
+    uint32_t          send_posted;
+    uint32_t          send_completed;
+    uint32_t          recv_posted;
+    uint32_t          recv_completed;
+    uint32_t          tag;
+    uint32_t          n_polls;
+    ucc_team_subset_t subset;
     union {
         struct {
             int                     phase;

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -153,7 +153,7 @@ err_cfg:
 static void ucc_tl_ucp_context_barrier(ucc_tl_ucp_context_t *ctx,
                                        ucc_context_oob_coll_t *oob)
 {
-    char        *rbuf = ucc_malloc(sizeof(char) * oob->participants,
+    char        *rbuf = ucc_malloc(sizeof(char) * oob->n_oob_eps,
                                    "tmp_barrier");
     ucc_status_t status;
     char         sbuf;
@@ -162,7 +162,7 @@ static void ucc_tl_ucp_context_barrier(ucc_tl_ucp_context_t *ctx,
     if (!rbuf) {
         tl_error(ctx->super.super.lib,
                  "failed to allocate %zd bytes for tmp barrier array",
-                 sizeof(char) * oob->participants);
+                 sizeof(char) * oob->n_oob_eps);
         return;
     }
     if (UCC_OK == oob->allgather(&sbuf, rbuf, sizeof(char), oob->coll_info,

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -68,5 +68,6 @@ ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
             return UCC_ERR_NO_RESOURCE;
     }
     attr->super.attr.coll_types = UCC_TL_UCP_SUPPORTED_COLLS;
+    attr->super.flags           = UCC_BASE_LIB_FLAG_TEAM_ID_REQUIRED;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -8,6 +8,7 @@
 #include "tl_ucp_coll.h"
 #include "tl_ucp_tag.h"
 #include "allreduce/allreduce.h"
+#include "allgather/allgather.h"
 
 ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
                                           void *rbuf, ucc_datatype_t dt,
@@ -41,9 +42,10 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
     }
     task->subset = subset;
     task->tag  = UCC_TL_UCP_SERVICE_TAG;
-    task->n_polls = 10; // TODO need a var ?
+    task->n_polls = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
-    *task_p = &task->super;
+    task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;
+
     status = ucc_tl_ucp_allreduce_knomial_init_common(task);
     if (status != UCC_OK) {
         goto free_task;
@@ -53,6 +55,7 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
         goto finalize_coll;
     }
 
+    *task_p = &task->super;
     return status;
 finalize_coll:
    ucc_tl_ucp_allreduce_knomial_finalize(*task_p);
@@ -61,15 +64,54 @@ free_task:
     return status;
 }
 
-ucc_status_t ucc_tl_ucp_service_test(ucc_coll_task_t *task)
+ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf, void *rbuf,
+                                          size_t msgsize, ucc_tl_team_subset_t subset,
+                                          ucc_coll_task_t **task_p)
 {
-    return task->super.status;
-}
+    ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_tl_ucp_task_t *task    = ucc_tl_ucp_get_task(tl_team);
+    ucc_status_t status;
 
+    int in_place = (sbuf ==
+                    PTR_OFFSET(rbuf, msgsize * ucc_ep_map_eval(subset.map, subset.myrank)));
+    ucc_coll_args_t args = {
+        .coll_type            = UCC_COLL_TYPE_ALLGATHER,
+        .mask                 = in_place ? UCC_COLL_ARGS_FLAG_IN_PLACE : 0 ,
+        .src.info = {
+            .buffer   = sbuf,
+            .count    = msgsize,
+            .datatype = UCC_DT_UINT8,
+            .mem_type = UCC_MEMORY_TYPE_HOST
+        },
+        .dst.info = {
+            .buffer   = rbuf,
+            .count    = msgsize,
+            .datatype = UCC_DT_UINT8,
+            .mem_type = UCC_MEMORY_TYPE_HOST
+        }
+    };
+    status = ucc_coll_task_init(&task->super, &args, team);
+    if (status != UCC_OK) {
+        goto free_task;
+    }
+    task->subset = subset;
+    task->tag  = UCC_TL_UCP_SERVICE_TAG;
+    task->n_polls = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
+    task->super.progress = ucc_tl_ucp_allgather_ring_progress;
+    task->super.finalize = ucc_tl_ucp_coll_finalize;
 
-void ucc_tl_ucp_service_cleanup(ucc_coll_task_t *task)
-{
-    ucc_tl_ucp_allreduce_knomial_finalize(task);
+    status = ucc_tl_ucp_allgather_ring_start(&task->super);
+    if (status != UCC_OK) {
+        goto finalize_coll;
+    }
+
+    *task_p = &task->super;
+    return status;
+finalize_coll:
+   ucc_tl_ucp_coll_finalize(*task_p);
+free_task:
+    ucc_tl_ucp_put_task(task);
+    return status;
 }
 
 void ucc_tl_ucp_service_update_id(ucc_base_team_t *team, uint16_t id) {

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -83,7 +83,7 @@ ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
                                          .datatype = UCC_DT_UINT8,
                                          .mem_type = UCC_MEMORY_TYPE_HOST},
                             .dst.info = {.buffer   = rbuf,
-                                         .count    = msgsize,
+                                         .count    = msgsize * subset.map.ep_num,
                                          .datatype = UCC_DT_UINT8,
                                          .mem_type = UCC_MEMORY_TYPE_HOST}};
 

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -13,7 +13,7 @@
 ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
                                           void *rbuf, ucc_datatype_t dt,
                                           size_t count, ucc_reduction_op_t op,
-                                          ucc_tl_team_subset_t subset,
+                                          ucc_team_subset_t subset,
                                           ucc_coll_task_t **task_p)
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
@@ -66,8 +66,8 @@ free_task:
 
 ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
                                           void *rbuf, size_t msgsize,
-                                          ucc_tl_team_subset_t subset,
-                                          ucc_coll_task_t    **task_p)
+                                          ucc_team_subset_t subset,
+                                          ucc_coll_task_t **task_p)
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_task_t *task    = ucc_tl_ucp_get_task(tl_team);

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -42,7 +42,7 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
     }
     task->subset = subset;
     task->tag  = UCC_TL_UCP_SERVICE_TAG;
-    task->n_polls = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
+    task->n_polls        = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;
 
@@ -64,39 +64,36 @@ free_task:
     return status;
 }
 
-ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf, void *rbuf,
-                                          size_t msgsize, ucc_tl_team_subset_t subset,
-                                          ucc_coll_task_t **task_p)
+ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
+                                          void *rbuf, size_t msgsize,
+                                          ucc_tl_team_subset_t subset,
+                                          ucc_coll_task_t    **task_p)
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_task_t *task    = ucc_tl_ucp_get_task(tl_team);
-    ucc_status_t status;
+    ucc_status_t       status;
 
-    int in_place = (sbuf ==
-                    PTR_OFFSET(rbuf, msgsize * ucc_ep_map_eval(subset.map, subset.myrank)));
-    ucc_coll_args_t args = {
-        .coll_type            = UCC_COLL_TYPE_ALLGATHER,
-        .mask                 = in_place ? UCC_COLL_ARGS_FLAG_IN_PLACE : 0 ,
-        .src.info = {
-            .buffer   = sbuf,
-            .count    = msgsize,
-            .datatype = UCC_DT_UINT8,
-            .mem_type = UCC_MEMORY_TYPE_HOST
-        },
-        .dst.info = {
-            .buffer   = rbuf,
-            .count    = msgsize,
-            .datatype = UCC_DT_UINT8,
-            .mem_type = UCC_MEMORY_TYPE_HOST
-        }
-    };
-    status = ucc_coll_task_init(&task->super, &args, team);
+    int in_place =
+        (sbuf == PTR_OFFSET(rbuf, msgsize * ucc_ep_map_eval(subset.map,
+                                                            subset.myrank)));
+    ucc_coll_args_t args = {.coll_type = UCC_COLL_TYPE_ALLGATHER,
+                            .mask = in_place ? UCC_COLL_ARGS_FLAG_IN_PLACE : 0,
+                            .src.info = {.buffer   = sbuf,
+                                         .count    = msgsize,
+                                         .datatype = UCC_DT_UINT8,
+                                         .mem_type = UCC_MEMORY_TYPE_HOST},
+                            .dst.info = {.buffer   = rbuf,
+                                         .count    = msgsize,
+                                         .datatype = UCC_DT_UINT8,
+                                         .mem_type = UCC_MEMORY_TYPE_HOST}};
+
+    status               = ucc_coll_task_init(&task->super, &args, team);
     if (status != UCC_OK) {
         goto free_task;
     }
-    task->subset = subset;
-    task->tag  = UCC_TL_UCP_SERVICE_TAG;
-    task->n_polls = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
+    task->subset         = subset;
+    task->tag            = UCC_TL_UCP_SERVICE_TAG;
+    task->n_polls        = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
     task->super.progress = ucc_tl_ucp_allgather_ring_progress;
     task->super.finalize = ucc_tl_ucp_coll_finalize;
 
@@ -108,7 +105,7 @@ ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf, voi
     *task_p = &task->super;
     return status;
 finalize_coll:
-   ucc_tl_ucp_coll_finalize(*task_p);
+    ucc_tl_ucp_coll_finalize(*task_p);
 free_task:
     ucc_tl_ucp_put_task(task);
     return status;

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -20,7 +20,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     /* TODO: init based on ctx settings and on params: need to check
              if all the necessary ranks mappings are provided */
     self->preconnect_task    = NULL;
-    self->size               = params->params.oob.participants;
+    self->size               = params->params.oob.n_oob_eps;
     self->scope              = params->scope;
     self->scope_id           = params->scope_id;
     self->rank               = params->rank;

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -16,6 +16,7 @@ typedef struct ucc_lib_info          ucc_lib_info_t;
 typedef struct ucc_cl_context        ucc_cl_context_t;
 typedef struct ucc_tl_context        ucc_tl_context_t;
 typedef struct ucc_cl_context_config ucc_cl_context_config_t;
+typedef struct ucc_tl_team           ucc_tl_team_t;
 
 typedef unsigned (*ucc_context_progress_fn_t)(void *progress_arg);
 typedef struct ucc_context_progress {
@@ -65,6 +66,7 @@ typedef struct ucc_context {
                                      OOB) context */
     ucc_topo_t              *topo;
     uint64_t                 cl_flags;
+    ucc_tl_team_t           *service_team;
 } ucc_context_t;
 
 typedef struct ucc_context_config {
@@ -75,6 +77,7 @@ typedef struct ucc_context_config {
     uint32_t                  estimated_num_eps;
     uint32_t                  estimated_num_ppn;
     uint32_t                  lock_free_progress_q;
+    uint32_t                  internal_oob;
 } ucc_context_config_t;
 
 /* Any internal UCC component (TL, CL, etc) may register its own

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -64,6 +64,7 @@ typedef struct ucc_context {
     ucc_rank_t               rank; /*< rank of a process in the "global" (with
                                      OOB) context */
     ucc_topo_t              *topo;
+    uint64_t                 cl_flags;
 } ucc_context_t;
 
 typedef struct ucc_context_config {

--- a/src/core/ucc_service_coll.c
+++ b/src/core/ucc_service_coll.c
@@ -17,7 +17,7 @@ uint64_t ucc_service_coll_map_cb(uint64_t ep, void *cb_ctx)
 }
 
 static inline ucc_status_t
-ucc_service_coll_req_init(ucc_team_t *team, ucc_tl_team_subset_t subset,
+ucc_service_coll_req_init(ucc_team_t *team, ucc_tl_team_subset_t *subset,
                           ucc_tl_team_t          **service_team,
                           ucc_service_coll_req_t **_req)
 {
@@ -32,13 +32,13 @@ ucc_service_coll_req_init(ucc_team_t *team, ucc_tl_team_subset_t subset,
         return UCC_ERR_NO_MEMORY;
     }
     req->team   = team;
-    req->subset = subset;
+    req->subset = *subset;
 
     if (ctx->service_team) {
-        *service_team        = ctx->service_team;
-        subset.map.type      = UCC_EP_MAP_CB;
-        subset.map.cb.cb     = ucc_service_coll_map_cb;
-        subset.map.cb.cb_ctx = req;
+        *service_team         = ctx->service_team;
+        subset->map.type      = UCC_EP_MAP_CB;
+        subset->map.cb.cb     = ucc_service_coll_map_cb;
+        subset->map.cb.cb_ctx = req;
     } else {
         ucc_assert(team->service_team);
         *service_team = team->service_team;
@@ -58,7 +58,7 @@ ucc_status_t ucc_service_allreduce(ucc_team_t *team, void *sbuf, void *rbuf,
     ucc_tl_iface_t *tl_iface;
     ucc_status_t    status;
 
-    status = ucc_service_coll_req_init(team, subset, &steam, req);
+    status = ucc_service_coll_req_init(team, &subset, &steam, req);
     if (UCC_OK != status) {
         return status;
     }
@@ -84,7 +84,7 @@ ucc_status_t ucc_service_allgather(ucc_team_t *team, void *sbuf, void *rbuf,
     ucc_tl_iface_t *tl_iface;
     ucc_status_t    status;
 
-    status = ucc_service_coll_req_init(team, subset, &steam, req);
+    status = ucc_service_coll_req_init(team, &subset, &steam, req);
     if (UCC_OK != status) {
         return status;
     }

--- a/src/core/ucc_service_coll.c
+++ b/src/core/ucc_service_coll.c
@@ -104,7 +104,13 @@ ucc_status_t ucc_service_allgather(ucc_team_t *team, void *sbuf, void *rbuf,
 
 ucc_status_t ucc_service_coll_test(ucc_service_coll_req_t *req)
 {
-    return ucc_collective_test(&req->task->super);
+    ucc_status_t status;
+
+    status = ucc_collective_test(&req->task->super);
+    if (UCC_INPROGRESS == status) {
+        ucc_context_progress(req->team->contexts[0]);
+    }
+    return status;
 }
 
 ucc_status_t ucc_service_coll_finalize(ucc_service_coll_req_t *req)

--- a/src/core/ucc_service_coll.c
+++ b/src/core/ucc_service_coll.c
@@ -1,0 +1,175 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_service_coll.h"
+#include "ucc_team.h"
+
+uint64_t ucc_service_coll_map_cb(uint64_t ep, void *cb_ctx)
+{
+    ucc_service_coll_req_t *req     = cb_ctx;
+    ucc_team_t             *team    = req->team;
+    ucc_rank_t              team_rank;
+
+    team_rank = ucc_ep_map_eval(req->subset.map, (ucc_rank_t)ep);
+    return ucc_ep_map_eval(team->ctx_map, team_rank);
+}
+
+static inline ucc_status_t
+ucc_service_coll_req_init(ucc_team_t *team, ucc_tl_team_subset_t subset,
+                          ucc_tl_team_t **service_team,
+                          ucc_service_coll_req_t **_req)
+{
+    ucc_context_t          *ctx = team->contexts[0];
+    ucc_service_coll_req_t *req;
+
+    req = ucc_malloc(sizeof(*req), "service_req");
+    if (!req) {
+        ucc_error("failed to allocate %zd bytes for service coll req",
+                  sizeof(*req));
+        return UCC_ERR_NO_MEMORY;
+    }
+    req->team   = team;
+    req->subset = subset;
+
+    if (ctx->service_team) {
+        *service_team        = ctx->service_team;
+        subset.map.type      = UCC_EP_MAP_CB;
+        subset.map.cb.cb     = ucc_service_coll_map_cb;
+        subset.map.cb.cb_ctx = req;
+    } else {
+        ucc_assert(team->service_team);
+        *service_team = team->service_team;
+    }
+
+    *_req = req;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_service_allreduce(ucc_team_t *team, void *sbuf, void *rbuf,
+                                   ucc_datatype_t dt, size_t count,
+                                   ucc_reduction_op_t op,
+                                   ucc_tl_team_subset_t subset,
+                                   ucc_service_coll_req_t **req)
+{
+    ucc_tl_team_t          *steam;
+    ucc_tl_iface_t         *tl_iface;
+    ucc_status_t            status;
+
+    status = ucc_service_coll_req_init(team, subset, &steam, req);
+    if (UCC_OK != status) {
+        return status;
+    }
+
+    tl_iface = UCC_TL_TEAM_IFACE(steam);
+    status = tl_iface->scoll.allreduce(&steam->super, sbuf, rbuf, dt, count,
+                                       op, subset, &(*req)->task);
+    if (status < 0) {
+        ucc_free(*req);
+        ucc_error("failed to start service allreduce for team %p: %s",
+                  team, ucc_status_string(status));
+        return status;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_service_allgather(ucc_team_t *team, void *sbuf, void *rbuf,
+                                   size_t msgsize,
+                                   ucc_tl_team_subset_t subset,
+                                   ucc_service_coll_req_t **req)
+{
+    ucc_tl_team_t          *steam;
+    ucc_tl_iface_t         *tl_iface;
+    ucc_status_t            status;
+
+    status = ucc_service_coll_req_init(team, subset, &steam, req);
+    if (UCC_OK != status) {
+        return status;
+    }
+
+    tl_iface = UCC_TL_TEAM_IFACE(steam);
+    status = tl_iface->scoll.allgather(&steam->super, sbuf, rbuf, msgsize,
+                                       subset, &(*req)->task);
+    if (status < 0) {
+        ucc_free(*req);
+        ucc_error("failed to start service allreduce for team %p: %s",
+                  team, ucc_status_string(status));
+        return status;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_service_coll_test(ucc_service_coll_req_t *req)
+{
+    return ucc_collective_test(&req->task->super);
+}
+
+ucc_status_t ucc_service_coll_finalize(ucc_service_coll_req_t *req)
+{
+    ucc_status_t status;
+
+    status = ucc_collective_finalize(&req->task->super);
+    ucc_free(req);
+    return status;
+}
+
+typedef struct ucc_internal_oob_coll_info {
+    ucc_team_t          *team;
+    ucc_tl_team_subset_t subset;
+} ucc_internal_oob_coll_info_t;
+
+
+static ucc_status_t ucc_internal_oob_allgather(void *sbuf, void *rbuf, size_t size,
+                                        void* coll_info, void **request)
+{
+    ucc_internal_oob_coll_info_t *ci = coll_info;
+    ucc_service_coll_req_t       *req;
+    ucc_status_t                  status;
+
+    status = ucc_service_allgather(ci->team, sbuf, rbuf, size, ci->subset, &req);
+    *request = (void*)req;
+    return status;
+}
+
+static ucc_status_t ucc_internal_oob_test(void *request)
+{
+    ucc_service_coll_req_t *req = request;
+    return ucc_service_coll_test(req);
+}
+
+static ucc_status_t ucc_internal_oob_free(void *request)
+{
+    ucc_service_coll_req_t *req = request;
+    return ucc_service_coll_finalize(req);
+}
+
+ucc_status_t ucc_internal_oob_init(ucc_team_t *team, ucc_tl_team_subset_t subset,
+                                   ucc_team_oob_coll_t *oob)
+{
+    ucc_internal_oob_coll_info_t *ci;
+
+    ci = ucc_malloc(sizeof(*ci), "internal_coll_info");
+    if (!ci) {
+        ucc_error("failed to allocate %zd bytes for internal_coll_info",
+                  sizeof(*ci));
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    ci->team          = team;
+    ci->subset        = subset;
+    oob->coll_info    = ci;
+    oob->allgather    = ucc_internal_oob_allgather;
+    oob->req_test     = ucc_internal_oob_test;
+    oob->req_free     = ucc_internal_oob_free;
+    oob->participants = (uint32_t)subset.map.ep_num;
+
+    return UCC_OK;
+}
+
+void ucc_internal_oob_finalize(ucc_team_oob_coll_t *oob)
+{
+    ucc_free(oob->coll_info);
+}

--- a/src/core/ucc_service_coll.c
+++ b/src/core/ucc_service_coll.c
@@ -166,13 +166,14 @@ ucc_status_t ucc_internal_oob_init(ucc_team_t          *team,
         return UCC_ERR_NO_MEMORY;
     }
 
-    ci->team          = team;
-    ci->subset        = subset;
-    oob->coll_info    = ci;
-    oob->allgather    = ucc_internal_oob_allgather;
-    oob->req_test     = ucc_internal_oob_test;
-    oob->req_free     = ucc_internal_oob_free;
-    oob->participants = (uint32_t)subset.map.ep_num;
+    ci->team       = team;
+    ci->subset     = subset;
+    oob->coll_info = ci;
+    oob->allgather = ucc_internal_oob_allgather;
+    oob->req_test  = ucc_internal_oob_test;
+    oob->req_free  = ucc_internal_oob_free;
+    oob->n_oob_eps = (uint32_t)subset.map.ep_num;
+    oob->oob_ep    = (uint32_t)subset.myrank;
 
     return UCC_OK;
 }

--- a/src/core/ucc_service_coll.c
+++ b/src/core/ucc_service_coll.c
@@ -17,7 +17,7 @@ uint64_t ucc_service_coll_map_cb(uint64_t ep, void *cb_ctx)
 }
 
 static inline ucc_status_t
-ucc_service_coll_req_init(ucc_team_t *team, ucc_tl_team_subset_t *subset,
+ucc_service_coll_req_init(ucc_team_t *team, ucc_team_subset_t *subset,
                           ucc_tl_team_t          **service_team,
                           ucc_service_coll_req_t **_req)
 {
@@ -51,7 +51,7 @@ ucc_service_coll_req_init(ucc_team_t *team, ucc_tl_team_subset_t *subset,
 ucc_status_t ucc_service_allreduce(ucc_team_t *team, void *sbuf, void *rbuf,
                                    ucc_datatype_t dt, size_t count,
                                    ucc_reduction_op_t       op,
-                                   ucc_tl_team_subset_t     subset,
+                                   ucc_team_subset_t        subset,
                                    ucc_service_coll_req_t **req)
 {
     ucc_tl_team_t  *steam;
@@ -77,7 +77,7 @@ ucc_status_t ucc_service_allreduce(ucc_team_t *team, void *sbuf, void *rbuf,
 }
 
 ucc_status_t ucc_service_allgather(ucc_team_t *team, void *sbuf, void *rbuf,
-                                   size_t msgsize, ucc_tl_team_subset_t subset,
+                                   size_t msgsize, ucc_team_subset_t subset,
                                    ucc_service_coll_req_t **req)
 {
     ucc_tl_team_t  *steam;
@@ -118,7 +118,7 @@ ucc_status_t ucc_service_coll_finalize(ucc_service_coll_req_t *req)
 
 typedef struct ucc_internal_oob_coll_info {
     ucc_team_t          *team;
-    ucc_tl_team_subset_t subset;
+    ucc_team_subset_t    subset;
 } ucc_internal_oob_coll_info_t;
 
 static ucc_status_t ucc_internal_oob_allgather(void *sbuf, void *rbuf,
@@ -148,7 +148,7 @@ static ucc_status_t ucc_internal_oob_free(void *request)
 }
 
 ucc_status_t ucc_internal_oob_init(ucc_team_t          *team,
-                                   ucc_tl_team_subset_t subset,
+                                   ucc_team_subset_t    subset,
                                    ucc_team_oob_coll_t *oob)
 {
     ucc_internal_oob_coll_info_t *ci;

--- a/src/core/ucc_service_coll.h
+++ b/src/core/ucc_service_coll.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_SERVICE_COLL_H_
+#define UCC_SERVICE_COLL_H_
+
+#include "ucc/api/ucc.h"
+#include "components/tl/ucc_tl.h"
+
+typedef struct ucc_service_coll_req {
+    ucc_coll_task_t     *task;
+    ucc_team_t          *team;
+    ucc_tl_team_subset_t subset;
+} ucc_service_coll_req_t;
+
+ucc_status_t ucc_service_allreduce(ucc_team_t *team, void *sbuf, void *rbuf,
+                                   ucc_datatype_t dt, size_t count, ucc_reduction_op_t op,
+                                   ucc_tl_team_subset_t subset, ucc_service_coll_req_t **req);
+
+ucc_status_t ucc_service_allgather(ucc_team_t *team, void *sbuf, void *rbuf,
+                                   size_t msgsize,
+                                   ucc_tl_team_subset_t subset,
+                                   ucc_service_coll_req_t **req);
+
+ucc_status_t ucc_service_coll_test(ucc_service_coll_req_t *req);
+
+ucc_status_t ucc_service_coll_finalize(ucc_service_coll_req_t *req);
+
+ucc_status_t ucc_internal_oob_init(ucc_team_t *team, ucc_tl_team_subset_t subset,
+                                   ucc_team_oob_coll_t *oob);
+
+void ucc_internal_oob_finalize(ucc_team_oob_coll_t *oob);
+#endif

--- a/src/core/ucc_service_coll.h
+++ b/src/core/ucc_service_coll.h
@@ -10,19 +10,19 @@
 #include "components/tl/ucc_tl.h"
 
 typedef struct ucc_service_coll_req {
-    ucc_coll_task_t     *task;
-    ucc_team_t          *team;
-    ucc_tl_team_subset_t subset;
+    ucc_coll_task_t  *task;
+    ucc_team_t       *team;
+    ucc_team_subset_t subset;
 } ucc_service_coll_req_t;
 
 ucc_status_t ucc_service_allreduce(ucc_team_t *team, void *sbuf, void *rbuf,
                                    ucc_datatype_t dt, size_t count,
                                    ucc_reduction_op_t       op,
-                                   ucc_tl_team_subset_t     subset,
+                                   ucc_team_subset_t        subset,
                                    ucc_service_coll_req_t **req);
 
 ucc_status_t ucc_service_allgather(ucc_team_t *team, void *sbuf, void *rbuf,
-                                   size_t msgsize, ucc_tl_team_subset_t subset,
+                                   size_t msgsize, ucc_team_subset_t subset,
                                    ucc_service_coll_req_t **req);
 
 ucc_status_t ucc_service_coll_test(ucc_service_coll_req_t *req);
@@ -30,7 +30,7 @@ ucc_status_t ucc_service_coll_test(ucc_service_coll_req_t *req);
 ucc_status_t ucc_service_coll_finalize(ucc_service_coll_req_t *req);
 
 ucc_status_t ucc_internal_oob_init(ucc_team_t          *team,
-                                   ucc_tl_team_subset_t subset,
+                                   ucc_team_subset_t    subset,
                                    ucc_team_oob_coll_t *oob);
 
 void ucc_internal_oob_finalize(ucc_team_oob_coll_t *oob);

--- a/src/core/ucc_service_coll.h
+++ b/src/core/ucc_service_coll.h
@@ -16,19 +16,21 @@ typedef struct ucc_service_coll_req {
 } ucc_service_coll_req_t;
 
 ucc_status_t ucc_service_allreduce(ucc_team_t *team, void *sbuf, void *rbuf,
-                                   ucc_datatype_t dt, size_t count, ucc_reduction_op_t op,
-                                   ucc_tl_team_subset_t subset, ucc_service_coll_req_t **req);
+                                   ucc_datatype_t dt, size_t count,
+                                   ucc_reduction_op_t       op,
+                                   ucc_tl_team_subset_t     subset,
+                                   ucc_service_coll_req_t **req);
 
 ucc_status_t ucc_service_allgather(ucc_team_t *team, void *sbuf, void *rbuf,
-                                   size_t msgsize,
-                                   ucc_tl_team_subset_t subset,
+                                   size_t msgsize, ucc_tl_team_subset_t subset,
                                    ucc_service_coll_req_t **req);
 
 ucc_status_t ucc_service_coll_test(ucc_service_coll_req_t *req);
 
 ucc_status_t ucc_service_coll_finalize(ucc_service_coll_req_t *req);
 
-ucc_status_t ucc_internal_oob_init(ucc_team_t *team, ucc_tl_team_subset_t subset,
+ucc_status_t ucc_internal_oob_init(ucc_team_t          *team,
+                                   ucc_tl_team_subset_t subset,
                                    ucc_team_oob_coll_t *oob);
 
 void ucc_internal_oob_finalize(ucc_team_oob_coll_t *oob);

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -8,6 +8,7 @@
 #include "ucc_lib.h"
 #include "components/cl/ucc_cl.h"
 #include "components/tl/ucc_tl.h"
+#include "ucc_service_coll.h"
 
 static ucc_status_t ucc_team_alloc_id(ucc_team_t *team);
 static void ucc_team_relase_id(ucc_team_t *team);
@@ -35,11 +36,13 @@ void ucc_copy_team_params(ucc_team_params_t *dst, const ucc_team_params_t *src)
 static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
                                                 ucc_team_t *team)
 {
-    if ((team->params.mask & UCC_TEAM_PARAM_FIELD_EP) &&
-        (team->params.mask & UCC_TEAM_PARAM_FIELD_EP_RANGE) &&
-        (team->params.ep_range == UCC_COLLECTIVE_EP_RANGE_CONTIG)) {
+    ucc_status_t status;
+
+    if ((team->bp.params.mask & UCC_TEAM_PARAM_FIELD_EP) &&
+        (team->bp.params.mask & UCC_TEAM_PARAM_FIELD_EP_RANGE) &&
+        (team->bp.params.ep_range == UCC_COLLECTIVE_EP_RANGE_CONTIG)) {
         team->rank =
-            team->params.ep; //TODO need to make sure we don't exceed rank size
+            team->bp.params.ep; //TODO need to make sure we don't exceed rank size
     } else {
         ucc_error(
             "rank value of a process is not provided via ucc_team_params.ep "
@@ -47,12 +50,28 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
             "not supported yet...");
         return UCC_ERR_NOT_SUPPORTED;
     }
+
+    if (context->service_team)  {
+        /* User internal service team for OOB */
+        ucc_tl_team_subset_t subset = {
+            .myrank     = team->rank,
+            .map.ep_num = team->size,
+            .map.type   = UCC_EP_MAP_FULL
+        };
+        status = ucc_internal_oob_init(team, subset, &team->bp.params.oob);
+        if (UCC_OK != status) {
+            return status;
+        }
+    }
+
     team->cl_teams = ucc_malloc(sizeof(ucc_cl_team_t *) * context->n_cl_ctx);
     if (!team) {
         ucc_error("failed to allocate %zd bytes for cl teams array",
                   sizeof(ucc_cl_team_t *) * context->n_cl_ctx);
         return UCC_ERR_NO_MEMORY;
     }
+    team->bp.rank                 = team->rank;
+    team->bp.team                 = team;
     team->state                   = UCC_TEAM_ADDR_EXCHANGE;
     team->last_team_create_posted = -1;
     team->status                  = UCC_INPROGRESS;
@@ -101,7 +120,7 @@ ucc_status_t ucc_team_create_post(ucc_context_h *contexts, uint32_t num_contexts
                   sizeof(ucc_team_t));
         return UCC_ERR_NO_MEMORY;
     }
-
+    team->runtime_oob  = params->oob;
     team->num_contexts = num_contexts;
     team->size         = team_size;
     team->contexts =
@@ -114,7 +133,7 @@ ucc_status_t ucc_team_create_post(ucc_context_h *contexts, uint32_t num_contexts
     }
 
     memcpy(team->contexts, contexts, sizeof(ucc_context_t *) * num_contexts);
-    ucc_copy_team_params(&team->params, params);
+    ucc_copy_team_params(&team->bp.params, params);
     /* check if user provides team id and if it is not too large */
     if ((params->mask & UCC_TEAM_PARAM_FIELD_ID) &&
         (params->id <= UCC_TEAM_ID_MAX)) {
@@ -134,6 +153,11 @@ static inline ucc_status_t
 ucc_team_create_service_team(ucc_context_t *context, ucc_team_t *team)
 {
     ucc_status_t status;
+    if (context->service_team) {
+        /* Global single service team is allocated on ucc_context.
+           UCC_INTERNAL_OOB is enabled. Don't need another service team */
+        return UCC_OK;
+    }
     if (!team->service_team) {
         ucc_base_team_params_t b_params;
         ucc_base_team_t *      b_team;
@@ -143,8 +167,7 @@ ucc_team_create_service_team(ucc_context_t *context, ucc_team_t *team)
                      "service team can not be created");
             return status;
         }
-        memcpy(&b_params, &team->params, sizeof(ucc_team_params_t));
-        b_params.rank = team->rank;
+        memcpy(&b_params, &team->bp, sizeof(ucc_base_team_params_t));
         b_params.scope =
             UCC_CL_LAST + 1; // CORE scopre id - never overlaps with CL type
         b_params.scope_id = 0;
@@ -175,7 +198,6 @@ ucc_team_create_cls(ucc_context_t *context, ucc_team_t *team)
     ucc_cl_iface_t        *cl_iface;
     ucc_base_team_t       *b_team;
     ucc_status_t           status;
-    ucc_base_team_params_t b_params;
 
     if (context->topo && !team->topo) {
         /* Context->topo is not NULL if any of the enabled CLs
@@ -197,14 +219,11 @@ ucc_team_create_cls(ucc_context_t *context, ucc_team_t *team)
             return status;
         }
     }
-    memcpy(&b_params.params, &team->params, sizeof(ucc_team_params_t));
-    b_params.rank = team->rank;
-    b_params.id   = team->id;
-    b_params.team = team;
+
     for (i = team->last_team_create_posted + 1; i < context->n_cl_ctx; i++) {
         cl_iface = UCC_CL_CTX_IFACE(context->cl_ctx[i]);
         status   = cl_iface->team.create_post(&context->cl_ctx[i]->super,
-                                            &b_params, &b_team);
+                                            &team->bp, &b_team);
         if (status != UCC_OK) {
             ucc_info("failed to create CL %s team", cl_iface->super.name);
             /* TODO: see comment above*/
@@ -235,12 +254,14 @@ ucc_team_create_cls(ucc_context_t *context, ucc_team_t *team)
 static inline ucc_status_t ucc_team_exchange(ucc_context_t *context,
                                              ucc_team_t *   team)
 {
-    ucc_status_t status;
+    ucc_team_oob_coll_t oob = team->runtime_oob;
+    ucc_status_t        status;
+
     if (!context->addr_storage.storage) {
         /* There is no addresses collected on the context
            (can be, e.g., if user did not pass OOB for ctx
            creation). Need to exchange addresses here*/
-        return ucc_core_addr_exchange(context, NULL, &team->params.oob,
+        return ucc_core_addr_exchange(context, NULL, &oob,
                                       &team->addr_storage);
     }
     /* We only need to exchange ctx_ranks and build map to ctx array */
@@ -253,24 +274,24 @@ static inline ucc_status_t ucc_team_exchange(ucc_context_t *context,
                       team->size * sizeof(ucc_rank_t));
             return UCC_ERR_NO_MEMORY;
         }
-        status = team->params.oob.allgather(
+        status = oob.allgather(
             &context->rank, team->ctx_ranks, sizeof(ucc_rank_t),
-            team->params.oob.coll_info, &team->oob_req);
+            oob.coll_info, &team->oob_req);
         if (UCC_OK != status) {
             ucc_error("failed to start oob allgather for proc info exchange");
             ucc_free(team->ctx_ranks);
             return status;
         }
     }
-    status = team->params.oob.req_test(team->oob_req);
+    status = oob.req_test(team->oob_req);
     if (status < 0) {
-        team->params.oob.req_free(team->oob_req);
+        oob.req_free(team->oob_req);
         ucc_error("oob req test failed during team proc info exchange");
         return status;
     } else if (UCC_INPROGRESS == status) {
         return status;
     }
-    team->params.oob.req_free(team->oob_req);
+    oob.req_free(team->oob_req);
     ucc_assert(team->size >= 2);
     team->ctx_map = ucc_ep_map_from_array(&team->ctx_ranks, team->size,
                                           context->addr_storage.size, 1);
@@ -283,6 +304,7 @@ ucc_status_t ucc_team_create_test_single(ucc_context_t *context,
                                          ucc_team_t    *team)
 {
     ucc_status_t status = UCC_OK;
+
     switch (team->state) {
     case UCC_TEAM_ADDR_EXCHANGE:
         status = ucc_team_exchange(context, team);
@@ -310,6 +332,7 @@ ucc_status_t ucc_team_create_test_single(ucc_context_t *context,
                 goto out;
             }
         }
+        team->bp.id = team->id;
         team->state = UCC_TEAM_CL_CREATE;
         if (team->service_team) {
             /* update serivice team id */
@@ -363,7 +386,13 @@ static ucc_status_t ucc_team_destroy_single(ucc_team_h team)
         }
         team->cl_teams[i] = NULL;
     }
+
     ucc_team_topo_cleanup(team->topo);
+
+    if (team->contexts[0]->service_team) {
+        ucc_internal_oob_finalize(&team->bp.params.oob);
+    }
+
     ucc_free(team->addr_storage.storage);
     ucc_free(team->ctx_ranks);
     ucc_team_relase_id(team);
@@ -414,16 +443,15 @@ static ucc_status_t ucc_team_alloc_id(ucc_team_t *team)
 {
     /* at least 1 ctx is always available */
     ucc_context_t   *ctx      = team->contexts[0];
-    ucc_tl_iface_t  *tl_iface = UCC_TL_TEAM_IFACE(team->service_team);
     uint64_t        *local, *global;
     ucc_status_t     status;
     int              pos, i;
-    /* TODO: check if team id is required by CLs/TLs */
+
     if (team->id > 0) {
         ucc_assert(UCC_TEAM_ID_IS_EXTERNAL(team));
         return UCC_OK;
     }
-    ucc_assert(team->service_team);
+
     if (!ctx->ids.pool) {
         ctx->ids.pool = ucc_malloc(ctx->ids.pool_size*2*sizeof(uint64_t), "ids_pool");
         if (!ctx->ids.pool) {
@@ -437,23 +465,21 @@ static ucc_status_t ucc_team_alloc_id(ucc_team_t *team)
     local  = ctx->ids.pool;
     global = ctx->ids.pool + ctx->ids.pool_size;
 
-    if (!team->task) {
+    if (!team->sreq) {
         ucc_tl_team_subset_t subset = {
             .map.type   = UCC_EP_MAP_FULL,
-            .map.ep_num = team->params.oob.participants,
+            .map.ep_num = team->size,
             .myrank     = team->rank
         };
-        status = tl_iface->scoll.allreduce(
-            &team->service_team->super, local, global, UCC_DT_UINT64, ctx->ids.pool_size, UCC_OP_BAND,
-            subset, &team->task);
+        status = ucc_service_allreduce(team, local, global, UCC_DT_UINT64,
+                                       ctx->ids.pool_size, UCC_OP_BAND,
+                                       subset, &team->sreq);
         if (status < 0) {
-            ucc_error("failed to start service allreduce for team ids pool allocation: %s",
-                      ucc_status_string(status));
             return status;
         }
     }
     ucc_context_progress(ctx);
-    status = tl_iface->scoll.test(team->task);
+    status = ucc_service_coll_test(team->sreq);
     if (status < 0) {
         ucc_error("service allreduce test failure: %s",
                   ucc_status_string(status));
@@ -461,8 +487,8 @@ static ucc_status_t ucc_team_alloc_id(ucc_team_t *team)
     } else if (status != UCC_OK) {
         return status;
     }
-    tl_iface->scoll.cleanup(team->task);
-    team->task = NULL;
+    ucc_service_coll_finalize(team->sreq);
+    team->sreq = NULL;
     memcpy(local, global, ctx->ids.pool_size*sizeof(uint64_t));
     pos = 0;
     for (i=0; i<ctx->ids.pool_size; i++) {

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -53,9 +53,9 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
 
     if (context->service_team) {
         /* User internal service team for OOB */
-        ucc_tl_team_subset_t subset = {.myrank     = team->rank,
-                                       .map.ep_num = team->size,
-                                       .map.type   = UCC_EP_MAP_FULL};
+        ucc_team_subset_t subset = {.myrank     = team->rank,
+                                    .map.ep_num = team->size,
+                                    .map.type   = UCC_EP_MAP_FULL};
         status = ucc_internal_oob_init(team, subset, &team->bp.params.oob);
         if (UCC_OK != status) {
             return status;
@@ -463,9 +463,9 @@ static ucc_status_t ucc_team_alloc_id(ucc_team_t *team)
     global = ctx->ids.pool + ctx->ids.pool_size;
 
     if (!team->sreq) {
-        ucc_tl_team_subset_t subset = {.map.type   = UCC_EP_MAP_FULL,
-                                       .map.ep_num = team->size,
-                                       .myrank     = team->rank};
+        ucc_team_subset_t subset = {.map.type   = UCC_EP_MAP_FULL,
+                                    .map.ep_num = team->size,
+                                    .myrank     = team->rank};
         status = ucc_service_allreduce(team, local, global, UCC_DT_UINT64,
                                        ctx->ids.pool_size, UCC_OP_BAND, subset,
                                        &team->sreq);

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -41,8 +41,8 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
     if ((team->bp.params.mask & UCC_TEAM_PARAM_FIELD_EP) &&
         (team->bp.params.mask & UCC_TEAM_PARAM_FIELD_EP_RANGE) &&
         (team->bp.params.ep_range == UCC_COLLECTIVE_EP_RANGE_CONTIG)) {
-        team->rank =
-            team->bp.params.ep; //TODO need to make sure we don't exceed rank size
+        /* TODO need to make sure we don't exceed rank size */
+        team->rank = team->bp.params.ep;
     } else {
         ucc_error(
             "rank value of a process is not provided via ucc_team_params.ep "
@@ -51,13 +51,11 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    if (context->service_team)  {
+    if (context->service_team) {
         /* User internal service team for OOB */
-        ucc_tl_team_subset_t subset = {
-            .myrank     = team->rank,
-            .map.ep_num = team->size,
-            .map.type   = UCC_EP_MAP_FULL
-        };
+        ucc_tl_team_subset_t subset = {.myrank     = team->rank,
+                                       .map.ep_num = team->size,
+                                       .map.type   = UCC_EP_MAP_FULL};
         status = ucc_internal_oob_init(team, subset, &team->bp.params.oob);
         if (UCC_OK != status) {
             return status;
@@ -261,8 +259,7 @@ static inline ucc_status_t ucc_team_exchange(ucc_context_t *context,
         /* There is no addresses collected on the context
            (can be, e.g., if user did not pass OOB for ctx
            creation). Need to exchange addresses here*/
-        return ucc_core_addr_exchange(context, NULL, &oob,
-                                      &team->addr_storage);
+        return ucc_core_addr_exchange(context, NULL, &oob, &team->addr_storage);
     }
     /* We only need to exchange ctx_ranks and build map to ctx array */
     ucc_assert(context->addr_storage.storage);
@@ -274,9 +271,9 @@ static inline ucc_status_t ucc_team_exchange(ucc_context_t *context,
                       team->size * sizeof(ucc_rank_t));
             return UCC_ERR_NO_MEMORY;
         }
-        status = oob.allgather(
-            &context->rank, team->ctx_ranks, sizeof(ucc_rank_t),
-            oob.coll_info, &team->oob_req);
+        status =
+            oob.allgather(&context->rank, team->ctx_ranks, sizeof(ucc_rank_t),
+                          oob.coll_info, &team->oob_req);
         if (UCC_OK != status) {
             ucc_error("failed to start oob allgather for proc info exchange");
             ucc_free(team->ctx_ranks);
@@ -466,14 +463,12 @@ static ucc_status_t ucc_team_alloc_id(ucc_team_t *team)
     global = ctx->ids.pool + ctx->ids.pool_size;
 
     if (!team->sreq) {
-        ucc_tl_team_subset_t subset = {
-            .map.type   = UCC_EP_MAP_FULL,
-            .map.ep_num = team->size,
-            .myrank     = team->rank
-        };
+        ucc_tl_team_subset_t subset = {.map.type   = UCC_EP_MAP_FULL,
+                                       .map.ep_num = team->size,
+                                       .myrank     = team->rank};
         status = ucc_service_allreduce(team, local, global, UCC_DT_UINT64,
-                                       ctx->ids.pool_size, UCC_OP_BAND,
-                                       subset, &team->sreq);
+                                       ctx->ids.pool_size, UCC_OP_BAND, subset,
+                                       &team->sreq);
         if (status < 0) {
             return status;
         }

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -68,8 +68,10 @@ ucc_get_team_ep_header(ucc_context_t *context, ucc_team_t *team,
     ucc_addr_storage_t *storage      = context->addr_storage.storage
                                            ? &context->addr_storage
                                            : &team->addr_storage;
-    ucc_rank_t          storage_rank = context->addr_storage.storage
-        ? (team ? ucc_ep_map_eval(team->ctx_map, rank) : rank) : rank;
+    ucc_rank_t          storage_rank =
+        context->addr_storage.storage
+                     ? (team ? ucc_ep_map_eval(team->ctx_map, rank) : rank)
+                     : rank;
 
     return UCC_ADDR_STORAGE_RANK_HEADER(storage, storage_rank);
 }

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -11,11 +11,12 @@
 #include "utils/ucc_coll_utils.h"
 #include "ucc_context.h"
 #include "utils/ucc_math.h"
+#include "components/base/ucc_base_iface.h"
 
-typedef struct ucc_context ucc_context_t;
-typedef struct ucc_cl_team ucc_cl_team_t;
-typedef struct ucc_tl_team ucc_tl_team_t;
-typedef struct ucc_coll_task ucc_coll_task_t;
+typedef struct ucc_context          ucc_context_t;
+typedef struct ucc_cl_team          ucc_cl_team_t;
+typedef struct ucc_tl_team          ucc_tl_team_t;
+typedef struct ucc_service_coll_req ucc_service_coll_req_t;
 typedef enum {
     UCC_TEAM_ADDR_EXCHANGE,
     UCC_TEAM_SERVICE_TEAM,
@@ -24,23 +25,24 @@ typedef enum {
 } ucc_team_state_t;
 
 typedef struct ucc_team {
-    ucc_status_t       status;
-    ucc_team_state_t   state;
-    ucc_context_t **   contexts;
-    uint32_t           num_contexts;
-    ucc_team_params_t  params;
-    ucc_cl_team_t **   cl_teams;
-    int                n_cl_teams;
-    int                last_team_create_posted;
-    uint16_t           id; /*< context-uniq team identifier */
-    ucc_rank_t         rank;
-    ucc_rank_t         size;
-    ucc_tl_team_t *    service_team;
-    ucc_coll_task_t *  task;
-    ucc_addr_storage_t addr_storage; /*< addresses of team endpoints */
-    ucc_rank_t *       ctx_ranks;
-    void *             oob_req;
-    ucc_ep_map_t       ctx_map; /*< map to the ctx ranks, defined if CTX
+    ucc_status_t            status;
+    ucc_team_state_t        state;
+    ucc_context_t **        contexts;
+    uint32_t                num_contexts;
+    ucc_base_team_params_t  bp;
+    ucc_team_oob_coll_t     runtime_oob;
+    ucc_cl_team_t **        cl_teams;
+    int                     n_cl_teams;
+    int                     last_team_create_posted;
+    uint16_t                id; /*< context-uniq team identifier */
+    ucc_rank_t              rank;
+    ucc_rank_t              size;
+    ucc_tl_team_t *         service_team;
+    ucc_service_coll_req_t *sreq;
+    ucc_addr_storage_t      addr_storage; /*< addresses of team endpoints */
+    ucc_rank_t *            ctx_ranks;
+    void *                  oob_req;
+    ucc_ep_map_t            ctx_map; /*< map to the ctx ranks, defined if CTX
                                   type is global (oob provided) */
     ucc_team_topo_t   *topo;
 } ucc_team_t;
@@ -67,8 +69,7 @@ ucc_get_team_ep_header(ucc_context_t *context, ucc_team_t *team,
                                            ? &context->addr_storage
                                            : &team->addr_storage;
     ucc_rank_t          storage_rank = context->addr_storage.storage
-                                           ? ucc_ep_map_eval(team->ctx_map, rank)
-                                           : rank;
+        ? (team ? ucc_ep_map_eval(team->ctx_map, rank) : rank) : rank;
 
     return UCC_ADDR_STORAGE_RANK_HEADER(storage, storage_rank);
 }

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -639,15 +639,26 @@ enum ucc_context_attr_field {
  *
  * @brief OOB collective operation for creating the context
  */
-typedef struct ucc_context_oob_coll {
+typedef struct ucc_oob_coll {
     ucc_status_t    (*allgather)(void *src_buf, void *recv_buf, size_t size,
                                  void *allgather_info,  void **request);
     ucc_status_t    (*req_test)(void *request);
     ucc_status_t    (*req_free)(void *request);
-    uint32_t        participants;
     void            *coll_info;
-}  ucc_context_oob_coll_t;
+    uint32_t        n_oob_eps; /*!< Number of endpoints participating in the
+                                    oob operation (e.g., number of processes
+                                    representing a ucc team) */
+    uint32_t        oob_ep; /*!< Integer value that represents the position
+                                 of the calling processes in the given oob op:
+                                 the data specified by "src_buf" will be placed
+                                 at the offset "oob_ep*size" in the "recv_buf".
+                                 oob_ep must be uniq at every calling process
+                                 and shuold be in the range [0:n_oob_eps). */
 
+}  ucc_oob_coll_t;
+
+typedef ucc_oob_coll_t ucc_context_oob_coll_t;
+typedef ucc_oob_coll_t ucc_team_oob_coll_t;
 /**
  *
  *  @ingroup UCC_CONTEXT_DT
@@ -995,19 +1006,6 @@ typedef struct ucc_team_p2p_conn {
     ucc_status_t    (*req_test)(void *request);
     ucc_status_t    (*req_free)(void *request);
 } ucc_team_p2p_conn_t;
-
-/**
- *
- *  @ingroup UCC_TEAM_DT
- */
-typedef struct  ucc_team_oob_coll {
-    ucc_status_t    (*allgather)(void *src_buf, void *recv_buf, size_t size,
-                                 void *allgather_info,  void **request);
-    ucc_status_t    (*req_test)(void *request);
-    ucc_status_t    (*req_free)(void *request);
-    uint32_t         participants;
-    void             *coll_info;
-}  ucc_team_oob_coll_t;
 
 /**
  *

--- a/src/utils/ucc_datastruct.h
+++ b/src/utils/ucc_datastruct.h
@@ -5,10 +5,17 @@
 
 #ifndef UCC_DATASTRUCT_H_
 #define UCC_DATASTRUCT_H_
-
+#include <ucc/api/ucc.h>
 #include <ucs/datastruct/list.h>
 #include <stdint.h>
+
 #define UCC_LIST_HEAD UCS_LIST_HEAD
 typedef uint32_t ucc_rank_t;
 #define UCC_RANK_MAX UINT32_MAX
+
+typedef struct ucc_team_subset {
+    ucc_ep_map_t map;
+    ucc_rank_t   myrank;
+} ucc_team_subset_t ;
+
 #endif

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -85,6 +85,7 @@ gtest_SOURCES =                     \
 	core/test_allreduce.cc          \
 	core/test_schedule.cc           \
 	core/test_topo.cc               \
+	core/test_service_coll.cc       \
 	utils/test_string.cc            \
 	utils/test_ep_map.cc            \
 	utils/test_lock_free_queue.cc   \

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -10,15 +10,16 @@ constexpr ucc_lib_params_t UccProcess::default_lib_params;
 constexpr ucc_context_params_t UccProcess::default_ctx_params;
 constexpr int UccJob::staticTeamSizes[];
 
-UccProcess::UccProcess(const ucc_lib_params_t &lib_params,
+UccProcess::UccProcess(int _job_rank, const ucc_lib_params_t &lib_params,
                        const ucc_context_params_t &_ctx_params)
 {
     ucc_lib_config_h     lib_config;
     ucc_status_t         status;
     std::stringstream    err_msg;
 
+    job_rank   = _job_rank;
     ctx_params = _ctx_params;
-    status = ucc_lib_config_read(NULL, NULL, &lib_config);
+    status     = ucc_lib_config_read(NULL, NULL, &lib_config);
     if (status != UCC_OK) {
         err_msg << "ucc_lib_config_read failed";
         goto exit_err;
@@ -151,25 +152,39 @@ ucc_status_t UccTeam::req_free(void *request)
     return UCC_OK;
 }
 
-void UccTeam::init_team()
+uint64_t rank_map_cb(uint64_t ep, void *cb_ctx) {
+    UccTeam *team = (UccTeam*)cb_ctx;
+    return (uint64_t)team->procs[(int)ep].p.get()->job_rank;
+}
+
+void UccTeam::init_team(bool use_team_ep_map)
 {
     ucc_team_params_t                    team_params;
     std::vector<allgather_coll_info_t *> cis;
     ucc_status_t                         status;
     for (int i = 0; i < n_procs; i++) {
         cis.push_back(new allgather_coll_info);
-        cis.back()->self             = this;
-        cis.back()->my_rank          = i;
-        team_params.oob.allgather    = allgather;
-        team_params.oob.req_test     = req_test;
-        team_params.oob.req_free     = req_free;
-        team_params.oob.coll_info    = (void *)cis.back();
-        team_params.oob.participants = n_procs;
-        team_params.ep               = i;
-        team_params.ep_range         = UCC_COLLECTIVE_EP_RANGE_CONTIG;
-        team_params.mask             = UCC_TEAM_PARAM_FIELD_OOB |
-            UCC_TEAM_PARAM_FIELD_EP  |
-            UCC_TEAM_PARAM_FIELD_EP_RANGE ;
+        cis.back()->self     = this;
+        cis.back()->my_rank  = i;
+        team_params.ep       = i;
+        team_params.ep_range = UCC_COLLECTIVE_EP_RANGE_CONTIG;
+        team_params.mask     = UCC_TEAM_PARAM_FIELD_EP  |
+                               UCC_TEAM_PARAM_FIELD_EP_RANGE;
+        if (use_team_ep_map) {
+            team_params.mask |= UCC_TEAM_PARAM_FIELD_EP_MAP;
+            team_params.ep_map.type      = UCC_EP_MAP_CB;
+            team_params.ep_map.ep_num    = n_procs;
+            team_params.ep_map.cb.cb     = rank_map_cb;
+            team_params.ep_map.cb.cb_ctx = (void*)this;
+        } else {
+            team_params.oob.allgather = allgather;
+            team_params.oob.req_test  = req_test;
+            team_params.oob.req_free  = req_free;
+            team_params.oob.coll_info = (void *)cis.back();
+            team_params.oob.n_oob_eps = n_procs;
+            team_params.oob.oob_ep    = i;
+            team_params.mask         |= UCC_TEAM_PARAM_FIELD_OOB;
+        }
         EXPECT_EQ(UCC_OK,
                   ucc_team_create_post(&(procs[i].p.get()->ctx_h), 1, &team_params,
                                        &(procs[i].team)));
@@ -221,7 +236,7 @@ void UccTeam::progress()
     }
 }
 
-UccTeam::UccTeam(std::vector<UccProcess_h> &_procs)
+UccTeam::UccTeam(std::vector<UccProcess_h> &_procs, bool use_team_ep_map)
 {
     n_procs = _procs.size();
     ag.resize(n_procs);
@@ -232,7 +247,7 @@ UccTeam::UccTeam(std::vector<UccProcess_h> &_procs)
         a.phase = AG_INIT;
     }
     copy_complete_count = 0;
-    init_team();
+    init_team(use_team_ep_map);
     // test_allgather(128);
 }
 
@@ -265,7 +280,7 @@ UccJob::UccJob(int _n_procs, ucc_job_ctx_mode_t _ctx_mode, ucc_job_env_t vars) :
         setenv(v.first.c_str(), v.second.c_str(), 1);
     }
     for (int i = 0; i < n_procs; i++) {
-        procs.push_back(std::make_shared<UccProcess>());
+        procs.push_back(std::make_shared<UccProcess>(i));
     }
 
     create_context();
@@ -352,10 +367,11 @@ void proc_context_create(UccProcess_h proc, int id, ThreadAllgather *ta, bool is
     if (is_global) {
         proc->ctx_params.mask |= UCC_CONTEXT_PARAM_FIELD_OOB;
         proc->ctx_params.oob.allgather = thread_allgather_start;
-        proc->ctx_params.oob.req_test = thread_allgather_req_test;
-        proc->ctx_params.oob.req_free = thread_allgather_req_free;
+        proc->ctx_params.oob.req_test  = thread_allgather_req_test;
+        proc->ctx_params.oob.req_free  = thread_allgather_req_free;
         proc->ctx_params.oob.coll_info = (void*) &ta->reqs[id];
-        proc->ctx_params.oob.participants = ta->n_procs;
+        proc->ctx_params.oob.n_oob_eps = ta->n_procs;
+        proc->ctx_params.oob.oob_ep    = id;
     }
     status = ucc_context_create(proc->lib_h, &proc->ctx_params, ctx_config, &proc->ctx_h);
     ucc_context_config_release(ctx_config);
@@ -429,7 +445,7 @@ const std::vector<UccTeam_h> &UccJob::getStaticTeams()
         for (auto r = staticUccJobSize - 1; r >= 0; r--) {
             ranks.push_back(r);
         }
-        staticTeams.push_back(getStaticJob()->create_team(ranks));
+        staticTeams.push_back(getStaticJob()->create_team(ranks, true));
     }
 
     return staticTeams;
@@ -452,14 +468,14 @@ UccTeam_h UccJob::create_team(int _n_procs)
     return std::make_shared<UccTeam>(team_procs);
 }
 
-UccTeam_h UccJob::create_team(std::vector<int> &ranks)
+UccTeam_h UccJob::create_team(std::vector<int> &ranks, bool use_team_ep_map)
 {
     EXPECT_GE(n_procs, ranks.size());
     std::vector<UccProcess_h> team_procs;
     for (int i=0; i<ranks.size(); i++) {
         team_procs.push_back(procs[ranks[i]]);
     }
-    return std::make_shared<UccTeam>(team_procs);
+    return std::make_shared<UccTeam>(team_procs, use_team_ep_map);
 }
 
 

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -424,7 +424,14 @@ const std::vector<UccTeam_h> &UccJob::getStaticTeams()
         for (auto ts : teamSizes) {
             staticTeams.push_back(getStaticJob()->create_team(ts));
         }
+        /* Create one more team with reversed ranks order */
+        std::vector<int> ranks;
+        for (auto r = staticUccJobSize - 1; r >= 0; r--) {
+            ranks.push_back(r);
+        }
+        staticTeams.push_back(getStaticJob()->create_team(ranks));
     }
+
     return staticTeams;
 }
 
@@ -441,6 +448,16 @@ UccTeam_h UccJob::create_team(int _n_procs)
     std::vector<UccProcess_h> team_procs;
     for (int i=0; i<_n_procs; i++) {
         team_procs.push_back(procs[i]);
+    }
+    return std::make_shared<UccTeam>(team_procs);
+}
+
+UccTeam_h UccJob::create_team(std::vector<int> &ranks)
+{
+    EXPECT_GE(n_procs, ranks.size());
+    std::vector<UccProcess_h> team_procs;
+    for (int i=0; i<ranks.size(); i++) {
+        team_procs.push_back(procs[ranks[i]]);
     }
     return std::make_shared<UccTeam>(team_procs);
 }

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -202,6 +202,7 @@ public:
     ~UccJob();
     std::vector<UccProcess_h> procs;
     UccTeam_h create_team(int n_procs);
+    UccTeam_h create_team(std::vector<int> &ranks);
     void create_context();
     ucc_job_ctx_mode_t ctx_mode;
 };

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -129,7 +129,9 @@ public:
     };
     ucc_lib_h            lib_h;
     ucc_context_h        ctx_h;
-    UccProcess(const ucc_lib_params_t &lp = default_lib_params,
+    int                  job_rank;
+    UccProcess(int _job_rank,
+               const ucc_lib_params_t &lp = default_lib_params,
                const ucc_context_params_t &cp = default_ctx_params);
     ~UccProcess();
 };
@@ -161,7 +163,7 @@ class UccTeam {
         UccTeam *self;
     } allgather_coll_info_t;
     std::vector<struct allgather_data> ag;
-    void init_team();
+    void init_team(bool use_team_ep_map);
     void destroy_team();
     void test_allgather(size_t msglen);
     static ucc_status_t allgather(void *src_buf, void *recv_buf, size_t size,
@@ -173,7 +175,7 @@ public:
     int n_procs;
     void progress();
     std::vector<proc> procs;
-    UccTeam(std::vector<UccProcess_h> &_procs);
+    UccTeam(std::vector<UccProcess_h> &_procs, bool use_team_ep_map = false);
     ~UccTeam();
 };
 typedef std::shared_ptr<UccTeam> UccTeam_h;
@@ -202,7 +204,7 @@ public:
     ~UccJob();
     std::vector<UccProcess_h> procs;
     UccTeam_h create_team(int n_procs);
-    UccTeam_h create_team(std::vector<int> &ranks);
+    UccTeam_h create_team(std::vector<int> &ranks, bool use_team_ep_map = false);
     void create_context();
     ucc_job_ctx_mode_t ctx_mode;
 };

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -192,7 +192,7 @@ public:
     } ucc_job_ctx_mode_t;
     static const int nStaticTeams     = 3;
     static const int staticUccJobSize = 16;
-    static constexpr int staticTeamSizes[nStaticTeams] = {2, 11, 16};
+    static constexpr int staticTeamSizes[nStaticTeams] = {2, 11, staticUccJobSize};
     static void cleanup();
     static UccJob* getStaticJob();
     static const std::vector<UccTeam_h> &getStaticTeams();

--- a/test/gtest/core/test_service_coll.cc
+++ b/test/gtest/core/test_service_coll.cc
@@ -15,7 +15,7 @@ class test_service_coll {
   public:
     int *                                 array;
     UccTeam_h                             team;
-    std::vector<ucc_tl_team_subset_t>     subsets;
+    std::vector<ucc_team_subset_t>        subsets;
     std::vector<ucc_service_coll_req_t *> reqs;
     test_service_coll(std::vector<int> _subset, UccTeam_h _team)
     {

--- a/test/gtest/core/test_service_coll.cc
+++ b/test/gtest/core/test_service_coll.cc
@@ -114,6 +114,7 @@ class test_scoll_allreduce
 
 UCC_TEST_P(test_scoll_allreduce, allreduce)
 {
+    /* Reversed team of size staticUccJobSize - last one in static teawms array */
     auto team = UccJob::getStaticTeams().back();
     ASSERT_EQ(team.get()->procs.size(), 16);
     std::vector<int>       subset = GetParam();
@@ -186,6 +187,7 @@ class test_scoll_allgather
 
 UCC_TEST_P(test_scoll_allgather, allgather)
 {
+    /* Reversed team of size staticUccJobSize - last one in static teawms array */
     auto team = UccJob::getStaticTeams().back();
     ASSERT_EQ(team.get()->procs.size(), 16);
     std::vector<int>       subset = GetParam();

--- a/test/gtest/core/test_service_coll.cc
+++ b/test/gtest/core/test_service_coll.cc
@@ -11,39 +11,41 @@ extern "C" {
 #include "core/ucc_service_coll.h"
 }
 
-
-class test_service_coll
-{
-public:
-    int *array;
-    UccTeam_h team;
-    std::vector<ucc_tl_team_subset_t> subsets;
-    std::vector<ucc_service_coll_req_t*> reqs;
-    test_service_coll(std::vector<int> _subset, UccTeam_h _team) {
-        team = _team;
+class test_service_coll {
+  public:
+    int *                                 array;
+    UccTeam_h                             team;
+    std::vector<ucc_tl_team_subset_t>     subsets;
+    std::vector<ucc_service_coll_req_t *> reqs;
+    test_service_coll(std::vector<int> _subset, UccTeam_h _team)
+    {
+        team  = _team;
         array = new int[_subset.size()];
         memcpy(array, _subset.data(), sizeof(int) * _subset.size());
         subsets.resize(_subset.size());
         reqs.resize(_subset.size());
         for (auto i = 0; i < _subset.size(); i++) {
-            subsets[i].myrank = i;
-            subsets[i].map.type = UCC_EP_MAP_ARRAY;
-            subsets[i].map.array.map = (void*)array;
+            subsets[i].myrank              = i;
+            subsets[i].map.type            = UCC_EP_MAP_ARRAY;
+            subsets[i].map.array.map       = (void *)array;
             subsets[i].map.array.elem_size = sizeof(int);
-            subsets[i].map.ep_num = _subset.size();
+            subsets[i].map.ep_num          = _subset.size();
         }
     }
-    ~test_service_coll() {
+    ~test_service_coll()
+    {
         delete[] array;
     }
-    void progress() {
+    void progress()
+    {
         for (auto i = 0; i < reqs.size(); i++) {
             ucc_context_progress(team.get()->procs[array[i]].p->ctx_h);
         }
     }
-    void wait() {
+    void wait()
+    {
         ucc_status_t status;
-        bool ready;
+        bool         ready;
         do {
             ready = true;
             progress();
@@ -61,15 +63,16 @@ public:
     }
 };
 
-class test_service_allreduce : public test_service_coll
-{
-    std::vector<std::vector<int> > sbuf;
-    std::vector<std::vector<int> > rbuf;
-    size_t count;
+class test_service_allreduce : public test_service_coll {
+    std::vector<std::vector<int>> sbuf;
+    std::vector<std::vector<int>> rbuf;
+    size_t                        count;
 
-public:
-    test_service_allreduce(std::vector<int> _subset, size_t count, UccTeam_h _team) :
-        test_service_coll(_subset, _team) {
+  public:
+    test_service_allreduce(std::vector<int> _subset, size_t count,
+                           UccTeam_h _team)
+        : test_service_coll(_subset, _team)
+    {
         sbuf.resize(_subset.size());
         rbuf.resize(_subset.size());
         for (auto i = 0; i < _subset.size(); i++) {
@@ -81,60 +84,64 @@ public:
             }
         }
     }
-    void start() {
+    void start()
+    {
         ucc_status_t status;
         for (auto i = 0; i < reqs.size(); i++) {
             auto r = array[i];
-            status = ucc_service_allreduce(team.get()->procs[r].team, sbuf[i].data(),
-                                           rbuf[i].data(), UCC_DT_INT32,
-                                           sbuf[i].size(), UCC_OP_SUM, subsets[i], &reqs[i]);
+            status = ucc_service_allreduce(
+                team.get()->procs[r].team, sbuf[i].data(), rbuf[i].data(),
+                UCC_DT_INT32, sbuf[i].size(), UCC_OP_SUM, subsets[i], &reqs[i]);
             EXPECT_EQ(UCC_OK, status);
         }
     }
-    void check() {
+    void check()
+    {
         int size = reqs.size();
         for (auto i = 0; i < size; i++) {
             for (auto j = 0; j < sbuf[i].size(); j++) {
-                int check = size * (size + 1) / 2 + j*size;
+                int check = size * (size + 1) / 2 + j * size;
                 EXPECT_EQ(check, rbuf[i][j]);
             }
         }
     }
 };
 
-class test_scoll_allreduce : public ucc::test,
-                public ::testing::WithParamInterface<std::vector<int> >{};
+class test_scoll_allreduce
+    : public ucc::test,
+      public ::testing::WithParamInterface<std::vector<int>> {
+};
 
 UCC_TEST_P(test_scoll_allreduce, allreduce)
 {
     auto team = UccJob::getStaticTeams().back();
     ASSERT_EQ(team.get()->procs.size(), 16);
-    std::vector<int> subset = GetParam();
+    std::vector<int>       subset = GetParam();
     test_service_allreduce t(subset, 4, team);
     t.start();
     t.wait();
     t.check();
 }
 
-INSTANTIATE_TEST_CASE_P(, test_scoll_allreduce,
-                        ::testing::Values(
-                            std::vector<int>({1, 0}),
-                            std::vector<int>({2, 3}),
-                            std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8,
-                                              9, 10, 11, 12, 13, 14, 15}),
-                            std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8}),
-                            std::vector<int>({15, 14, 13, 12, 11, 10, 9}),
-                            std::vector<int>({0, 2, 4, 6, 8})));
+INSTANTIATE_TEST_CASE_P(
+    , test_scoll_allreduce,
+    ::testing::Values(std::vector<int>({1, 0}), std::vector<int>({2, 3}),
+                      std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+                                        12, 13, 14, 15}),
+                      std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8}),
+                      std::vector<int>({15, 14, 13, 12, 11, 10, 9}),
+                      std::vector<int>({0, 2, 4, 6, 8})));
 
-class test_service_allgather : public test_service_coll
-{
-    std::vector<std::vector<int> > sbuf;
-    std::vector<std::vector<int> > rbuf;
-    size_t count;
+class test_service_allgather : public test_service_coll {
+    std::vector<std::vector<int>> sbuf;
+    std::vector<std::vector<int>> rbuf;
+    size_t                        count;
 
-public:
-    test_service_allgather(std::vector<int> _subset, size_t count, UccTeam_h _team) :
-        test_service_coll(_subset, _team) {
+  public:
+    test_service_allgather(std::vector<int> _subset, size_t count,
+                           UccTeam_h _team)
+        : test_service_coll(_subset, _team)
+    {
         sbuf.resize(_subset.size());
         rbuf.resize(_subset.size());
         for (auto i = 0; i < _subset.size(); i++) {
@@ -148,18 +155,20 @@ public:
             }
         }
     }
-    void start() {
+    void start()
+    {
         ucc_status_t status;
         for (auto i = 0; i < reqs.size(); i++) {
             auto r = array[i];
-            status = ucc_service_allgather(team.get()->procs[r].team, sbuf[i].data(),
-                                           rbuf[i].data(), sbuf[i].size() *sizeof(int),
-                                           subsets[i], &reqs[i]);
+            status = ucc_service_allgather(
+                team.get()->procs[r].team, sbuf[i].data(), rbuf[i].data(),
+                sbuf[i].size() * sizeof(int), subsets[i], &reqs[i]);
             EXPECT_EQ(UCC_OK, status);
         }
     }
-    void check() {
-        int size = reqs.size();
+    void check()
+    {
+        int size  = reqs.size();
         int count = sbuf[0].size();
         for (auto i = 0; i < size; i++) {
             for (auto j = 0; j < rbuf[i].size(); j++) {
@@ -170,26 +179,27 @@ public:
     }
 };
 
-class test_scoll_allgather : public ucc::test,
-                public ::testing::WithParamInterface<std::vector<int> >{};
+class test_scoll_allgather
+    : public ucc::test,
+      public ::testing::WithParamInterface<std::vector<int>> {
+};
 
 UCC_TEST_P(test_scoll_allgather, allgather)
 {
     auto team = UccJob::getStaticTeams().back();
     ASSERT_EQ(team.get()->procs.size(), 16);
-    std::vector<int> subset = GetParam();
+    std::vector<int>       subset = GetParam();
     test_service_allgather t(subset, 4, team);
     t.start();
     t.wait();
     t.check();
 }
 
-INSTANTIATE_TEST_CASE_P(, test_scoll_allgather,
-                        ::testing::Values(
-                            std::vector<int>({1, 0}),
-                            std::vector<int>({2, 3}),
-                            std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8,
-                                              9, 10, 11, 12, 13, 14, 15}),
-                            std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8}),
-                            std::vector<int>({15, 14, 13, 12, 11, 10, 9}),
-                            std::vector<int>({0, 2, 4, 6, 8})));
+INSTANTIATE_TEST_CASE_P(
+    , test_scoll_allgather,
+    ::testing::Values(std::vector<int>({1, 0}), std::vector<int>({2, 3}),
+                      std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+                                        12, 13, 14, 15}),
+                      std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8}),
+                      std::vector<int>({15, 14, 13, 12, 11, 10, 9}),
+                      std::vector<int>({0, 2, 4, 6, 8})));

--- a/test/gtest/core/test_service_coll.cc
+++ b/test/gtest/core/test_service_coll.cc
@@ -1,0 +1,195 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#include <common/test.h>
+#include <common/test_ucc.h>
+#include <vector>
+
+extern "C" {
+#include "core/ucc_team.h"
+#include "core/ucc_service_coll.h"
+}
+
+
+class test_service_coll
+{
+public:
+    int *array;
+    UccTeam_h team;
+    std::vector<ucc_tl_team_subset_t> subsets;
+    std::vector<ucc_service_coll_req_t*> reqs;
+    test_service_coll(std::vector<int> _subset, UccTeam_h _team) {
+        team = _team;
+        array = new int[_subset.size()];
+        memcpy(array, _subset.data(), sizeof(int) * _subset.size());
+        subsets.resize(_subset.size());
+        reqs.resize(_subset.size());
+        for (auto i = 0; i < _subset.size(); i++) {
+            subsets[i].myrank = i;
+            subsets[i].map.type = UCC_EP_MAP_ARRAY;
+            subsets[i].map.array.map = (void*)array;
+            subsets[i].map.array.elem_size = sizeof(int);
+            subsets[i].map.ep_num = _subset.size();
+        }
+    }
+    ~test_service_coll() {
+        delete[] array;
+    }
+    void progress() {
+        for (auto i = 0; i < reqs.size(); i++) {
+            ucc_context_progress(team.get()->procs[array[i]].p->ctx_h);
+        }
+    }
+    void wait() {
+        ucc_status_t status;
+        bool ready;
+        do {
+            ready = true;
+            progress();
+            for (auto &r : reqs) {
+                status = ucc_service_coll_test(r);
+                EXPECT_GE(status, 0);
+                if (UCC_INPROGRESS == status) {
+                    ready = false;
+                }
+            }
+        } while (!ready);
+        for (auto &r : reqs) {
+            ucc_service_coll_finalize(r);
+        }
+    }
+};
+
+class test_service_allreduce : public test_service_coll
+{
+    std::vector<std::vector<int> > sbuf;
+    std::vector<std::vector<int> > rbuf;
+    size_t count;
+
+public:
+    test_service_allreduce(std::vector<int> _subset, size_t count, UccTeam_h _team) :
+        test_service_coll(_subset, _team) {
+        sbuf.resize(_subset.size());
+        rbuf.resize(_subset.size());
+        for (auto i = 0; i < _subset.size(); i++) {
+            sbuf[i].resize(count);
+            rbuf[i].resize(count);
+            for (auto j = 0; j < count; j++) {
+                sbuf[i][j] = i + j + 1;
+                rbuf[i][j] = 0;
+            }
+        }
+    }
+    void start() {
+        ucc_status_t status;
+        for (auto i = 0; i < reqs.size(); i++) {
+            auto r = array[i];
+            status = ucc_service_allreduce(team.get()->procs[r].team, sbuf[i].data(),
+                                           rbuf[i].data(), UCC_DT_INT32,
+                                           sbuf[i].size(), UCC_OP_SUM, subsets[i], &reqs[i]);
+            EXPECT_EQ(UCC_OK, status);
+        }
+    }
+    void check() {
+        int size = reqs.size();
+        for (auto i = 0; i < size; i++) {
+            for (auto j = 0; j < sbuf[i].size(); j++) {
+                int check = size * (size + 1) / 2 + j*size;
+                EXPECT_EQ(check, rbuf[i][j]);
+            }
+        }
+    }
+};
+
+class test_scoll_allreduce : public ucc::test,
+                public ::testing::WithParamInterface<std::vector<int> >{};
+
+UCC_TEST_P(test_scoll_allreduce, allreduce)
+{
+    auto team = UccJob::getStaticTeams().back();
+    ASSERT_EQ(team.get()->procs.size(), 16);
+    std::vector<int> subset = GetParam();
+    test_service_allreduce t(subset, 4, team);
+    t.start();
+    t.wait();
+    t.check();
+}
+
+INSTANTIATE_TEST_CASE_P(, test_scoll_allreduce,
+                        ::testing::Values(
+                            std::vector<int>({1, 0}),
+                            std::vector<int>({2, 3}),
+                            std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8,
+                                              9, 10, 11, 12, 13, 14, 15}),
+                            std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8}),
+                            std::vector<int>({15, 14, 13, 12, 11, 10, 9}),
+                            std::vector<int>({0, 2, 4, 6, 8})));
+
+class test_service_allgather : public test_service_coll
+{
+    std::vector<std::vector<int> > sbuf;
+    std::vector<std::vector<int> > rbuf;
+    size_t count;
+
+public:
+    test_service_allgather(std::vector<int> _subset, size_t count, UccTeam_h _team) :
+        test_service_coll(_subset, _team) {
+        sbuf.resize(_subset.size());
+        rbuf.resize(_subset.size());
+        for (auto i = 0; i < _subset.size(); i++) {
+            sbuf[i].resize(count);
+            rbuf[i].resize(count * _subset.size());
+            for (auto j = 0; j < count; j++) {
+                sbuf[i][j] = i + j + 1;
+            }
+            for (auto j = 0; j < count * _subset.size(); j++) {
+                rbuf[i][j] = 0;
+            }
+        }
+    }
+    void start() {
+        ucc_status_t status;
+        for (auto i = 0; i < reqs.size(); i++) {
+            auto r = array[i];
+            status = ucc_service_allgather(team.get()->procs[r].team, sbuf[i].data(),
+                                           rbuf[i].data(), sbuf[i].size() *sizeof(int),
+                                           subsets[i], &reqs[i]);
+            EXPECT_EQ(UCC_OK, status);
+        }
+    }
+    void check() {
+        int size = reqs.size();
+        int count = sbuf[0].size();
+        for (auto i = 0; i < size; i++) {
+            for (auto j = 0; j < rbuf[i].size(); j++) {
+                int check = (j % count) + 1 + (j / count);
+                EXPECT_EQ(check, rbuf[i][j]);
+            }
+        }
+    }
+};
+
+class test_scoll_allgather : public ucc::test,
+                public ::testing::WithParamInterface<std::vector<int> >{};
+
+UCC_TEST_P(test_scoll_allgather, allgather)
+{
+    auto team = UccJob::getStaticTeams().back();
+    ASSERT_EQ(team.get()->procs.size(), 16);
+    std::vector<int> subset = GetParam();
+    test_service_allgather t(subset, 4, team);
+    t.start();
+    t.wait();
+    t.check();
+}
+
+INSTANTIATE_TEST_CASE_P(, test_scoll_allgather,
+                        ::testing::Values(
+                            std::vector<int>({1, 0}),
+                            std::vector<int>({2, 3}),
+                            std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8,
+                                              9, 10, 11, 12, 13, 14, 15}),
+                            std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8}),
+                            std::vector<int>({15, 14, 13, 12, 11, 10, 9}),
+                            std::vector<int>({0, 2, 4, 6, 8})));

--- a/tools/perf/ucc_pt_bootstrap_mpi.cc
+++ b/tools/perf/ucc_pt_bootstrap_mpi.cc
@@ -30,17 +30,19 @@ ucc_pt_bootstrap_mpi::ucc_pt_bootstrap_mpi()
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
-    context_oob.coll_info    = (void*)MPI_COMM_WORLD;
-    context_oob.allgather    = mpi_oob_allgather;
-    context_oob.req_test     = mpi_oob_allgather_test;
-    context_oob.req_free     = mpi_oob_allgather_free;
-    context_oob.participants = size;
+    context_oob.coll_info = (void*)MPI_COMM_WORLD;
+    context_oob.allgather = mpi_oob_allgather;
+    context_oob.req_test  = mpi_oob_allgather_test;
+    context_oob.req_free  = mpi_oob_allgather_free;
+    context_oob.n_oob_eps = size;
+    context_oob.oob_ep    = rank;
 
-    team_oob.coll_info    = (void*)MPI_COMM_WORLD;
-    team_oob.allgather    = mpi_oob_allgather;
-    team_oob.req_test     = mpi_oob_allgather_test;
-    team_oob.req_free     = mpi_oob_allgather_free;
-    team_oob.participants = size;
+    team_oob.coll_info = (void*)MPI_COMM_WORLD;
+    team_oob.allgather = mpi_oob_allgather;
+    team_oob.req_test  = mpi_oob_allgather_test;
+    team_oob.req_free  = mpi_oob_allgather_free;
+    team_oob.n_oob_eps = size;
+    team_oob.oob_ep    = rank;
 }
 
 int ucc_pt_bootstrap_mpi::get_rank()


### PR DESCRIPTION
## What
- Optimize team creation: don't perform service team allocation or team_id allocation during ucc_team_create if CL/TL components don't report they need those features
- Add service allgather at tl interface
- Add service allgather implementation in the TL/UCP via allgather ring (adds support for subsets to ring allgather alg)
- Adds service coll helper layer in CORE
- Adds an option (UCC_OOB_INTERNAL) that allocates a single global service team per ucc_context (instead of 1 service team per ucc team). That team is then used for oob during CL/TL team creations (as well as team_id alloc) instead of runtime OOB. This can be useful when runtime OOB allgather is not efficient (e.g. implemented over TCP). This option can be used when context creation is in GLOBAL mode (with OOB). Still 1 allgather is made via runtime oob durin team_create - the one that builds context rank map. @manju i still insist we should expose the mapping via our UCC API. In that case i can eliminate this last OOB allgather (this is for another discussion, regardless of this PR)
- Adds gtests for service collectives

## Why ?
Optimizes team creation by: (1) not performing unneeded exchanges when possible (e.g. if only NCCL TL is used, then team_id is not required) (2) switching to internal OOB via UCX

