### PR TITLE
Enabled UCC unit tests

### DIFF
--- a/.ci/job_matrix.yaml
+++ b/.ci/job_matrix.yaml
@@ -56,23 +56,18 @@ steps:
       echo "INFO: check code format"
       ${SRC_DIR}/ucc/.ci/scripts/check_code_format.sh
   #============================================================================
-  # TODO temporarily excluded because UCC unit tests corrupts the CI cluster
-  #- name: Run UCC tests
-  #  containerSelector: "{name:'centos8'}"
-  #  run: |
-  #    echo "INFO: Run UCC tests"
-  #    hostname
-  #    cat /proc/1/cgroup
-  #    pip3 list | grep torch
-  #    ${SRC_DIR}/ucc/.ci/scripts/run_tests_ucc.sh
+  - name: Run UCC tests
+    containerSelector: "{name:'centos8'}"
+    run: |
+      echo "INFO: Run UCC tests"
+      hostname
+      ${SRC_DIR}/ucc/.ci/scripts/run_tests_ucc.sh
   #============================================================================
   - name: Run Torch-UCC tests (UCC)
     containerSelector: "{name:'centos8'}"
     run: |
       echo "INFO: Run Torch-UCC tests (UCC)"
       hostname
-      cat /proc/1/cgroup
-      pip3 list | grep torch
       ${SRC_DIR}/ucc/.ci/scripts/run_tests_torch_ucc.sh
   #============================================================================
   - name: Run docker containers


### PR DESCRIPTION
Signed-off-by: artemry-nv <artemry@nvidia.com>

## What
Re-enabled UCC unit tests after GDR is disabled inside the tests 

## Why ?
UCC unit tests breaks the CI cluster because of a bug in GDR.

