### PR TITLE
UTIL: proper fix for config_names_search

### DIFF
--- a/config/m4/ucx.m4
+++ b/config/m4/ucx.m4
@@ -92,24 +92,6 @@ AS_IF([test "x$ucx_checked" != "xyes"],[
 
             AC_SUBST(UCX_LIBADD, "-lucp -lucm")
             AC_SUBST(UCS_LIBADD, "-lucs")
-
-            AC_TRY_COMPILE([#include <ucs/config/parser.h>],
-            [
-                ucs_config_names_array_t array;
-                const char *str = "aaa";
-                ucs_config_names_search(array, str);
-            ],
-            [AC_DEFINE([UCS_CONFIG_NAMES_SEARCH_V1], 1, [ucs_config_names_search with array by value])],
-            [])
-
-            AC_TRY_COMPILE([#include <ucs/config/parser.h>],
-            [
-                ucs_config_names_array_t array;
-                const char *str = "aaa";
-                ucs_config_names_search(&array, str);
-            ],
-            [AC_DEFINE([UCS_CONFIG_NAMES_SEARCH_V2], 1, [ucs_config_names_search with array by ptr])],
-            [])
         ],
         [
             AS_IF([test "x$with_ucx" != "xguess"],

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -41,3 +41,17 @@ void ucc_config_names_array_free(ucc_config_names_array_t *array)
     }
     ucc_free(array->names);
 }
+
+
+int ucc_config_names_search(ucc_config_names_array_t *config_names,
+                            const char *str) {
+    unsigned i;
+
+    for (i = 0; i < config_names->count; ++i) {
+        if (!strcmp(config_names->names[i], str)) {
+           return i;
+        }
+    }
+
+    return -1;
+}

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -115,16 +115,6 @@ ucc_status_t ucc_config_names_array_dup(ucc_config_names_array_t *dst,
 
 void ucc_config_names_array_free(ucc_config_names_array_t *array);
 
-static inline int ucc_config_names_search(ucc_config_names_array_t *config_names,
-                                          const char *str)
-{
-#ifdef UCS_CONFIG_NAMES_SEARCH_V2
-    return ucs_config_names_search(config_names, str);
-#elif UCS_CONFIG_NAMES_SEARCH_V1
-    return ucs_config_names_search(*config_names, str);
-#else
-    #error Unsupported signature of ucs_config_names_search
-#endif
-}
-
+int ucc_config_names_search(ucc_config_names_array_t *config_names,
+                            const char *str);
 #endif


### PR DESCRIPTION
## What
Revert #300  and Re-implement internally to keep backward bin-compat.
