### PR TITLE
Topic/node hash fix

### DIFF
--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -77,6 +77,7 @@ typedef struct ucc_tl_ucp_context {
     ucc_tl_ucp_ep_close_state_t ep_close_state;
     ucc_mpool_t                 req_mp;
     tl_ucp_ep_hash_t           *ep_hash;
+    ucp_ep_h                   *eps;
 } ucc_tl_ucp_context_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -121,9 +121,25 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
                       (ucc_context_progress_fn_t)ucp_worker_progress,
                       self->ucp_worker)) {
         tl_error(self->super.super.lib, "failed to register progress function");
+        ucc_status = UCC_ERR_NO_MESSAGE;
         goto err_thread_mode;
     }
-    self->ep_hash = kh_init(tl_ucp_ep_hash);
+
+    if (params->context->addr_storage.storage) {
+        /* Global ctx mode, we will have ctx_map so can use array for eps */
+        self->eps = ucc_calloc(params->context->addr_storage.size,
+                               sizeof(ucp_ep_h), "ucp_eps");
+        if (self->eps) {
+            tl_error(self->super.super.lib,
+                     "failed to allocate %zd bytes for ucp_eps",
+                     params->context->addr_storage.size * sizeof(ucp_ep_h));
+            ucc_status = UCC_ERR_NO_MEMORY;
+            goto err_thread_mode;
+        }
+    } else {
+        self->eps     = NULL;
+        self->ep_hash = kh_init(tl_ucp_ep_hash);
+    }
     tl_info(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 
@@ -177,7 +193,11 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_context_t)
             break;
         }
     }
-    kh_destroy(tl_ucp_ep_hash, self->ep_hash);
+    if (self->eps) {
+        ucc_free(self->eps);
+    } else {
+        kh_destroy(tl_ucp_ep_hash, self->ep_hash);
+    }
     if (UCC_TL_CTX_HAS_OOB(self)) {
         ucc_tl_ucp_context_barrier(self, &UCC_TL_CTX_OOB(self));
     }

--- a/src/components/tl/ucp/tl_ucp_ep.c
+++ b/src/components/tl/ucp/tl_ucp_ep.c
@@ -40,19 +40,14 @@ static inline ucc_status_t ucc_tl_ucp_connect_ep(ucc_tl_ucp_context_t *ctx,
 
 ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t         *team,
                                         ucc_rank_t                 team_rank,
-                                        ucc_context_addr_header_t *h,
                                         ucp_ep_h                  *ep)
 {
     ucc_tl_ucp_context_t *ctx = UCC_TL_UCP_TEAM_CTX(team);
-    ucc_status_t          status;
-    status = ucc_tl_ucp_connect_ep(
-        ctx, ep,
-        ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), team->super.super.team,
-                             team_rank, ucc_tl_ucp.super.super.id));
-    if (UCC_OK == status) {
-        tl_ucp_hash_put(ctx->ep_hash, h->ctx_id, *ep);
-    }
-    return status;
+    void                 *addr;
+
+    addr = ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), team->super.super.team,
+                                team_rank, ucc_tl_ucp.super.super.id);
+    return ucc_tl_ucp_connect_ep(ctx, ep, addr);
 }
 
 ucc_status_t ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx)

--- a/src/components/tl/ucp/tl_ucp_ep.h
+++ b/src/components/tl/ucp/tl_ucp_ep.h
@@ -17,7 +17,6 @@ typedef struct ucc_tl_ucp_team    ucc_tl_ucp_team_t;
 
 ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t         *team,
                                         ucc_rank_t                 team_rank,
-                                        ucc_context_addr_header_t *h,
                                         ucp_ep_h                  *ep);
 
 ucc_status_t ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx);
@@ -39,18 +38,30 @@ ucc_tl_ucp_get_rank_key(ucc_tl_ucp_team_t *team, ucc_rank_t rank)
 static inline ucc_status_t ucc_tl_ucp_get_ep(ucc_tl_ucp_team_t *team, ucc_rank_t rank,
                                              ucp_ep_h *ep)
 {
-    ucc_tl_ucp_context_t      *ctx = UCC_TL_UCP_TEAM_CTX(team);
-    ucc_context_addr_header_t *h   = ucc_tl_ucp_get_team_ep_header(team, rank);
+    ucc_tl_ucp_context_t      *ctx      = UCC_TL_UCP_TEAM_CTX(team);
+    ucc_context_addr_header_t *h        = NULL;
+    ucc_rank_t                 ctx_rank = 0;
     ucc_status_t               status;
 
-    *ep = tl_ucp_hash_get(ctx->ep_hash, h->ctx_id);
+    if (ctx->eps) {
+        ctx_rank = ucc_get_ctx_rank(team->super.super.team, rank);
+        *ep      = ctx->eps[ctx_rank];
+    } else {
+        h   = ucc_tl_ucp_get_team_ep_header(team, rank);
+        *ep = tl_ucp_hash_get(ctx->ep_hash, h->ctx_id);
+    }
     if (NULL == (*ep)) {
         /* Not connected yet */
-        status = ucc_tl_ucp_connect_team_ep(team, rank, h, ep);
+        status = ucc_tl_ucp_connect_team_ep(team, rank, ep);
         if (ucc_unlikely(UCC_OK != status)) {
             tl_error(UCC_TL_TEAM_LIB(team), "failed to connect team ep");
             *ep = NULL;
             return status;
+        }
+        if (ctx->eps) {
+            ctx->eps[ctx_rank] = *ep;
+        } else {
+            tl_ucp_hash_put(ctx->ep_hash, h->ctx_id, *ep);
         }
     }
     return UCC_OK;

--- a/src/components/tl/ucp/tl_ucp_ep_hash.h
+++ b/src/components/tl/ucp/tl_ucp_ep_hash.h
@@ -20,11 +20,14 @@ static inline uint32_t tl_ucp_ctx_id_hash_fn_impl(uint32_t h, uint32_t k)
     return h;
 }
 
+/* Collisions are handled in khash implementation */
 static inline khint32_t tl_ucp_ctx_id_hash_fn(ucc_context_id_t k)
 {
     uint32_t h = 0;
 
-    h = tl_ucp_ctx_id_hash_fn_impl(h, k.pi.host_hash);
+    ucc_assert(sizeof(k.pi.host_hash) == 8);
+    h = tl_ucp_ctx_id_hash_fn_impl(h,
+                                   kh_int64_hash_func(k.pi.host_hash));
     h = tl_ucp_ctx_id_hash_fn_impl(h, k.pi.pid);
     h = tl_ucp_ctx_id_hash_fn_impl(h, k.seq_num);
     return (khint32_t)h;

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -39,6 +39,7 @@ typedef struct ucc_addr_storage {
     void      *oob_req;
     size_t     addr_len;
     ucc_rank_t size;
+    ucc_rank_t rank;
 } ucc_addr_storage_t;
 
 typedef struct ucc_context {

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -93,4 +93,9 @@ static inline void *ucc_get_team_ep_addr(ucc_context_t *context,
     return addr;
 }
 
+static inline ucc_rank_t ucc_get_ctx_rank(ucc_team_t *team, ucc_rank_t team_rank)
+{
+    return ucc_ep_map_eval(team->ctx_map, team_rank);
+}
+
 #endif

--- a/src/utils/ucc_proc_info.c
+++ b/src/utils/ucc_proc_info.c
@@ -1,14 +1,33 @@
 #include "ucc_proc_info.h"
+#include "ucc_math.h"
+#include "ucc_log.h"
+#include <limits.h>
+#include <stdint.h>
+
 ucc_proc_info_t ucc_local_proc;
-char ucc_local_hostname[128];
+static char ucc_local_hostname[HOST_NAME_MAX];
+
+const char*  ucc_hostname()
+{
+    return ucc_local_hostname;
+}
 
 ucc_status_t ucc_local_proc_info_init()
 {
     ucc_local_proc.host_hash = gethostid();
     if (gethostname(ucc_local_hostname, sizeof(ucc_local_hostname))) {
+        ucc_warn("couldn't get local hostname");
         ucc_local_hostname[0] = '\0';
+    } else {
+        strtok(ucc_local_hostname, ".");
+        ucc_assert(sizeof(ucc_host_id_t) >= sizeof(unsigned long));
+        //TODO: switch to ucs_machine_guid when it is available
+        ucc_local_proc.host_hash = ucc_str_hash_djb2(ucc_local_hostname);
     }
     ucc_local_proc.pid       = getpid();
     ucc_local_proc.socket_id = -1;
+
+    ucc_debug("proc pid %d, host %s, host_hash %lu",
+              ucc_local_proc.pid, ucc_local_hostname, ucc_local_proc.host_hash);
     return UCC_OK;
 }

--- a/src/utils/ucc_proc_info.h
+++ b/src/utils/ucc_proc_info.h
@@ -9,8 +9,8 @@
 #include "config.h"
 #include "ucc/api/ucc.h"
 #include <unistd.h>
-#include <stdint.h>
-typedef uint32_t ucc_host_id_t;
+
+typedef uint64_t ucc_host_id_t;
 typedef uint32_t ucc_socket_id_t;
 
 typedef struct ucc_proc_info {
@@ -21,14 +21,13 @@ typedef struct ucc_proc_info {
 } ucc_proc_info_t;
 
 extern ucc_proc_info_t ucc_local_proc;
-extern char ucc_local_hostname[128];
 
 #define UCC_PROC_INFO_EQUAL(_pi1, _pi2)                                        \
     (((_pi1).host_hash == (_pi2).host_hash) &&                                 \
      ((_pi1).pid == (_pi2).pid)) //TODO maybe need tid ?
+
 ucc_status_t ucc_local_proc_info_init();
 
-static inline const char*  ucc_hostname() {
-    return ucc_local_hostname;
-}
+const char*  ucc_hostname();
+
 #endif


### PR DESCRIPTION
## What
Fixes issues with gethostid() which may return non-uniq values if not configured properly (FB hang issue)
Additionally: 
- adds check for the uniq proc_info identifiers and prints error in case of collision (unlikely event after that fix)
- adds array storage for TL/UCP ucp_ep_h instead of khash that can be used when OOB is global and tl team has ctx_map


## How ?
Compute the 64 bit node hash using string hash function (todo: switch to UCS ucs_machine_guid when it is made public).
