### PR TITLE
UCP: Implementing Bcast SAG for large messages

### DIFF
--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -151,6 +151,19 @@ ucc_knomial_pattern_next_iteration_backward(ucc_knomial_pattern_t *p)
     p->radix_pow /= p->radix;
 }
 
+static inline ucc_kn_radix_t
+ucc_knomial_pattern_get_min_radix(ucc_kn_radix_t cfg_radix,
+                                  ucc_rank_t team_size, size_t count)
+{
+	ucc_kn_radix_t radix = ucc_min(cfg_radix, team_size);
+
+    if (((count + radix - 1) / radix * (radix - 1) > count) ||
+        ((radix - 1) > count)) {
+    	radix = 2;
+    }
+    return radix;
+}
+
 /* A set of convenience macros used to implement sw based progress
    of the algorithms that use kn pattern */
 enum {

--- a/src/coll_patterns/sra_knomial.h
+++ b/src/coll_patterns/sra_knomial.h
@@ -79,12 +79,12 @@ static inline size_t ucc_sra_kn_compute_block_count(size_t     count,
 static inline void
 ucc_sra_kn_get_offset_and_seglen(size_t count, size_t dt_size, ucc_rank_t rank,
                                  ucc_rank_t size, ucc_kn_radix_t radix,
-                                 ptrdiff_t *offset, int *seglen)
+                                 ptrdiff_t *offset, size_t *seglen)
 {
     ptrdiff_t             _offset     = 0;
     size_t                block_count = count;
     ucc_rank_t            step_radix  = 0;
-    ucc_rank_t            my_seg_len  = 0;
+    size_t                my_seg_len  = 0;
     ucc_rank_t            k, r, peer, my_si;
     size_t                my_seg_offset;
     ucc_knomial_pattern_t p;

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -20,7 +20,8 @@ alltoallv =                        \
 bcast =                   \
 	bcast/bcast.h         \
 	bcast/bcast.c         \
-	bcast/bcast_knomial.c
+	bcast/bcast_knomial.c \
+	bcast/bcast_sag_knomial.c
 
 allreduce =                           \
 	allreduce/allreduce.h             \
@@ -48,6 +49,10 @@ reduce_scatter =	                        \
 	reduce_scatter/reduce_scatter.h         \
 	reduce_scatter/reduce_scatter_knomial.c
 
+scatter =	                   \
+	scatter/scatter.h          \
+	scatter/scatter_knomial.c
+
 sources =                 \
 	tl_ucp.h              \
 	tl_ucp.c              \
@@ -66,7 +71,8 @@ sources =                 \
 	$(allgatherv)         \
 	$(bcast)              \
 	$(reduce)             \
-	$(reduce_scatter)
+	$(reduce_scatter)     \
+	$(scatter)
 
 module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -19,8 +19,8 @@
         task->allgather_kn.phase = _phase;                                     \
     } while (0)
 
-#define VRANK(_rank, _root, _team_size) (((_rank) - (_root) + (_team_size)) % (_team_size))
-#define INV_VRANK(_rank, _root, _team_size) (((_rank) + (_root)) % (_team_size))
+//#define VRANK(_rank, _root, _team_size) (((_rank) - (_root) + (_team_size)) % (_team_size))
+//#define INV_VRANK(_rank, _root, _team_size) (((_rank) + (_root)) % (_team_size))
 
 /* #define VRANK(_rank, _root, _team_size) ((_rank) + (_root) - (_root)) */
 /* #define INV_VRANK(_rank, _root, _team_size) ((_rank) + (_root) - (_root)) */

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -19,12 +19,6 @@
         task->allgather_kn.phase = _phase;                                     \
     } while (0)
 
-//#define VRANK(_rank, _root, _team_size) (((_rank) - (_root) + (_team_size)) % (_team_size))
-//#define INV_VRANK(_rank, _root, _team_size) (((_rank) + (_root)) % (_team_size))
-
-/* #define VRANK(_rank, _root, _team_size) ((_rank) + (_root) - (_root)) */
-/* #define INV_VRANK(_rank, _root, _team_size) ((_rank) + (_root) - (_root)) */
-
 ucc_status_t ucc_tl_ucp_allgather_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
@@ -48,6 +42,11 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_kn_radix_t         loop_step;
     size_t                 block_count, peer_seg_count, local_seg_count;
 
+    /* Bcast will first call scatter and then allgather.
+       In case of non-full tree with "extra" ranks, scatter will give each rank
+       a new virtual rank number - "vrank".
+       As such allgather must keep to this ranking to be aligned with scatter.
+    */
     if (coll_task->args.coll_type == UCC_COLL_TYPE_BCAST) {
         broot = coll_task->args.root;
         rank = VRANK(rank, broot, size);

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -103,16 +103,11 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
     ucc_base_coll_args_t args     = *coll_args;
     ucc_coll_task_t     *task, *rs_task;
     ucc_status_t         status;
-    ucc_kn_radix_t       radix;
+    ucc_kn_radix_t       radix, cfg_radix;
 
     ucc_schedule_init(schedule, &coll_args->args, team);
-    radix = ucc_min(UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_radix,
-                    tl_team->size);
-
-    if (((count + radix - 1) / radix * (radix - 1) > count) ||
-        ((radix - 1) > count)) {
-        radix = 2;
-    }
+    cfg_radix = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_radix;
+    radix = ucc_knomial_pattern_get_min_radix(cfg_radix, tl_team->size, count);
 
     /* 1st step of allreduce: knomial reduce_scatter */
     status = ucc_tl_ucp_reduce_scatter_knomial_init_r(&args, team, &task, radix);

--- a/src/components/tl/ucp/bcast/bcast.c
+++ b/src/components/tl/ucp/bcast/bcast.c
@@ -7,6 +7,21 @@
 #include "tl_ucp.h"
 #include "bcast.h"
 
+ucc_base_coll_alg_info_t
+    ucc_tl_ucp_bcast_algs[UCC_TL_UCP_BCAST_ALG_LAST + 1] = {
+        [UCC_TL_UCP_BCAST_ALG_KNOMIAL] =
+            {.id   = UCC_TL_UCP_BCAST_ALG_KNOMIAL,
+             .name = "knomial",
+             .desc =
+                 "recursive k-ing with arbitrary radix (latency oriented alg)"},
+        [UCC_TL_UCP_BCAST_ALG_SAG_KNOMIAL] =
+            {.id   = UCC_TL_UCP_BCAST_ALG_SAG_KNOMIAL,
+             .name = "sag_knomial",
+             .desc = "recursive k-nomial scatter followed by k-nomial "
+                     "allgather (bw oriented alg)"},
+        [UCC_TL_UCP_BCAST_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};
+
 ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *task);
 ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *task);
 
@@ -15,4 +30,16 @@ ucc_status_t ucc_tl_ucp_bcast_init(ucc_tl_ucp_task_t *task)
     task->super.post     = ucc_tl_ucp_bcast_knomial_start;
     task->super.progress = ucc_tl_ucp_bcast_knomial_progress;
     return UCC_OK;
+}
+
+ucc_status_t ucc_tl_ucp_bcast_knomial_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t *     team,
+                                               ucc_coll_task_t **    task_h)
+{
+    ucc_tl_ucp_task_t *task;
+    ucc_status_t       status;
+    task                 = ucc_tl_ucp_init_task(coll_args, team);
+    status               = ucc_tl_ucp_bcast_init(task);
+    *task_h              = &task->super;
+    return status;
 }

--- a/src/components/tl/ucp/bcast/bcast.c
+++ b/src/components/tl/ucp/bcast/bcast.c
@@ -12,8 +12,8 @@ ucc_base_coll_alg_info_t
         [UCC_TL_UCP_BCAST_ALG_KNOMIAL] =
             {.id   = UCC_TL_UCP_BCAST_ALG_KNOMIAL,
              .name = "knomial",
-             .desc =
-                 "recursive k-ing with arbitrary radix (latency oriented alg)"},
+             .desc = "bcast over knomial tree with arbitrary radix "
+                     "(latency oriented alg)"},
         [UCC_TL_UCP_BCAST_ALG_SAG_KNOMIAL] =
             {.id   = UCC_TL_UCP_BCAST_ALG_SAG_KNOMIAL,
              .name = "sag_knomial",
@@ -38,8 +38,9 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_init(ucc_base_coll_args_t *coll_args,
 {
     ucc_tl_ucp_task_t *task;
     ucc_status_t       status;
-    task                 = ucc_tl_ucp_init_task(coll_args, team);
-    status               = ucc_tl_ucp_bcast_init(task);
-    *task_h              = &task->super;
+
+    task    = ucc_tl_ucp_init_task(coll_args, team);
+    status  = ucc_tl_ucp_bcast_init(task);
+    *task_h = &task->super;
     return status;
 }

--- a/src/components/tl/ucp/bcast/bcast.h
+++ b/src/components/tl/ucp/bcast/bcast.h
@@ -8,6 +8,34 @@
 #include "../tl_ucp.h"
 #include "../tl_ucp_coll.h"
 
+enum {
+    UCC_TL_UCP_BCAST_ALG_KNOMIAL,
+    UCC_TL_UCP_BCAST_ALG_SAG_KNOMIAL,
+    UCC_TL_UCP_BCAST_ALG_LAST
+};
+
+extern ucc_base_coll_alg_info_t
+             ucc_tl_ucp_bcast_algs[UCC_TL_UCP_BCAST_ALG_LAST + 1];
 ucc_status_t ucc_tl_ucp_bcast_init(ucc_tl_ucp_task_t *task);
+ucc_status_t
+ucc_tl_ucp_bcast_knomial_init(ucc_base_coll_args_t *coll_args,
+                              ucc_base_team_t *team, ucc_coll_task_t **task_h);
+ucc_status_t
+ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
+                              ucc_base_team_t *team, ucc_coll_task_t **task_h);
+
+#define UCC_TL_UCP_BCAST_DEFAULT_ALG_SELECT_STR              \
+    "bcast:0-4k:@0#bcast:4k-inf:@1"
+
+static inline int ucc_tl_ucp_bcast_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_TL_UCP_BCAST_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_tl_ucp_bcast_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
 
 #endif

--- a/src/components/tl/ucp/bcast/bcast.h
+++ b/src/components/tl/ucp/bcast/bcast.h
@@ -25,7 +25,7 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
                               ucc_base_team_t *team, ucc_coll_task_t **task_h);
 
 #define UCC_TL_UCP_BCAST_DEFAULT_ALG_SELECT_STR              \
-    "bcast:0-4k:@0#bcast:4k-inf:@1"
+    "bcast:0-32k:@0#bcast:32k-inf:@1"
 
 static inline int ucc_tl_ucp_bcast_alg_from_str(const char *str)
 {

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "tl_ucp.h"
+#include "bcast.h"
+#include "core/ucc_progress_queue.h"
+#include "tl_ucp_sendrecv.h"
+#include "coll_patterns/sra_knomial.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
+#include "core/ucc_mc.h"
+#include "../scatter/scatter.h"
+#include "../allgather/allgather.h"
+
+/* SRA - scatter-reduce-allgather knomial algorithm
+   1. The algorithm performs collective bcast operation for large messages
+      as a sequence of K-nomial Scatter followed by K-nomial
+      (with the same radix K) allgather.
+   2. In essence this is an extension of the Bi-nomial SRA algorithm algorithm
+      proposed by Rabenseifner2004 (https://doi.org/10.1007/978-3-540-24685-5_1).
+      The extension adds the support for arbitrary radix.
+   3. The algorithm targets Large message sizes (ie. optimized for max bandwidth).
+   4. If number of ranks in the team can not form a full radix subtree
+      (for radix=2 this means the team size is not power of 2) then there will be
+      "extra" ranks which don't participate in the main exchange loop. They
+      will send the data to their "proxy" ranks in the beginning and then wait
+      for the response with the final data.
+   5. The knomial reduce-scatter and allgather primitives can be used separately.
+      However, if they are used together as part of SRA allreduce one has to
+      provide the same radix for both routines.
+   6. If the allreduce is INPLACE or if a rank serves as a PROXY then the algorithm
+      requires allocation of a scratch buffer of the size equal to input buffer.
+   7. After the completion of reduce-scatter phase the local result (at non EXTRA
+      ranks) will be located in dst buffer at offset the can be commputed by the
+      routine from coll_patterns/sra_knomial.h: ucc_sra_kn_get_offset.
+ */
+ucc_status_t ucc_tl_ucp_bcast_sag_knomial_start(ucc_coll_task_t *coll_task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
+
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(schedule, "ucp_bcast_sag_kn_start", 0);
+    return ucc_schedule_start(schedule);
+}
+
+ucc_status_t
+ucc_tl_ucp_bcast_sag_knomial_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
+    ucc_status_t    status;
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(schedule, "ucp_bcast_sag_kn_done", 0);
+
+    status = ucc_schedule_finalize(coll_task);
+    ucc_tl_ucp_put_schedule(schedule);
+    return status;
+}
+
+ucc_status_t
+ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
+                                      ucc_base_team_t      *team,
+                                      ucc_coll_task_t     **task_h)
+{
+    ucc_tl_ucp_team_t   *tl_team  = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_schedule_t      *schedule = ucc_tl_ucp_get_schedule(tl_team);
+    size_t               count    = coll_args->args.src.info.count;
+    ucc_base_coll_args_t args     = *coll_args;
+    ucc_coll_task_t     *task, *rs_task;
+    ucc_status_t         status;
+    ucc_kn_radix_t       radix;
+    radix = ucc_min(UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.bcast_kn_radix,
+                    tl_team->size);
+
+    if (((count + radix - 1) / radix * (radix - 1) > count) ||
+        ((radix - 1) > count)) {
+        radix = 2;
+    }
+
+    /* 1st step of bcast: knomial scatter */
+    args.args.dst.info.buffer   = args.args.src.info.buffer;
+    args.args.dst.info.mem_type = args.args.src.info.mem_type;
+//    args.args.dst.info.datatype = args.args.src.info.datatype; //needed for api?
+//    args.args.dst.info.count    = args.args.src.info.count; // needed for api?
+    status = ucc_tl_ucp_scatter_knomial_init_r(&args, team, &task, radix);
+    if (UCC_OK != status) {
+        tl_error(UCC_TL_TEAM_LIB(tl_team),
+                 "failed to init scatter_knomial task");
+        goto out;
+    }
+    ucc_schedule_add_task(schedule, task);
+    ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
+                                task, ucc_task_start_handler);
+    rs_task = task;
+
+    /* 2nd step of bcast: knomial allgather. 2nd task subscribes
+     to completion event of scatter task. */
+    args.args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
+    args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+    status = ucc_tl_ucp_allgather_knomial_init_r(&args, team, &task, radix);
+    if (UCC_OK != status) {
+        tl_error(UCC_TL_TEAM_LIB(tl_team),
+                 "failed to init allgather_knomial task");
+        goto out;
+    }
+
+    ucc_schedule_add_task(schedule, task);
+    ucc_event_manager_subscribe(&rs_task->em, UCC_EVENT_COMPLETED, task,
+                                ucc_task_start_handler);
+
+    schedule->super.post           = ucc_tl_ucp_bcast_sag_knomial_start;
+    schedule->super.progress       = NULL;
+    schedule->super.finalize       = ucc_tl_ucp_bcast_sag_knomial_finalize;
+    schedule->super.triggered_post = ucc_tl_ucp_triggered_post;
+    *task_h                        = &schedule->super;
+    return UCC_OK;
+out:
+    ucc_tl_ucp_put_schedule(schedule);
+    return status;
+}

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -67,14 +67,10 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
     ucc_base_coll_args_t args     = *coll_args;
     ucc_coll_task_t     *task, *rs_task;
     ucc_status_t         status;
-    ucc_kn_radix_t       radix;
-    radix = ucc_min(UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.bcast_kn_radix,
-                    tl_team->size);
+    ucc_kn_radix_t       radix, cfg_radix;
 
-    if (((count + radix - 1) / radix * (radix - 1) > count) ||
-        ((radix - 1) > count)) {
-        radix = 2;
-    }
+    cfg_radix = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.bcast_sag_kn_radix;
+    radix = ucc_knomial_pattern_get_min_radix(cfg_radix, tl_team->size, count);
 
     /* 1st step of bcast: knomial scatter */
     args.args.dst.info.buffer   = args.args.src.info.buffer;

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -16,7 +16,7 @@
 #include "../scatter/scatter.h"
 #include "../allgather/allgather.h"
 
-/* SRA - scatter-allgather knomial algorithm
+/* SAG - scatter-allgather knomial algorithm
    1. The algorithm performs collective bcast operation for large messages
       as a sequence of K-nomial Scatter followed by K-nomial
       (with the same radix K) allgather.
@@ -49,8 +49,8 @@ ucc_tl_ucp_bcast_sag_knomial_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
     ucc_status_t    status;
-    UCC_TL_UCP_PROFILE_REQUEST_EVENT(schedule, "ucp_bcast_sag_kn_done", 0);
 
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(schedule, "ucp_bcast_sag_kn_done", 0);
     status = ucc_schedule_finalize(coll_task);
     ucc_tl_ucp_put_schedule(schedule);
     return status;
@@ -94,7 +94,7 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
 
     /* 2nd step of bcast: knomial allgather. 2nd task subscribes
      to completion event of scatter task. */
-    args.args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
+    args.args.mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
     args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
     status = ucc_tl_ucp_allgather_knomial_init_r(&args, team, &task, radix);
     if (UCC_OK != status) {

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -16,7 +16,7 @@
 #include "../scatter/scatter.h"
 #include "../allgather/allgather.h"
 
-/* SRA - scatter-reduce-allgather knomial algorithm
+/* SRA - scatter-allgather knomial algorithm
    1. The algorithm performs collective bcast operation for large messages
       as a sequence of K-nomial Scatter followed by K-nomial
       (with the same radix K) allgather.
@@ -27,14 +27,12 @@
    4. If number of ranks in the team can not form a full radix subtree
       (for radix=2 this means the team size is not power of 2) then there will be
       "extra" ranks which don't participate in the main exchange loop. They
-      will send the data to their "proxy" ranks in the beginning and then wait
-      for the response with the final data.
-   5. The knomial reduce-scatter and allgather primitives can be used separately.
-      However, if they are used together as part of SRA allreduce one has to
+      will wait to recieve the final data from their "proxy" ranks at the end of
+      exchange loop of all other ranks.
+   5. The knomial scatter and allgather primitives can be used separately.
+      However, if they are used together as part of SAG bcast one has to
       provide the same radix for both routines.
-   6. If the allreduce is INPLACE or if a rank serves as a PROXY then the algorithm
-      requires allocation of a scratch buffer of the size equal to input buffer.
-   7. After the completion of reduce-scatter phase the local result (at non EXTRA
+   6. After the completion of scatter phase the local result (at non EXTRA
       ranks) will be located in dst buffer at offset the can be commputed by the
       routine from coll_patterns/sra_knomial.h: ucc_sra_kn_get_offset.
  */
@@ -81,8 +79,8 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
     /* 1st step of bcast: knomial scatter */
     args.args.dst.info.buffer   = args.args.src.info.buffer;
     args.args.dst.info.mem_type = args.args.src.info.mem_type;
-//    args.args.dst.info.datatype = args.args.src.info.datatype; //needed for api?
-//    args.args.dst.info.count    = args.args.src.info.count; // needed for api?
+    args.args.dst.info.datatype = args.args.src.info.datatype;
+    args.args.dst.info.count    = args.args.src.info.count;
     status = ucc_tl_ucp_scatter_knomial_init_r(&args, team, &task, radix);
     if (UCC_OK != status) {
         tl_error(UCC_TL_TEAM_LIB(tl_team),

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -263,14 +263,10 @@ ucc_tl_ucp_reduce_scatter_knomial_init(ucc_base_coll_args_t *coll_args,
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_rank_t         size    = tl_team->size;
     size_t             count   = coll_args->args.dst.info.count;
-    ucc_kn_radix_t     radix;
+    ucc_kn_radix_t     radix, cfg_radix;
 
-    radix = ucc_min(UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.reduce_scatter_kn_radix,
-                    size);
-    if (((count + radix - 1) / radix * (radix - 1) > count) ||
-        ((radix - 1) > count)) {
-        radix = 2;
-    }
+    cfg_radix = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.reduce_scatter_kn_radix;
+    radix = ucc_knomial_pattern_get_min_radix(cfg_radix, size, count);
     return ucc_tl_ucp_reduce_scatter_knomial_init_r(coll_args, team, task_h,
                                                     radix);
 }

--- a/src/components/tl/ucp/scatter/scatter.h
+++ b/src/components/tl/ucp/scatter/scatter.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#ifndef SCATTER_H_
+#define SCATTER_H_
+#include "../tl_ucp.h"
+#include "../tl_ucp_coll.h"
+
+/* A set of convenience macros used to implement sw based progress
+   of the scatter algorithm that uses kn pattern */
+//enum {
+//    UCC_SCATTER_KN_PHASE_INIT,
+//    UCC_SCATTER_KN_PHASE_LOOP, /* main loop of recursive k-ing */
+//};
+
+/*
+#define UCC_SCATTER_KN_CHECK_PHASE(_p)                                        \
+    case _p:                                                                  \
+        goto _p;
+
+#define UCC_SCATTER_KN_GOTO_PHASE(_phase)                                     \
+    do {                                                                      \
+        switch (_phase) {                                                     \
+            UCC_SCATTER_KN_CHECK_PHASE(UCC_SCATTER_KN_PHASE_LOOP);            \
+        case UCC_SCATTER_KN_PHASE_INIT:                                       \
+            break;                                                            \
+        };                                                                    \
+    } while (0)
+    */
+
+/* Base interface signature: uses scatter_kn_radix from config. */
+
+ucc_status_t
+ucc_tl_ucp_scatter_knomial_init(ucc_base_coll_args_t *coll_args,
+                                ucc_base_team_t      *team,
+                                ucc_coll_task_t     **task_h);
+
+/* Internal interface to KN scatter with custom radix */
+ucc_status_t ucc_tl_ucp_scatter_knomial_init_r(
+    ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+    ucc_coll_task_t **task_h, ucc_kn_radix_t radix);
+#endif

--- a/src/components/tl/ucp/scatter/scatter.h
+++ b/src/components/tl/ucp/scatter/scatter.h
@@ -8,28 +8,6 @@
 #include "../tl_ucp.h"
 #include "../tl_ucp_coll.h"
 
-/* A set of convenience macros used to implement sw based progress
-   of the scatter algorithm that uses kn pattern */
-//enum {
-//    UCC_SCATTER_KN_PHASE_INIT,
-//    UCC_SCATTER_KN_PHASE_LOOP, /* main loop of recursive k-ing */
-//};
-
-/*
-#define UCC_SCATTER_KN_CHECK_PHASE(_p)                                        \
-    case _p:                                                                  \
-        goto _p;
-
-#define UCC_SCATTER_KN_GOTO_PHASE(_phase)                                     \
-    do {                                                                      \
-        switch (_phase) {                                                     \
-            UCC_SCATTER_KN_CHECK_PHASE(UCC_SCATTER_KN_PHASE_LOOP);            \
-        case UCC_SCATTER_KN_PHASE_INIT:                                       \
-            break;                                                            \
-        };                                                                    \
-    } while (0)
-    */
-
 /* Base interface signature: uses scatter_kn_radix from config. */
 
 ucc_status_t

--- a/src/components/tl/ucp/scatter/scatter_knomial.c
+++ b/src/components/tl/ucp/scatter/scatter_knomial.c
@@ -1,0 +1,249 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "tl_ucp.h"
+#include "tl_ucp_coll.h"
+#include "tl_ucp_sendrecv.h"
+#include "core/ucc_progress_queue.h"
+#include "core/ucc_mc.h"
+#include "coll_patterns/sra_knomial.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
+
+#define SAVE_STATE(_phase)                                                    \
+    do {                                                                      \
+        task->scatter_kn.phase = _phase;                                      \
+    } while (0)
+
+#define GET_BASE_PEER(_radix, _rank, _dist, _peer)                            \
+    do {                                                                      \
+        _peer = _rank - ((_rank / _dist) % _radix) * _dist;                   \
+} while (0)
+
+enum {
+    UCC_SCATTER_KN_PHASE_INIT,
+    UCC_SCATTER_KN_PHASE_LOOP, /* main loop of recursive k-ing */
+};
+
+ucc_rank_t calc_recv_dist(ucc_rank_t team_size, ucc_rank_t rank,
+                                     ucc_rank_t radix, ucc_rank_t root)
+{
+	if (rank == root) {
+		return 0;
+	}
+    ucc_rank_t root_base;
+    ucc_rank_t dist = 1;
+    GET_BASE_PEER(radix, root, dist, root_base);
+    while (dist <= team_size) {
+        if (rank >= root_base && rank < root_base + radix * dist) {
+            break;
+        }
+        dist *= radix;
+        GET_BASE_PEER(radix, root_base, dist, root_base);
+    }
+    return dist;
+}
+
+ucc_status_t
+ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t     *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_coll_args_t       *args = &coll_task->args;
+    ucc_tl_ucp_team_t     *team = TASK_TEAM(task);
+    ucc_kn_radix_t         radix     = task->scatter_kn.p.radix;
+    uint8_t                node_type = task->scatter_kn.p.node_type;
+    ucc_knomial_pattern_t *p         = &task->scatter_kn.p;
+    void                  *sbuf      = args->src.info.buffer;
+    void                  *rbuf      = args->dst.info.buffer;
+    ucc_memory_type_t      mem_type  = args->src.info.mem_type;
+    size_t                 count     = args->src.info.count;
+    ucc_datatype_t         dt        = args->src.info.datatype;
+    size_t                 dt_size   = ucc_dt_size(dt);
+    ucc_rank_t             size      = team->size;
+    ucc_rank_t             rank      = team->rank;
+    ucc_rank_t             root      = (ucc_rank_t)args->root;
+    ucc_rank_t             team_size = team->size - p->n_extra;
+    ucc_rank_t             peer, vroot, vpeer, peer_recv_dist;
+    ucc_rank_t             step_radix, peer_seg_index, local_seg_index;
+    ptrdiff_t              peer_seg_offset, offset;
+    ucc_status_t           status;
+    ucc_kn_radix_t         loop_step;
+    size_t                 block_count, peer_seg_count, local_seg_count;
+
+//    UCC_SCATTER_KN_GOTO_PHASE(task->scatter_kn.phase);
+    if (task->scatter_kn.phase == UCC_SCATTER_KN_PHASE_LOOP) {
+    	goto UCC_SCATTER_KN_PHASE_LOOP;
+    }
+
+    if (KN_NODE_EXTRA == node_type || KN_NODE_PROXY == node_type) {
+        goto out;
+    }
+
+    while (!ucc_knomial_pattern_loop_done(p)) {
+        step_radix  = ucc_sra_kn_compute_step_radix(rank, size, p);
+        block_count = ucc_sra_kn_compute_block_count(count, rank, p);
+        sbuf        = (rank == root)
+                           ? args->src.info.buffer : args->dst.info.buffer;
+        rbuf        = args->dst.info.buffer;
+        local_seg_index = ucc_sra_kn_compute_seg_index(rank, p->radix_pow, p);
+        local_seg_count = ucc_sra_kn_compute_seg_size(block_count, step_radix,
+                                                      local_seg_index);
+
+        if (rank != root && task->scatter_kn.recv_dist == p->radix_pow &&
+                                                      task->recv_posted == 0) {
+            for (loop_step = 1; loop_step < radix; loop_step++) {
+                peer = ucc_knomial_pattern_get_loop_peer(p, rank, size,
+                                                             loop_step);
+                if (peer == UCC_KN_PEER_NULL)
+                    continue;
+                vpeer = ucc_knomial_pattern_loop_rank(p, peer);
+                vroot = ucc_knomial_pattern_loop_rank(p, root);
+                peer_recv_dist = calc_recv_dist(team_size, vpeer, radix, vroot);
+                if (peer_recv_dist < task->scatter_kn.recv_dist) {
+//                	printf("inside recv, rank = %d, root = %d, task->scatter_kn.recv_dist = %d, peer_recv_dist = %d, peer = %d, vpeer = %d, p->iter = %d \n",
+//                	        			rank, root, task->scatter_kn.recv_dist, peer_recv_dist, peer, vpeer, p->iteration);
+                    UCPCHECK_GOTO(
+                        ucc_tl_ucp_recv_nb(rbuf, local_seg_count * dt_size,
+                                       mem_type, peer, team, task), task, out);
+                }
+                rbuf = PTR_OFFSET(rbuf, local_seg_count * dt_size);
+            }
+        }
+
+        if (root == rank || (task->recv_posted > 0 &&
+                             task->recv_posted == task->recv_completed)) {
+            for (loop_step = 1; loop_step < radix; loop_step++) {
+                peer = ucc_knomial_pattern_get_loop_peer(p, rank, size,
+                                                             loop_step);
+                if (peer == UCC_KN_PEER_NULL)
+                    continue;
+                peer_seg_index =
+                    ucc_sra_kn_compute_seg_index(peer, p->radix_pow, p);
+                peer_seg_count = ucc_sra_kn_compute_seg_size(
+                    block_count, step_radix, peer_seg_index);
+                peer_seg_offset = ucc_sra_kn_compute_seg_offset(
+                    block_count, step_radix, peer_seg_index);
+//                printf("inside send, rank = %d, root = %d, task->recv_posted = %d, peer = %d, p->iter = %d \n",
+//                                	        			rank, root, task->recv_posted, peer, p->iteration);
+                UCPCHECK_GOTO(
+                    ucc_tl_ucp_send_nb(PTR_OFFSET(sbuf,
+                                       peer_seg_offset * dt_size),
+                                       peer_seg_count * dt_size, mem_type,
+                                       peer, team, task), task, out);
+            }
+        }
+
+UCC_SCATTER_KN_PHASE_LOOP:
+        if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+            SAVE_STATE(UCC_SCATTER_KN_PHASE_LOOP);
+            return task->super.super.status;
+        }
+//        SAVE_STATE(UCC_SCATTER_KN_PHASE_INIT);
+//        task->scatter_kn.dist *= radix;
+        ucc_knomial_pattern_next_iteration(p);
+    }
+
+    step_radix      = ucc_sra_kn_compute_step_radix(rank, size, p);
+    block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
+    local_seg_index = ucc_sra_kn_compute_seg_index(rank, p->radix_pow, p);
+    local_seg_count = ucc_sra_kn_compute_seg_size(block_count, step_radix,
+                                                          local_seg_index);
+    offset          = ucc_sra_kn_get_offset(count, dt_size, rank, size, radix);
+    // check of need to do memcpy at root? and not needed if offset == 0
+    if (rank != root && offset != 0) {
+        status = ucc_mc_memcpy(PTR_OFFSET(args->dst.info.buffer, offset), rbuf,
+                               local_seg_count * dt_size, mem_type, mem_type);
+        if (UCC_OK != status) {
+            return status;
+        }
+    }
+out:
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_scatter_kn_done", 0);
+    task->super.super.status = UCC_OK;
+    return task->super.super.status;
+}
+
+ucc_status_t ucc_tl_ucp_scatter_knomial_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t     *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t     *team = TASK_TEAM(task);
+    ucc_knomial_pattern_t *p    = &task->scatter_kn.p;
+    ucc_rank_t             vrank, vroot;
+    ucc_status_t           status;
+
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_scatter_kn_start", 0);
+    ucc_tl_ucp_task_reset(task);
+
+    ucc_knomial_pattern_init(team->size, team->rank,
+                             task->scatter_kn.p.radix,
+                             &task->scatter_kn.p);
+    task->scatter_kn.phase = UCC_SCATTER_KN_PHASE_INIT;
+//    task->scatter_kn.dist  = 1;
+    vroot = ucc_knomial_pattern_loop_rank(p, coll_task->args.root);
+    vrank = ucc_knomial_pattern_loop_rank(p, team->rank);
+    task->scatter_kn.recv_dist = calc_recv_dist(team->size - p->n_extra, vrank,
+                                                p->radix, vroot);
+//    printf("rank = %d, vrank = %d, root = %ld, vroot = %d, recv_dst = %d, radix = %d \n",
+//    		team->rank, vrank, coll_task->args.root, vroot, task->scatter_kn.recv_dist, p->radix);
+
+    status = ucc_tl_ucp_scatter_knomial_progress(&task->super);
+    if (UCC_INPROGRESS == status) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+        return UCC_OK;
+    }
+    return ucc_task_complete(coll_task);
+}
+
+ucc_status_t
+ucc_tl_ucp_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
+{
+    return ucc_tl_ucp_coll_finalize(coll_task);
+}
+
+ucc_status_t ucc_tl_ucp_scatter_knomial_init_r(
+    ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+    ucc_coll_task_t **task_h, ucc_kn_radix_t radix)
+{
+    ucc_tl_ucp_team_t *tl_team   = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_rank_t         size      = tl_team->size;
+    ucc_rank_t         rank      = tl_team->rank;
+    ucc_tl_ucp_task_t *task;
+
+    task                 = ucc_tl_ucp_init_task(coll_args, team);
+    task->super.post     = ucc_tl_ucp_scatter_knomial_start;
+    task->super.progress = ucc_tl_ucp_scatter_knomial_progress;
+    task->super.finalize = ucc_tl_ucp_scatter_knomial_finalize;
+
+    ucc_assert(coll_args->args.src.info.mem_type ==
+               coll_args->args.dst.info.mem_type);
+    ucc_knomial_pattern_init(size, rank, radix, &task->scatter_kn.p);
+
+    /* In place currently not supported */
+
+    *task_h = &task->super;
+    return UCC_OK;
+}
+
+ucc_status_t
+ucc_tl_ucp_scatter_knomial_init(ucc_base_coll_args_t *coll_args,
+                                       ucc_base_team_t *     team,
+                                       ucc_coll_task_t **    task_h)
+{
+    ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_rank_t         size    = tl_team->size;
+    size_t             count   = coll_args->args.src.info.count;
+    ucc_kn_radix_t     radix;
+
+    radix = ucc_min(UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.bcast_kn_radix, size);
+    radix = 2;
+    if (((count + radix - 1) / radix * (radix - 1) > count) ||
+        ((radix - 1) > count)) {
+        radix = 2;
+    }
+    return ucc_tl_ucp_scatter_knomial_init_r(coll_args, team, task_h,
+                                                    radix);
+}

--- a/src/components/tl/ucp/scatter/scatter_knomial.c
+++ b/src/components/tl/ucp/scatter/scatter_knomial.c
@@ -48,6 +48,12 @@ ucc_rank_t calc_recv_dist(ucc_rank_t team_size, ucc_rank_t rank,
     return dist;
 }
 
+#define VRANK(_rank, _root, _team_size) (((_rank) - (_root) + (_team_size)) % (_team_size))
+#define INV_VRANK(_rank, _root, _team_size) (((_rank) + (_root)) % (_team_size))
+
+/* #define VRANK(_rank, _root, _team_size) ((_rank) + (_root) - (_root)) */
+/* #define INV_VRANK(_rank, _root, _team_size) ((_rank) + (_root) - (_root)) */
+
 ucc_status_t
 ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 {
@@ -63,9 +69,9 @@ ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     size_t                 count     = args->src.info.count;
     ucc_datatype_t         dt        = args->src.info.datatype;
     size_t                 dt_size   = ucc_dt_size(dt);
-    ucc_rank_t             size      = team->size;
-    ucc_rank_t             rank      = team->rank;
     ucc_rank_t             root      = (ucc_rank_t)args->root;
+    ucc_rank_t             size      = team->size;
+    ucc_rank_t             rank      = VRANK(team->rank, root, size);
     ucc_rank_t             team_size = team->size - p->n_extra;
     ucc_rank_t             peer, vroot, vpeer, peer_recv_dist;
     ucc_rank_t             step_radix, peer_seg_index, local_seg_index;
@@ -74,14 +80,17 @@ ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_kn_radix_t         loop_step;
     size_t                 block_count, peer_seg_count, local_seg_count;
 
-//    UCC_SCATTER_KN_GOTO_PHASE(task->scatter_kn.phase);
+    root = VRANK(root, root, size);
+
     if (task->scatter_kn.phase == UCC_SCATTER_KN_PHASE_LOOP) {
     	goto UCC_SCATTER_KN_PHASE_LOOP;
     }
 
-    if (KN_NODE_EXTRA == node_type || KN_NODE_PROXY == node_type) {
+    if (KN_NODE_EXTRA == node_type) {
         goto out;
     }
+
+
 
     while (!ucc_knomial_pattern_loop_done(p)) {
         step_radix  = ucc_sra_kn_compute_step_radix(rank, size, p);
@@ -104,13 +113,13 @@ ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
                 vroot = ucc_knomial_pattern_loop_rank(p, root);
                 peer_recv_dist = calc_recv_dist(team_size, vpeer, radix, vroot);
                 if (peer_recv_dist < task->scatter_kn.recv_dist) {
-//                	printf("inside recv, rank = %d, root = %d, task->scatter_kn.recv_dist = %d, peer_recv_dist = %d, peer = %d, vpeer = %d, p->iter = %d \n",
-//                	        			rank, root, task->scatter_kn.recv_dist, peer_recv_dist, peer, vpeer, p->iteration);
+               	/* printf(" RECV, rank = %d, root = %d, task->scatter_kn.recv_dist = %d, peer_recv_dist = %d, peer = %d, vpeer = %d, p->iter = %d, len %zd \n", */
+                /*        rank, root, task->scatter_kn.recv_dist, peer_recv_dist, peer, vpeer, p->iteration, local_seg_count * dt_size); */
                     UCPCHECK_GOTO(
                         ucc_tl_ucp_recv_nb(rbuf, local_seg_count * dt_size,
-                                       mem_type, peer, team, task), task, out);
+                                           mem_type, INV_VRANK(peer, (ucc_rank_t)args->root, size), team, task), task, out);
+                    goto UCC_SCATTER_KN_PHASE_LOOP;
                 }
-                rbuf = PTR_OFFSET(rbuf, local_seg_count * dt_size);
             }
         }
 
@@ -127,14 +136,23 @@ ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
                     block_count, step_radix, peer_seg_index);
                 peer_seg_offset = ucc_sra_kn_compute_seg_offset(
                     block_count, step_radix, peer_seg_index);
-//                printf("inside send, rank = %d, root = %d, task->recv_posted = %d, peer = %d, p->iter = %d \n",
-//                                	        			rank, root, task->recv_posted, peer, p->iteration);
+               /* printf("SEND rank = %d, root = %d, task->recv_posted = %d, peer = %d, p->iter = %d, offset %zd, len %zd \n", */
+               /*        rank, root, task->recv_posted, peer, p->iteration, */
+               /*        peer_seg_offset * dt_size + task->scatter_kn.send_offset, */
+               /*        peer_seg_count * dt_size); */
                 UCPCHECK_GOTO(
                     ucc_tl_ucp_send_nb(PTR_OFFSET(sbuf,
-                                       peer_seg_offset * dt_size),
+                                       peer_seg_offset * dt_size + task->scatter_kn.send_offset),
                                        peer_seg_count * dt_size, mem_type,
-                                       peer, team, task), task, out);
+                                       INV_VRANK(peer, (ucc_rank_t)args->root, size), team, task), task, out);
             }
+            local_seg_index = ucc_sra_kn_compute_seg_index(rank, p->radix_pow, p);
+            offset = ucc_sra_kn_compute_seg_offset(
+                block_count, step_radix, local_seg_index);
+            task->scatter_kn.send_offset += offset * dt_size;
+            /* printf("AFTER SEND: rank %d, block_count %zd, local_seg_index %d, offset %zd, total send offset %zd\n", */
+                   /* rank, block_count, (int)local_seg_index, offset, task->scatter_kn.send_offset); */
+
         }
 
 UCC_SCATTER_KN_PHASE_LOOP:
@@ -147,15 +165,13 @@ UCC_SCATTER_KN_PHASE_LOOP:
         ucc_knomial_pattern_next_iteration(p);
     }
 
-    step_radix      = ucc_sra_kn_compute_step_radix(rank, size, p);
-    block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
-    local_seg_index = ucc_sra_kn_compute_seg_index(rank, p->radix_pow, p);
-    local_seg_count = ucc_sra_kn_compute_seg_size(block_count, step_radix,
-                                                          local_seg_index);
-    offset          = ucc_sra_kn_get_offset(count, dt_size, rank, size, radix);
+
+    ucc_sra_kn_get_offset_and_seglen(count, dt_size, rank, size, radix, &offset, &local_seg_count);
     // check of need to do memcpy at root? and not needed if offset == 0
-    if (rank != root && offset != 0) {
-        status = ucc_mc_memcpy(PTR_OFFSET(args->dst.info.buffer, offset), rbuf,
+    if (offset != 0) {
+        /* printf("rank %d, memcpy offset %zd, len %zd\n", rank, offset, local_seg_count *dt_size); */
+        status = ucc_mc_memcpy(PTR_OFFSET(args->dst.info.buffer, offset),
+                               PTR_OFFSET(rbuf, task->scatter_kn.send_offset),
                                local_seg_count * dt_size, mem_type, mem_type);
         if (UCC_OK != status) {
             return status;
@@ -178,17 +194,19 @@ ucc_status_t ucc_tl_ucp_scatter_knomial_start(ucc_coll_task_t *coll_task)
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_scatter_kn_start", 0);
     ucc_tl_ucp_task_reset(task);
 
-    ucc_knomial_pattern_init(team->size, team->rank,
+
+    ucc_knomial_pattern_init(team->size, VRANK(team->rank, coll_task->args.root, team->size),
                              task->scatter_kn.p.radix,
                              &task->scatter_kn.p);
     task->scatter_kn.phase = UCC_SCATTER_KN_PHASE_INIT;
 //    task->scatter_kn.dist  = 1;
-    vroot = ucc_knomial_pattern_loop_rank(p, coll_task->args.root);
-    vrank = ucc_knomial_pattern_loop_rank(p, team->rank);
+    vroot = ucc_knomial_pattern_loop_rank(p, VRANK(coll_task->args.root, coll_task->args.root, team->size));
+    vrank = ucc_knomial_pattern_loop_rank(p, VRANK(team->rank, coll_task->args.root, team->size));
     task->scatter_kn.recv_dist = calc_recv_dist(team->size - p->n_extra, vrank,
                                                 p->radix, vroot);
-//    printf("rank = %d, vrank = %d, root = %ld, vroot = %d, recv_dst = %d, radix = %d \n",
-//    		team->rank, vrank, coll_task->args.root, vroot, task->scatter_kn.recv_dist, p->radix);
+    task->scatter_kn.send_offset = 0;
+   /* printf("rank = %d, vrank = %d, root = %ld, vroot = %d, recv_dst = %d, radix = %d \n", */
+   /* 		team->rank, vrank, coll_task->args.root, vroot, task->scatter_kn.recv_dist, p->radix); */
 
     status = ucc_tl_ucp_scatter_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -94,8 +94,17 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, bcast_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
+    {"BCAST_SAG_KN_RADIX", "4",
+     "Radix of the scatter-allgather (SAG) knomial bcast algorithm",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, bcast_sag_kn_radix),
+     UCC_CONFIG_TYPE_UINT},
+
     {"REDUCE_KN_RADIX", "4", "Radix of the knomial tree reduce algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_kn_radix),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"SCATTER_KN_RADIX", "4", "Radix of the knomial scatter algorithm",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, scatter_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
     {NULL}};

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -44,7 +44,9 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t            reduce_scatter_kn_radix;
     uint32_t            allgather_kn_radix;
     uint32_t            bcast_kn_radix;
+    uint32_t            bcast_sag_kn_radix;
     uint32_t            reduce_kn_radix;
+    uint32_t            scatter_kn_radix;
     uint32_t            alltoall_pairwise_num_posts;
     uint32_t            alltoallv_pairwise_num_posts;
     uint32_t            allreduce_sra_kn_n_frags;

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -276,7 +276,7 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
     case UCC_COLL_TYPE_BCAST:
         switch (alg_id) {
         case UCC_TL_UCP_BCAST_ALG_KNOMIAL:
-        	*init = ucc_tl_ucp_bcast_knomial_init;
+            *init = ucc_tl_ucp_bcast_knomial_init;
             break;
         case UCC_TL_UCP_BCAST_ALG_SAG_KNOMIAL:
             *init = ucc_tl_ucp_bcast_sag_knomial_init;

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -18,7 +18,7 @@
 #include "reduce/reduce.h"
 const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR] = {
-        UCC_TL_UCP_ALLREDUCE_DEFAULT_ALG_SELECT_STR};
+        UCC_TL_UCP_ALLREDUCE_DEFAULT_ALG_SELECT_STR, UCC_TL_UCP_BCAST_DEFAULT_ALG_SELECT_STR};
 
 void ucc_tl_ucp_send_completion_cb(void *request, ucs_status_t status,
                                    void *user_data)
@@ -241,6 +241,8 @@ static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
     switch (coll_type) {
     case UCC_COLL_TYPE_ALLREDUCE:
         return ucc_tl_ucp_allreduce_alg_from_str(str);
+    case UCC_COLL_TYPE_BCAST:
+        return ucc_tl_ucp_bcast_alg_from_str(str);
     default:
         break;
     }
@@ -269,6 +271,19 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
         default:
             status = UCC_ERR_INVALID_PARAM;
             break;
+        };
+        break;
+    case UCC_COLL_TYPE_BCAST:
+        switch (alg_id) {
+        case UCC_TL_UCP_BCAST_ALG_KNOMIAL:
+        	*init = ucc_tl_ucp_bcast_knomial_init;
+            break;
+        case UCC_TL_UCP_BCAST_ALG_SAG_KNOMIAL:
+            *init = ucc_tl_ucp_bcast_sag_knomial_init;
+            break;
+        default:
+           status = UCC_ERR_INVALID_PARAM;
+           break;
         };
         break;
     default:

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -57,6 +57,7 @@ typedef struct ucc_tl_ucp_task {
 //            ucc_rank_t              dist;
             ucc_rank_t              recv_dist;
 //            ucc_rank_t              vroot;
+            ptrdiff_t               send_offset;
         } scatter_kn;
         struct {
             int                     phase;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -13,7 +13,7 @@
 #include "components/mc/base/ucc_mc_base.h"
 #include "tl_ucp_tag.h"
 
-#define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 1
+#define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 2
 extern const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR];
 
@@ -51,6 +51,13 @@ typedef struct ucc_tl_ucp_task {
             void                   *scratch;
             ucc_mc_buffer_header_t *scratch_mc_header;
         } reduce_scatter_kn;
+        struct {
+            int                     phase;
+            ucc_knomial_pattern_t   p;
+//            ucc_rank_t              dist;
+            ucc_rank_t              recv_dist;
+//            ucc_rank_t              vroot;
+        } scatter_kn;
         struct {
             int                     phase;
             ucc_knomial_pattern_t   p;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -17,13 +17,19 @@
 extern const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR];
 
-#define CALC_KN_TREE_DIST(_size, _radix, _dist)                                        \
-    do {                                                                       \
-        _dist = 1;                                                             \
-        while (_dist * _radix < _size) {                                       \
-            _dist *= _radix;                                                   \
-        }                                                                      \
+#define CALC_KN_TREE_DIST(_size, _radix, _dist)                               \
+    do {                                                                      \
+        _dist = 1;                                                            \
+        while (_dist * _radix < _size) {                                      \
+            _dist *= _radix;                                                  \
+        }                                                                     \
     } while (0)
+
+#define VRANK(_rank, _root, _team_size)                                       \
+    (((_rank) - (_root) + (_team_size)) % (_team_size))
+
+#define INV_VRANK(_rank, _root, _team_size)                                   \
+    (((_rank) + (_root)) % (_team_size))
 
 typedef struct ucc_tl_ucp_task {
     ucc_coll_task_t   super;
@@ -54,9 +60,7 @@ typedef struct ucc_tl_ucp_task {
         struct {
             int                     phase;
             ucc_knomial_pattern_t   p;
-//            ucc_rank_t              dist;
             ucc_rank_t              recv_dist;
-//            ucc_rank_t              vroot;
             ptrdiff_t               send_offset;
         } scatter_kn;
         struct {

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -23,7 +23,9 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
         self->cfg.reduce_scatter_kn_radix = tl_ucp_config->kn_radix;
         self->cfg.allgather_kn_radix      = tl_ucp_config->kn_radix;
         self->cfg.bcast_kn_radix          = tl_ucp_config->kn_radix;
+        self->cfg.bcast_sag_kn_radix      = tl_ucp_config->kn_radix;
         self->cfg.reduce_kn_radix         = tl_ucp_config->kn_radix;
+        self->cfg.scatter_kn_radix        = tl_ucp_config->kn_radix;
     }
     tl_info(&self->super, "initialized lib object: %p", self);
     return UCC_OK;


### PR DESCRIPTION
## What
Implementing Bcast SAG (Scatter & Allgather) for large messages.

## Why ?
Current bcast implementation is latency optimized but performs poorly for large messages.

## How ?
The implementation is split into two - first scatter_knomial, in which the order of stages and the communication pattern is somewhat similar to that of ucc_tl_ucp_reduce_scatter_knomial, and in which 1/N of the message is sent to each node (original message size = N). Second is an inplace Allgather which is already implemented as part of allreduce. 
Finally, an algorithm selection logic is added in TL/UCP (similar to what is done for allreduce), to choose which implementation of bcast to use.



Bcast,   nnodes=30, ppn=32
--
msgsize | UCC, KN tree | UCC, SAG | OMPI/tuned
--|--|--|--
16384 | 42 | 41.3 | 70.23
32768 | 107.2 | 50.37 | 36.57
65536 | 74.89 | 62.4 | 62.59
131072 | 128.85 | 91.99 | 112.08
262144 | 242.46 | 145.48 | 209.33
524288 | 502.7 | 257.3 | 403.04
1048576 | 953.15 | 483.99 | 809.92
2097152 | 2152.83 | 1412.76 | 1937.24
4194304 | 4542.7 | 2910.32 | 4342.56
8388608 | 9363.6 | 6225.89 | 8954.63
16777216 | 18711 | 12832.46 | 18087.47



Bcast,   nnodes=20, ppn=1
--
msgsize | UCC, KN tree | UCC, SAG | OMPI/tuned
--|--|--|--
8192 | 12.85 | 14.35 | 19.36
16384 | 18.52 | 17.86 | 29.84
32768 | 27 | 24.16 | 35.06
65536 | 36.86 | 32.3 | 52.6
131072 | 55.48 | 43.9 | 89.26
262144 | 93.17 | 64.51 | 157.54
524288 | 167.39 | 99.21 | 296.64
1048576 | 325.05 | 164.28 | 293.15
2097152 | 615.23 | 307.71 | 422.93
4194304 | 1214.22 | 559.42 | 665.81
