### PR TITLE
TL/UCP: remove duplicate init declaration

### DIFF
--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -199,10 +199,6 @@ static inline ucc_status_t ucc_tl_ucp_test(ucc_tl_ucp_task_t *task)
     return UCC_INPROGRESS;
 }
 
-ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_args_t *coll_args,
-                                  ucc_base_team_t      *team,
-                                  ucc_coll_task_t     **task_h);
-
 ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
                                        ucc_coll_type_t          coll_type,
                                        ucc_memory_type_t        mem_type,


### PR DESCRIPTION
## Why ?
Duplicated ucc_tl_ucp_coll_init function declaration

