### PR TITLE
[POC] support reduce_scatter in NCCL TL

### DIFF
--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -82,7 +82,8 @@ typedef struct ucc_tl_nccl_task {
 #define UCC_TL_NCCL_SUPPORTED_COLLS                         \
     (UCC_COLL_TYPE_ALLTOALL  | UCC_COLL_TYPE_ALLTOALLV  |   \
      UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |   \
-     UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST)
+     UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST |        \
+     UCC_COLL_TYPE_REDUCE_SCATTER)
 
 UCC_CLASS_DECLARE(ucc_tl_nccl_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -374,3 +374,45 @@ ucc_status_t ucc_tl_nccl_bcast_init(ucc_tl_nccl_task_t *task)
     task->super.post     = ucc_tl_nccl_bcast_start;
     return UCC_OK;
 }
+
+ucc_status_t ucc_tl_nccl_reduce_scatter_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_coll_args_t    *args   = &coll_task->args;
+    ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
+    ucc_ee_h            ee     = coll_task->ee;
+    cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
+    void               *dst    = args->dst.info.buffer;
+    void               *src    =
+        UCC_IS_INPLACE(*args) ? args->dst.info.buffer : args->src.info.buffer;
+    ucc_status_t        status = UCC_OK;
+    ncclDataType_t      dt     = ucc_to_nccl_dtype[args->src.info.datatype];
+    ncclRedOp_t         op = ucc_to_nccl_reduce_op[args->reduce.predefined_op];
+    size_t              count = args->dst.info.count;
+
+    task->super.super.status = UCC_INPROGRESS;
+    NCCLCHECK_GOTO(ncclReduceScatter(src, dst, count, dt, op, team->nccl_comm,
+                                 stream),
+                   exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_nccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_nccl_reduce_scatter_init(ucc_tl_nccl_task_t *task)
+{
+    if ((task->super.args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
+        (ucc_to_nccl_reduce_op[task->super.args.reduce.predefined_op] ==
+         ncclOpUnsupported)) {
+        tl_error(UCC_TASK_LIB(task), "reduction operation is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    if (UCC_OK !=
+        ucc_nccl_check_dt_supported(task->super.args.src.info.datatype,
+                                    task->super.args.src.info.datatype)) {
+        tl_error(UCC_TASK_LIB(task), "dataype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    task->super.post     = ucc_tl_nccl_reduce_scatter_start;
+    return UCC_OK;
+}

--- a/src/components/tl/nccl/tl_nccl_coll.h
+++ b/src/components/tl/nccl/tl_nccl_coll.h
@@ -21,4 +21,6 @@ ucc_status_t ucc_tl_nccl_alltoallv_init(ucc_tl_nccl_task_t *task);
 
 ucc_status_t ucc_tl_nccl_bcast_init(ucc_tl_nccl_task_t *task);
 
+ucc_status_t ucc_tl_nccl_reduce_scatter_init(ucc_tl_nccl_task_t *task);
+
 #endif

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -201,6 +201,9 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
     case UCC_COLL_TYPE_BCAST:
         status = ucc_tl_nccl_bcast_init(task);
         break;
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        status = ucc_tl_nccl_reduce_scatter_init(task);
+        break;
     default:
         tl_error(UCC_TASK_LIB(task),
                  "collective %d is not supported by nccl tl",

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -72,6 +72,8 @@ static inline const char* ucc_coll_type_str(ucc_coll_type_t ct)
         return "Gather";
     case UCC_COLL_TYPE_SCATTER:
         return "Scatter";
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        return "Reduce_Scatter";
     case UCC_COLL_TYPE_FANIN:
         return "Fanin";
     case UCC_COLL_TYPE_FANOUT:


### PR DESCRIPTION
## What
support reduce_scatter in NCCL TL

## Why ?
unblock some workloads need to perform reduce_scatter on GPU buffers

## How ?
- Add `UCC_COLL_TYPE_REDUCE_SCATTER ` to `UCC_TL_NCCL_SUPPORTED_COLLS `
- Add `ucc_tl_nccl_reduce_scatter_init ` and `ucc_tl_nccl_reduce_scatter_start `
- Use `ncclReduceScatter` to perform reduce-scatter, and use existing sync and progress functions
