### PR TITLE
SCHEDULE: init args mask to 0

### DIFF
--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -42,6 +42,7 @@ ucc_status_t ucc_coll_task_init(ucc_coll_task_t *task,
     task->team             = team;
     task->n_deps           = 0;
     task->n_deps_satisfied = 0;
+    task->bargs.args.mask  = 0;
     if (bargs) {
         memcpy(&task->bargs, bargs, sizeof(*bargs));
     }


### PR DESCRIPTION
## What
Set task args mask to 0 in task_init.

## Why
When internal task (for triggered post e.g.) is allocated we don't pass "args" to ucc_coll_task_init and hence it is left un-initialized
