### PR TITLE
CORE: coll seq_num

### DIFF
--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -199,10 +199,12 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
         task->cb = coll_args->cb;
         task->flags |= UCC_COLL_TASK_FLAG_CB;
     }
+    task->seq_num = team->seq_num++;
     if (ucc_global_config.log_component.log_level >= UCC_LOG_LEVEL_DEBUG) {
         char coll_debug_str[256];
         ucc_coll_str(&op_args, coll_debug_str, sizeof(coll_debug_str));
-        ucc_debug("coll_init: %s, req %p", coll_debug_str, task);
+        ucc_debug("coll_init: %s, req %p, seq_num %u", coll_debug_str, task,
+                  task->seq_num);
     }
     *request = &task->super;
     return UCC_OK;

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -135,6 +135,7 @@ ucc_status_t ucc_team_create_post(ucc_context_h *contexts, uint32_t num_contexts
     team->runtime_oob  = params->oob;
     team->num_contexts = num_contexts;
     team->size         = team_size;
+    team->seq_num      = 0;
     team->contexts =
         ucc_malloc(sizeof(ucc_context_t *) * num_contexts, "ucc_team_ctx");
     if (!team->contexts) {

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -44,7 +44,8 @@ typedef struct ucc_team {
     void *                  oob_req;
     ucc_ep_map_t            ctx_map; /*< map to the ctx ranks, defined if CTX
                                   type is global (oob provided) */
-    ucc_team_topo_t   *topo;
+    ucc_team_topo_t        *topo;
+    uint32_t                seq_num;
 } ucc_team_t;
 
 /* If the bit is set then team_id is provided by the user */

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -67,11 +67,12 @@ typedef struct ucc_coll_task {
         /* used for lf mt progress queue */
         ucc_lf_queue_elem_t          lf_elem;
     };
-    uint8_t n_deps;
-    uint8_t n_deps_satisfied;
-    uint8_t n_deps_base;
-    double  start_time; /* timestamp of the start time:
-                           either post or triggered_post */
+    uint8_t  n_deps;
+    uint8_t  n_deps_satisfied;
+    uint8_t  n_deps_base;
+    double   start_time; /* timestamp of the start time:
+                            either post or triggered_post */
+    uint32_t seq_num;
 } ucc_coll_task_t;
 
 typedef struct ucc_context ucc_context_t;
@@ -123,8 +124,8 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
         if (UCC_ERR_TIMED_OUT == status) {
             char coll_str[256];
             ucc_coll_str(&task->bargs, coll_str, sizeof(coll_str));
-            ucc_warn("timeout %g sec has expired on task %p, %s",
-                     task->bargs.args.timeout, task, coll_str);
+            ucc_warn("timeout %g sec has expired on task %p, seq_num %u, %s",
+                     task->bargs.args.timeout, task, task->seq_num, coll_str);
         } else {
             ucc_error("failure in task %p, %s", task,
                       ucc_status_string(task->super.status));


### PR DESCRIPTION
## What
Adds running sequence number per ucc team.

## Why ?
Current use case: this significantly simplifies debug of the hanging apps (because it is easy to find late process from the log). 
