### PR TITLE
API: Update mem_map_params to hold multiple buffers

### DIFF
--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1659,7 +1659,7 @@ typedef struct ucc_coll_args {
                                              collectives */
     ucc_error_type_t                error_type; /*!< Error type */
     ucc_coll_id_t                   tag; /*!< Used for ordering collectives */
-    void                           *global_work_buffer; /*!< scratch pad for one-sided collectives */
+    void                           *global_work_buffer; /*!< User allocated scratchpad buffer for one-sided collectives. The buffer provided should be at least the size returned by @ref ucc_context_get_attr with the field mask - UCC_CONTEXT_ATTR_FIELD_WORK_BUFFER_SIZE set to 1. */
     ucc_coll_callback_t             cb;
     double                          timeout; /*!< Timeout in seconds */
 } ucc_coll_args_t;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -632,7 +632,8 @@ enum ucc_context_attr_field {
     UCC_CONTEXT_ATTR_FIELD_TYPE               = UCC_BIT(0),
     UCC_CONTEXT_ATTR_FIELD_SYNC_TYPE          = UCC_BIT(1),
     UCC_CONTEXT_ATTR_FIELD_CTX_ADDR           = UCC_BIT(2),
-    UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN       = UCC_BIT(3)
+    UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN       = UCC_BIT(3),
+    UCC_CONTEXT_ATTR_FIELD_WORK_BUFFER_SIZE   = UCC_BIT(4)
 };
 
 /**
@@ -735,6 +736,7 @@ typedef struct ucc_context_attr {
     ucc_coll_sync_type_t    sync_type;
     ucc_context_addr_h      ctx_addr;
     ucc_context_addr_len_t  ctx_addr_len;
+    uint64_t                global_work_buffer_size;
 } ucc_context_attr_t;
 
 /**
@@ -969,6 +971,7 @@ enum ucc_team_params_field {
     UCC_TEAM_PARAM_FIELD_MEM_PARAMS             = UCC_BIT(9),
     UCC_TEAM_PARAM_FIELD_EP_MAP                 = UCC_BIT(10),
     UCC_TEAM_PARAM_FIELD_ID                     = UCC_BIT(11),
+    UCC_TEAM_PARAM_FIELD_FLAGS                  = UCC_BIT(12)
 };
 
 /**
@@ -982,6 +985,14 @@ enum ucc_team_attr_field {
     UCC_TEAM_ATTR_FIELD_EP_RANGE               = UCC_BIT(3),
     UCC_TEAM_ATTR_FIELD_SYNC_TYPE              = UCC_BIT(4),
     UCC_TEAM_ATTR_FIELD_MEM_PARAMS             = UCC_BIT(5)
+};
+
+/**
+ *
+ * @ingroup UCC_TEAM_DT
+ */
+enum ucc_team_flags {
+    UCC_TEAM_FLAG_COLL_WORK_BUFFER             = UCC_BIT(0)
 };
 
 /**
@@ -1127,6 +1138,7 @@ typedef struct ucc_ep_map_t {
 typedef struct ucc_team_params {
 
     uint64_t                mask;
+    uint64_t                flags;
     /** @ref ucc_team_params.ordering is set to one the values defined by @ref
       *  ucc_post_ordering_t
       */

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -665,33 +665,9 @@ typedef ucc_oob_coll_t ucc_team_oob_coll_t;
  *
  *  @ingroup UCC_CONTEXT_DT
  */
-typedef enum  {
-    UCC_MEM_CONSTRAINT_SYMMETRIC   = UCC_BIT(0),
-    UCC_MEM_CONSTRAINT_PERSISTENT  = UCC_BIT(1),
-    UCC_MEM_CONSTRAINT_ALIGN32     = UCC_BIT(2),
-    UCC_MEM_CONSTRAINT_ALIGN64     = UCC_BIT(3),
-    UCC_MEM_CONSTRAINT_ALIGN128    = UCC_BIT(4),
-    UCC_MEM_CONSTRAINT_ALIGN256    = UCC_BIT(5)
-} ucc_mem_constraints_t;
-
-/**
- *
- *  @ingroup UCC_CONTEXT_DT
- */
-typedef enum {
-    UCC_MEM_HINT_REMOTE_ATOMICS    = UCC_BIT(0),
-    UCC_MEM_HINT_REMOTE_COUNTERS   = UCC_BIT(1)
-} ucc_mem_hints_t;
-
-/**
- *
- *  @ingroup UCC_CONTEXT_DT
- */
 typedef struct ucc_mem_map {
-    void *   address; /*!< the address of a buffer to be attached to the NIC. If address is NULL, a buffer will be allocated based on the provided hints and constraints */
+    void *   address; /*!< the address of a buffer to be attached to the NIC */
     size_t   len;     /*!< the length of the buffer */
-    uint64_t hints;   /*!< optional hints on where to allocate memory for use in collective operations */
-    uint64_t constraints; /*!< requirements pertaining to the memory to be allocated */
 } ucc_mem_map_t;
 
 /**
@@ -1611,8 +1587,7 @@ enum ucc_coll_args_field {
     UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS          = UCC_BIT(2),
     UCC_COLL_ARGS_FIELD_TAG                             = UCC_BIT(3),
     UCC_COLL_ARGS_FIELD_CB                              = UCC_BIT(4),
-    UCC_COLL_ARGS_FIELD_PSYNC                           = UCC_BIT(5),
-    UCC_COLL_ARGS_FIELD_PWORK                           = UCC_BIT(6)
+    UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER              = UCC_BIT(5)
 };
 
 /**
@@ -1672,8 +1647,7 @@ typedef struct ucc_coll_args {
                                              collectives */
     ucc_error_type_t                error_type; /*!< Error type */
     ucc_coll_id_t                   tag; /*!< Used for ordering collectives */
-    void                           *pSync; /*!< pSync array for one-sided collectives */
-    void                           *pWrk; /*!< pWrk array for one-sided reductions */
+    void                           *global_work_buffer; /*!< scratch pad for one-sided collectives */
     ucc_coll_callback_t             cb;
     double                          timeout; /*!< Timeout in seconds */
 } ucc_coll_args_t;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -621,8 +621,7 @@ enum ucc_context_params_field {
     UCC_CONTEXT_PARAM_FIELD_SYNC_TYPE         = UCC_BIT(1),
     UCC_CONTEXT_PARAM_FIELD_OOB               = UCC_BIT(2),
     UCC_CONTEXT_PARAM_FIELD_ID                = UCC_BIT(3),
-    UCC_CONTEXT_PARAM_FIELD_MEM_PARAMS        = UCC_BIT(4),
-    UCC_CONTEXT_PARAM_FIELD_MEM_PARAMS_TYPE   = UCC_BIT(5)
+    UCC_CONTEXT_PARAM_FIELD_MEM_PARAMS        = UCC_BIT(4)
 };
 
 /**
@@ -661,15 +660,6 @@ typedef struct ucc_oob_coll {
 
 typedef ucc_oob_coll_t ucc_context_oob_coll_t;
 typedef ucc_oob_coll_t ucc_team_oob_coll_t;
-
-/**
- *
- *  @ingroup UCC_CONTEXT_DT
- */
-typedef enum {
-    UCC_MEM_SYMMETRIC_SEGMENTS  = 0,
-    UCC_MEM_ASYMMETRIC_SEGMENTS = 1
-} ucc_mem_map_type_t;
 
 /**
  *
@@ -741,7 +731,6 @@ typedef struct ucc_context_params {
     ucc_coll_sync_type_t    sync_type;
     ucc_context_oob_coll_t  oob;
     uint64_t                ctx_id;
-    ucc_mem_map_type_t      mem_params_type;
     ucc_mem_map_params_t    mem_params;
 } ucc_context_params_t;
 

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -667,7 +667,7 @@ typedef ucc_oob_coll_t ucc_team_oob_coll_t;
  *  @ingroup UCC_CONTEXT_DT
  */
 typedef struct ucc_mem_map {
-    void *   address; /*!< the address of a buffer to be attached to the NIC */
+    void *   address; /*!< the address of a buffer to be attached to a UCC context */
     size_t   len;     /*!< the length of the buffer */
 } ucc_mem_map_t;
 
@@ -992,7 +992,13 @@ enum ucc_team_attr_field {
  * @ingroup UCC_TEAM_DT
  */
 enum ucc_team_flags {
-    UCC_TEAM_FLAG_COLL_WORK_BUFFER             = UCC_BIT(0)
+    UCC_TEAM_FLAG_COLL_WORK_BUFFER             = UCC_BIT(0) /*< If set, this indicates
+                                                                the user will provide 
+                                                                a scratchpad buffer for 
+                                                                use in one-sided 
+                                                                collectives. Otherwise, 
+                                                                an internal buffer will
+                                                                used. */
 };
 
 /**
@@ -1659,7 +1665,15 @@ typedef struct ucc_coll_args {
                                              collectives */
     ucc_error_type_t                error_type; /*!< Error type */
     ucc_coll_id_t                   tag; /*!< Used for ordering collectives */
-    void                           *global_work_buffer; /*!< User allocated scratchpad buffer for one-sided collectives. The buffer provided should be at least the size returned by @ref ucc_context_get_attr with the field mask - UCC_CONTEXT_ATTR_FIELD_WORK_BUFFER_SIZE set to 1. */
+    void                           *global_work_buffer; /*!< User allocated scratchpad 
+                                                             buffer for one-sided 
+                                                             collectives. The buffer 
+                                                             provided should be at least 
+                                                             the size returned by @ref 
+                                                             ucc_context_get_attr with 
+                                                             the field mask - 
+                                                             UCC_CONTEXT_ATTR_FIELD_WORK_BUFFER_SIZE 
+                                                             set to 1. */
     ucc_coll_callback_t             cb;
     double                          timeout; /*!< Timeout in seconds */
 } ucc_coll_args_t;


### PR DESCRIPTION
## What
Update the ucc_mem_map_params structure to hold an array of addresses, lengths, hints, and constraints in order to support multiple buffers being associated with a team for collective operations. In addition, adds a n_param integer to hold the number of addresses passed in. 

## Why ?
Currently, the ucc_mem_map_params structure will hold a single buffer that may be attached to a team for use with collectives. It may be the case that more than one buffer may be used over a series of collectives issued by a team. 
