### PR TITLE
Poc/nccl tl reduce scatter

### DIFF
--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -138,7 +138,7 @@ extern ucc_mc_cuda_t ucc_mc_cuda;
 
 #define UCC_MC_CUDA_INIT_STREAM() do {                                         \
     if (ucc_mc_cuda.stream == NULL) {                                          \
-        cudaError_t cuda_st;                                                   \
+        cudaError_t cuda_st = cudaSuccess;                                     \
         ucc_spin_lock(&ucc_mc_cuda.init_spinlock);                             \
         if (ucc_mc_cuda.stream == NULL) {                                      \
             cuda_st = cudaStreamCreateWithFlags(&ucc_mc_cuda.stream,           \

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -67,7 +67,8 @@ typedef struct ucc_tl_nccl_task {
 #define UCC_TL_NCCL_SUPPORTED_COLLS                         \
     (UCC_COLL_TYPE_ALLTOALL  | UCC_COLL_TYPE_ALLTOALLV  |   \
      UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |   \
-     UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST)
+     UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST |        \
+     UCC_COLL_TYPE_REDUCE_SCATTER)
 
 UCC_CLASS_DECLARE(ucc_tl_nccl_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/nccl/tl_nccl_coll.h
+++ b/src/components/tl/nccl/tl_nccl_coll.h
@@ -21,4 +21,6 @@ ucc_status_t ucc_tl_nccl_alltoallv_init(ucc_tl_nccl_task_t *task);
 
 ucc_status_t ucc_tl_nccl_bcast_init(ucc_tl_nccl_task_t *task);
 
+ucc_status_t ucc_tl_nccl_reduce_scatter_init(ucc_tl_nccl_task_t *task);
+
 #endif

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -197,6 +197,9 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
     case UCC_COLL_TYPE_BCAST:
         status = ucc_tl_nccl_bcast_init(task);
         break;
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        status = ucc_tl_nccl_reduce_scatter_init(task);
+        break;
     default:
         tl_error(UCC_TL_TEAM_LIB(task->team),
                  "collective %d is not supported by nccl tl",

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -72,6 +72,8 @@ static inline const char* ucc_coll_type_str(ucc_coll_type_t ct)
         return "Gather";
     case UCC_COLL_TYPE_SCATTER:
         return "Scatter";
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        return "Reduce_Scatter";
     case UCC_COLL_TYPE_FANIN:
         return "Fanin";
     case UCC_COLL_TYPE_FANOUT:


### PR DESCRIPTION
## What
support reduce_scatter in NCCL TL

## Why ?
unblock some workloads need to perform reduce_scatter on GPU buffers

## How ?
- Add `UCC_COLL_TYPE_REDUCE_SCATTER ` to `UCC_TL_NCCL_SUPPORTED_COLLS `
- Add `ucc_tl_nccl_reduce_scatter_init ` and `ucc_tl_nccl_reduce_scatter_start `
- Use `ncclReduceScatter` to perform reduce-scatter, and use existing sync and progress functions
