### PR TITLE
Topic/schedule pipelined

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,7 @@ noinst_HEADERS =                      \
 	core/ucc_sbgp.h                   \
 	core/ucc_service_coll.h           \
 	schedule/ucc_schedule.h           \
+	schedule/ucc_schedule_pipelined.h \
 	coll_score/ucc_coll_score.h       \
 	utils/ucc_compiler_def.h          \
 	utils/ucc_log.h                   \
@@ -73,37 +74,38 @@ noinst_HEADERS =                      \
 	coll_patterns/recursive_knomial.h \
 	coll_patterns/sra_knomial.h
 
-libucc_la_SOURCES =                  \
-	core/ucc_lib.c                   \
-	core/ucc_constructor.c           \
-	core/ucc_global_opts.c           \
-	core/ucc_version.c               \
-	core/ucc_context.c               \
-	core/ucc_mc.c                    \
-	core/ucc_team.c                  \
-	core/ucc_ee.c                    \
-	core/ucc_coll.c                  \
-	core/ucc_progress_queue.c        \
-	core/ucc_progress_queue_st.c     \
-	core/ucc_progress_queue_mt.c     \
-	core/ucc_topo.c                  \
-	core/ucc_sbgp.c                  \
-	core/ucc_service_coll.c          \
-	schedule/ucc_schedule.c          \
-	coll_score/ucc_coll_score.c      \
-	coll_score/ucc_coll_score_map.c  \
-	utils/ucc_component.c            \
-	utils/ucc_status.c               \
-	utils/ucc_mpool.c                \
-	utils/ucc_math.c                 \
-	utils/ucc_proc_info.c            \
-	utils/ucc_string.c               \
-	utils/ucc_coll_utils.c           \
-	utils/ucc_parser.c               \
-	utils/profile/ucc_profile.c      \
-	components/base/ucc_base_iface.c \
-	components/cl/ucc_cl.c           \
-	components/tl/ucc_tl.c           \
+libucc_la_SOURCES =                   \
+	core/ucc_lib.c                    \
+	core/ucc_constructor.c            \
+	core/ucc_global_opts.c            \
+	core/ucc_version.c                \
+	core/ucc_context.c                \
+	core/ucc_mc.c                     \
+	core/ucc_team.c                   \
+	core/ucc_ee.c                     \
+	core/ucc_coll.c                   \
+	core/ucc_progress_queue.c         \
+	core/ucc_progress_queue_st.c      \
+	core/ucc_progress_queue_mt.c      \
+	core/ucc_topo.c                   \
+	core/ucc_sbgp.c                   \
+	core/ucc_service_coll.c           \
+	schedule/ucc_schedule.c           \
+	schedule/ucc_schedule_pipelined.c \
+	coll_score/ucc_coll_score.c       \
+	coll_score/ucc_coll_score_map.c   \
+	utils/ucc_component.c             \
+	utils/ucc_status.c                \
+	utils/ucc_mpool.c                 \
+	utils/ucc_math.c                  \
+	utils/ucc_proc_info.c             \
+	utils/ucc_string.c                \
+	utils/ucc_coll_utils.c            \
+	utils/ucc_parser.c                \
+	utils/profile/ucc_profile.c       \
+	components/base/ucc_base_iface.c  \
+	components/cl/ucc_cl.c            \
+	components/tl/ucc_tl.c            \
 	components/mc/base/ucc_mc_base.c
 
 libucc_ladir = $(includedir)

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -28,9 +28,9 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_progress(ucc_coll_task_t *coll_task)
     uint8_t                node_type  = task->allgather_kn.p.node_type;
     ucc_knomial_pattern_t *p          = &task->allgather_kn.p;
     void                  *rbuf       = args->dst.info.buffer;
-    ucc_memory_type_t      mem_type   = args->src.info.mem_type;
-    size_t                 count      = args->src.info.count;
-    ucc_datatype_t         dt         = args->src.info.datatype;
+    ucc_memory_type_t      mem_type   = args->dst.info.mem_type;
+    size_t                 count      = args->dst.info.count;
+    ucc_datatype_t         dt         = args->dst.info.datatype;
     size_t                 dt_size    = ucc_dt_size(dt);
     size_t                 data_size  = count * dt_size;
     ucc_rank_t             size       = team->size;
@@ -140,8 +140,8 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
     ucc_assert(args->src.info.mem_type == args->dst.info.mem_type);
 
     ucc_knomial_pattern_init_backward(size, rank, radix, &task->allgather_kn.p);
-    offset = ucc_sra_kn_get_offset(args->src.info.count,
-                                   ucc_dt_size(args->src.info.datatype), rank,
+    offset = ucc_sra_kn_get_offset(args->dst.info.count,
+                                   ucc_dt_size(args->dst.info.datatype), rank,
                                    size, radix);
     if (!UCC_IS_INPLACE(*args)) {
         status = ucc_mc_memcpy(

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -38,30 +38,64 @@
       ranks) will be located in dst buffer at offset the can be commputed by the
       routine from coll_patterns/sra_knomial.h: ucc_sra_kn_get_offset.
  */
-ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_start(ucc_coll_task_t *coll_task)
+static ucc_status_t
+ucc_tl_ucp_allreduce_sra_knomial_frag_start(ucc_coll_task_t *task)
 {
-    ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
 
-    UCC_TL_UCP_PROFILE_REQUEST_EVENT(schedule, "ucp_allreduce_sra_kn_start", 0);
     return ucc_schedule_start(schedule);
 }
 
-ucc_status_t
-ucc_tl_ucp_allreduce_sra_knomial_finalize(ucc_coll_task_t *coll_task)
+static ucc_status_t
+ucc_tl_ucp_allreduce_sra_knomial_frag_finalize(ucc_coll_task_t *task)
 {
-    ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
     ucc_status_t    status;
-    UCC_TL_UCP_PROFILE_REQUEST_EVENT(schedule, "ucp_allreduce_sra_kn_done", 0);
 
-    status = ucc_schedule_finalize(coll_task);
+    status = ucc_schedule_finalize(task);
     ucc_tl_ucp_put_schedule(schedule);
     return status;
 }
 
-ucc_status_t
-ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
-                                      ucc_base_team_t      *team,
-                                      ucc_coll_task_t     **task_h)
+static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_setup(
+    ucc_schedule_pipelined_t *schedule_p, ucc_schedule_t *frag, int frag_num)
+{
+    ucc_coll_args_t *args    = &schedule_p->super.super.args;
+    ucc_datatype_t   dt      = args->src.info.datatype;
+    size_t           dt_size = ucc_dt_size(dt);
+    ucc_coll_args_t *targs;
+    int              n_frags    = schedule_p->super.n_tasks;
+    size_t           frag_count = args->src.info.count / n_frags;
+    size_t           left       = args->src.info.count % n_frags;
+    size_t           offset     = frag_num * frag_count + left;
+
+    if (frag_num < left) {
+        frag_count++;
+        offset -= left - frag_num;
+    }
+
+    targs = &frag->tasks[0]->args; //REDUCE_SCATTER
+    targs->src.info.buffer =
+        PTR_OFFSET(args->src.info.buffer, offset * dt_size);
+    targs->dst.info.buffer =
+        PTR_OFFSET(args->dst.info.buffer, offset * dt_size);
+    targs->src.info.count = frag_count;
+    targs->dst.info.count = frag_count;
+
+    targs                  = &frag->tasks[1]->args; //ALLGATHER
+    targs->src.info.buffer = NULL;
+    targs->dst.info.buffer =
+        PTR_OFFSET(args->dst.info.buffer, offset * dt_size);
+    targs->src.info.count = 0;
+    targs->dst.info.count = frag_count;
+
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
+    ucc_base_coll_args_t     *coll_args,
+    ucc_schedule_pipelined_t *sp, //NOLINT
+    ucc_base_team_t *team, ucc_schedule_t **frag_p)
 {
     ucc_tl_ucp_team_t   *tl_team  = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_schedule_t      *schedule = ucc_tl_ucp_get_schedule(tl_team);
@@ -70,7 +104,8 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
     ucc_coll_task_t     *task, *rs_task;
     ucc_status_t         status;
     ucc_kn_radix_t       radix;
-    ALLREDUCE_TASK_CHECK(coll_args->args, tl_team);
+
+    ucc_schedule_init(schedule, &coll_args->args, team);
     radix = ucc_min(UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_radix,
                     tl_team->size);
 
@@ -87,13 +122,11 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
         goto out;
     }
     ucc_schedule_add_task(schedule, task);
-    ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
-                                task, ucc_task_start_handler);
+    ucc_task_subscribe_dep(&schedule->super, task, UCC_EVENT_SCHEDULE_STARTED);
     rs_task = task;
-
     /* 2nd step of allreduce: knomial allgather. 2nd task subscribes
      to completion event of reduce_scatter task. */
-    args.args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
+    args.args.mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
     args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
     status = ucc_tl_ucp_allgather_knomial_init_r(&args, team, &task, radix);
     if (UCC_OK != status) {
@@ -101,18 +134,84 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
                  "failed to init allgather_knomial task");
         goto out;
     }
-
     ucc_schedule_add_task(schedule, task);
-    ucc_event_manager_subscribe(&rs_task->em, UCC_EVENT_COMPLETED, task,
-                                ucc_task_start_handler);
-
-    schedule->super.post           = ucc_tl_ucp_allreduce_sra_knomial_start;
-    schedule->super.progress       = NULL;
-    schedule->super.finalize       = ucc_tl_ucp_allreduce_sra_knomial_finalize;
-    schedule->super.triggered_post = ucc_tl_ucp_triggered_post;
-    *task_h                        = &schedule->super;
+    ucc_task_subscribe_dep(rs_task, task, UCC_EVENT_COMPLETED);
+    schedule->super.finalize = ucc_tl_ucp_allreduce_sra_knomial_frag_finalize;
+    schedule->super.post     = ucc_tl_ucp_allreduce_sra_knomial_frag_start;
+    *frag_p                  = schedule;
     return UCC_OK;
 out:
-    ucc_tl_ucp_put_schedule(schedule);
     return status;
+}
+
+static inline void get_sra_n_frags(ucc_base_coll_args_t *coll_args,
+                                   ucc_tl_ucp_team_t *team, int *n_frags,
+                                   int *pipeline_depth)
+{
+    //TODO make selection mem_type - specific
+    ucc_tl_ucp_lib_config_t *cfg     = &UCC_TL_UCP_TEAM_LIB(team)->cfg;
+    size_t                   msgsize = coll_args->args.src.info.count *
+                     ucc_dt_size(coll_args->args.src.info.datatype);
+    int min_num_frags;
+
+    *n_frags = 1;
+    if (msgsize > cfg->allreduce_sra_kn_frag_thresh) {
+        min_num_frags = ucc_div_round_up(msgsize,
+                                             cfg->allreduce_sra_kn_frag_size);
+        *n_frags = ucc_max(min_num_frags, cfg->allreduce_sra_kn_n_frags);
+    }
+    *pipeline_depth = ucc_min(*n_frags, cfg->allreduce_sra_kn_pipeline_depth);
+}
+
+static ucc_status_t
+ucc_tl_ucp_allreduce_sra_knomial_finalize(ucc_coll_task_t *task)
+{
+    ucc_schedule_pipelined_t *schedule =
+        ucc_derived_of(task, ucc_schedule_pipelined_t);
+    ucc_status_t status;
+
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(schedule, "ucp_allreduce_sra_kn_done", 0);
+    status = ucc_schedule_pipelined_finalize(task);
+    ucc_tl_ucp_put_schedule_pipelined(schedule);
+    return status;
+}
+
+ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_start(ucc_coll_task_t *task)
+{
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(task, "ucp_allreduce_sra_kn_start", 0);
+    return ucc_schedule_pipelined_post(task);
+}
+
+ucc_status_t
+ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
+                                      ucc_base_team_t      *team,
+                                      ucc_coll_task_t     **task_h)
+{
+    ucc_tl_ucp_team_t        *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_tl_ucp_lib_config_t  *cfg     = &UCC_TL_UCP_TEAM_LIB(tl_team)->cfg;
+    int                       n_frags, pipeline_depth;
+    ucc_schedule_pipelined_t *schedule_p =
+        ucc_tl_ucp_get_schedule_pipelined(tl_team);
+    ucc_status_t status;
+
+    if (!schedule_p) {
+        tl_error(team->context->lib, "failed to allocate pipelined schedule");
+        return UCC_ERR_NO_MEMORY;
+    }
+    get_sra_n_frags(coll_args, tl_team, &n_frags, &pipeline_depth);
+    status = ucc_schedule_pipelined_init(
+        coll_args, team, ucc_tl_ucp_allreduce_sra_knomial_frag_init,
+        ucc_tl_ucp_allreduce_sra_knomial_frag_setup, pipeline_depth, n_frags,
+        cfg->allreduce_sra_kn_seq, schedule_p);
+    if (UCC_OK != status) {
+        tl_error(team->context->lib, "failed to init pipelined schedule");
+        ucc_tl_ucp_put_schedule_pipelined(schedule_p);
+        return status;
+    }
+    schedule_p->super.super.finalize =
+        ucc_tl_ucp_allreduce_sra_knomial_finalize;
+    schedule_p->super.super.triggered_post = ucc_tl_ucp_triggered_post;
+    schedule_p->super.super.post = ucc_tl_ucp_allreduce_sra_knomial_start;
+    *task_h                                = &schedule_p->super.super;
+    return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -52,6 +52,35 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
+    {"ALLREDUCE_SRA_KN_FRAG_THRESH", "inf",
+     "Threshold to enable fragmentation and pipelining of SRA Knomial "
+     "allreduce alg",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_frag_thresh),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"ALLREDUCE_SRA_KN_FRAG_SIZE", "inf",
+     "Maximum allowed fragment size of SRA knomial alg",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_frag_size),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"ALLREDUCE_SRA_KN_N_FRAGS", "2",
+     "Number of fragments each allreduce is split into when SRA knomial alg is "
+     "used\n"
+     "The actual number of fragments can be larger if fragment size exceeds\n"
+     "ALLREDUCE_SRA_KN_FRAG_SIZE",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_n_frags),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLREDUCE_SRA_KN_PIPELINE_DEPTH", "2",
+     "Number of fragments simultaneously progressed by the SRA knomial alg",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_pipeline_depth),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLREDUCE_SRA_KN_SEQUENTIAL", "n",
+     "Type of pipelined schedule for SRA knomial alg (sequential/parallel)",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_seq),
+     UCC_CONFIG_TYPE_BOOL},
+
     {"REDUCE_SCATTER_KN_RADIX", "4",
      "Radix of the knomial reduce-scatter algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_scatter_kn_radix),

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -47,6 +47,11 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t            reduce_kn_radix;
     uint32_t            alltoall_pairwise_num_posts;
     uint32_t            alltoallv_pairwise_num_posts;
+    uint32_t            allreduce_sra_kn_n_frags;
+    uint32_t            allreduce_sra_kn_pipeline_depth;
+    int                 allreduce_sra_kn_seq;
+    size_t              allreduce_sra_kn_frag_thresh;
+    size_t              allreduce_sra_kn_frag_size;
 } ucc_tl_ucp_lib_config_t;
 
 typedef struct ucc_tl_ucp_context_config {

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -60,9 +60,7 @@ static ucc_status_t
 ucc_tl_ucp_triggered_coll_complete(ucc_coll_task_t *parent_task, //NOLINT
                                    ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-
-    tl_trace(UCC_TASK_LIB(task), "triggered collective complete. task:%p",
+    tl_trace(UCC_TASK_LIB(coll_task), "triggered collective complete. task:%p",
              coll_task);
     return ucc_mc_ee_task_end(coll_task->ee_task, coll_task->ee->ee_type);
 }

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -8,7 +8,7 @@
 #define UCC_TL_UCP_COLL_H_
 
 #include "tl_ucp.h"
-#include "schedule/ucc_schedule.h"
+#include "schedule/ucc_schedule_pipelined.h"
 #include "coll_patterns/recursive_knomial.h"
 #include "components/mc/base/ucc_mc_base.h"
 #include "tl_ucp_tag.h"
@@ -116,12 +116,29 @@ static inline ucc_schedule_t *ucc_tl_ucp_get_schedule(ucc_tl_ucp_team_t *team)
     ucc_tl_ucp_context_t *ctx      = UCC_TL_UCP_TEAM_CTX(team);
     ucc_schedule_t       *schedule = ucc_mpool_get(&ctx->req_mp);
 
-    UCC_TL_UCP_PROFILE_REQUEST_NEW(schedule, "tl_ucp_task", 0);
+    UCC_TL_UCP_PROFILE_REQUEST_NEW(schedule, "tl_ucp_sched", 0);
     ucc_schedule_init(schedule, NULL, &team->super.super);
     return schedule;
 }
 
+static inline ucc_schedule_pipelined_t *
+ucc_tl_ucp_get_schedule_pipelined(ucc_tl_ucp_team_t *team)
+{
+    ucc_tl_ucp_context_t     *ctx      = UCC_TL_UCP_TEAM_CTX(team);
+    ucc_schedule_pipelined_t *schedule = ucc_mpool_get(&ctx->req_mp);
+
+    UCC_TL_UCP_PROFILE_REQUEST_NEW(schedule, "tl_ucp_sched_p", 0);
+    return schedule;
+}
+
 static inline void ucc_tl_ucp_put_schedule(ucc_schedule_t *schedule)
+{
+    UCC_TL_UCP_PROFILE_REQUEST_FREE(schedule);
+    ucc_mpool_put(schedule);
+}
+
+static inline void
+ucc_tl_ucp_put_schedule_pipelined(ucc_schedule_pipelined_t *schedule)
 {
     UCC_TL_UCP_PROFILE_REQUEST_FREE(schedule);
     ucc_mpool_put(schedule);

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -9,6 +9,7 @@
 #include "tl_ucp_coll.h"
 #include "tl_ucp_ep.h"
 #include "utils/ucc_math.h"
+#include "schedule/ucc_schedule_pipelined.h"
 #include <limits.h>
 
 static ucc_mpool_ops_t ucc_tl_ucp_req_mpool_ops = {
@@ -107,7 +108,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
 
     ucc_status = ucc_mpool_init(
         &self->req_mp, 0,
-        ucc_max(sizeof(ucc_tl_ucp_task_t), sizeof(ucc_schedule_t)), 0,
+        ucc_max(sizeof(ucc_tl_ucp_task_t), sizeof(ucc_schedule_pipelined_t)), 0,
         UCC_CACHE_LINE_SIZE, 8, UINT_MAX, &ucc_tl_ucp_req_mpool_ops,
         params->thread_mode, "tl_ucp_req_mp");
     if (UCC_OK != ucc_status) {

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -34,10 +34,12 @@ void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
 ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task, ucc_coll_args_t *args,
                                 ucc_base_team_t *team)
 {
-    task->super.status = UCC_OPERATION_INITIALIZED;
-    task->ee           = NULL;
-    task->flags        = 0;
-    task->team         = team;
+    task->super.status     = UCC_OPERATION_INITIALIZED;
+    task->ee               = NULL;
+    task->flags            = 0;
+    task->team             = team;
+    task->n_deps           = 0;
+    task->n_deps_satisfied = 0;
     if (args) {
         memcpy(&task->args, args, sizeof(*args));
     }

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -105,6 +105,9 @@ ucc_status_t ucc_task_start_handler(ucc_coll_task_t *parent,
                                     ucc_coll_task_t *task);
 ucc_status_t ucc_schedule_finalize(ucc_coll_task_t *task);
 
+ucc_status_t ucc_dependency_handler(ucc_coll_task_t *parent, /* NOLINT */
+                                    ucc_coll_task_t *task);
+
 static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
 {
     ucc_status_t status = task->super.status;
@@ -128,6 +131,15 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
         task->finalize(task);
     }
     return status;
+}
+
+static inline void ucc_task_subscribe_dep(ucc_coll_task_t *target,
+                                          ucc_coll_task_t *subscriber,
+                                          ucc_event_t      event)
+{
+    ucc_event_manager_subscribe(&target->em, event, subscriber,
+                                ucc_dependency_handler);
+    subscriber->n_deps++;
 }
 
 #define UCC_TASK_LIB(_task) (((ucc_coll_task_t *)_task)->team->context->lib)

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -15,6 +15,7 @@
 typedef enum {
     UCC_EVENT_COMPLETED = 0,
     UCC_EVENT_SCHEDULE_STARTED,
+    UCC_EVENT_TASK_STARTED,
     UCC_EVENT_ERROR,
     UCC_EVENT_LAST
 } ucc_event_t;
@@ -64,6 +65,9 @@ typedef struct ucc_coll_task {
         /* used for lf mt progress queue */
         ucc_lf_queue_elem_t          lf_elem;
     };
+    uint8_t n_deps;
+    uint8_t n_deps_satisfied;
+    uint8_t n_deps_base;
 } ucc_coll_task_t;
 
 typedef struct ucc_context ucc_context_t;

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -1,0 +1,198 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#include "ucc_schedule.h"
+#include "ucc_schedule_pipelined.h"
+
+static ucc_status_t ucc_frag_start_handler(ucc_coll_task_t *parent,
+                                           ucc_coll_task_t *task)
+{
+    ucc_schedule_pipelined_t *schedule =
+        ucc_derived_of(parent, ucc_schedule_pipelined_t);
+    ucc_schedule_t *frag               = ucc_derived_of(task, ucc_schedule_t);
+    ucc_status_t    status;
+
+    if (schedule->frag_setup) {
+        status =
+            schedule->frag_setup(schedule, frag, schedule->n_frags_started);
+        if (UCC_OK != status) {
+            ucc_error("failed to setup fragment %d of pipelined schedule",
+                      schedule->n_frags_started);
+            return status;
+        }
+    }
+    schedule->next_frag_to_post =
+        (schedule->next_frag_to_post + 1) % schedule->n_frags;
+    ucc_trace_req("sched %p started frag %p frag_num %d next_to_post %d",
+                  schedule, frag, schedule->n_frags_started,
+                  schedule->next_frag_to_post);
+    schedule->n_frags_started++;
+    schedule->n_frags_in_pipeline++;
+    return task->post(task);
+}
+
+static ucc_status_t
+ucc_schedule_pipelined_completed_handler(ucc_coll_task_t *parent_task, //NOLINT
+                                         ucc_coll_task_t *task)
+{
+    ucc_schedule_pipelined_t *schedule =
+        ucc_container_of(task, ucc_schedule_pipelined_t, super);
+    ucc_schedule_t *frag = ucc_derived_of(parent_task, ucc_schedule_t);
+    int             i;
+
+    schedule->super.n_completed_tasks += 1;
+    schedule->n_frags_in_pipeline--;
+    ucc_trace_req(
+        "sched %p completed frag %p, n_completed %d, n_started %d, n_total %d",
+        schedule, frag, schedule->super.n_completed_tasks,
+        schedule->n_frags_started, schedule->super.n_tasks);
+    ucc_assert(frag->super.super.status == UCC_OK);
+    if (schedule->super.n_completed_tasks == schedule->super.n_tasks) {
+        schedule->super.super.super.status = UCC_OK;
+        ucc_task_complete(task);
+        return UCC_OK;
+    }
+    while ((schedule->super.n_completed_tasks + schedule->n_frags_in_pipeline <
+            schedule->super.n_tasks) &&
+           (frag->super.super.status == UCC_OK)) {
+        /* need to post more frags*/
+        if (frag == schedule->frags[schedule->next_frag_to_post]) {
+            ucc_trace_req("sched %p restarting frag %d %p", schedule,
+                          schedule->next_frag_to_post, frag);
+            frag->super.super.status = UCC_OPERATION_INITIALIZED;
+            frag->n_completed_tasks  = 0;
+            for (i = 0; i < frag->n_tasks; i++) {
+                frag->tasks[i]->n_deps += frag->tasks[i]->n_deps_base;
+                frag->tasks[i]->super.status = UCC_OPERATION_INITIALIZED;
+            }
+            ucc_frag_start_handler(&schedule->super.super, &frag->super);
+        }
+        frag = schedule->frags[schedule->next_frag_to_post];
+        if (&frag->super == parent_task) {
+            break;
+        }
+    }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_schedule_pipelined_finalize(ucc_coll_task_t *task)
+{
+    ucc_schedule_pipelined_t *schedule_p =
+        ucc_derived_of(task, ucc_schedule_pipelined_t);
+    ucc_schedule_t **frags = schedule_p->frags;
+    int              i;
+
+    ucc_trace_req("schedule pipelined %p is complete", schedule_p);
+    for (i = 0; i < schedule_p->n_frags; i++) {
+        schedule_p->frags[i]->super.finalize(&frags[i]->super);
+    }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_schedule_pipelined_post(ucc_coll_task_t *task)
+{
+    ucc_schedule_pipelined_t *schedule_p =
+        ucc_derived_of(task, ucc_schedule_pipelined_t);
+    ucc_schedule_t **frags = schedule_p->frags;
+    int              i, j;
+
+    schedule_p->super.super.super.status = UCC_OPERATION_INITIALIZED;
+    schedule_p->super.n_completed_tasks  = 0;
+    schedule_p->n_frags_started          = 0;
+    schedule_p->next_frag_to_post        = 0;
+    schedule_p->n_frags_in_pipeline      = 0;
+
+    for (i = 0; i < schedule_p->n_frags; i++) {
+        frags[i]->n_completed_tasks  = 0;
+        frags[i]->super.super.status = UCC_OPERATION_INITIALIZED;
+        for (j = 0; j < frags[0]->n_tasks; j++) {
+            frags[i]->tasks[j]->n_deps = frags[i]->tasks[j]->n_deps_base;
+            frags[i]->tasks[j]->n_deps_satisfied = 0;
+            frags[i]->tasks[j]->super.status     = UCC_OPERATION_INITIALIZED;
+            if (i == 0 && schedule_p->n_frags > 1 && schedule_p->sequential) {
+                frags[0]->tasks[j]->n_deps_satisfied++;
+            }
+        }
+    }
+
+    return ucc_schedule_start(&schedule_p->super);
+}
+
+ucc_status_t ucc_schedule_pipelined_init(
+    ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+    ucc_schedule_frag_init_fn_t  frag_init,
+    ucc_schedule_frag_setup_fn_t frag_setup, int n_frags, int n_frags_total,
+    int sequential, ucc_schedule_pipelined_t *schedule)
+{
+    int              i, j;
+    ucc_status_t     status;
+    ucc_schedule_t **frags;
+
+    if (n_frags > UCC_SCHEDULE_PIPELINED_MAX_FRAGS) {
+        ucc_error("n_frags %d exceeds max limit of %d",
+                  n_frags, UCC_SCHEDULE_PIPELINED_MAX_FRAGS);
+        return UCC_ERR_INVALID_PARAM;
+    }
+    ucc_schedule_init(&schedule->super, &coll_args->args, team);
+    schedule->super.n_tasks        = n_frags_total;
+    schedule->n_frags              = n_frags;
+    schedule->sequential           = sequential;
+    schedule->frag_setup           = frag_setup;
+    schedule->next_frag_to_post    = 0;
+    schedule->n_frags_in_pipeline  = 0;
+    schedule->super.super.finalize = ucc_schedule_pipelined_finalize;
+    schedule->super.super.post     = ucc_schedule_pipelined_post;
+    frags                          = schedule->frags;
+    for (i = 0; i < n_frags; i++) {
+        status = frag_init(coll_args, schedule, team, &frags[i]);
+        if (UCC_OK != status) {
+            ucc_error("failed to initialize fragment for pipeline");
+            goto err;
+        }
+        frags[i]->super.super.status = UCC_OPERATION_INITIALIZED;
+    }
+    for (i = 0; i < n_frags; i++) {
+        for (j = 0; j < frags[i]->n_tasks; j++) {
+            frags[i]->tasks[j]->n_deps_base = frags[i]->tasks[j]->n_deps;
+            if (n_frags > 1 && sequential) {
+                ucc_event_manager_subscribe(
+                    &frags[(i > 0) ? (i - 1) : (n_frags - 1)]->tasks[j]->em,
+                    UCC_EVENT_TASK_STARTED, frags[i]->tasks[j],
+                    ucc_dependency_handler);
+                frags[i]->tasks[j]->n_deps_base++;
+            }
+        }
+        ucc_event_manager_subscribe(&schedule->super.super.em,
+                                    UCC_EVENT_SCHEDULE_STARTED,
+                                    &frags[i]->super, ucc_frag_start_handler);
+        ucc_event_manager_subscribe(
+            &frags[i]->super.em, UCC_EVENT_COMPLETED, &schedule->super.super,
+                        ucc_schedule_pipelined_completed_handler);
+    }
+    return UCC_OK;
+err:
+    for (i = i - 1; i >= 0; i--) {
+        frags[i]->super.finalize(&frags[i]->super);
+    }
+    return status;
+}
+
+ucc_status_t ucc_dependency_handler(ucc_coll_task_t *parent, /* NOLINT */
+                                    ucc_coll_task_t *task)
+{
+    ucc_status_t status;
+
+    task->n_deps_satisfied++;
+    ucc_trace_req("task %p, n_deps %d, satisfied %d", task, task->n_deps,
+                  task->n_deps_satisfied);
+    if (task->n_deps == task->n_deps_satisfied) {
+        status = task->post(task);
+        if (status >= 0) {
+            ucc_event_manager_notify(task, UCC_EVENT_TASK_STARTED);
+        }
+        return status;
+    }
+
+    return UCC_OK;
+}

--- a/src/schedule/ucc_schedule_pipelined.h
+++ b/src/schedule/ucc_schedule_pipelined.h
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#ifndef UCC_SCHEDULE_PIPELINED_H_
+#define UCC_SCHEDULE_PIPELINED_H_
+#include "components/base/ucc_base_iface.h"
+
+#define UCC_SCHEDULE_FRAG_MAX_TASKS 8
+
+typedef struct ucc_schedule_pipelined ucc_schedule_pipelined_t;
+
+#define UCC_SCHEDULE_PIPELINED_MAX_FRAGS 4
+
+/* frag_init is the callback provided by the user of pipelined
+   framework (e.g., TL that needs to build a pipeline) that is reponsible
+   for allocation of a single fragment schedule  */
+typedef ucc_status_t (*ucc_schedule_frag_init_fn_t)(
+    ucc_base_coll_args_t *coll_args, ucc_schedule_pipelined_t *schedule_p,
+    ucc_base_team_t *team, ucc_schedule_t **frag);
+
+/* frag setup is the callback which is triggered whenever a fragment is
+   being re-launched (or launched for the first time ).
+   This callback is used to update coll_args values (ptr offsets, counts)
+   depending on the frag num.
+
+   frag_num - is the sequencial number of currently launched fragment. */
+typedef ucc_status_t (*ucc_schedule_frag_setup_fn_t)(
+    ucc_schedule_pipelined_t *schedule_p, ucc_schedule_t *frag, int frag_num);
+
+typedef struct ucc_schedule_pipelined {
+    ucc_schedule_t               super;
+    /* Array of the frag schedules - 1 schedule per pipeline entry */
+    ucc_schedule_t *             frags[UCC_SCHEDULE_PIPELINED_MAX_FRAGS];
+    /* n_frags - is the depth of the pipeline, ie how many fragments can
+       be outstanding at a time */
+    int                          n_frags;
+    /* total number of fragments started so far. Note, total number of frags
+       to be executed is stored in super.n_tasks */
+    int                          n_frags_started;
+    /* number of frags active in the pipeline */
+    int                          n_frags_in_pipeline;
+    /* sequential flag. if set to 1 the pipeline sets additional deps
+       between the tasks in different frags. This prevents out-of-order
+       task launch in different frags of a pipeline */
+    int                          sequential;
+    int                          next_frag_to_post;
+    ucc_schedule_frag_setup_fn_t frag_setup;
+} ucc_schedule_pipelined_t;
+
+/* Creates a pipelined schedule for the algorithm defined by "frag_init".
+
+   frag_init, frag_setup - client callbacks used to init the pipeline.
+   n_frags - pipeline depth
+   n_frags_total - total number of fragments to be launched. If n_frags_total
+   > n_frags, then some frag schedules will be re-launched multiple times. */
+ucc_status_t ucc_schedule_pipelined_init(
+    ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+    ucc_schedule_frag_init_fn_t  frag_init,
+    ucc_schedule_frag_setup_fn_t frag_setup, int n_frags, int n_frags_total,
+    int sequential, ucc_schedule_pipelined_t *schedule_p);
+
+ucc_status_t ucc_dependency_handler(ucc_coll_task_t *parent, /* NOLINT */
+                                    ucc_coll_task_t *task);
+
+ucc_status_t ucc_schedule_pipelined_post(ucc_coll_task_t *task);
+
+ucc_status_t ucc_schedule_pipelined_finalize(ucc_coll_task_t *task);
+#endif

--- a/src/schedule/ucc_schedule_pipelined.h
+++ b/src/schedule/ucc_schedule_pipelined.h
@@ -60,9 +60,6 @@ ucc_status_t ucc_schedule_pipelined_init(
     ucc_schedule_frag_setup_fn_t frag_setup, int n_frags, int n_frags_total,
     int sequential, ucc_schedule_pipelined_t *schedule_p);
 
-ucc_status_t ucc_dependency_handler(ucc_coll_task_t *parent, /* NOLINT */
-                                    ucc_coll_task_t *task);
-
 ucc_status_t ucc_schedule_pipelined_post(ucc_coll_task_t *task);
 
 ucc_status_t ucc_schedule_pipelined_finalize(ucc_coll_task_t *task);

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -64,4 +64,6 @@ int ucc_sort_uniq(int *array, int len, int inverse);
         (_y)     = _tmp;                                                       \
     } while (0)
 
+#define ucc_div_round_up(_n, _d) (((_n) + (_d) - 1) / (_d))
+
 #endif

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -38,6 +38,7 @@ typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
 #define UCC_ULUNITS_AUTO                UCS_ULUNITS_AUTO
 #define UCC_CONFIG_TYPE_BITMAP          UCS_CONFIG_TYPE_BITMAP
 #define UCC_CONFIG_TYPE_MEMUNITS        UCS_CONFIG_TYPE_MEMUNITS
+#define UCC_CONFIG_TYPE_BOOL            UCS_CONFIG_TYPE_BOOL
 
 static inline ucc_status_t
 ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,


### PR DESCRIPTION
## What
Adds pipelined schedule interface and the  corresponding implementation for TL/UCP SRA allreduce algorithm

## Why ?
Pipelining improves performance of large message collectives in multiple cases

## How ?
- Pipelined schedule data structure is introduced that runs a collective as a sequence of fragments
- The interface is generic: user (tl/ucp e.g.) passes a cb that allocates a schedule -> it defines an execution of a collective fragment
- Number of simultaneously allocated fragments - pipeline depth - can be varied. 
- Frag schedules are restarted automatically keeping the dependencies
- 2 types of pipelines are supported: parallel and sequential. In parallel pipeline the tasks at the same position in frag schedule can be started out of order, in sequential the order is fixed (needed for example when TL that is used in frag schedule can't support out of order tasks)

