### PR TITLE
Scoremap selection fallback

### DIFF
--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -119,6 +119,7 @@ static ucc_status_t ucc_fallback_alloc(ucc_score_t              score,
 
     fb = ucc_malloc(sizeof(*fb), "fallback");
     if (ucc_unlikely(!fb)) {
+        *_fb = NULL;
         ucc_error("failed to allocate %zd bytes for fallback", sizeof(*fb));
         return UCC_ERR_NO_MEMORY;
     }
@@ -181,6 +182,7 @@ static ucc_status_t ucc_msg_range_dup(const ucc_msg_range_t *in,
 
     r = ucc_malloc(sizeof(*r), "msg_range");
     if (ucc_unlikely(!r)) {
+        *out = NULL;
         ucc_error("failed to allocate %zd bytes for msgrange", sizeof(*r));
         return UCC_ERR_NO_MEMORY;
     }

--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -28,7 +28,7 @@ ucc_status_t ucc_coll_score_alloc(ucc_coll_score_t **score)
 
 static inline void ucc_msg_range_free(ucc_msg_range_t *r)
 {
-    ucc_list_destruct(&r->fallback, ucc_msg_range_fb_t, ucc_free, list_elem);
+    ucc_list_destruct(&r->fallback, ucc_coll_entry_t, ucc_free, list_elem);
     ucc_free(r);
 }
 
@@ -53,27 +53,28 @@ coll_score_add_range(ucc_coll_score_t *score, ucc_coll_type_t coll_type,
 
     ucc_list_head_init(&r->fallback);
 
-    r->start   = start;
-    r->end     = end;
-    r->score   = msg_score;
-    r->init    = init;
-    r->team    = team;
-    list       = &score->scores[ucc_ilog2(coll_type)][mem_type];
-    insert_pos = list;
-    ucc_list_for_each(range, list, list_elem) {
+    r->start       = start;
+    r->end         = end;
+    r->super.score = msg_score;
+    r->super.init  = init;
+    r->super.team  = team;
+    list           = &score->scores[ucc_ilog2(coll_type)][mem_type];
+    insert_pos     = list;
+    ucc_list_for_each(range, list, super.list_elem) {
         if (start >= range->end) {
-            insert_pos = &range->list_elem;
+            insert_pos = &range->super.list_elem;
         } else {
             break;
         }
     }
-    ucc_list_insert_after(insert_pos, &r->list_elem);
+    ucc_list_insert_after(insert_pos, &r->super.list_elem);
     /*sanity check: ranges shuold not overlap */
-    next = r->list_elem.next;
+    next = r->super.list_elem.next;
     if ((next != list) &&
-        (ucc_container_of(next, ucc_msg_range_t, list_elem)->start < r->end)) {
+        (ucc_container_of(next, ucc_msg_range_t, super.list_elem)->start <
+         r->end)) {
         ucc_error("attempt to add overlaping range");
-        ucc_list_del(&r->list_elem);
+        ucc_list_del(&r->super.list_elem);
         ucc_msg_range_free(r);
         return UCC_ERR_INVALID_PARAM;
     }
@@ -103,7 +104,7 @@ void ucc_coll_score_free(ucc_coll_score_t *score)
     for (i = 0; i < UCC_COLL_TYPE_NUM; i++) {
         for (j = 0; j < UCC_MEMORY_TYPE_LAST; j++) {
             ucc_list_destruct(&score->scores[i][j], ucc_msg_range_t,
-                              ucc_msg_range_free, list_elem);
+                              ucc_msg_range_free, super.list_elem);
         }
     }
     ucc_free(score);
@@ -112,10 +113,11 @@ void ucc_coll_score_free(ucc_coll_score_t *score)
 static ucc_status_t ucc_fallback_alloc(ucc_score_t              score,
                                        ucc_base_coll_init_fn_t  init,
                                        ucc_base_team_t         *team,
-                                       ucc_msg_range_fb_t     **_fb)
+                                       ucc_coll_entry_t       **_fb)
 {
-    ucc_msg_range_fb_t *fb = ucc_malloc(sizeof(*fb), "fallback");
+    ucc_coll_entry_t *fb;
 
+    fb = ucc_malloc(sizeof(*fb), "fallback");
     if (ucc_unlikely(!fb)) {
         ucc_error("failed to allocate %zd bytes for fallback", sizeof(*fb));
         return UCC_ERR_NO_MEMORY;
@@ -127,11 +129,11 @@ static ucc_status_t ucc_fallback_alloc(ucc_score_t              score,
     return UCC_OK;
 }
 
-static inline void ucc_fallback_insert(ucc_list_link_t *list,
-                                       ucc_msg_range_fb_t *fb)
+static inline void ucc_fallback_insert(ucc_list_link_t  *list,
+                                       ucc_coll_entry_t *fb)
 {
-    ucc_list_link_t    *insert_pos;
-    ucc_msg_range_fb_t *f;
+    ucc_list_link_t  *insert_pos;
+    ucc_coll_entry_t *f;
 
     insert_pos = list;
     ucc_list_for_each(f, list, list_elem) {
@@ -149,28 +151,35 @@ static inline void ucc_fallback_insert(ucc_list_link_t *list,
     ucc_list_insert_after(insert_pos, &fb->list_elem);
 }
 
+#define FB_ALLOC_INSERT(_fb_in, _fb_out, _dest, _status, _label) do {   \
+        _status =                                                       \
+            ucc_fallback_alloc((_fb_in)->score, (_fb_in)->init,         \
+                               (_fb_in)->team, &(_fb_out));             \
+        if (ucc_unlikely(UCC_OK != _status)) {                          \
+            goto _label;                                                \
+        }                                                               \
+        ucc_fallback_insert(&(_dest)->fallback, _fb_out);               \
+    } while (0)
+
 static ucc_status_t ucc_fallback_copy(const ucc_msg_range_t *in,
                                       ucc_msg_range_t       *out)
 {
-    ucc_msg_range_fb_t *fb_in, *fb;
-    ucc_status_t        status;
+    ucc_status_t      status = UCC_OK;
+    ucc_coll_entry_t *fb_in, *fb;
 
     ucc_list_for_each(fb_in, &in->fallback, list_elem) {
-        status =
-            ucc_fallback_alloc(fb_in->score, fb_in->init, fb_in->team, &fb);
-        if (ucc_unlikely(UCC_OK != status)) {
-            return status;
-        }
-        ucc_fallback_insert(&out->fallback, fb);
+        FB_ALLOC_INSERT(fb_in, fb, out, status, out);
     }
-    return UCC_OK;
+out:
+    return status;
 }
 
 static ucc_status_t ucc_msg_range_dup(const ucc_msg_range_t *in,
                                       ucc_msg_range_t      **out)
 {
-    ucc_msg_range_t *r = ucc_malloc(sizeof(*r), "msg_range");
+    ucc_msg_range_t *r;
 
+    r = ucc_malloc(sizeof(*r), "msg_range");
     if (ucc_unlikely(!r)) {
         ucc_error("failed to allocate %zd bytes for msgrange", sizeof(*r));
         return UCC_ERR_NO_MEMORY;
@@ -194,14 +203,16 @@ static ucc_status_t ucc_msg_range_dup(const ucc_msg_range_t *in,
 static ucc_status_t ucc_msg_range_add_fallback(const ucc_msg_range_t *in,
                                                ucc_msg_range_t       *out)
 {
-    ucc_msg_range_fb_t *fb;
-    ucc_status_t        status;
+    ucc_coll_entry_t *fb;
+    ucc_status_t      status;
 
-    if (in->init == out->init && in->team == out->team) {
+    if (in->super.init == out->super.init &&
+        in->super.team == out->super.team) {
         return UCC_OK;
     }
 
-    status = ucc_fallback_alloc(in->score, in->init, in->team, &fb);
+    status = ucc_fallback_alloc(in->super.score, in->super.init, in->super.team,
+                                &fb);
     if (ucc_unlikely(UCC_OK != status)) {
         return status;
     }
@@ -225,14 +236,14 @@ static ucc_status_t ucc_score_list_dup(ucc_list_link_t *src,
     ucc_status_t     status;
 
     ucc_list_head_init(dst);
-    ucc_list_for_each(range, src, list_elem) {
+    ucc_list_for_each(range, src, super.list_elem) {
         r = MSG_RANGE_DUP(range);
-        ucc_list_add_tail(dst, &r->list_elem);
+        ucc_list_add_tail(dst, &r->super.list_elem);
     }
     return UCC_OK;
 out:
-    ucc_list_for_each_safe(range, r, dst, list_elem) {
-        ucc_list_del(&range->list_elem);
+    ucc_list_for_each_safe(range, r, dst, super.list_elem) {
+        ucc_list_del(&range->super.list_elem);
         ucc_msg_range_free(range);
     }
     ucc_assert(ucc_list_is_empty(dst));
@@ -242,8 +253,8 @@ out:
 static inline int ucc_msg_range_fb_compare(ucc_msg_range_t *r1,
                                            ucc_msg_range_t *r2)
 {
-    ucc_list_link_t    *l1, *l2;
-    ucc_msg_range_fb_t *fb1, *fb2;
+    ucc_list_link_t  *l1, *l2;
+    ucc_coll_entry_t *fb1, *fb2;
 
     l1 = &r1->fallback;
     l2 = &r2->fallback;
@@ -252,13 +263,13 @@ static inline int ucc_msg_range_fb_compare(ucc_msg_range_t *r1,
         return 0;
     }
 
-    fb2 = ucc_list_head(l2, ucc_msg_range_fb_t, list_elem);
+    fb2 = ucc_list_head(l2, ucc_coll_entry_t, list_elem);
     ucc_list_for_each(fb1, l1, list_elem) {
         if (fb1->score != fb2->score || fb1->init != fb2->init ||
             fb1->team != fb2->team) {
             return 0;
         }
-        fb2 = ucc_list_next(&fb2->list_elem, ucc_msg_range_fb_t, list_elem);
+        fb2 = ucc_list_next(&fb2->list_elem, ucc_coll_entry_t, list_elem);
     }
     return 1;
 }
@@ -292,25 +303,25 @@ static ucc_status_t ucc_coll_score_merge_one(ucc_list_link_t *list1,
     while (!(ucc_list_is_empty(&lst1) && ucc_list_is_empty(&lst2))) {
         if (ucc_list_is_empty(&lst1)) {
             ucc_list_add_tail(out, &(ucc_list_extract_head(&lst2,
-                                     ucc_msg_range_t, list_elem)->list_elem));
+                                     ucc_coll_entry_t, list_elem)->list_elem));
             continue;
         }
         if (ucc_list_is_empty(&lst2)) {
             ucc_list_add_tail(out, &(ucc_list_extract_head(&lst1,
-                                     ucc_msg_range_t, list_elem)->list_elem));
+                                     ucc_coll_entry_t, list_elem)->list_elem));
             continue;
         }
-        r1 = ucc_list_head(&lst1, ucc_msg_range_t, list_elem);
-        r2 = ucc_list_head(&lst2, ucc_msg_range_t, list_elem);
+        r1   = ucc_list_head(&lst1, ucc_msg_range_t, super.list_elem);
+        r2   = ucc_list_head(&lst2, ucc_msg_range_t, super.list_elem);
         left = (r1->start < r2->start) ? r1 : r2; //NOLINT
 
         if (r1->start == r2->start) {
             if (r1->end == r2->end) {
-                best = (r1->score > r2->score) ? r1 : r2;
+                best = (r1->super.score > r2->super.score) ? r1 : r2;
                 left                  = (best == r1) ? r2 : r1;
-                ucc_list_del(&r1->list_elem);
-                ucc_list_del(&r2->list_elem);
-                ucc_list_add_tail(out, &best->list_elem);
+                ucc_list_del(&r1->super.list_elem);
+                ucc_list_del(&r2->super.list_elem);
+                ucc_list_add_tail(out, &best->super.list_elem);
                 ADD_FALLBACK(left, best);
                 ucc_msg_range_free(left);
                 continue;
@@ -319,25 +330,25 @@ static ucc_status_t ucc_coll_score_merge_one(ucc_list_link_t *list1,
             right        = (left == r1) ? r2 : r1;
             new          = MSG_RANGE_DUP(right);
             right->start = new->end = left->end;
-            ucc_list_del(&left->list_elem);
-            if (left->score < new->score) {
+            ucc_list_del(&left->super.list_elem);
+            if (left->super.score < new->super.score) {
                 SWAP(left, new, void *);
             }
             ADD_FALLBACK(new, left);
             ucc_msg_range_free(new);
 
-            ucc_list_add_tail(out, &left->list_elem);
+            ucc_list_add_tail(out, &left->super.list_elem);
             continue;
         }
         right = (left == r1) ? r2 : r1;
         if (left->end <= right->start) {
             /* ranges don't overlap - copy over */
-            ucc_list_del(&left->list_elem);
-            ucc_list_add_tail(out, &left->list_elem);
+            ucc_list_del(&left->super.list_elem);
+            ucc_list_add_tail(out, &left->super.list_elem);
         } else {
             new      = MSG_RANGE_DUP(left);
             new->end = right->start;
-            ucc_list_add_tail(out, &new->list_elem);
+            ucc_list_add_tail(out, &new->super.list_elem);
             left->start = right->start;
         }
     }
@@ -345,15 +356,17 @@ static ucc_status_t ucc_coll_score_merge_one(ucc_list_link_t *list1,
        same team and same fallback sequence
        if any have been produced by the algorithm above */
 
-    ucc_list_for_each_safe(range, temp, out, list_elem) {
-        if (range->list_elem.next != out) {
-            next = ucc_container_of(range->list_elem.next, ucc_msg_range_t,
-                                    list_elem);
-            if (range->score == next->score && range->end == next->start &&
-                range->init == next->init && range->team == next->team &&
+    ucc_list_for_each_safe(range, temp, out, super.list_elem) {
+        if (range->super.list_elem.next != out) {
+            next = ucc_container_of(range->super.list_elem.next,
+                                    ucc_msg_range_t, super.list_elem);
+            if (range->super.score == next->super.score &&
+                range->end == next->start &&
+                range->super.init == next->super.init &&
+                range->super.team == next->super.team &&
                 1 == ucc_msg_range_fb_compare(range, next)) {
                 next->start = range->start;
-                ucc_list_del(&range->list_elem);
+                ucc_list_del(&range->super.list_elem);
                 ucc_msg_range_free(range);
             }
         }
@@ -361,9 +374,12 @@ static ucc_status_t ucc_coll_score_merge_one(ucc_list_link_t *list1,
     return UCC_OK;
 
 out:
-    ucc_list_destruct(&lst2, ucc_msg_range_t, ucc_msg_range_free, list_elem);
-    ucc_list_destruct(&lst1, ucc_msg_range_t, ucc_msg_range_free, list_elem);
-    ucc_list_destruct(out, ucc_msg_range_t, ucc_msg_range_free, list_elem);
+    ucc_list_destruct(&lst2, ucc_msg_range_t, ucc_msg_range_free,
+                      super.list_elem);
+    ucc_list_destruct(&lst1, ucc_msg_range_t, ucc_msg_range_free,
+                      super.list_elem);
+    ucc_list_destruct(out, ucc_msg_range_t, ucc_msg_range_free,
+                      super.list_elem);
     return status;
 }
 
@@ -811,28 +827,28 @@ static ucc_status_t ucc_coll_score_update_one(ucc_list_link_t *dest,
                                               ucc_list_link_t *src,
                                               ucc_score_t      default_score)
 {
-    ucc_list_link_t    *s = src->next;
-    ucc_list_link_t    *d = dest->next;
-    ucc_msg_range_t    *range, *tmp, *next, *rs, *rd, *new;
-    ucc_msg_range_fb_t *fb;
-    ucc_status_t        status;
+    ucc_list_link_t  *s = src->next;
+    ucc_list_link_t  *d = dest->next;
+    ucc_msg_range_t  *range, *tmp, *next, *rs, *rd, *new;
+    ucc_coll_entry_t *fb;
+    ucc_status_t      status;
 
     if (ucc_list_is_empty(src) || ucc_list_is_empty(dest)) {
         return UCC_OK;
     }
     while (s != src && d != dest) {
-        rs = ucc_container_of(s, ucc_msg_range_t, list_elem);
-        rd = ucc_container_of(d, ucc_msg_range_t, list_elem);
-        ucc_assert((NULL == rs->init) || (NULL != rs->team));
+        rs = ucc_container_of(s, ucc_msg_range_t, super.list_elem);
+        rd = ucc_container_of(d, ucc_msg_range_t, super.list_elem);
+        ucc_assert((NULL == rs->super.init) || (NULL != rs->super.team));
         if (rd->start >= rs->end) {
             /* skip src range - no overlap */
             s = s->next;
-            if (rs->init) {
+            if (rs->super.init) {
                 new = MSG_RANGE_DUP(rs);
-                if (new->score == UCC_SCORE_INVALID) {
-                    new->score = default_score;
+                if (new->super.score == UCC_SCORE_INVALID) {
+                    new->super.score = default_score;
                 }
-                ucc_list_insert_before(d, &new->list_elem);
+                ucc_list_insert_before(d, &new->super.list_elem);
             }
         } else if (rd->end <= rs->start) {
             /* no overlap - inverse case: skip dst range */
@@ -841,76 +857,61 @@ static ucc_status_t ucc_coll_score_update_one(ucc_list_link_t *dest,
             new       = MSG_RANGE_DUP(rd);
             new->end  = rs->start;
             rd->start = rs->start;
-            ucc_list_insert_before(d, &new->list_elem);
+            ucc_list_insert_before(d, &new->super.list_elem);
         } else if (rd->start > rs->start) {
-            if (rs->init) {
+            if (rs->super.init) {
                 new = MSG_RANGE_DUP(rs);
-                if (new->score == UCC_SCORE_INVALID) {
-                    new->score = default_score;
+                if (new->super.score == UCC_SCORE_INVALID) {
+                    new->super.score = default_score;
                 }
                 new->end = rd->start;
-                ucc_list_insert_before(d, &new->list_elem);
+                ucc_list_insert_before(d, &new->super.list_elem);
             }
             rs->start = rd->start;
         } else {
             /* same start */
             if (rs->end > rd->end) {
-                if (UCC_SCORE_INVALID != rs->score) {
-                    rd->score = rs->score;
+                if (UCC_SCORE_INVALID != rs->super.score) {
+                    rd->super.score = rs->super.score;
                 }
-                if (rs->init) {
-                    if (rs->init != rd->init) {
+                if (rs->super.init) {
+                    if (rs->super.init != rd->super.init) {
                         /* User setting overrides existing init fn. Save it as a fallback */
-                        status = ucc_fallback_alloc(rd->score, rd->init,
-                                                    rd->team, &fb);
-                        if (ucc_unlikely(UCC_OK != status)) {
-                            goto out;
-                        }
-                        ucc_fallback_insert(&rd->fallback, fb);
+                        FB_ALLOC_INSERT(&rd->super, fb, rd, status, out);
                     }
-                    rd->init = rs->init;
-                    rd->team = rs->team;
+                    rd->super.init = rs->super.init;
+                    rd->super.team = rs->super.team;
                 }
                 rs->start = rd->end;
                 d         = d->next;
             } else if (rs->end < rd->end) {
                 new      = MSG_RANGE_DUP(rd);
                 new->end = rs->end;
-                if (UCC_SCORE_INVALID != rs->score) {
-                    new->score = rs->score;
+                if (UCC_SCORE_INVALID != rs->super.score) {
+                    new->super.score = rs->super.score;
                 }
-                if (rs->init) {
-                    if (rs->init != rd->init) {
+                if (rs->super.init) {
+                    if (rs->super.init != rd->super.init) {
                         /* User setting overrides existing init fn. Save it as a fallback */
-                        status = ucc_fallback_alloc(rd->score, rd->init,
-                                                    rd->team, &fb);
-                        if (ucc_unlikely(UCC_OK != status)) {
-                            goto out;
-                        }
-                        ucc_fallback_insert(&new->fallback, fb);
+                        FB_ALLOC_INSERT(&rd->super, fb, new, status, out);
                     }
-                    new->init = rs->init;
-                    new->team = rs->team;
+                    new->super.init = rs->super.init;
+                    new->super.team = rs->super.team;
                 }
-                ucc_list_insert_before(d, &new->list_elem);
+                ucc_list_insert_before(d, &new->super.list_elem);
                 rd->start = rs->end;
                 s         = s->next;
             } else {
-                if (UCC_SCORE_INVALID != rs->score) {
-                    rd->score = rs->score;
+                if (UCC_SCORE_INVALID != rs->super.score) {
+                    rd->super.score = rs->super.score;
                 }
-                if (rs->init) {
-                    if (rs->init != rd->init) {
+                if (rs->super.init) {
+                    if (rs->super.init != rd->super.init) {
                         /* User setting overrides existing init fn. Save it as a fallback */
-                        status = ucc_fallback_alloc(rd->score, rd->init,
-                                                    rd->team, &fb);
-                        if (ucc_unlikely(UCC_OK != status)) {
-                            goto out;
-                        }
-                        ucc_fallback_insert(&rd->fallback, fb);
+                        FB_ALLOC_INSERT(&rd->super, fb, rd, status, out);
                     }
-                    rd->init = rs->init;
-                    rd->team = rs->team;
+                    rd->super.init = rs->super.init;
+                    rd->super.team = rs->super.team;
                 }
                 s = s->next;
                 d = d->next;
@@ -918,17 +919,17 @@ static ucc_status_t ucc_coll_score_update_one(ucc_list_link_t *dest,
         }
     }
     while (s != src) {
-        rs = ucc_container_of(s, ucc_msg_range_t, list_elem);
-        if (rs->init) {
+        rs = ucc_container_of(s, ucc_msg_range_t, super.list_elem);
+        if (rs->super.init) {
             new = MSG_RANGE_DUP(rs);
-            ucc_list_add_tail(dest, &new->list_elem);
+            ucc_list_add_tail(dest, &new->super.list_elem);
         }
         s = s->next;
     }
     /* remove potentially disabled ranges */
-    ucc_list_for_each_safe(range, tmp, dest, list_elem) {
-        if (0 == range->score) {
-            ucc_list_del(&range->list_elem);
+    ucc_list_for_each_safe(range, tmp, dest, super.list_elem) {
+        if (0 == range->super.score) {
+            ucc_list_del(&range->super.list_elem);
             ucc_msg_range_free(range);
         }
     }
@@ -936,16 +937,18 @@ static ucc_status_t ucc_coll_score_update_one(ucc_list_link_t *dest,
     /* Merge consequtive ranges with the same score, same init fn,
        same team and same fallback sequence
        if any have been produced by the algorithm above */
-    ucc_list_for_each_safe(range, tmp, dest, list_elem) { //NOLINT
-        if (range->list_elem.next != dest) {
-            next = ucc_container_of(range->list_elem.next, ucc_msg_range_t,
-                                    list_elem);
+    ucc_list_for_each_safe(range, tmp, dest, super.list_elem) { //NOLINT
+        if (range->super.list_elem.next != dest) {
+            next = ucc_container_of(range->super.list_elem.next,
+                                    ucc_msg_range_t, super.list_elem);
             //NOLINTNEXTLINE
-            if (range->score == next->score && range->end == next->start &&
-                range->init == next->init && range->team == next->team &&
+            if (range->super.score == next->super.score &&
+                range->end == next->start &&
+                range->super.init == next->super.init &&
+                range->super.team == next->super.team &&
                 1 == ucc_msg_range_fb_compare(range, next)) {
                 next->start = range->start;
-                ucc_list_del(&range->list_elem);
+                ucc_list_del(&range->super.list_elem);
                 ucc_msg_range_free(range);
             }
         }

--- a/src/coll_score/ucc_coll_score.h
+++ b/src/coll_score/ucc_coll_score.h
@@ -19,8 +19,16 @@
 
 #define UCC_MSG_MAX UINT64_MAX
 
+typedef struct ucc_msg_range_fb {
+    ucc_list_link_t          list_elem;
+    ucc_score_t              score;
+    ucc_base_coll_init_fn_t  init;
+    ucc_base_team_t         *team;
+} ucc_msg_range_fb_t;
+
 typedef struct ucc_msg_range {
     ucc_list_link_t         list_elem;
+    ucc_list_link_t         fallback;
     size_t                  start;
     size_t                  end;
     ucc_score_t             score;
@@ -134,9 +142,9 @@ ucc_status_t ucc_coll_score_build_map(ucc_coll_score_t *score,
 
 void         ucc_coll_score_free_map(ucc_score_map_t *map);
 
-/* Selects the "init" function from score map based on coll_args */
-ucc_status_t ucc_coll_score_map_lookup(ucc_score_map_t         *map,
-                                       ucc_base_coll_args_t    *args,
-                                       ucc_base_coll_init_fn_t *init,
-                                       ucc_base_team_t        **team);
+/* Initializes task based on args selection and score map.
+   Checks fallbacks if necessary. */
+ucc_status_t ucc_coll_score_map_init(ucc_score_map_t      *map,
+                                     ucc_base_coll_args_t *bargs,
+                                     ucc_coll_task_t     **task);
 #endif

--- a/src/coll_score/ucc_coll_score.h
+++ b/src/coll_score/ucc_coll_score.h
@@ -19,21 +19,18 @@
 
 #define UCC_MSG_MAX UINT64_MAX
 
-typedef struct ucc_msg_range_fb {
+typedef struct ucc_coll_entry {
     ucc_list_link_t          list_elem;
     ucc_score_t              score;
     ucc_base_coll_init_fn_t  init;
     ucc_base_team_t         *team;
-} ucc_msg_range_fb_t;
+} ucc_coll_entry_t;
 
 typedef struct ucc_msg_range {
-    ucc_list_link_t         list_elem;
+    ucc_coll_entry_t        super;
     ucc_list_link_t         fallback;
     size_t                  start;
     size_t                  end;
-    ucc_score_t             score;
-    ucc_base_coll_init_fn_t init;
-    ucc_base_team_t        *team;
 } ucc_msg_range_t;
 
 typedef struct ucc_coll_score {
@@ -144,7 +141,7 @@ void         ucc_coll_score_free_map(ucc_score_map_t *map);
 
 /* Initializes task based on args selection and score map.
    Checks fallbacks if necessary. */
-ucc_status_t ucc_coll_score_map_init(ucc_score_map_t      *map,
-                                     ucc_base_coll_args_t *bargs,
-                                     ucc_coll_task_t     **task);
+ucc_status_t ucc_coll_init(ucc_score_map_t      *map,
+                           ucc_base_coll_args_t *bargs,
+                           ucc_coll_task_t     **task);
 #endif

--- a/src/coll_score/ucc_coll_score_map.c
+++ b/src/coll_score/ucc_coll_score_map.c
@@ -82,8 +82,11 @@ ucc_status_t ucc_coll_init(ucc_score_map_t      *map,
 
     team   = r->super.team;
     status = r->super.init(bargs, team, task);
-    fb     = ucc_list_head(&r->fallback, ucc_coll_entry_t, list_elem);
+    if (UCC_OK == status) {
+        return UCC_OK;
+    }
 
+    fb = ucc_list_head(&r->fallback, ucc_coll_entry_t, list_elem);
     while (&fb->list_elem != &r->fallback &&
            (status == UCC_ERR_NOT_SUPPORTED ||
             status == UCC_ERR_NOT_IMPLEMENTED)) {

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -10,14 +10,12 @@
 #define UCC_BASE_IFACE_H_
 #include "ucc/api/ucc.h"
 #include "core/ucc_lib.h"
-//#include "core/ucc_context.h"
 #include "utils/ucc_component.h"
 #include "utils/ucc_parser.h"
 #include "utils/ucc_class.h"
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_log.h"
 #include "utils/ucc_coll_utils.h"
-//#include "schedule/ucc_schedule.h"
 
 typedef struct ucc_team ucc_team_t;
 typedef struct ucc_context ucc_context_t;

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -10,14 +10,21 @@
 #define UCC_BASE_IFACE_H_
 #include "ucc/api/ucc.h"
 #include "core/ucc_lib.h"
-#include "core/ucc_context.h"
+//#include "core/ucc_context.h"
 #include "utils/ucc_component.h"
 #include "utils/ucc_parser.h"
 #include "utils/ucc_class.h"
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_log.h"
 #include "utils/ucc_coll_utils.h"
-#include "schedule/ucc_schedule.h"
+//#include "schedule/ucc_schedule.h"
+
+typedef struct ucc_team ucc_team_t;
+typedef struct ucc_context ucc_context_t;
+typedef struct ucc_coll_score ucc_coll_score_t;
+typedef struct ucc_coll_task ucc_coll_task_t;
+
+
 
 typedef struct ucc_base_lib {
     ucc_log_component_config_t log_component;
@@ -81,7 +88,7 @@ typedef struct ucc_base_context_iface {
                              ucc_base_ctx_attr_t      *attr);
 } ucc_base_context_iface_t;
 
-typedef struct ucc_team ucc_team_t;
+
 typedef struct ucc_base_team_params {
     ucc_team_params_t params;
     int               scope; /* Scope that allocates the team. When TL team is created
@@ -104,7 +111,6 @@ typedef struct ucc_base_team {
                                  (which inherit from base) during class init. */
 } ucc_base_team_t;
 
-typedef struct ucc_coll_score ucc_coll_score_t;
 typedef struct ucc_base_team_iface {
     ucc_status_t (*create_post)(ucc_base_context_t *context,
                                 const ucc_base_team_params_t *params,
@@ -113,8 +119,6 @@ typedef struct ucc_base_team_iface {
     ucc_status_t (*destroy)(ucc_base_team_t *team);
     ucc_status_t (*get_scores)(ucc_base_team_t *team, ucc_coll_score_t **score);
 } ucc_base_team_iface_t;
-
-typedef struct ucc_team ucc_team_t;
 
 typedef struct ucc_base_coll_args {
     uint64_t        mask;

--- a/src/components/cl/basic/cl_basic_coll.c
+++ b/src/components/cl/basic/cl_basic_coll.c
@@ -11,18 +11,14 @@ ucc_status_t ucc_cl_basic_coll_init(ucc_base_coll_args_t *coll_args,
                                     ucc_base_team_t *team,
                                     ucc_coll_task_t **task)
 {
-    ucc_cl_basic_team_t    *cl_team = ucc_derived_of(team, ucc_cl_basic_team_t);
-    ucc_base_coll_init_fn_t init;
-    ucc_base_team_t        *bteam;
-    ucc_status_t            status;
-    status =
-        ucc_coll_score_map_lookup(cl_team->score_map, coll_args, &init, &bteam);
+    ucc_cl_basic_team_t *cl_team = ucc_derived_of(team, ucc_cl_basic_team_t);
+    ucc_status_t         status;
+
+    status = ucc_coll_score_map_init(cl_team->score_map, coll_args, task);
     if (UCC_ERR_NOT_FOUND == status) {
         cl_warn(UCC_CL_TEAM_LIB(cl_team),
                 "no TL supporting given coll args is available");
         return UCC_ERR_NOT_SUPPORTED;
-    } else if (UCC_OK != status) {
-        return status;
     }
-    return init(coll_args, bteam, task);
+    return status;
 }

--- a/src/components/cl/basic/cl_basic_coll.c
+++ b/src/components/cl/basic/cl_basic_coll.c
@@ -14,7 +14,7 @@ ucc_status_t ucc_cl_basic_coll_init(ucc_base_coll_args_t *coll_args,
     ucc_cl_basic_team_t *cl_team = ucc_derived_of(team, ucc_cl_basic_team_t);
     ucc_status_t         status;
 
-    status = ucc_coll_score_map_init(cl_team->score_map, coll_args, task);
+    status = ucc_coll_init(cl_team->score_map, coll_args, task);
     if (UCC_ERR_NOT_FOUND == status) {
         cl_warn(UCC_CL_TEAM_LIB(cl_team),
                 "no TL supporting given coll args is available");

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -12,6 +12,7 @@
 #include "components/base/ucc_base_iface.h"
 #include "ucc_cl_type.h"
 #include "utils/ucc_parser.h"
+#include "core/ucc_context.h"
 
 /** CL (collective layer) is an internal collective interface reflecting the
     public UCC API and extensions to support modularity, the composition of

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -78,6 +78,7 @@ typedef struct ucc_tl_nccl_task {
     (ucc_derived_of((_task)->super.team->context, ucc_tl_nccl_context_t))
 #define TASK_LIB(_task)                                                        \
     (ucc_derived_of((_task)->super.team->context->lib, ucc_tl_nccl_lib_t))
+#define TASK_ARGS(_task) (_task)->super.bargs.args
 
 #define UCC_TL_NCCL_SUPPORTED_COLLS                                            \
     (UCC_COLL_TYPE_ALLTOALL       | UCC_COLL_TYPE_ALLTOALLV  |                 \

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -233,13 +233,13 @@ ucc_status_t ucc_tl_nccl_allreduce_init(ucc_tl_nccl_task_t *task)
     if ((task->super.args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
         (ucc_to_nccl_reduce_op[task->super.args.reduce.predefined_op] ==
          ncclOpUnsupported)) {
-        tl_error(UCC_TASK_LIB(task), "reduction operation is not supported");
+        tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     if (UCC_OK !=
         ucc_nccl_check_dt_supported(task->super.args.dst.info.datatype,
                                     task->super.args.dst.info.datatype)) {
-        tl_error(UCC_TASK_LIB(task), "dataype is not supported");
+        tl_debug(UCC_TASK_LIB(task), "dataype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     task->super.post     = ucc_tl_nccl_allreduce_start;
@@ -414,13 +414,13 @@ ucc_status_t ucc_tl_nccl_reduce_scatter_init(ucc_tl_nccl_task_t *task)
     if ((task->super.args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
         (ucc_to_nccl_reduce_op[task->super.args.reduce.predefined_op] ==
          ncclOpUnsupported)) {
-        tl_error(UCC_TASK_LIB(task), "reduction operation is not supported");
+        tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     if (UCC_OK !=
         ucc_nccl_check_dt_supported(task->super.args.dst.info.datatype,
                                     task->super.args.dst.info.datatype)) {
-        tl_error(UCC_TASK_LIB(task), "dataype is not supported");
+        tl_debug(UCC_TASK_LIB(task), "dataype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     task->super.post     = ucc_tl_nccl_reduce_scatter_start;
@@ -469,13 +469,13 @@ ucc_status_t ucc_tl_nccl_reduce_init(ucc_tl_nccl_task_t *task)
     if ((task->super.args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
         (ucc_to_nccl_reduce_op[task->super.args.reduce.predefined_op] ==
          ncclOpUnsupported)) {
-        tl_error(UCC_TASK_LIB(task), "reduction operation is not supported");
+        tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
 
     if (UCC_OK !=
         ucc_nccl_check_dt_supported(dt, dt)) {
-        tl_error(UCC_TASK_LIB(task), "dataype is not supported");
+        tl_debug(UCC_TASK_LIB(task), "dataype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     task->super.post     = ucc_tl_nccl_reduce_start;

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -97,7 +97,7 @@ ucc_status_t ucc_tl_nccl_collective_sync(ucc_tl_nccl_task_t *task,
 ucc_status_t ucc_tl_nccl_alltoall_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_coll_args_t    *args   = &coll_task->args;
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
     ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
     ucc_ee_h            ee     = coll_task->ee;
     cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
@@ -133,12 +133,12 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task)
 {
-    if (UCC_IS_INPLACE(task->super.args)) {
+    if (UCC_IS_INPLACE(TASK_ARGS(task))) {
         tl_error(UCC_TASK_LIB(task), "inplace alltoallv is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((task->super.args.src.info.datatype == UCC_DT_USERDEFINED) ||
-        (task->super.args.dst.info.datatype == UCC_DT_USERDEFINED)) {
+    if ((TASK_ARGS(task).src.info.datatype == UCC_DT_USERDEFINED) ||
+        (TASK_ARGS(task).dst.info.datatype == UCC_DT_USERDEFINED)) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -149,7 +149,7 @@ ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task)
 ucc_status_t ucc_tl_nccl_alltoallv_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_coll_args_t    *args   = &coll_task->args;
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
     ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
     ucc_ee_h            ee     = coll_task->ee;
     cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
@@ -191,12 +191,12 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_alltoallv_init(ucc_tl_nccl_task_t *task)
 {
-    if (UCC_IS_INPLACE(task->super.args)) {
+    if (UCC_IS_INPLACE(TASK_ARGS(task))) {
         tl_error(UCC_TASK_LIB(task), "inplace alltoall is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((task->super.args.src.info_v.datatype == UCC_DT_USERDEFINED) ||
-        (task->super.args.dst.info_v.datatype == UCC_DT_USERDEFINED)) {
+    if ((TASK_ARGS(task).src.info_v.datatype == UCC_DT_USERDEFINED) ||
+        (TASK_ARGS(task).dst.info_v.datatype == UCC_DT_USERDEFINED)) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -207,7 +207,7 @@ ucc_status_t ucc_tl_nccl_alltoallv_init(ucc_tl_nccl_task_t *task)
 ucc_status_t ucc_tl_nccl_allreduce_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_coll_args_t    *args   = &coll_task->args;
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
     ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
     ucc_ee_h            ee     = coll_task->ee;
     cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
@@ -230,15 +230,15 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_allreduce_init(ucc_tl_nccl_task_t *task)
 {
-    if ((task->super.args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
-        (ucc_to_nccl_reduce_op[task->super.args.reduce.predefined_op] ==
+    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
+        (ucc_to_nccl_reduce_op[TASK_ARGS(task).reduce.predefined_op] ==
          ncclOpUnsupported)) {
         tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     if (UCC_OK !=
-        ucc_nccl_check_dt_supported(task->super.args.dst.info.datatype,
-                                    task->super.args.dst.info.datatype)) {
+        ucc_nccl_check_dt_supported(TASK_ARGS(task).dst.info.datatype,
+                                    TASK_ARGS(task).dst.info.datatype)) {
         tl_debug(UCC_TASK_LIB(task), "dataype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -249,7 +249,7 @@ ucc_status_t ucc_tl_nccl_allreduce_init(ucc_tl_nccl_task_t *task)
 ucc_status_t ucc_tl_nccl_allgather_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_coll_args_t    *args   = &coll_task->args;
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
     ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
     ucc_ee_h            ee     = coll_task->ee;
     cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
@@ -274,10 +274,10 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_allgather_init(ucc_tl_nccl_task_t *task)
 {
-    ucc_datatype_t dt1 = UCC_IS_INPLACE(task->super.args)
-                             ? task->super.args.dst.info.datatype
-                             : task->super.args.src.info.datatype;
-    ucc_datatype_t dt2 = task->super.args.dst.info.datatype;
+    ucc_datatype_t dt1 = UCC_IS_INPLACE(TASK_ARGS(task))
+                             ? TASK_ARGS(task).dst.info.datatype
+                             : TASK_ARGS(task).src.info.datatype;
+    ucc_datatype_t dt2 = TASK_ARGS(task).dst.info.datatype;
 
     if (UCC_OK != ucc_nccl_check_dt_supported(dt1, dt2)) {
         /* TODO: can we use ncclChar if datatype is not supported? */
@@ -291,7 +291,7 @@ ucc_status_t ucc_tl_nccl_allgather_init(ucc_tl_nccl_task_t *task)
 ucc_status_t ucc_tl_nccl_allgatherv_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_coll_args_t    *args   = &coll_task->args;
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
     ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
     ucc_ee_h            ee     = coll_task->ee;
     cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
@@ -332,12 +332,12 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_allgatherv_init(ucc_tl_nccl_task_t *task)
 {
-    if (UCC_IS_INPLACE(task->super.args)) {
+    if (UCC_IS_INPLACE(TASK_ARGS(task))) {
         tl_error(UCC_TASK_LIB(task), "inplace allgatherv is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((task->super.args.src.info_v.datatype == UCC_DT_USERDEFINED) ||
-        (task->super.args.dst.info_v.datatype == UCC_DT_USERDEFINED)) {
+    if ((TASK_ARGS(task).src.info_v.datatype == UCC_DT_USERDEFINED) ||
+        (TASK_ARGS(task).dst.info_v.datatype == UCC_DT_USERDEFINED)) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -348,7 +348,7 @@ ucc_status_t ucc_tl_nccl_allgatherv_init(ucc_tl_nccl_task_t *task)
 ucc_status_t ucc_tl_nccl_bcast_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_coll_args_t    *args   = &coll_task->args;
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
     ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
     ucc_ee_h            ee     = coll_task->ee;
     cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
@@ -370,8 +370,8 @@ exit_coll:
 ucc_status_t ucc_tl_nccl_bcast_init(ucc_tl_nccl_task_t *task)
 {
     if (UCC_OK !=
-        ucc_nccl_check_dt_supported(task->super.args.src.info.datatype,
-                                    task->super.args.src.info.datatype)) {
+        ucc_nccl_check_dt_supported(TASK_ARGS(task).src.info.datatype,
+                                    TASK_ARGS(task).src.info.datatype)) {
         /* TODO: can we use ncclChar if datatype is not supported? */
         tl_error(UCC_TASK_LIB(task), "dataype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
@@ -383,7 +383,7 @@ ucc_status_t ucc_tl_nccl_bcast_init(ucc_tl_nccl_task_t *task)
 ucc_status_t ucc_tl_nccl_reduce_scatter_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_coll_args_t    *args   = &coll_task->args;
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
     ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
     ucc_ee_h            ee     = coll_task->ee;
     cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
@@ -411,15 +411,15 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_reduce_scatter_init(ucc_tl_nccl_task_t *task)
 {
-    if ((task->super.args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
-        (ucc_to_nccl_reduce_op[task->super.args.reduce.predefined_op] ==
+    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
+        (ucc_to_nccl_reduce_op[TASK_ARGS(task).reduce.predefined_op] ==
          ncclOpUnsupported)) {
         tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
     if (UCC_OK !=
-        ucc_nccl_check_dt_supported(task->super.args.dst.info.datatype,
-                                    task->super.args.dst.info.datatype)) {
+        ucc_nccl_check_dt_supported(TASK_ARGS(task).dst.info.datatype,
+                                    TASK_ARGS(task).dst.info.datatype)) {
         tl_debug(UCC_TASK_LIB(task), "dataype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -430,7 +430,7 @@ ucc_status_t ucc_tl_nccl_reduce_scatter_init(ucc_tl_nccl_task_t *task)
 ucc_status_t ucc_tl_nccl_reduce_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task    = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_coll_args_t    *args    = &coll_task->args;
+    ucc_coll_args_t    *args    = &TASK_ARGS(task);
     ucc_tl_nccl_team_t *team    = TASK_TEAM(task);
     ucc_ee_h            ee      = coll_task->ee;
     cudaStream_t        stream  = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
@@ -444,8 +444,8 @@ ucc_status_t ucc_tl_nccl_reduce_start(ucc_coll_task_t *coll_task)
     ncclDataType_t      nccl_dt;
 
     if (args->root == team->rank) {
-        ucc_dt = task->super.args.dst.info.datatype;
-        count = task->super.args.dst.info.count;
+        ucc_dt = TASK_ARGS(task).dst.info.datatype;
+        count = TASK_ARGS(task).dst.info.count;
         if (UCC_IS_INPLACE(*args)) {
             src = args->dst.info.buffer;
         }
@@ -462,12 +462,12 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_reduce_init(ucc_tl_nccl_task_t *task)
 {
-    ucc_datatype_t dt = (task->super.args.root == TASK_TEAM(task)->rank) ?
-                           task->super.args.dst.info.datatype:
-                           task->super.args.src.info.datatype;
+    ucc_datatype_t dt = (TASK_ARGS(task).root == TASK_TEAM(task)->rank) ?
+                           TASK_ARGS(task).dst.info.datatype:
+                           TASK_ARGS(task).src.info.datatype;
 
-    if ((task->super.args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
-        (ucc_to_nccl_reduce_op[task->super.args.reduce.predefined_op] ==
+    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
+        (ucc_to_nccl_reduce_op[TASK_ARGS(task).reduce.predefined_op] ==
          ncclOpUnsupported)) {
         tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -169,7 +169,7 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
     ucc_status_t status;
 
     task = ucc_mpool_get(&nccl_ctx->req_mp);
-    ucc_coll_task_init(&task->super, &coll_args->args, team);
+    ucc_coll_task_init(&task->super, coll_args, team);
     task->super.finalize       = ucc_tl_nccl_coll_finalize;
     task->super.triggered_post = ucc_tl_nccl_triggered_post;
     task->completed            = NULL;

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -170,7 +170,6 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
 
     task = ucc_mpool_get(&nccl_ctx->req_mp);
     ucc_coll_task_init(&task->super, &coll_args->args, team);
-
     task->super.finalize       = ucc_tl_nccl_coll_finalize;
     task->super.triggered_post = ucc_tl_nccl_triggered_post;
     task->completed            = NULL;
@@ -181,6 +180,7 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
             goto free_task;
         }
     }
+
     switch (coll_args->args.coll_type)
     {
     case UCC_COLL_TYPE_ALLGATHER:
@@ -222,7 +222,7 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
 
 free_event:
     if (task->completed) {
-        cudaEventDestroy(task->completed);
+        ucc_mc_ee_destroy_event(task->completed, UCC_EE_CUDA_STREAM);
     }
 free_task:
     ucc_mpool_put(task);

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -10,6 +10,7 @@
 #define UCC_TL_H_
 
 #include "components/base/ucc_base_iface.h"
+#include "core/ucc_context.h"
 
 /** TL (transport layer) is an internal interface that provides a basic
     implementation of collectives and p2p primitives. It differs from CL in that

--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -12,8 +12,8 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
 {
-    if ((task->super.args.src.info.datatype == UCC_DT_USERDEFINED) ||
-        (task->super.args.dst.info.datatype == UCC_DT_USERDEFINED)) {
+    if ((TASK_ARGS(task).src.info.datatype == UCC_DT_USERDEFINED) ||
+        (TASK_ARGS(task).dst.info.datatype == UCC_DT_USERDEFINED)) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -22,7 +22,7 @@
 ucc_status_t ucc_tl_ucp_allgather_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t       *args  = &coll_task->args;
+    ucc_coll_args_t       *args  = &TASK_ARGS(task);
     ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
     ucc_kn_radix_t         radix = task->allgather_kn.p.radix;
     uint8_t                node_type  = task->allgather_kn.p.node_type;
@@ -47,8 +47,8 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_progress(ucc_coll_task_t *coll_task)
        a new virtual rank number - "vrank".
        As such allgather must keep to this ranking to be aligned with scatter.
     */
-    if (coll_task->args.coll_type == UCC_COLL_TYPE_BCAST) {
-        broot = coll_task->args.root;
+    if (coll_task->bargs.args.coll_type == UCC_COLL_TYPE_BCAST) {
+        broot = coll_task->bargs.args.root;
         rank = VRANK(rank, broot, size);
     }
 
@@ -140,7 +140,7 @@ out:
 ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t   *args  = &coll_task->args;
+    ucc_coll_args_t   *args  = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
     ucc_rank_t         size  = team->size;
     ucc_rank_t         rank  = team->rank;
@@ -151,8 +151,8 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_kn_start", 0);
     ucc_tl_ucp_task_reset(task);
-    if (coll_task->args.coll_type == UCC_COLL_TYPE_BCAST) {
-        broot = coll_task->args.root;
+    if (coll_task->bargs.args.coll_type == UCC_COLL_TYPE_BCAST) {
+        broot = coll_task->bargs.args.root;
         rank = VRANK(rank, broot, size);
     }
 

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -19,10 +19,10 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_team_t *team       = TASK_TEAM(task);
     ucc_rank_t         group_rank = task->subset.myrank;
     ucc_rank_t         group_size = (ucc_rank_t)task->subset.map.ep_num;
-    void              *rbuf       = coll_task->args.dst.info.buffer;
-    ucc_memory_type_t  rmem       = coll_task->args.dst.info.mem_type;
-    size_t             count      = coll_task->args.dst.info.count;
-    ucc_datatype_t     dt         = coll_task->args.dst.info.datatype;
+    void              *rbuf       = TASK_ARGS(task).dst.info.buffer;
+    ucc_memory_type_t  rmem       = TASK_ARGS(task).dst.info.mem_type;
+    size_t             count      = TASK_ARGS(task).dst.info.count;
+    ucc_datatype_t     dt         = TASK_ARGS(task).dst.info.datatype;
     size_t             data_size  = (count / group_size) * ucc_dt_size(dt);
     ucc_rank_t         sendto     = (group_rank + 1) % group_size;
     ucc_rank_t         recvfrom   = (group_rank - 1 + group_size) % group_size;
@@ -64,12 +64,12 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
-    size_t             count     = coll_task->args.dst.info.count;
-    void              *sbuf      = coll_task->args.src.info.buffer;
-    void              *rbuf      = coll_task->args.dst.info.buffer;
-    ucc_memory_type_t  smem      = coll_task->args.src.info.mem_type;
-    ucc_memory_type_t  rmem      = coll_task->args.dst.info.mem_type;
-    ucc_datatype_t     dt        = coll_task->args.dst.info.datatype;
+    size_t             count     = TASK_ARGS(task).dst.info.count;
+    void              *sbuf      = TASK_ARGS(task).src.info.buffer;
+    void              *rbuf      = TASK_ARGS(task).dst.info.buffer;
+    ucc_memory_type_t  smem      = TASK_ARGS(task).src.info.mem_type;
+    ucc_memory_type_t  rmem      = TASK_ARGS(task).dst.info.mem_type;
+    ucc_datatype_t     dt        = TASK_ARGS(task).dst.info.datatype;
     size_t             data_size = (count / task->subset.map.ep_num) *
         ucc_dt_size(dt);
     ucc_status_t       status;
@@ -77,7 +77,7 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_ring_start", 0);
     ucc_tl_ucp_task_reset(task);
 
-    if (!UCC_IS_INPLACE(coll_task->args)) {
+    if (!UCC_IS_INPLACE(TASK_ARGS(task))) {
         status =
             ucc_mc_memcpy(PTR_OFFSET(rbuf, data_size * task->subset.myrank),
                           sbuf, data_size, rmem, smem);

--- a/src/components/tl/ucp/allgatherv/allgatherv.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv.c
@@ -14,9 +14,9 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task)
 {
-    if ((task->super.args.dst.info_v.datatype == UCC_DT_USERDEFINED) ||
-        (!UCC_IS_INPLACE(task->super.args) &&
-         (task->super.args.src.info.datatype == UCC_DT_USERDEFINED))) {
+    if ((TASK_ARGS(task).dst.info_v.datatype == UCC_DT_USERDEFINED) ||
+        (!UCC_IS_INPLACE(TASK_ARGS(task)) &&
+         (TASK_ARGS(task).src.info.datatype == UCC_DT_USERDEFINED))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/ucp/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv_ring.c
@@ -15,7 +15,7 @@
 ucc_status_t ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task     = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t   *args     = &coll_task->args;
+    ucc_coll_args_t   *args     = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team     = TASK_TEAM(task);
     ucc_rank_t         grank    = team->rank;
     ucc_rank_t         gsize    = team->size;
@@ -65,26 +65,26 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
-    ptrdiff_t          sbuf  = (ptrdiff_t)coll_task->args.src.info.buffer;
-    ptrdiff_t          rbuf  = (ptrdiff_t)coll_task->args.dst.info_v.buffer;
-    ucc_memory_type_t  smem  = coll_task->args.src.info.mem_type;
-    ucc_memory_type_t  rmem  = coll_task->args.dst.info_v.mem_type;
+    ptrdiff_t          sbuf  = (ptrdiff_t)TASK_ARGS(task).src.info.buffer;
+    ptrdiff_t          rbuf  = (ptrdiff_t)TASK_ARGS(task).dst.info_v.buffer;
+    ucc_memory_type_t  smem  = TASK_ARGS(task).src.info.mem_type;
+    ucc_memory_type_t  rmem  = TASK_ARGS(task).dst.info_v.mem_type;
     ucc_rank_t         grank = team->rank;
     size_t             data_size, data_displ, rdt_size;
     ucc_status_t       status;
 
     ucc_tl_ucp_task_reset(task);
 
-    if (!UCC_IS_INPLACE(coll_task->args)) {
+    if (!UCC_IS_INPLACE(TASK_ARGS(task))) {
         /* TODO replace local sendrecv with memcpy? */
-        rdt_size   = ucc_dt_size(coll_task->args.dst.info_v.datatype);
+        rdt_size   = ucc_dt_size(TASK_ARGS(task).dst.info_v.datatype);
         data_displ = ucc_coll_args_get_displacement(
-                         &coll_task->args,
-                         coll_task->args.dst.info_v.displacements, grank) *
+                        &TASK_ARGS(task),
+                         TASK_ARGS(task).dst.info_v.displacements, grank) *
                      rdt_size;
         data_size =
-            ucc_coll_args_get_count(&coll_task->args,
-                                    coll_task->args.dst.info_v.counts, grank) *
+            ucc_coll_args_get_count(&TASK_ARGS(task),
+                                    TASK_ARGS(task).dst.info_v.counts, grank) *
             rdt_size;
         UCPCHECK_GOTO(ucc_tl_ucp_recv_nb((void *)rbuf + data_displ, data_size,
                                          rmem, grank, team, task),

--- a/src/components/tl/ucp/allreduce/allreduce.c
+++ b/src/components/tl/ucp/allreduce/allreduce.c
@@ -26,7 +26,7 @@ ucc_base_coll_alg_info_t
 ucc_status_t ucc_tl_ucp_allreduce_init(ucc_tl_ucp_task_t *task)
 {
     ucc_status_t status;
-    ALLREDUCE_TASK_CHECK(task->super.args, TASK_TEAM(task));
+    ALLREDUCE_TASK_CHECK(TASK_ARGS(task), TASK_TEAM(task));
     status = ucc_tl_ucp_allreduce_knomial_init_common(task);
 out:
     return status;

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -22,7 +22,7 @@
 ucc_status_t ucc_tl_ucp_allreduce_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t       *args = &coll_task->args;
+    ucc_coll_args_t       *args = &TASK_ARGS(task);
     ucc_tl_ucp_team_t     *team = TASK_TEAM(task);
     ucc_kn_radix_t         radix     = task->allreduce_kn.p.radix;
     uint8_t                node_type = task->allreduce_kn.p.node_type;
@@ -172,8 +172,8 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
     ucc_status_t       status;
 
     task->allreduce_kn.phase = UCC_KN_PHASE_INIT;
-    ucc_assert(coll_task->args.src.info.mem_type ==
-               coll_task->args.dst.info.mem_type);
+    ucc_assert(TASK_ARGS(task).src.info.mem_type ==
+               TASK_ARGS(task).dst.info.mem_type);
     ucc_knomial_pattern_init(size, rank,
                              ucc_min(UCC_TL_UCP_TEAM_LIB(team)->
                                      cfg.allreduce_kn_radix, size),
@@ -190,8 +190,8 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
 
 ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
 {
-    size_t             count     = task->super.args.dst.info.count;
-    ucc_datatype_t     dt        = task->super.args.dst.info.datatype;
+    size_t             count     = TASK_ARGS(task).dst.info.count;
+    ucc_datatype_t     dt        = TASK_ARGS(task).dst.info.datatype;
     size_t             data_size = count * ucc_dt_size(dt);
     ucc_rank_t         size      = (ucc_rank_t)task->subset.map.ep_num;
     ucc_kn_radix_t     radix =
@@ -203,7 +203,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;
     status               = ucc_mc_alloc(&task->allreduce_kn.scratch_mc_header,
                           (radix - 1) * data_size,
-                          task->super.args.dst.info.mem_type);
+                          TASK_ARGS(task).dst.info.mem_type);
     task->allreduce_kn.scratch = task->allreduce_kn.scratch_mc_header->addr;
     if (ucc_unlikely(status != UCC_OK)) {
         tl_error(UCC_TASK_LIB(task), "failed to allocate scratch buffer");

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -60,7 +60,7 @@ ucc_tl_ucp_allreduce_sra_knomial_frag_finalize(ucc_coll_task_t *task)
 static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_setup(
     ucc_schedule_pipelined_t *schedule_p, ucc_schedule_t *frag, int frag_num)
 {
-    ucc_coll_args_t *args    = &schedule_p->super.super.args;
+    ucc_coll_args_t *args    = &schedule_p->super.super.bargs.args;
     ucc_datatype_t   dt      = args->src.info.datatype;
     size_t           dt_size = ucc_dt_size(dt);
     ucc_coll_args_t *targs;
@@ -74,7 +74,7 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_setup(
         offset -= left - frag_num;
     }
 
-    targs = &frag->tasks[0]->args; //REDUCE_SCATTER
+    targs = &frag->tasks[0]->bargs.args; //REDUCE_SCATTER
     targs->src.info.buffer =
         PTR_OFFSET(args->src.info.buffer, offset * dt_size);
     targs->dst.info.buffer =
@@ -82,7 +82,7 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_setup(
     targs->src.info.count = frag_count;
     targs->dst.info.count = frag_count;
 
-    targs                  = &frag->tasks[1]->args; //ALLGATHER
+    targs                  = &frag->tasks[1]->bargs.args; //ALLGATHER
     targs->src.info.buffer = NULL;
     targs->dst.info.buffer =
         PTR_OFFSET(args->dst.info.buffer, offset * dt_size);
@@ -105,7 +105,8 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
     ucc_status_t         status;
     ucc_kn_radix_t       radix, cfg_radix;
 
-    ucc_schedule_init(schedule, &coll_args->args, team);
+
+    ucc_schedule_init(schedule, coll_args, team);
     cfg_radix = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_radix;
     radix = ucc_knomial_pattern_get_min_radix(cfg_radix, tl_team->size, count);
 

--- a/src/components/tl/ucp/alltoall/alltoall.c
+++ b/src/components/tl/ucp/alltoall/alltoall.c
@@ -15,7 +15,7 @@ ucc_status_t ucc_tl_ucp_alltoall_init(ucc_tl_ucp_task_t *task)
 {
     ucc_status_t status;
 
-    ALLTOALL_TASK_CHECK(task->super.args, TASK_TEAM(task));
+    ALLTOALL_TASK_CHECK(TASK_ARGS(task), TASK_TEAM(task));
     status = ucc_tl_ucp_alltoall_pairwise_init_common(task);
 out:
     return status;

--- a/src/components/tl/ucp/alltoall/alltoall_pairwise.c
+++ b/src/components/tl/ucp/alltoall/alltoall_pairwise.c
@@ -27,10 +27,10 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
-    ptrdiff_t          sbuf  = (ptrdiff_t)coll_task->args.src.info.buffer;
-    ptrdiff_t          rbuf  = (ptrdiff_t)coll_task->args.dst.info.buffer;
-    ucc_memory_type_t  smem  = coll_task->args.src.info.mem_type;
-    ucc_memory_type_t  rmem  = coll_task->args.dst.info.mem_type;
+    ptrdiff_t          sbuf  = (ptrdiff_t)TASK_ARGS(task).src.info.buffer;
+    ptrdiff_t          rbuf  = (ptrdiff_t)TASK_ARGS(task).dst.info.buffer;
+    ucc_memory_type_t  smem  = TASK_ARGS(task).src.info.mem_type;
+    ucc_memory_type_t  rmem  = TASK_ARGS(task).dst.info.mem_type;
     ucc_rank_t         grank = team->rank;
     ucc_rank_t         gsize = team->size;
     ucc_rank_t         peer;
@@ -40,8 +40,8 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *coll_task)
 
     posts     = UCC_TL_UCP_TEAM_LIB(team)->cfg.alltoall_pairwise_num_posts;
     nreqs     = (posts > gsize || posts == 0) ? gsize : posts;
-    data_size = (size_t)(coll_task->args.src.info.count / gsize) *
-                ucc_dt_size(coll_task->args.src.info.datatype);
+    data_size = (size_t)(TASK_ARGS(task).src.info.count / gsize) *
+                ucc_dt_size(TASK_ARGS(task).src.info.datatype);
     while ((task->send_posted < gsize || task->recv_posted < gsize) &&
            (polls++ < task->n_polls)) {
         ucp_worker_progress(UCC_TL_UCP_TEAM_CTX(team)->ucp_worker);
@@ -94,7 +94,7 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_start(ucc_coll_task_t *coll_task)
 ucc_status_t ucc_tl_ucp_alltoall_pairwise_init_common(ucc_tl_ucp_task_t *task)
 {
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);
-    ucc_coll_args_t   *args = &task->super.args;
+    ucc_coll_args_t   *args = &TASK_ARGS(task);
     size_t data_size;
 
     task->super.post     = ucc_tl_ucp_alltoall_pairwise_start;

--- a/src/components/tl/ucp/alltoallv/alltoallv.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv.c
@@ -15,7 +15,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_init(ucc_tl_ucp_task_t *task)
 {
     ucc_status_t status;
 
-    ALLTOALLV_TASK_CHECK(task->super.args, TASK_TEAM(task));
+    ALLTOALLV_TASK_CHECK(TASK_ARGS(task), TASK_TEAM(task));
     status = ucc_tl_ucp_alltoallv_pairwise_init_common(task);
 out:
     return status;

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -17,14 +17,14 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
     ucc_rank_t         myrank    = team->rank;
     ucc_rank_t         team_size = team->size;
-    ucc_rank_t         root      = (uint32_t)coll_task->args.root;
+    ucc_rank_t         root      = (uint32_t)TASK_ARGS(task).root;
     uint32_t           radix     = task->bcast_kn.radix;
     ucc_rank_t         vrank     = (myrank - root + team_size) % team_size;
     ucc_rank_t         dist      = task->bcast_kn.dist;
-    void              *buffer    = coll_task->args.src.info.buffer;
-    ucc_memory_type_t  mtype     = coll_task->args.src.info.mem_type;
-    size_t             data_size = coll_task->args.src.info.count *
-                       ucc_dt_size(coll_task->args.src.info.datatype);
+    void              *buffer    = TASK_ARGS(task).src.info.buffer;
+    ucc_memory_type_t  mtype     = TASK_ARGS(task).src.info.mem_type;
+    size_t             data_size = TASK_ARGS(task).src.info.count *
+                       ucc_dt_size(TASK_ARGS(task).src.info.datatype);
     ucc_rank_t vpeer, peer, vroot_at_level, root_at_level, pos;
     uint32_t i;
 

--- a/src/components/tl/ucp/reduce/reduce.c
+++ b/src/components/tl/ucp/reduce/reduce.c
@@ -13,7 +13,7 @@ ucc_status_t ucc_tl_ucp_reduce_knomial_finalize(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_reduce_init(ucc_tl_ucp_task_t *task)
 {
-    ucc_coll_args_t   *args      = &task->super.args;
+    ucc_coll_args_t   *args      = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
     ucc_rank_t         myrank    = team->rank;
     ucc_rank_t         team_size = team->size;

--- a/src/components/tl/ucp/reduce/reduce_knomial.c
+++ b/src/components/tl/ucp/reduce/reduce_knomial.c
@@ -19,7 +19,7 @@
 ucc_status_t ucc_tl_ucp_reduce_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t   *args      = &coll_task->args;
+    ucc_coll_args_t   *args      = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
     ucc_rank_t         myrank    = team->rank;
     ucc_rank_t         team_size = team->size;
@@ -117,7 +117,7 @@ ucc_status_t ucc_tl_ucp_reduce_knomial_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task      =
         ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t   *args      = &coll_task->args;
+    ucc_coll_args_t   *args      = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
     uint32_t           radix     = task->reduce_kn.radix;
     ucc_rank_t         root      = (ucc_rank_t)args->root;

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -23,7 +23,7 @@ ucc_status_t
 ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t       *args  = &coll_task->args;
+    ucc_coll_args_t       *args  = &TASK_ARGS(task);
     ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
     ucc_kn_radix_t         radix = task->reduce_scatter_kn.p.radix;
     uint8_t                node_type = task->reduce_scatter_kn.p.node_type;
@@ -178,7 +178,7 @@ out:
 ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t   *args = &coll_task->args;
+    ucc_coll_args_t   *args = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);
     ucc_status_t       status;
     uint8_t            node_type;
@@ -210,7 +210,7 @@ ucc_tl_ucp_reduce_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     uint8_t            node_type = task->reduce_scatter_kn.p.node_type;
 
-    if (UCC_IS_INPLACE(coll_task->args) || (KN_NODE_PROXY == node_type)) {
+    if (UCC_IS_INPLACE(TASK_ARGS(task)) || (KN_NODE_PROXY == node_type)) {
         ucc_mc_free(task->reduce_scatter_kn.scratch_mc_header);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -167,8 +167,8 @@ ucc_status_t ucc_tl_ucp_triggered_post(ucc_ee_h ee, ucc_ev_t *ev, //NOLINT
     ev_task->super.finalize       = ucc_tl_ucp_coll_finalize;
     ev_task->super.super.status   = UCC_INPROGRESS;
 
-    if (UCC_COLL_TIMEOUT_REQUIRED(coll_task->args)) {
-        UCC_COLL_SET_TIMEOUT(&ev_task->super, coll_task->args.timeout);
+    if (UCC_COLL_TIMEOUT_REQUIRED(coll_task)) {
+        UCC_COLL_SET_TIMEOUT(&ev_task->super, coll_task->bargs.args.timeout);
     }
 
     tl_trace(UCC_TASK_LIB(task), "triggered post. ev_task:%p coll_task:%p",

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -90,6 +90,7 @@ typedef struct ucc_tl_ucp_task {
     (ucc_derived_of((_task)->super.team->context, ucc_tl_ucp_context_t))
 #define TASK_LIB(_task)                                                        \
     (ucc_derived_of((_task)->super.team->context->lib, ucc_tl_ucp_lib_t))
+#define TASK_ARGS(_task) (_task)->super.bargs.args
 
 static inline void ucc_tl_ucp_task_reset(ucc_tl_ucp_task_t *task)
 {
@@ -171,7 +172,7 @@ ucc_tl_ucp_init_task(ucc_base_coll_args_t *coll_args, ucc_base_team_t *team)
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_task_t *task    = ucc_tl_ucp_get_task(tl_team);
 
-    ucc_coll_task_init(&task->super, &coll_args->args, team);
+    ucc_coll_task_init(&task->super, coll_args, team);
     task->tag            = tl_team->seq_num;
     tl_team->seq_num     = (tl_team->seq_num + 1) % UCC_TL_UCP_MAX_COLL_TAG;
     task->super.finalize = ucc_tl_ucp_coll_finalize;

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -210,7 +210,7 @@ ucc_status_t ucc_collective_post(ucc_coll_req_h request)
 
     ucc_debug("coll_post: req %p", task);
 
-    if (UCC_COLL_TIMEOUT_REQUIRED(task->args)) {
+    if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
         task->start_time = ucc_get_time();
     }
 
@@ -223,7 +223,7 @@ ucc_status_t ucc_collective_triggered_post(ucc_ee_h ee, ucc_ev_t *ev)
 
     ucc_debug("coll_triggered_post: req %p", task);
     task->ee = ee;
-    if (UCC_COLL_TIMEOUT_REQUIRED(task->args)) {
+    if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
         task->start_time = ucc_get_time();
     }
     return task->triggered_post(ee, ev, task);

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -14,6 +14,7 @@
 #include "utils/ucc_time.h"
 #include "utils/profile/ucc_profile_core.h"
 #include "schedule/ucc_schedule.h"
+#include "coll_score/ucc_coll_score.h"
 
 /* NOLINTNEXTLINE  */
 static ucc_cl_team_t *ucc_select_cl_team(ucc_coll_args_t *coll_args,
@@ -212,6 +213,7 @@ ucc_status_t ucc_collective_post(ucc_coll_req_h request)
     if (UCC_COLL_TIMEOUT_REQUIRED(task->args)) {
         task->start_time = ucc_get_time();
     }
+
     return task->post(task);
 }
 

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -77,12 +77,12 @@ static int ucc_pq_mt_progress(ucc_progress_queue_t *pq)
             task->progress(task);
         }
         if (UCC_INPROGRESS == task->super.status) {
-            if (UCC_COLL_TIMEOUT_REQUIRED(task->args)) {
+            if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
                 if (timestamp < 0) {
                     timestamp = ucc_get_time();
                 }
                 if (ucc_unlikely(timestamp - task->start_time >
-                                 task->args.timeout)) {
+                                 task->bargs.args.timeout)) {
                     task->super.status = UCC_ERR_TIMED_OUT;
                     ucc_task_complete(task);
                     return UCC_ERR_TIMED_OUT;

--- a/src/core/ucc_progress_queue_st.c
+++ b/src/core/ucc_progress_queue_st.c
@@ -29,12 +29,12 @@ static int ucc_pq_st_progress(ucc_progress_queue_t *pq)
             task->progress(task);
         }
         if (UCC_INPROGRESS == task->super.status) {
-            if (UCC_COLL_TIMEOUT_REQUIRED(task->args)) {
+            if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
                 if (timestamp < 0) {
                     timestamp = ucc_get_time();
                 }
                 if (ucc_unlikely(timestamp - task->start_time >
-                                 task->args.timeout)) {
+                                 task->bargs.args.timeout)) {
                     task->super.status = UCC_ERR_TIMED_OUT;
                     ucc_list_del(&task->list_elem);
                     ucc_task_complete(task);

--- a/src/core/ucc_sbgp.c
+++ b/src/core/ucc_sbgp.c
@@ -64,7 +64,7 @@ static inline ucc_status_t sbgp_create_socket(ucc_team_topo_t *topo,
             sbgp->group_rank = nlr_pos;
         if (sock_rank == nlr_pos)
             sbgp->group_rank = 0;
-        SWAP(local_ranks[nlr_pos], local_ranks[0]);
+        SWAP(local_ranks[nlr_pos], local_ranks[0], int);
     }
     if (sock_size > 1) {
         sbgp->status = UCC_SBGP_ENABLED;
@@ -314,7 +314,7 @@ static ucc_status_t sbgp_create_socket_leaders(ucc_team_topo_t *topo,
                     sbgp->group_rank = nlr_pos;
                 if (sl_rank == nlr_pos)
                     sbgp->group_rank = 0;
-                SWAP(sbgp->rank_map[nlr_pos], sbgp->rank_map[0]);
+                SWAP(sbgp->rank_map[nlr_pos], sbgp->rank_map[0], int);
             }
 
             sbgp->group_size = n_socket_leaders;

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -31,7 +31,8 @@ void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
     ucc_assert(i < MAX_LISTENERS);
 }
 
-ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task, ucc_coll_args_t *args,
+ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task,
+                                ucc_base_coll_args_t *bargs,
                                 ucc_base_team_t *team)
 {
     task->super.status     = UCC_OPERATION_INITIALIZED;
@@ -40,8 +41,8 @@ ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task, ucc_coll_args_t *args,
     task->team             = team;
     task->n_deps           = 0;
     task->n_deps_satisfied = 0;
-    if (args) {
-        memcpy(&task->args, args, sizeof(*args));
+    if (bargs) {
+        memcpy(&task->bargs, bargs, sizeof(*bargs));
     }
     ucc_lf_queue_init_elem(&task->lf_elem);
     return ucc_event_manager_init(&task->em);
@@ -104,12 +105,12 @@ ucc_schedule_completed_handler(ucc_coll_task_t *parent_task, //NOLINT
     return UCC_OK;
 }
 
-ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_coll_args_t *args,
+ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_base_coll_args_t *bargs,
                                ucc_base_team_t *team)
 {
     ucc_status_t status;
 
-    status            = ucc_coll_task_init(&schedule->super, args, team);
+    status            = ucc_coll_task_init(&schedule->super, bargs, team);
     schedule->ctx     = team->context->ucc_context;
     schedule->n_tasks = 0;
     return status;

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -5,6 +5,7 @@
 #include "ucc_schedule.h"
 #include "utils/ucc_compiler_def.h"
 #include "components/base/ucc_base_iface.h"
+#include "coll_score/ucc_coll_score.h"
 
 ucc_status_t ucc_event_manager_init(ucc_event_manager_t *em)
 {

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -121,11 +121,10 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
     } else {
         /* error in task status */
         if (UCC_ERR_TIMED_OUT == status) {
-            //char coll_str[256];
-            //            ucc_coll_str(&task->bargs, coll_str, sizeof(coll_str));
-            //TODO: coll str desc will printed when rebased on top of fallback PR
-            ucc_warn("timeout %g sec has expired on task %p",
-                     task->bargs.args.timeout, task);
+            char coll_str[256];
+            ucc_coll_str(&task->bargs, coll_str, sizeof(coll_str));
+            ucc_warn("timeout %g sec has expired on task %p, %s",
+                     task->bargs.args.timeout, task, coll_str);
         } else {
             ucc_error("failure in task %p, %s", task,
                       ucc_status_string(task->super.status));

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -10,6 +10,7 @@
 #include "utils/ucc_log.h"
 #include "utils/ucc_lock_free_queue.h"
 #include "utils/ucc_coll_utils.h"
+#include "components/base/ucc_base_iface.h"
 
 #define MAX_LISTENERS 4
 
@@ -47,8 +48,8 @@ enum {
 typedef struct ucc_coll_task {
     ucc_coll_req_t               super;
     uint32_t                     flags;
-    ucc_coll_args_t              args;
-    ucc_base_team_t             *team;
+    ucc_base_coll_args_t         bargs;
+    ucc_base_team_t             *team; //CL/TL team pointer
     ucc_coll_post_fn_t           post;
     ucc_coll_triggered_post_fn_t triggered_post;
     ucc_coll_finalize_fn_t       finalize;
@@ -87,8 +88,8 @@ typedef struct ucc_schedule {
 
 ucc_status_t ucc_event_manager_init(ucc_event_manager_t *em);
 
-ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task, ucc_coll_args_t *args,
-                                ucc_base_team_t *team);
+ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task,
+                                ucc_base_coll_args_t *args, ucc_base_team_t *team);
 
 void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
                                  ucc_coll_task_t *task,
@@ -97,7 +98,7 @@ void ucc_event_manager_subscribe(ucc_event_manager_t *em, ucc_event_t event,
 ucc_status_t ucc_event_manager_notify(ucc_coll_task_t *parent_task,
                                       ucc_event_t event);
 
-ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_coll_args_t *args,
+ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule, ucc_base_coll_args_t *bargs,
                                ucc_base_team_t *team);
 
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -125,7 +125,7 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
             //            ucc_coll_str(&task->bargs, coll_str, sizeof(coll_str));
             //TODO: coll str desc will printed when rebased on top of fallback PR
             ucc_warn("timeout %g sec has expired on task %p",
-                     task->args.timeout, task);
+                     task->bargs.args.timeout, task);
         } else {
             ucc_error("failure in task %p, %s", task,
                       ucc_status_string(task->super.status));

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -4,6 +4,7 @@
  */
 #include "ucc_schedule.h"
 #include "ucc_schedule_pipelined.h"
+#include "coll_score/ucc_coll_score.h"
 
 static ucc_status_t ucc_frag_start_handler(ucc_coll_task_t *parent,
                                            ucc_coll_task_t *task)

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -134,7 +134,7 @@ ucc_status_t ucc_schedule_pipelined_init(
                   n_frags, UCC_SCHEDULE_PIPELINED_MAX_FRAGS);
         return UCC_ERR_INVALID_PARAM;
     }
-    ucc_schedule_init(&schedule->super, &coll_args->args, team);
+    ucc_schedule_init(&schedule->super, coll_args, team);
     schedule->super.n_tasks        = n_frags_total;
     schedule->n_frags              = n_frags;
     schedule->sequential           = sequential;

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -30,15 +30,15 @@
     (((_args).mask & UCC_COLL_ARGS_FIELD_FLAGS) && \
      ((_args).flags & UCC_COLL_ARGS_FLAG_IN_PLACE))
 
-#define UCC_COLL_TIMEOUT_REQUIRED(_args) \
-    (((_args).mask & UCC_COLL_ARGS_FIELD_FLAGS) && \
-     ((_args).flags & UCC_COLL_ARGS_FLAG_TIMEOUT))
+#define UCC_COLL_TIMEOUT_REQUIRED(_task)                       \
+    (((_task)->bargs.args.mask & UCC_COLL_ARGS_FIELD_FLAGS) && \
+     ((_task)->bargs.args.flags & UCC_COLL_ARGS_FLAG_TIMEOUT))
 
-#define UCC_COLL_SET_TIMEOUT(_task, _timeout) do {           \
-        (_task)->args.mask   |= UCC_COLL_ARGS_FIELD_FLAGS;   \
-        (_task)->args.flags  |= UCC_COLL_ARGS_FLAG_TIMEOUT;  \
-        (_task)->args.timeout = _timeout;                    \
-        (_task)->start_time   = ucc_get_time();              \
+#define UCC_COLL_SET_TIMEOUT(_task, _timeout) do {                 \
+        (_task)->bargs.args.mask   |= UCC_COLL_ARGS_FIELD_FLAGS;   \
+        (_task)->bargs.args.flags  |= UCC_COLL_ARGS_FLAG_TIMEOUT;  \
+        (_task)->bargs.args.timeout = _timeout;                    \
+        (_task)->start_time   = ucc_get_time();                    \
     } while(0)
 
 static inline size_t

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -57,11 +57,11 @@ static inline unsigned long ucc_str_hash_djb2(const char *str)
    unique elements */
 int ucc_sort_uniq(int *array, int len, int inverse);
 
-#define SWAP(_x, _y)                                                           \
+#define SWAP(_x, _y, _type)                                                    \
     do {                                                                       \
-        int _tmp = (_x);                                                       \
-        (_x)     = (_y);                                                       \
-        (_y)     = _tmp;                                                       \
+        _type _tmp = (_x);                                                     \
+        (_x)       = (_y);                                                     \
+        (_y)       = _tmp;                                                     \
     } while (0)
 
 #define ucc_div_round_up(_n, _d) (((_n) + (_d) - 1) / (_d))

--- a/test/gtest/coll_score/test_score.cc
+++ b/test/gtest/coll_score/test_score.cc
@@ -53,7 +53,7 @@ UCC_TEST_F(test_score, add_range_sorted)
     ucc_msg_range_t *range;
     size_t           expected[4] = {0, 20, 50, 100};
     size_t *         e           = expected;
-    ucc_list_for_each(range, list, list_elem)
+    ucc_list_for_each(range, list, super.list_elem)
     {
         EXPECT_EQ(*e, range->start);
         e++;
@@ -89,10 +89,10 @@ ucc_status_t test_score::check_range(ucc_coll_score_t *   score,
     if (check.size() != ucc_list_length(list)) {
         return UCC_ERR_NO_MESSAGE;
     }
-    ucc_list_for_each(range, list, list_elem)
+    ucc_list_for_each(range, list, super.list_elem)
     {
         if (range->start != std::get<0>(*r) || range->end != std::get<1>(*r) ||
-            range->score != std::get<2>(*r)) {
+            range->super.score != std::get<2>(*r)) {
             return UCC_ERR_NO_MESSAGE;
         }
         r++;
@@ -105,16 +105,16 @@ ucc_status_t test_score::check_fallback(ucc_coll_score_t *   score,
                                         ucc_memory_type_t    m,
                                         std::vector<std::vector<fallback_t> > check)
 {
-    ucc_list_link_t    *list = &score->scores[ucc_ilog2(c)][m];
-    auto                fb   = check.begin();
-    ucc_list_link_t    *fallback;
-    ucc_msg_range_t    *range;
-    ucc_msg_range_fb_t *fb_r;
+    ucc_list_link_t  *list = &score->scores[ucc_ilog2(c)][m];
+    auto              fb   = check.begin();
+    ucc_list_link_t  *fallback;
+    ucc_msg_range_t  *range;
+    ucc_coll_entry_t *fb_r;
 
     if (check.size() != ucc_list_length(list)) {
         return UCC_ERR_NO_MESSAGE;
     }
-    ucc_list_for_each(range, list, list_elem)
+    ucc_list_for_each(range, list, super.list_elem)
     {
         fallback = &range->fallback;
 

--- a/test/gtest/coll_score/test_score.cc
+++ b/test/gtest/coll_score/test_score.cc
@@ -100,6 +100,40 @@ ucc_status_t test_score::check_range(ucc_coll_score_t *   score,
     return UCC_OK;
 }
 
+ucc_status_t test_score::check_fallback(ucc_coll_score_t *   score,
+                                        ucc_coll_type_t      c,
+                                        ucc_memory_type_t    m,
+                                        std::vector<std::vector<fallback_t> > check)
+{
+    ucc_list_link_t    *list = &score->scores[ucc_ilog2(c)][m];
+    auto                fb   = check.begin();
+    ucc_list_link_t    *fallback;
+    ucc_msg_range_t    *range;
+    ucc_msg_range_fb_t *fb_r;
+
+    if (check.size() != ucc_list_length(list)) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    ucc_list_for_each(range, list, list_elem)
+    {
+        fallback = &range->fallback;
+
+        if (fb->size() != ucc_list_length(fallback)) {
+            return UCC_ERR_NO_MESSAGE;
+        }
+        auto f = fb->begin();
+        ucc_list_for_each(fb_r, fallback, list_elem) {
+            if (fb_r->score != std::get<0>(*f) ||
+                (uint64_t)fb_r->init != std::get<1>(*f)) {
+                return UCC_ERR_NO_MESSAGE;
+            }
+            f++;
+        }
+        fb++;
+    }
+    return UCC_OK;
+}
+
 void test_score::init_score(ucc_coll_score_t *score, std::vector<range_t> v,
                             ucc_coll_type_t c, uint64_t init_fn, uint64_t team)
 {
@@ -231,4 +265,53 @@ UCC_TEST_F(test_score_merge, same_score)
     EXPECT_EQ(UCC_OK,
               check_range(merge, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 200, 100)})));
+}
+
+UCC_TEST_F(test_score_merge, fallback_single)
+{
+    init_score(score1, RLIST({RANGE(0, 100, 100), RANGE(200, 300, 5)}),
+               UCC_COLL_TYPE_BARRIER, 0x1, 0x2);
+    init_score(score2, RLIST({RANGE(0, 100, 200), RANGE(250, 350, 3)}),
+               UCC_COLL_TYPE_BARRIER, 0x3, 0x4);
+    EXPECT_EQ(UCC_OK, ucc_coll_score_merge(score1, score2, &merge, 1));
+    /* First range overlaps intirely with 200 being higer score: fallback must be init=0x1.
+       Second range overlaps into 3 pieces: 2 w/o fallback and 1 with fallback init=0x3
+       since its score (3) is smaller */
+    EXPECT_EQ(UCC_OK,
+              check_fallback(merge, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
+                             FB_LLIST({FB_LIST({FB(100, 0x1)}), FB_LIST({}),
+                                       FB_LIST({FB(3, 0x3)}), FB_LIST({})})));
+}
+
+UCC_TEST_F(test_score_merge, fallback_multiple)
+{
+    /* Same range has 5 different scores. There must be 4 fallbask ordered by score */
+    init_score(score1, RLIST({RANGE(0, 100, 100)}), UCC_COLL_TYPE_BARRIER, 0x1,
+               0x2);
+    init_score(score2, RLIST({RANGE(0, 100, 300)}), UCC_COLL_TYPE_BARRIER, 0x3,
+               0x4);
+    EXPECT_EQ(UCC_OK, ucc_coll_score_merge(score1, score2, &merge, 1));
+
+    score1 = merge;
+    ASSERT_EQ(UCC_OK, ucc_coll_score_alloc(&score2));
+    init_score(score2, RLIST({RANGE(0, 100, 500)}), UCC_COLL_TYPE_BARRIER, 0x5,
+               0x6);
+    EXPECT_EQ(UCC_OK, ucc_coll_score_merge(score1, score2, &merge, 1));
+
+    score1 = merge;
+    ASSERT_EQ(UCC_OK, ucc_coll_score_alloc(&score2));
+    init_score(score2, RLIST({RANGE(0, 100, 400)}), UCC_COLL_TYPE_BARRIER, 0x7,
+               0x8);
+    EXPECT_EQ(UCC_OK, ucc_coll_score_merge(score1, score2, &merge, 1));
+
+    score1 = merge;
+    ASSERT_EQ(UCC_OK, ucc_coll_score_alloc(&score2));
+    init_score(score2, RLIST({RANGE(0, 100, 600)}), UCC_COLL_TYPE_BARRIER, 0x9,
+               0x10);
+    EXPECT_EQ(UCC_OK, ucc_coll_score_merge(score1, score2, &merge, 1));
+
+    EXPECT_EQ(UCC_OK, check_fallback(
+                          merge, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
+                          FB_LLIST({FB_LIST({FB(500, 0x5), FB(400, 0x7),
+                                             FB(300, 0x3), FB(100, 0x1)})})));
 }

--- a/test/gtest/coll_score/test_score.h
+++ b/test/gtest/coll_score/test_score.h
@@ -13,8 +13,14 @@ extern "C" {
 #include <vector>
 
 typedef std::tuple<size_t, size_t, ucc_score_t> range_t;
+typedef std::tuple<ucc_score_t, uint64_t>       fallback_t;
+
 #define RANGE(_start, _end, _score) std::make_tuple(_start, _end, _score)
 #define RLIST(...) std::vector<range_t>(__VA_ARGS__)
+
+#define FB(_score, _init) std::make_tuple(_score, _init)
+#define FB_LIST(...) std::vector<fallback_t>(__VA_ARGS__)
+#define FB_LLIST(...) std::vector<std::vector<fallback_t>>(__VA_ARGS__)
 
 #define FIRST_RANGE(_score, _ct, _mt)                                          \
     ({                                                                         \
@@ -31,6 +37,9 @@ class test_score : public ucc::test {
 public:
     ucc_status_t check_range(ucc_coll_score_t *score, ucc_coll_type_t c,
                              ucc_memory_type_t m, std::vector<range_t> check);
+    ucc_status_t check_fallback(ucc_coll_score_t *score, ucc_coll_type_t c,
+                                ucc_memory_type_t                    m,
+                                std::vector<std::vector<fallback_t>> check);
     void         init_score(ucc_coll_score_t *score, std::vector<range_t> v,
                             ucc_coll_type_t c, uint64_t init_fn = 0, uint64_t team = 0);
 };

--- a/test/gtest/coll_score/test_score.h
+++ b/test/gtest/coll_score/test_score.h
@@ -29,7 +29,7 @@ typedef std::tuple<ucc_score_t, uint64_t>       fallback_t;
                           [UCC_MEMORY_TYPE_##_mt]                              \
                               .next;                                           \
         ucc_msg_range_t *range =                                               \
-            ucc_container_of(l, ucc_msg_range_t, list_elem);                   \
+            ucc_container_of(l, ucc_msg_range_t, super.list_elem);             \
         range;                                                                 \
     })
 

--- a/test/gtest/coll_score/test_score_str.cc
+++ b/test/gtest/coll_score/test_score_str.cc
@@ -14,14 +14,15 @@ class test_score_str : public test_score {
                           [UCC_MEMORY_TYPE_##_mt]                              \
                               .next;                                           \
         ucc_msg_range_t *range =                                               \
-            ucc_container_of(l, ucc_msg_range_t, list_elem);                   \
-        range->score;                                                          \
+            ucc_container_of(l, ucc_msg_range_t, super.list_elem);             \
+        range->super.score;                                                    \
     })
 
 UCC_TEST_F(test_score_str, check_valid)
 {
     std::string       str = "alltoall:cuda:10";
     ucc_coll_score_t *score;
+
     EXPECT_EQ(UCC_OK, ucc_coll_score_alloc_from_str(str.c_str(), &score, 0,
                                                     NULL, NULL, NULL));
     EXPECT_EQ(10, SCORE(score, ALLTOALL, CUDA));

--- a/test/gtest/coll_score/test_score_update.cc
+++ b/test/gtest/coll_score/test_score_update.cc
@@ -161,7 +161,7 @@ UCC_TEST_F(test_score_update, init_reset)
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 100, 100)})));
-    EXPECT_EQ(0x2, (uint64_t)(FIRST_RANGE(score, BARRIER, HOST)->init));
+    EXPECT_EQ(0x2, (uint64_t)(FIRST_RANGE(score, BARRIER, HOST)->super.init));
 
     reset();
 
@@ -174,7 +174,7 @@ UCC_TEST_F(test_score_update, init_reset)
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 50, 100), RANGE(50, 100, 50),
                                  RANGE(100, 150, 50)})));
-    EXPECT_EQ(0x1, (uint64_t)(FIRST_RANGE(score, BARRIER, HOST)->init));
+    EXPECT_EQ(0x1, (uint64_t)(FIRST_RANGE(score, BARRIER, HOST)->super.init));
 
     reset();
     init_score(score, RLIST({RANGE(50, 150, 100)}), UCC_COLL_TYPE_BARRIER, 0x1,
@@ -186,5 +186,5 @@ UCC_TEST_F(test_score_update, init_reset)
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 50, 50), RANGE(50, 100, 50),
                                  RANGE(100, 150, 100)})));
-    EXPECT_EQ(0x2, (uint64_t)(FIRST_RANGE(score, BARRIER, HOST)->init));
+    EXPECT_EQ(0x2, (uint64_t)(FIRST_RANGE(score, BARRIER, HOST)->super.init));
 }

--- a/test/gtest/coll_score/test_score_update.cc
+++ b/test/gtest/coll_score/test_score_update.cc
@@ -164,6 +164,7 @@ UCC_TEST_F(test_score_update, init_reset)
     EXPECT_EQ(0x2, (uint64_t)(FIRST_RANGE(score, BARRIER, HOST)->init));
 
     reset();
+
     init_score(score, RLIST({RANGE(0, 100, 100)}), UCC_COLL_TYPE_BARRIER, 0x1,
                0x1);
     init_score(update, RLIST({RANGE(50, 150, 50)}), UCC_COLL_TYPE_BARRIER, 0x2,
@@ -171,7 +172,8 @@ UCC_TEST_F(test_score_update, init_reset)
     EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
-                          RLIST({RANGE(0, 50, 100), RANGE(50, 150, 50)})));
+                          RLIST({RANGE(0, 50, 100), RANGE(50, 100, 50),
+                                 RANGE(100, 150, 50)})));
     EXPECT_EQ(0x1, (uint64_t)(FIRST_RANGE(score, BARRIER, HOST)->init));
 
     reset();
@@ -182,6 +184,7 @@ UCC_TEST_F(test_score_update, init_reset)
     EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
-                          RLIST({RANGE(0, 100, 50), RANGE(100, 150, 100)})));
+                          RLIST({RANGE(0, 50, 50), RANGE(50, 100, 50),
+                                 RANGE(100, 150, 100)})));
     EXPECT_EQ(0x2, (uint64_t)(FIRST_RANGE(score, BARRIER, HOST)->init));
 }


### PR DESCRIPTION
## What
Implements automatic score-based fallback logic for TL/CL coll_init flow.

## Why ?
Currently when multiple TLs (CLs) are used (e.g. NCCL + UCP via CL/basic) the selection is done based on highest component score (e.g., NCCL can be chosen for cuda based colls). However, if some TL (CL) did not support certain configuration of coll_args (e.g. TL/NCCL does not support allreduce with int16_t datatype) then user would get UCC_ERR_NOT_SUPPORTED. 

Same will be used e.g. for SHARP TL for unsupported dtypes/ops. CL/HIER will also use that when some hierarchical algorithms (e.g. hybrid AR) can not support team topology, etc.

## How ?
This PR implements support for fallbacks in the scoring framework. Nothing changes in the CL/TL - everything is inside coll_score and score_map. Fallbacks are stored in the score-sorted order. So now, when NCCL can't run allreduce int16_t it will automatically fallback to TL/UCP and user will not get error. If user wants to force NCCL only this is of course always an option. 

Looks like this:
```
nnodes=1; ppn=2; mpirun  -x UCC_LOG_LEVEL=debug --map-by ppr:$ppn:node $WDIR/dgx_set_dev.sh ./install/bin/ucc_test_mpi -c allreduce   -t world 32 -M cuda -o sum -d int16 -m 32768:32768
(... part of output from 1 rank ...)
27811:0]    tl_nccl_coll.c:237  TL_NCCL DEBUG dataype is not supported
[1631130400.958187] [swx-dgx01:27811:0] ucc_coll_score_map.c:88   UCC  DEBUG coll is not supported for TL_NCCL, fallback TL_UCP
[1631130400.958208] [swx-dgx01:27811:0]        ucc_coll.c:160  UCC  DEBUG coll_init: team id 1 size 2 rank 0 ctx_rank 0: Allreduce Cuda inplace=0 bytes=32768 int16 sum, req 0x3210f00
tc=Allreduce team=world msgsize=32768 inplace=0 dt=int16 op=sum
[1631130400.958235] [swx-dgx01:27811:0]        ucc_coll.c:170  UCC  DEBUG coll_post: req 0x3210f00
```