### PR TITLE
TL/UCP: add one-sided collective support

### DIFF
--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -31,6 +31,8 @@
 #define UCC_TL_UCP_PROFILE_REQUEST_FREE UCC_PROFILE_REQUEST_FREE
 
 #define MAX_NR_SEGMENTS 32
+#define ONESIDED_SYNC_SIZE 1
+#define ONESIDED_REDUCE_SIZE 4
 
 typedef struct ucc_tl_ucp_iface {
     ucc_tl_iface_t super;

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -30,6 +30,8 @@
 #define UCC_TL_UCP_PROFILE_REQUEST_EVENT UCC_PROFILE_REQUEST_EVENT
 #define UCC_TL_UCP_PROFILE_REQUEST_FREE UCC_PROFILE_REQUEST_FREE
 
+#define MAX_NR_SEGMENTS 32
+
 typedef struct ucc_tl_ucp_iface {
     ucc_tl_iface_t super;
 } ucc_tl_ucp_iface_t;
@@ -73,16 +75,27 @@ typedef struct ucc_tl_ucp_lib {
 UCC_CLASS_DECLARE(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);
 
+typedef struct ucc_tl_ucp_remote_info {
+    void * va_base;
+    size_t len;
+    void * mem_h;
+    void * packed_key;
+    void * rkey;
+} ucc_tl_ucp_remote_info_t;
+
 typedef struct ucc_tl_ucp_context {
     ucc_tl_context_t            super;
     ucc_tl_ucp_context_config_t cfg;
     ucp_context_h               ucp_context;
     ucp_worker_h                ucp_worker;
     size_t                      ucp_addrlen;
-    ucp_address_t              *worker_address;
+    ucp_address_t *             worker_address;
     ucc_mpool_t                 req_mp;
-    tl_ucp_ep_hash_t           *ep_hash;
-    ucp_ep_h                   *eps;
+    tl_ucp_ep_hash_t *          ep_hash;
+    ucp_ep_h *                  eps;
+    tl_ucp_rinfo_hash_t *       rinfo_hash;
+    ucc_tl_ucp_remote_info_t ** remote_info;
+    uint64_t                    n_rinfo_segs;
 } ucc_tl_ucp_context_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
@@ -93,15 +106,18 @@ typedef struct ucc_tl_ucp_team {
     ucc_status_t               status;
     uint32_t                   seq_num;
     ucc_tl_ucp_task_t         *preconnect_task;
+    ucc_ep_map_t               map; /*< map to the core ucc team */
+    void *                     va_base[MAX_NR_SEGMENTS];
+    size_t                     base_length[MAX_NR_SEGMENTS];
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
 
-#define UCC_TL_UCP_SUPPORTED_COLLS                         \
-    (UCC_COLL_TYPE_ALLTOALL  | UCC_COLL_TYPE_ALLTOALLV  |  \
-     UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |  \
-     UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST      |  \
-     UCC_COLL_TYPE_BARRIER   | UCC_COLL_TYPE_REDUCE)
+#define UCC_TL_UCP_SUPPORTED_COLLS                                             \
+    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                        \
+     UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                      \
+     UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST | UCC_COLL_TYPE_BARRIER |   \
+     UCC_COLL_TYPE_REDUCE)
 
 #define UCC_TL_UCP_TEAM_LIB(_team)                                             \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_ucp_lib_t))
@@ -111,8 +127,8 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
 
 #define UCC_TL_UCP_WORKER(_team) UCC_TL_UCP_TEAM_CTX(_team)->ucp_worker
 
-#define UCC_TL_CTX_HAS_OOB(_ctx) ((_ctx)->super.super.ucc_context->params.mask & \
-                                  UCC_CONTEXT_PARAM_FIELD_OOB)
+#define UCC_TL_CTX_HAS_OOB(_ctx)                                               \
+    ((_ctx)->super.super.ucc_context->params.mask & UCC_CONTEXT_PARAM_FIELD_OOB)
 
 #define UCC_TL_CTX_OOB(_ctx) ((_ctx)->super.super.ucc_context->params.oob)
 
@@ -120,4 +136,8 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
 
 void ucc_tl_ucp_pre_register_mem(ucc_tl_ucp_team_t *team, void *addr,
                                  size_t length, ucc_memory_type_t mem_type);
+
+ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t *ctx,
+                                            ucc_mem_map_params_t  map,
+                                            ucc_team_oob_coll_t   oob);
 #endif

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -107,7 +107,6 @@ typedef struct ucc_tl_ucp_team {
     ucc_status_t               status;
     uint32_t                   seq_num;
     ucc_tl_ucp_task_t         *preconnect_task;
-    ucc_ep_map_t               map; /*< map to the core ucc team */
     void *                     va_base[MAX_NR_SEGMENTS];
     size_t                     base_length[MAX_NR_SEGMENTS];
 } ucc_tl_ucp_team_t;

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -93,7 +93,6 @@ typedef struct ucc_tl_ucp_context {
     ucc_mpool_t                 req_mp;
     tl_ucp_ep_hash_t *          ep_hash;
     ucp_ep_h *                  eps;
-    tl_ucp_rinfo_hash_t *       rinfo_hash;
     ucc_tl_ucp_remote_info_t ** remote_info;
     uint64_t                    n_rinfo_segs;
 } ucc_tl_ucp_context_t;

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -364,6 +364,13 @@ ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t * ctx,
     int                        seg;
     void *                     addr;
 
+    if (size < 2) {
+        tl_error(
+            ctx->super.super.lib,
+            "oob.n_oob_eps set to incorrect value for remote exchange (%d)",
+            size);
+        return UCC_ERR_INVALID_PARAM;
+    }
     if (nsegs > MAX_NR_SEGMENTS) {
         tl_error(ctx->super.super.lib, "cannot map more than %d segments",
                  MAX_NR_SEGMENTS);

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -161,12 +161,16 @@ err_cfg:
 static void ucc_tl_ucp_context_barrier(ucc_tl_ucp_context_t *ctx,
                                        ucc_context_oob_coll_t *oob)
 {
-    char        *rbuf = ucc_malloc(sizeof(char) * oob->n_oob_eps,
-                                   "tmp_barrier");
+    char        *rbuf;
     ucc_status_t status;
     char         sbuf;
     void        *req;
 
+    if (ucc_unlikely(oob->n_oob_eps < 2)) {
+        return;
+    }
+
+    rbuf = ucc_malloc(sizeof(char) * oob->n_oob_eps, "tmp_barrier");
     if (!rbuf) {
         tl_error(ctx->super.super.lib,
                  "failed to allocate %zd bytes for tmp barrier array",

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -547,6 +547,10 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
     if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR) {
         memcpy(attr->attr.ctx_addr, ctx->worker_address, ctx->ucp_addrlen);
     }
+    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_WORK_BUFFER_SIZE) {
+        attr->attr.global_work_buffer_size =
+            ONESIDED_SYNC_SIZE + ONESIDED_REDUCE_SIZE;
+    }
     attr->topo_required = 0;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_ep_hash.h
+++ b/src/components/tl/ucp/tl_ucp_ep_hash.h
@@ -40,7 +40,11 @@ static inline khint32_t tl_ucp_ctx_id_hash_fn(ucc_context_id_t k)
 KHASH_INIT(tl_ucp_ep_hash, ucc_context_id_t, void*, 1, \
            tl_ucp_ctx_id_hash_fn, tl_ucp_ctx_id_equal_fn);
 
+KHASH_INIT(tl_ucp_rinfo_hash, ucc_context_id_t, void **, 1,
+           tl_ucp_ctx_id_hash_fn, tl_ucp_ctx_id_equal_fn);
+
 #define tl_ucp_ep_hash_t khash_t(tl_ucp_ep_hash)
+#define tl_ucp_rinfo_hash_t khash_t(tl_ucp_rinfo_hash)
 
 static inline void* tl_ucp_hash_get(tl_ucp_ep_hash_t *h, ucc_context_id_t key)
 {
@@ -63,6 +67,28 @@ static inline void tl_ucp_hash_put(tl_ucp_ep_hash_t *h, ucc_context_id_t key,
     kh_value(h, k) = value;
 }
 
+static inline void **tl_ucp_rinfo_hash_get(tl_ucp_rinfo_hash_t *h,
+                                           ucc_context_id_t     key)
+{
+    khiter_t k;
+    void *   value;
+    k = kh_get(tl_ucp_rinfo_hash, h, key);
+    if (k == kh_end(h)) {
+        return NULL;
+    }
+    value = kh_value(h, k);
+    return value;
+}
+
+static inline void tl_ucp_rinfo_hash_put(tl_ucp_rinfo_hash_t *h,
+                                         ucc_context_id_t key, void **value)
+{
+    int      ret;
+    khiter_t k;
+    k              = kh_put(tl_ucp_rinfo_hash, h, key, &ret);
+    kh_value(h, k) = value;
+}
+
 static inline void* tl_ucp_hash_pop(tl_ucp_ep_hash_t *h)
 {
     void    *ep = NULL;
@@ -79,5 +105,23 @@ static inline void* tl_ucp_hash_pop(tl_ucp_ep_hash_t *h)
         kh_del(tl_ucp_ep_hash, h, k);
     }
     return ep;
+}
+
+static inline void **tl_ucp_hash_rinfo_pop(tl_ucp_rinfo_hash_t *h)
+{
+    void **  rinfo = NULL;
+    khiter_t k;
+    k = kh_begin(h);
+    while (k != kh_end(h)) {
+        if (kh_exist(h, k)) {
+            rinfo = kh_value(h, k);
+            break;
+        }
+        k++;
+    }
+    if (rinfo) {
+        kh_del(tl_ucp_rinfo_hash, h, k);
+    }
+    return rinfo;
 }
 #endif

--- a/src/components/tl/ucp/tl_ucp_ep_hash.h
+++ b/src/components/tl/ucp/tl_ucp_ep_hash.h
@@ -40,11 +40,7 @@ static inline khint32_t tl_ucp_ctx_id_hash_fn(ucc_context_id_t k)
 KHASH_INIT(tl_ucp_ep_hash, ucc_context_id_t, void*, 1, \
            tl_ucp_ctx_id_hash_fn, tl_ucp_ctx_id_equal_fn);
 
-KHASH_INIT(tl_ucp_rinfo_hash, ucc_context_id_t, void **, 1,
-           tl_ucp_ctx_id_hash_fn, tl_ucp_ctx_id_equal_fn);
-
 #define tl_ucp_ep_hash_t khash_t(tl_ucp_ep_hash)
-#define tl_ucp_rinfo_hash_t khash_t(tl_ucp_rinfo_hash)
 
 static inline void* tl_ucp_hash_get(tl_ucp_ep_hash_t *h, ucc_context_id_t key)
 {
@@ -67,28 +63,6 @@ static inline void tl_ucp_hash_put(tl_ucp_ep_hash_t *h, ucc_context_id_t key,
     kh_value(h, k) = value;
 }
 
-static inline void **tl_ucp_rinfo_hash_get(tl_ucp_rinfo_hash_t *h,
-                                           ucc_context_id_t     key)
-{
-    khiter_t k;
-    void *   value;
-    k = kh_get(tl_ucp_rinfo_hash, h, key);
-    if (k == kh_end(h)) {
-        return NULL;
-    }
-    value = kh_value(h, k);
-    return value;
-}
-
-static inline void tl_ucp_rinfo_hash_put(tl_ucp_rinfo_hash_t *h,
-                                         ucc_context_id_t key, void **value)
-{
-    int      ret;
-    khiter_t k;
-    k              = kh_put(tl_ucp_rinfo_hash, h, key, &ret);
-    kh_value(h, k) = value;
-}
-
 static inline void* tl_ucp_hash_pop(tl_ucp_ep_hash_t *h)
 {
     void    *ep = NULL;
@@ -107,21 +81,4 @@ static inline void* tl_ucp_hash_pop(tl_ucp_ep_hash_t *h)
     return ep;
 }
 
-static inline void **tl_ucp_hash_rinfo_pop(tl_ucp_rinfo_hash_t *h)
-{
-    void **  rinfo = NULL;
-    khiter_t k;
-    k = kh_begin(h);
-    while (k != kh_end(h)) {
-        if (kh_exist(h, k)) {
-            rinfo = kh_value(h, k);
-            break;
-        }
-        k++;
-    }
-    if (rinfo) {
-        kh_del(tl_ucp_rinfo_hash, h, k);
-    }
-    return rinfo;
-}
 #endif

--- a/src/components/tl/ucp/tl_ucp_ep_hash.h
+++ b/src/components/tl/ucp/tl_ucp_ep_hash.h
@@ -80,5 +80,4 @@ static inline void* tl_ucp_hash_pop(tl_ucp_ep_hash_t *h)
     }
     return ep;
 }
-
 #endif

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -158,6 +158,203 @@ static inline ucc_status_t ucc_tl_ucp_send_nz(void *buffer, size_t msglen,
                               dest_group_rank, team, task);
 }
 
+static inline ucc_status_t
+ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
+                             ucc_rank_t peer, uint64_t *rva, ucp_rkey_h *rkey,
+                             int *segment)
+{
+    ucc_tl_ucp_context_t *     ctx = UCC_TL_UCP_TEAM_CTX(team);
+    ucc_context_id_t           key = ucc_tl_ucp_get_rank_key(team, peer);
+    ucc_tl_ucp_remote_info_t **remote_info;
+    *segment = 0;
+
+    remote_info = (ucc_tl_ucp_remote_info_t **)tl_ucp_rinfo_hash_get(
+        ctx->rinfo_hash, key);
+
+    for (int i = 0; i < ctx->n_rinfo_segs; i++) {
+        if (va >= team->va_base[i] &&
+            va < team->va_base[i] + team->base_length[i]) {
+            *segment = i;
+            break;
+        }
+    }
+
+    if (NULL == remote_info[0][*segment].rkey) {
+        ucp_ep_rkey_unpack(*ep, remote_info[0][*segment].packed_key,
+                           (ucp_rkey_h *)&remote_info[0][*segment].rkey);
+    }
+    *rkey = remote_info[0][*segment].rkey;
+    *rva  = (uint64_t)remote_info[0][*segment].va_base;
+    return UCC_OK;
+}
+
+static inline ucc_status_t ucc_tl_ucp_flush(ucc_tl_ucp_team_t *team)
+{
+    ucp_request_param_t req_param = {0};
+    ucs_status_ptr_t    req;
+
+    req =
+        ucp_worker_flush_nbx(UCC_TL_UCP_TEAM_CTX(team)->ucp_worker, &req_param);
+    if (UCS_OK != req) {
+        if (UCS_PTR_IS_ERR(req)) {
+            return UCC_ERR_NO_MESSAGE;
+        }
+        else {
+            ucp_request_free(req);
+        }
+    }
+    return UCC_OK;
+}
+
+static inline ucc_status_t ucc_tl_ucp_ep_flush(ucc_rank_t dest_group_rank,
+                                               ucc_tl_ucp_team_t *team,
+                                               ucc_tl_ucp_task_t *task)
+{
+    ucc_status_t        status;
+    ucp_request_param_t req_param = {0};
+    ucs_status_ptr_t    req;
+    ucp_ep_h            ep;
+
+    status = ucc_tl_ucp_get_ep(team, dest_group_rank, &ep);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+
+    req = ucp_ep_flush_nbx(ep, &req_param);
+    if (UCC_OK != req) {
+        if (UCS_PTR_IS_ERR(req)) {
+            return UCC_ERR_NO_MESSAGE;
+        }
+        ucp_request_free(req);
+    }
+    return UCC_OK;
+}
+
+static inline ucc_status_t ucc_tl_ucp_put_nb(void *buffer, void *target,
+                                             size_t             msglen,
+                                             ucc_rank_t         dest_group_rank,
+                                             ucc_tl_ucp_team_t *team,
+                                             ucc_tl_ucp_task_t *task)
+{
+    ucp_request_param_t req_param = {0};
+    ucs_status_ptr_t    ucp_status;
+    ucc_status_t        status;
+    ucp_ep_h            ep;
+    ucp_rkey_h          rkey;
+    uint64_t            rva;
+    int                 segment = 0;
+
+    // get the endpoint or create if doesn't exist
+    status = ucc_tl_ucp_get_ep(team, dest_group_rank, &ep);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+
+    // resolve the p2p info
+    status = ucc_tl_ucp_resolve_p2p_by_va(team, target, &ep, dest_group_rank,
+                                          &rva, &rkey, &segment);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+
+    rva = rva + ((ptrdiff_t)target - (ptrdiff_t)team->va_base[segment]);
+
+    // issue operation
+    ucp_status = ucp_put_nbx(ep, buffer, msglen, rva, rkey, &req_param);
+
+    if (UCC_OK != ucp_status) {
+        ucp_request_free(ucp_status);
+    }
+    return UCC_OK;
+}
+
+static inline ucc_status_t ucc_tl_ucp_get_nb(void *buffer, void *target,
+                                             size_t             msglen,
+                                             ucc_rank_t         dest_group_rank,
+                                             ucc_tl_ucp_team_t *team,
+                                             ucc_tl_ucp_task_t *task)
+{
+    ucp_request_param_t req_param = {0};
+    ucs_status_ptr_t    ucp_status;
+    ucc_status_t        status;
+    ucp_ep_h            ep;
+    ucp_rkey_h          rkey;
+    uint64_t            rva;
+    int                 segment = 0;
+
+    // get the endpoint or create if doesn't exist
+    status = ucc_tl_ucp_get_ep(team, dest_group_rank, &ep);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+
+    // resolve the p2p info
+    status = ucc_tl_ucp_resolve_p2p_by_va(team, target, &ep, dest_group_rank,
+                                          &rva, &rkey, &segment);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+    rva = rva + ((ptrdiff_t)target - (ptrdiff_t)team->va_base[segment]);
+
+    // issue operation
+    ucp_status = ucp_get_nbx(ep, buffer, msglen, rva, rkey, &req_param);
+
+    if (UCC_OK != ucp_status) {
+        if (UCS_PTR_IS_ERR(ucp_status)) {
+            return UCC_ERR_NO_MESSAGE;
+        }
+        ucp_request_free(ucp_status);
+    }
+
+    return UCC_OK;
+}
+
+static inline ucc_status_t ucc_tl_ucp_atomic_inc(void *     target,
+                                                 ucc_rank_t dest_group_rank,
+                                                 ucc_tl_ucp_team_t *team,
+                                                 ucc_tl_ucp_task_t *task)
+{
+    ucp_request_param_t req_param = {0};
+    ucs_status_ptr_t    ucp_status;
+    ucc_status_t        status;
+    ucp_ep_h            ep;
+    ucp_rkey_h          rkey;
+    uint64_t            rva;
+    int                 segment = 0;
+    uint64_t            one     = 1;
+
+    // get the endpoint or create if doesn't exist
+    status = ucc_tl_ucp_get_ep(team, dest_group_rank, &ep);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+
+    /* resolve the p2p info */
+    status = ucc_tl_ucp_resolve_p2p_by_va(team, target, &ep, dest_group_rank,
+                                          &rva, &rkey, &segment);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+
+    rva = rva + ((ptrdiff_t)target - (ptrdiff_t)team->va_base[segment]);
+
+    req_param.op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE;
+    req_param.datatype     = ucp_dt_make_contig(sizeof(uint64_t));
+
+    // issue operation
+    ucp_status = ucp_atomic_op_nbx(ep, UCP_ATOMIC_OP_ADD, &one, 1, rva, rkey,
+                                   &req_param);
+
+    if (UCC_OK != ucp_status) {
+        if (UCS_PTR_IS_ERR(ucp_status)) {
+            abort();
+        }
+        else {
+            ucp_request_free(ucp_status);
+        }
+    }
+    return UCC_OK;
+}
 
 #define UCPCHECK_GOTO(_cmd, _task, _label)                                     \
     do {                                                                       \

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -210,8 +210,7 @@ static inline ucc_status_t ucc_tl_ucp_flush(ucc_tl_ucp_team_t *team)
 }
 
 static inline ucc_status_t ucc_tl_ucp_ep_flush(ucc_rank_t dest_group_rank,
-                                               ucc_tl_ucp_team_t *team,
-                                               ucc_tl_ucp_task_t *task)
+                                               ucc_tl_ucp_team_t *team)
 {
     ucp_request_param_t req_param = {0};
     ucc_status_t        status;
@@ -327,8 +326,7 @@ static inline ucc_status_t ucc_tl_ucp_get_nb(void *buffer, void *target,
 
 static inline ucc_status_t ucc_tl_ucp_atomic_inc(void *     target,
                                                  ucc_rank_t dest_group_rank,
-                                                 ucc_tl_ucp_team_t *team,
-                                                 ucc_tl_ucp_task_t *task)
+                                                 ucc_tl_ucp_team_t *team)
 {
     ucp_request_param_t req_param = {0};
     int                 segment   = 0;

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -174,9 +174,9 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
             break;
         }
     }
-    core_rank = ucc_ep_map_eval(team->map, peer);
-    ucc_assert(team->super.super.params.team);
-    peer = ucc_get_ctx_rank(team->super.super.params.team, core_rank);
+    core_rank = ucc_ep_map_eval(UCC_TL_TEAM_MAP(team), peer);
+    ucc_assert(UCC_TL_CORE_TEAM(team));
+    peer = ucc_get_ctx_rank(UCC_TL_CORE_TEAM(team), core_rank);
     if (NULL == ctx->remote_info[peer][*segment].rkey) {
         ucs_status_t ucs_status = ucp_ep_rkey_unpack(
             *ep, ctx->remote_info[peer][*segment].packed_key,

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -101,28 +101,11 @@ ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team)
     }
 
     if (ctx->remote_info) {
-        ucc_context_id_t key = ucc_tl_ucp_get_rank_key(team, team->rank);
-        ucc_tl_ucp_remote_info_t **local =
-            (ucc_tl_ucp_remote_info_t **)tl_ucp_rinfo_hash_get(ctx->rinfo_hash,
-                                                               key);
-        if (NULL == local) {
-            for (int i = 0; i < team->size; i++) {
-                key = ucc_tl_ucp_get_rank_key(team, i);
-                tl_ucp_rinfo_hash_put(ctx->rinfo_hash, key,
-                                      (void **)&ctx->remote_info[i]);
-                if (i == team->rank) {
-                    for (int j = 0; j < ctx->n_rinfo_segs; j++) {
-                        team->va_base[j]     = ctx->remote_info[i][j].va_base;
-                        team->base_length[j] = ctx->remote_info[i][j].len;
-                    }
-                }
-            }
-        }
-        else {
-            for (int i = 0; i < ctx->n_rinfo_segs; i++) {
-                team->va_base[i]     = local[0][i].va_base;
-                team->base_length[i] = local[0][i].len;
-            }
+        ucc_rank_t rank = ctx->super.super.ucc_context->rank;
+
+        for (int i = 0; i < ctx->n_rinfo_segs; i++) {
+            team->va_base[i]     = ctx->remote_info[rank][i].va_base;
+            team->base_length[i] = ctx->remote_info[rank][i].len;
         }
     }
 

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -94,8 +94,7 @@ ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team)
         status = ucc_tl_ucp_team_preconnect(team);
         if (UCC_INPROGRESS == status) {
             return UCC_INPROGRESS;
-        }
-        else if (UCC_OK != status) {
+        } else if (UCC_OK != status) {
             goto err_preconnect;
         }
     }

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -266,6 +266,7 @@ static inline void ucc_copy_context_params(ucc_context_params_t *dst,
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_ID, ctx_id);
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_SYNC_TYPE,
                             sync_type);
+    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_CONTEXT_PARAM_FIELD_MEM_PARAMS, mem_params);
 }
 
 static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -890,6 +890,7 @@ ucc_status_t ucc_context_get_attr(ucc_context_t      *context,
     }
 
     if (context_attr->mask & UCC_CONTEXT_ATTR_FIELD_WORK_BUFFER_SIZE) {
+        uint64_t            max_buffer_size = 0;
         int                 i;
         ucc_base_ctx_attr_t attr;
         ucc_tl_lib_t *      tl_lib;
@@ -905,13 +906,11 @@ ucc_status_t ucc_context_get_attr(ucc_context_t      *context,
                 ucc_error("failed to obtain global work buffer size");
                 return status;
             }
-            /* currently only TL/UCP will return a value */
-            if (attr.attr.global_work_buffer_size > 0) {
-                break;
+            if (attr.attr.global_work_buffer_size > max_buffer_size) {
+                max_buffer_size = attr.attr.global_work_buffer_size;
             }
         }
-        context_attr->global_work_buffer_size =
-            attr.attr.global_work_buffer_size;
+        context_attr->global_work_buffer_size = max_buffer_size;
     }
 
     return status;


### PR DESCRIPTION
## What
This PR will provide the necessary communication support for one-sided collectives in the TL/UCP component.

## Why ?
Currently, there is support for two-sided collectives. This provides support for one-sided collectives that will map to PGAS programming models including OpenSHMEM.  
