### PR TITLE
CORE: fix coll args copy

### DIFF
--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -181,6 +181,10 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
     op_args.mask = 0;
     memcpy(&op_args.args, coll_args, sizeof(ucc_coll_args_t));
     op_args.team = team;
+    op_args.args.flags = 0;
+    UCC_COPY_PARAM_BY_FIELD(&op_args.args, coll_args, UCC_COLL_ARGS_FIELD_FLAGS,
+                            flags);
+
     cl_team      = ucc_select_cl_team(coll_args, team);
     status =
         UCC_CL_TEAM_IFACE(cl_team)->coll.init(&op_args, &cl_team->super, &task);

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -39,11 +39,4 @@ void ucc_get_version(unsigned *major_version, unsigned *minor_version,
 
 const char *ucc_get_version_string(void);
 
-#define UCC_COPY_PARAM_BY_FIELD(_dst, _src, _FIELD, _field)                    \
-    do {                                                                       \
-        if ((_src)->mask & (_FIELD)) {                                         \
-            (_dst)->_field = (_src)->_field;                                   \
-        }                                                                      \
-    } while (0)
-
 #endif

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -35,6 +35,13 @@ typedef int                        ucc_score_t;
 #define UCC_MASK     UCS_MASK
 #define UCC_EMPTY_STATEMENT {}
 
+#define UCC_COPY_PARAM_BY_FIELD(_dst, _src, _FIELD, _field)                    \
+    do {                                                                       \
+        if ((_src)->mask & (_FIELD)) {                                         \
+            (_dst)->_field = (_src)->_field;                                   \
+        }                                                                      \
+    } while (0)
+
 static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
 {
     switch (status) {


### PR DESCRIPTION
## What
Fixes false timed out error in torch_ucc
```
ucc_schedule.h:127  UCC  WARN  timeout 4.94066e-324 sec has expired on task 0x55dfa4e26180, team id 1 size 4 rank 2 ctx_rank 2: Bcast Host inplace=1 root=0 bytes=32768
```