### PR TITLE
CL/HIER: 2LvL RAB (reduce_allreduce_bcast) Allreduce algorithm

### DIFF
--- a/config/m4/configure.m4
+++ b/config/m4/configure.m4
@@ -7,11 +7,12 @@ AC_DEFUN([ENABLE_MODULE_PROFILING],
 [
     AS_IF([test "x$with_profiling" = xall],
         [
-            prof_modules=":core:mc:tl_ucp:tl_nccl:tl_sharp"
+            prof_modules=":core:mc:tl_ucp:tl_nccl:tl_sharp:cl_hier"
             AC_DEFINE([HAVE_PROFILING_CORE], [1], [Enable profiling for CORE])
             AC_DEFINE([HAVE_PROFILING_TL_UCP], [1], [Enable profiling for TL UCP])
             AC_DEFINE([HAVE_PROFILING_TL_NCCL], [1], [Enable profiling for TL NCCL])
             AC_DEFINE([HAVE_PROFILING_TL_SHARP], [1], [Enable profiling for TL SHARP])
+            AC_DEFINE([HAVE_PROFILING_CL_HIER], [1], [Enable profiling for CL HIER])
             AC_DEFINE([HAVE_PROFILING_MC], [1], [Enable profiling for MC])
         ],
         [
@@ -43,6 +44,12 @@ AC_DEFUN([ENABLE_MODULE_PROFILING],
             *tl_sharp*)
                 prof_modules="${prof_modules}:tl_sharp"
                 AC_DEFINE([HAVE_PROFILING_TL_SHARP], [1], [Enable profiling for TL SHARP])
+                ;;
+            esac
+            case $1 in
+            *cl_hier*)
+                prof_modules="${prof_modules}:cl_hier"
+                AC_DEFINE([HAVE_PROFILING_CL_HIER], [1], [Enable profiling for CL HIER])
                 ;;
             esac
         ])

--- a/src/components/cl/hier/Makefile.am
+++ b/src/components/cl/hier/Makefile.am
@@ -2,13 +2,18 @@
 # Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
 #
 
-sources =              \
+allreduce =                   \
+	allreduce/allreduce.h     \
+	allreduce/allreduce_rab.c
+
+sources =             \
 	cl_hier.h         \
 	cl_hier.c         \
 	cl_hier_lib.c     \
 	cl_hier_context.c \
 	cl_hier_team.c    \
-	cl_hier_coll.c
+	cl_hier_coll.c    \
+	$(allreduce)
 
 module_LTLIBRARIES         = libucc_cl_hier.la
 libucc_cl_hier_la_SOURCES  = $(sources)

--- a/src/components/cl/hier/Makefile.am
+++ b/src/components/cl/hier/Makefile.am
@@ -13,6 +13,7 @@ sources =             \
 	cl_hier_context.c \
 	cl_hier_team.c    \
 	cl_hier_coll.c    \
+	cl_hier_coll.h    \
 	$(allreduce)
 
 module_LTLIBRARIES         = libucc_cl_hier.la

--- a/src/components/cl/hier/allreduce/allreduce.h
+++ b/src/components/cl/hier/allreduce/allreduce.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef ALLREDUCE_H_
+#define ALLREDUCE_H_
+#include "../cl_hier.h"
+/* #include "../cl_hier_coll.h" */
+
+ucc_status_t ucc_cl_hier_allreduce_rab_init(ucc_base_coll_args_t *coll_args,
+                                            ucc_base_team_t      *team,
+                                            ucc_coll_task_t     **task);
+
+#endif

--- a/src/components/cl/hier/allreduce/allreduce.h
+++ b/src/components/cl/hier/allreduce/allreduce.h
@@ -7,7 +7,6 @@
 #ifndef ALLREDUCE_H_
 #define ALLREDUCE_H_
 #include "../cl_hier.h"
-/* #include "../cl_hier_coll.h" */
 
 ucc_status_t ucc_cl_hier_allreduce_rab_init(ucc_base_coll_args_t *coll_args,
                                             ucc_base_team_t      *team,

--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -22,7 +22,8 @@ static ucc_status_t ucc_cl_hier_allreduce_rab_finalize(ucc_coll_task_t *task)
     ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
     ucc_status_t    status;
 
-    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_allreduce_rab_finalize", 0);
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_allreduce_rab_finalize",
+                                      0);
     status = ucc_schedule_finalize(task);
     ucc_cl_hier_put_schedule(schedule);
     return status;
@@ -30,16 +31,15 @@ static ucc_status_t ucc_cl_hier_allreduce_rab_finalize(ucc_coll_task_t *task)
 
 UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
                          (coll_args, team, task),
-                         ucc_base_coll_args_t *coll_args,
-                         ucc_base_team_t      *team,
-                         ucc_coll_task_t     **task)
+                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+                         ucc_coll_task_t **task)
 {
-    ucc_cl_hier_team_t     *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
-    ucc_schedule_t         *schedule;
-    ucc_status_t            status;
-    ucc_base_coll_args_t    args;
-    ucc_coll_task_t        *tasks[MAX_AR_RAB_TASKS];
-    int                     n_tasks, i;
+    ucc_cl_hier_team_t  *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_schedule_t      *schedule;
+    ucc_status_t         status;
+    ucc_base_coll_args_t args;
+    ucc_coll_task_t     *tasks[MAX_AR_RAB_TASKS];
+    int                  n_tasks, i;
 
     schedule = &ucc_cl_hier_get_schedule(cl_team)->super.super;
     if (ucc_unlikely(!schedule)) {
@@ -62,12 +62,13 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
         } else {
             args.args.coll_type = UCC_COLL_TYPE_REDUCE;
         }
-        status = ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
+        status =
+            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
         if (ucc_unlikely(UCC_OK != status)) {
             goto out;
         }
         n_tasks++;
-        args.args.mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
+        args.args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
         args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
 
@@ -85,9 +86,11 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
     /* For bcast src.buffer should point to origin dst.buffer of allreduce */
     args.args.src.info.buffer = args.args.dst.info.buffer;
 
-    if (SBGP_ENABLED(cl_team, NODE) && cl_team->top_sbgp != UCC_HIER_SBGP_NODE) {
+    if (SBGP_ENABLED(cl_team, NODE) &&
+        cl_team->top_sbgp != UCC_HIER_SBGP_NODE) {
         args.args.coll_type = UCC_COLL_TYPE_BCAST;
-        status = ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
+        status =
+            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
         if (ucc_unlikely(UCC_OK != status)) {
             goto out;
         }
@@ -98,8 +101,8 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
                                 tasks[0], ucc_task_start_handler);
     ucc_schedule_add_task(schedule, tasks[0]);
     for (i = 1; i < n_tasks; i++) {
-        ucc_event_manager_subscribe(&tasks[i - 1]->em, UCC_EVENT_COMPLETED, tasks[i],
-                                    ucc_task_start_handler);
+        ucc_event_manager_subscribe(&tasks[i - 1]->em, UCC_EVENT_COMPLETED,
+                                    tasks[i], ucc_task_start_handler);
         ucc_schedule_add_task(schedule, tasks[i]);
     }
 

--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "allreduce.h"
+
+#define MAX_AR_RAB_TASKS 3
+
+static ucc_status_t ucc_cl_hier_allreduce_rab_start(ucc_coll_task_t *task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
+
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_allreduce_rab_start", 0);
+    return ucc_schedule_start(schedule);
+}
+
+static ucc_status_t ucc_cl_hier_allreduce_rab_finalize(ucc_coll_task_t *task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
+    ucc_status_t    status;
+
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_allreduce_rab_finalize", 0);
+    UCC_CL_HIER_PROFILE_REQUEST_FREE(task);
+    status = ucc_schedule_finalize(task);
+    ucc_free(schedule);
+    return status;
+}
+
+UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
+                         (coll_args, team, task),
+                         ucc_base_coll_args_t *coll_args,
+                         ucc_base_team_t      *team,
+                         ucc_coll_task_t     **task)
+{
+    ucc_cl_hier_team_t     *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_hier_sbgp_type_t    top_sbgp;
+    ucc_schedule_t         *schedule;
+    ucc_status_t            status;
+    ucc_base_coll_args_t    args;
+    ucc_coll_task_t        *tasks[MAX_AR_RAB_TASKS];
+    int                     n_tasks, i;
+
+    schedule = ucc_malloc(sizeof(*schedule), "hier ar rab schedule");
+    if (ucc_unlikely(!schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+    UCC_CL_HIER_PROFILE_REQUEST_NEW(schedule, "cl_hier_allreduce_rab", 0);
+
+    memcpy(&args, coll_args, sizeof(args));
+    args.args.root = 0; /* TODO: we can select the rank closest to HCA */
+    n_tasks        = 0;
+    status         = ucc_schedule_init(schedule, &args, team);
+    if (ucc_unlikely(UCC_OK != status)) {
+        goto out;
+    }
+
+    if (SBGP_EXISTS(cl_team, NODE_LEADERS)) {
+        top_sbgp = UCC_HIER_SBGP_NODE_LEADERS;
+    } else {
+        ucc_assert(SBGP_EXISTS(cl_team, NODE));
+        top_sbgp = UCC_HIER_SBGP_NODE;
+    }
+
+    if (SBGP_ENABLED(cl_team, NODE)) {
+        ucc_assert(n_tasks == 0);
+        /* can have only NODE sbgp, both above have been skipped */
+        if (top_sbgp == UCC_HIER_SBGP_NODE) {
+            args.args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
+        } else {
+            args.args.coll_type = UCC_COLL_TYPE_REDUCE;
+        }
+        status = ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+        args.args.mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
+        args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+
+    if (SBGP_ENABLED(cl_team, NODE_LEADERS)) {
+        ucc_assert(top_sbgp == UCC_HIER_SBGP_NODE_LEADERS);
+        args.args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
+        status = ucc_coll_init(SCORE_MAP(cl_team, NODE_LEADERS), &args, &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+    }
+
+    /* For bcast src.buffer should point to origin dst.buffer of allreduce */
+    args.args.src.info.buffer = args.args.dst.info.buffer;
+
+    if (SBGP_ENABLED(cl_team, NODE) && top_sbgp != UCC_HIER_SBGP_NODE) {
+        args.args.coll_type = UCC_COLL_TYPE_BCAST;
+        status = ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+    }
+
+    for (i = 0; i < n_tasks; i++) {
+        if (i == 0) {
+            ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
+                                        tasks[i], ucc_task_start_handler);
+        } else {
+            ucc_event_manager_subscribe(&tasks[i - 1]->em, UCC_EVENT_COMPLETED, tasks[i],
+                                        ucc_task_start_handler);
+        }
+        ucc_schedule_add_task(schedule, tasks[i]);
+    }
+
+    schedule->super.post     = ucc_cl_hier_allreduce_rab_start;
+    schedule->super.finalize = ucc_cl_hier_allreduce_rab_finalize;
+    *task                    = &schedule->super;
+    return UCC_OK;
+
+out:
+    //TODO cleanup tasks
+    ucc_free(schedule);
+    return status;
+}

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -15,15 +15,19 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_hier_lib_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_cl_lib_config_table)},
 
-    {"NODE_SBGP_TLS", "ucp", "TLS to be used for NODE subgroup",
+    {"NODE_SBGP_TLS", "ucp", "TLS to be used for NODE subgroup.\n"
+     "NODE subgroup contains processes of a team located on the same node",
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NODE]),
      UCC_CONFIG_TYPE_STRING_ARRAY},
 
-    {"NODE_LEADERS_SBGP_TLS", "ucp", "TLS to be used for NODE_LEADERS subgroup",
+    {"NODE_LEADERS_SBGP_TLS", "ucp", "TLS to be used for NODE_LEADERS subgroup.\n"
+     "NODE_LEADERS subgroup contains processes of a team with local node rank equal 0",
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NODE_LEADERS]),
      UCC_CONFIG_TYPE_STRING_ARRAY},
 
-    {"NET_SBGP_TLS", "ucp", "TLS to be used for NET subgroup",
+    {"NET_SBGP_TLS", "ucp", "TLS to be used for NET subgroup.\n"
+     "NET subgroup contains processes of a team with identical local node rank.\n"
+     "This subgroup only exists for teams with equal number of processes across the nodes",
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NET]),
      UCC_CONFIG_TYPE_STRING_ARRAY},
 

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -19,6 +19,10 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NODE]),
      UCC_CONFIG_TYPE_STRING_ARRAY},
 
+    {"NODE_LEADERS_SBGP_TLS", "ucp", "TLS to be used for NODE_LEADERS subgroup",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NODE_LEADERS]),
+     UCC_CONFIG_TYPE_STRING_ARRAY},
+
     {"NET_SBGP_TLS", "ucp", "TLS to be used for NET subgroup",
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NET]),
      UCC_CONFIG_TYPE_STRING_ARRAY},

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -15,19 +15,26 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_hier_lib_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_cl_lib_config_table)},
 
-    {"NODE_SBGP_TLS", "ucp", "TLS to be used for NODE subgroup.\n"
+    {"NODE_SBGP_TLS", "ucp",
+     "TLS to be used for NODE subgroup.\n"
      "NODE subgroup contains processes of a team located on the same node",
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NODE]),
      UCC_CONFIG_TYPE_STRING_ARRAY},
 
-    {"NODE_LEADERS_SBGP_TLS", "ucp", "TLS to be used for NODE_LEADERS subgroup.\n"
-     "NODE_LEADERS subgroup contains processes of a team with local node rank equal 0",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NODE_LEADERS]),
+    {"NODE_LEADERS_SBGP_TLS", "ucp",
+     "TLS to be used for NODE_LEADERS subgroup.\n"
+     "NODE_LEADERS subgroup contains processes of a team with local node rank "
+     "equal 0",
+     ucc_offsetof(ucc_cl_hier_lib_config_t,
+                  sbgp_tls[UCC_HIER_SBGP_NODE_LEADERS]),
      UCC_CONFIG_TYPE_STRING_ARRAY},
 
-    {"NET_SBGP_TLS", "ucp", "TLS to be used for NET subgroup.\n"
-     "NET subgroup contains processes of a team with identical local node rank.\n"
-     "This subgroup only exists for teams with equal number of processes across the nodes",
+    {"NET_SBGP_TLS", "ucp",
+     "TLS to be used for NET subgroup.\n"
+     "NET subgroup contains processes of a team with identical local node "
+     "rank.\n"
+     "This subgroup only exists for teams with equal number of processes "
+     "across the nodes",
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NET]),
      UCC_CONFIG_TYPE_STRING_ARRAY},
 

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -115,14 +115,14 @@ ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
 #define UCC_CL_HIER_TEAM_LIB(_team)                                            \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_cl_hier_lib_t))
 
-#define SBGP_ENABLED(_team, _sbgp)                          \
-    ((_team)->sbgps[UCC_HIER_SBGP_ ## _sbgp].state == UCC_HIER_SBGP_ENABLED)
+#define SBGP_ENABLED(_team, _sbgp)                                             \
+    ((_team)->sbgps[UCC_HIER_SBGP_##_sbgp].state == UCC_HIER_SBGP_ENABLED)
 
-#define SBGP_EXISTS(_team, _sbgp)                                       \
-    ((NULL != (_team)->sbgps[UCC_HIER_SBGP_ ## _sbgp].sbgp) &&          \
-    ((_team)->sbgps[UCC_HIER_SBGP_ ## _sbgp].sbgp->status != UCC_SBGP_NOT_EXISTS))
+#define SBGP_EXISTS(_team, _sbgp)                                              \
+    ((NULL != (_team)->sbgps[UCC_HIER_SBGP_##_sbgp].sbgp) &&                   \
+     ((_team)->sbgps[UCC_HIER_SBGP_##_sbgp].sbgp->status !=                    \
+      UCC_SBGP_NOT_EXISTS))
 
-#define SCORE_MAP(_team, _sbgp)                 \
-    (_team)->sbgps[UCC_HIER_SBGP_ ## _sbgp].score_map
+#define SCORE_MAP(_team, _sbgp) (_team)->sbgps[UCC_HIER_SBGP_##_sbgp].score_map
 
 #endif

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -11,6 +11,17 @@
 #include "components/tl/ucc_tl.h"
 #include "coll_score/ucc_coll_score.h"
 
+#ifdef HAVE_PROFILING_CL_HIER
+#include "utils/profile/ucc_profile.h"
+#else
+#include "utils/profile/ucc_profile_off.h"
+#endif
+
+#define UCC_CL_HIER_PROFILE_FUNC UCC_PROFILE_FUNC
+#define UCC_CL_HIER_PROFILE_REQUEST_NEW UCC_PROFILE_REQUEST_NEW
+#define UCC_CL_HIER_PROFILE_REQUEST_EVENT UCC_PROFILE_REQUEST_EVENT
+#define UCC_CL_HIER_PROFILE_REQUEST_FREE UCC_PROFILE_REQUEST_FREE
+
 #ifndef UCC_CL_HIER_DEFAULT_SCORE
 #define UCC_CL_HIER_DEFAULT_SCORE 50
 #endif
@@ -23,9 +34,11 @@ extern ucc_cl_hier_iface_t ucc_cl_hier;
 
 typedef enum {
     UCC_HIER_SBGP_NODE,
+    UCC_HIER_SBGP_NODE_LEADERS,
     UCC_HIER_SBGP_NET,
     UCC_HIER_SBGP_LAST,
 } ucc_hier_sbgp_type_t;
+//DO we need it? Potential use case: different hier sbgps over same sbgp
 
 typedef struct ucc_cl_hier_lib_config {
     ucc_cl_lib_config_t super;
@@ -98,5 +111,15 @@ ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
 
 #define UCC_CL_HIER_TEAM_LIB(_team)                                            \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_cl_hier_lib_t))
+
+#define SBGP_ENABLED(_team, _sbgp)                          \
+    ((_team)->sbgps[UCC_HIER_SBGP_ ## _sbgp].state == UCC_HIER_SBGP_ENABLED)
+
+#define SBGP_EXISTS(_team, _sbgp)                                       \
+    ((NULL != (_team)->sbgps[UCC_HIER_SBGP_ ## _sbgp].sbgp) &&          \
+    ((_team)->sbgps[UCC_HIER_SBGP_ ## _sbgp].sbgp->status != UCC_SBGP_NOT_EXISTS))
+
+#define SCORE_MAP(_team, _sbgp)                 \
+    (_team)->sbgps[UCC_HIER_SBGP_ ## _sbgp].score_map
 
 #endif

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -10,6 +10,7 @@
 #include "components/cl/ucc_cl_log.h"
 #include "components/tl/ucc_tl.h"
 #include "coll_score/ucc_coll_score.h"
+#include "utils/ucc_mpool.h"
 
 #ifdef HAVE_PROFILING_CL_HIER
 #include "utils/profile/ucc_profile.h"
@@ -63,6 +64,7 @@ typedef struct ucc_cl_hier_context {
     ucc_cl_context_t   super;
     ucc_tl_context_t **tl_ctxs;
     unsigned           n_tl_ctxs;
+    ucc_mpool_t        sched_mp;
 } ucc_cl_hier_context_t;
 UCC_CLASS_DECLARE(ucc_cl_hier_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
@@ -96,6 +98,7 @@ typedef struct ucc_cl_hier_team {
     unsigned                 n_tl_teams;
     ucc_coll_score_t        *score;
     ucc_hier_sbgp_t          sbgps[UCC_HIER_SBGP_LAST];
+    ucc_hier_sbgp_type_t     top_sbgp;
 } ucc_cl_hier_team_t;
 UCC_CLASS_DECLARE(ucc_cl_hier_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/cl/hier/cl_hier_coll.c
+++ b/src/components/cl/hier/cl_hier_coll.c
@@ -14,14 +14,13 @@ ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t      *team,
                                    ucc_coll_task_t     **task)
 {
-	switch(coll_args->args.coll_type) {
+    switch (coll_args->args.coll_type) {
     case UCC_COLL_TYPE_ALLREDUCE:
         return ucc_cl_hier_allreduce_rab_init(coll_args, team, task);
     default:
         cl_error(team->context->lib, "coll_type %s is not supported",
                  ucc_coll_type_str(coll_args->args.coll_type));
         break;
-	}
-	return UCC_ERR_NOT_SUPPORTED;
+    }
+    return UCC_ERR_NOT_SUPPORTED;
 }
-

--- a/src/components/cl/hier/cl_hier_coll.c
+++ b/src/components/cl/hier/cl_hier_coll.c
@@ -8,10 +8,19 @@
 #include "core/ucc_mc.h"
 #include "core/ucc_team.h"
 #include "utils/ucc_coll_utils.h"
+#include "allreduce/allreduce.h"
 
 ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t      *team,
                                    ucc_coll_task_t     **task)
 {
-    return UCC_ERR_NOT_IMPLEMENTED;
+	switch(coll_args->args.coll_type) {
+    case UCC_COLL_TYPE_ALLREDUCE:
+        return ucc_cl_hier_allreduce_rab_init(coll_args, team, task);
+        break;
+    default:
+        break;
+	}
+	return UCC_ERR_NOT_SUPPORTED;
 }
+

--- a/src/components/cl/hier/cl_hier_coll.c
+++ b/src/components/cl/hier/cl_hier_coll.c
@@ -17,8 +17,9 @@ ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
 	switch(coll_args->args.coll_type) {
     case UCC_COLL_TYPE_ALLREDUCE:
         return ucc_cl_hier_allreduce_rab_init(coll_args, team, task);
-        break;
     default:
+        cl_error(team->context->lib, "coll_type %s is not supported",
+                 ucc_coll_type_str(coll_args->args.coll_type));
         break;
 	}
 	return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/cl/hier/cl_hier_coll.h
+++ b/src/components/cl/hier/cl_hier_coll.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#ifndef UCC_CL_HIER_COLL_H_
+#define UCC_CL_HIER_COLL_H_
+
+#include "cl_hier.h"
+#include "schedule/ucc_schedule_pipelined.h"
+
+typedef struct ucc_cl_hier_schedule_t {
+    ucc_schedule_pipelined_t super;
+} ucc_cl_hier_schedule_t;
+
+static inline ucc_cl_hier_schedule_t *
+ucc_cl_hier_get_schedule(ucc_cl_hier_team_t *team)
+{
+    ucc_cl_hier_context_t  *ctx      = UCC_CL_HIER_TEAM_CTX(team);
+    ucc_cl_hier_schedule_t *schedule = ucc_mpool_get(&ctx->sched_mp);
+
+    UCC_CL_HIER_PROFILE_REQUEST_NEW(schedule, "cl_hier_sched_p", 0);
+    return schedule;
+}
+
+static inline void ucc_cl_hier_put_schedule(ucc_schedule_t *schedule)
+{
+    UCC_CL_HIER_PROFILE_REQUEST_FREE(schedule);
+    ucc_mpool_put(schedule);
+}
+
+#endif

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -8,6 +8,7 @@
 #include "utils/ucc_malloc.h"
 #include "core/ucc_team.h"
 #include "core/ucc_service_coll.h"
+#include "allreduce/allreduce.h"
 
 #define SBGP_SET(_team, _sbgp, _enable)                                        \
     _team->sbgps[UCC_HIER_SBGP_##_sbgp].sbgp_type = UCC_SBGP_##_sbgp;          \
@@ -19,8 +20,9 @@
    Next step is to enable sbgps based on the requested hierarchical algs. */
 static void ucc_cl_hier_enable_sbgps(ucc_cl_hier_team_t *team)
 {
-    SBGP_SET(team, NODE, ENABLED);
-    SBGP_SET(team, NET, ENABLED);
+    SBGP_SET(team, NET,            DISABLED);
+    SBGP_SET(team, NODE,           ENABLED);
+    SBGP_SET(team, NODE_LEADERS,   ENABLED);
 }
 
 UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
@@ -48,6 +50,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
     for (i = 0; i < UCC_HIER_SBGP_LAST; i++) {
         hs        = &self->sbgps[i];
         hs->score = NULL;
+        hs->sbgp  = NULL;
         if (hs->state == UCC_HIER_SBGP_ENABLED) {
             hs->sbgp =
                 ucc_team_topo_get_sbgp(params->team->topo, hs->sbgp_type);
@@ -281,19 +284,35 @@ ucc_status_t ucc_cl_hier_team_create_test(ucc_base_team_t *cl_team)
 ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
                                          ucc_coll_score_t **score_p)
 {
-    ucc_cl_hier_team_t *team = ucc_derived_of(cl_team, ucc_cl_hier_team_t);
-    ucc_base_lib_t     *lib  = UCC_CL_TEAM_LIB(team);
+    ucc_cl_hier_team_t *team  = ucc_derived_of(cl_team, ucc_cl_hier_team_t);
+    ucc_base_lib_t     *lib   = UCC_CL_TEAM_LIB(team);
+    ucc_memory_type_t   mt[2] = {UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA};
     ucc_coll_score_t   *score;
     ucc_status_t        status;
+    int                 i;
 
     status = ucc_coll_score_alloc(&score);
     if (UCC_OK != status) {
         cl_error(lib, "faild to alloc score_t");
         return status;
     }
+
+    for (i = 0; i < 2; i++) {
+        status = ucc_coll_score_add_range(score, UCC_COLL_TYPE_ALLREDUCE,
+                                          mt[i], 0, 2048,
+                                          UCC_CL_HIER_DEFAULT_SCORE,
+                                          ucc_cl_hier_allreduce_rab_init,
+                                          cl_team);
+        if (UCC_OK != status) {
+            cl_error(lib, "faild to add range to score_t");
+            return status;
+        }
+    }
+
     if (strlen(lib->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->score_str, score, cl_team->team->size, NULL, cl_team,
+            lib->score_str, score, cl_team->team->size,
+            ucc_cl_hier_coll_init, cl_team,
             UCC_CL_HIER_DEFAULT_SCORE, NULL);
 
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -20,9 +20,9 @@
    Next step is to enable sbgps based on the requested hierarchical algs. */
 static void ucc_cl_hier_enable_sbgps(ucc_cl_hier_team_t *team)
 {
-    SBGP_SET(team, NET,            DISABLED);
-    SBGP_SET(team, NODE,           ENABLED);
-    SBGP_SET(team, NODE_LEADERS,   ENABLED);
+    SBGP_SET(team, NET, DISABLED);
+    SBGP_SET(team, NODE, ENABLED);
+    SBGP_SET(team, NODE_LEADERS, ENABLED);
 }
 
 UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
@@ -311,11 +311,9 @@ ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
     }
 
     for (i = 0; i < 2; i++) {
-        status = ucc_coll_score_add_range(score, UCC_COLL_TYPE_ALLREDUCE,
-                                          mt[i], 0, 2048,
-                                          UCC_CL_HIER_DEFAULT_SCORE,
-                                          ucc_cl_hier_allreduce_rab_init,
-                                          cl_team);
+        status = ucc_coll_score_add_range(
+            score, UCC_COLL_TYPE_ALLREDUCE, mt[i], 0, 2048,
+            UCC_CL_HIER_DEFAULT_SCORE, ucc_cl_hier_allreduce_rab_init, cl_team);
         if (UCC_OK != status) {
             cl_error(lib, "faild to add range to score_t");
             return status;
@@ -324,9 +322,8 @@ ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
 
     if (strlen(lib->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->score_str, score, cl_team->team->size,
-            ucc_cl_hier_coll_init, cl_team,
-            UCC_CL_HIER_DEFAULT_SCORE, NULL);
+            lib->score_str, score, cl_team->team->size, ucc_cl_hier_coll_init,
+            cl_team, UCC_CL_HIER_DEFAULT_SCORE, NULL);
 
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -159,6 +159,7 @@ UCC_KN_PHASE_PROXY:
 completion:
     ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
     task->super.super.status = UCC_OK;
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allreduce_kn_done", 0);
 out:
     return task->super.super.status;
 }
@@ -171,6 +172,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
     ucc_rank_t         rank      = task->subset.myrank;
     ucc_status_t       status;
 
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allreduce_kn_start", 0);
     task->allreduce_kn.phase = UCC_KN_PHASE_INIT;
     ucc_assert(TASK_ARGS(task).src.info.mem_type ==
                TASK_ARGS(task).dst.info.mem_type);

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -12,13 +12,6 @@
 #include "schedule/ucc_schedule_pipelined.h"
 #include <limits.h>
 
-static ucc_mpool_ops_t ucc_tl_ucp_req_mpool_ops = {
-    .chunk_alloc   = ucc_mpool_hugetlb_malloc,
-    .chunk_release = ucc_mpool_hugetlb_free,
-    .obj_init      = NULL,
-    .obj_cleanup   = NULL
-};
-
 UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
                     const ucc_base_context_params_t *params,
                     const ucc_base_config_t *config)
@@ -109,7 +102,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     ucc_status = ucc_mpool_init(
         &self->req_mp, 0,
         ucc_max(sizeof(ucc_tl_ucp_task_t), sizeof(ucc_schedule_pipelined_t)), 0,
-        UCC_CACHE_LINE_SIZE, 8, UINT_MAX, &ucc_tl_ucp_req_mpool_ops,
+        UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL,
         params->thread_mode, "tl_ucp_req_mp");
     if (UCC_OK != ucc_status) {
         tl_error(self->super.super.lib,

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -102,8 +102,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     ucc_status = ucc_mpool_init(
         &self->req_mp, 0,
         ucc_max(sizeof(ucc_tl_ucp_task_t), sizeof(ucc_schedule_pipelined_t)), 0,
-        UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL,
-        params->thread_mode, "tl_ucp_req_mp");
+        UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL, params->thread_mode,
+        "tl_ucp_req_mp");
     if (UCC_OK != ucc_status) {
         tl_error(self->super.super.lib,
                  "failed to initialize tl_ucp_req mpool");

--- a/src/components/tl/ucp/tl_ucp_ep.c
+++ b/src/components/tl/ucp/tl_ucp_ep.c
@@ -39,9 +39,8 @@ static inline ucc_status_t ucc_tl_ucp_connect_ep(ucc_tl_ucp_context_t *ctx,
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t         *team,
-                                        ucc_rank_t                 core_rank,
-                                        ucp_ep_h                  *ep)
+ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t *team,
+                                        ucc_rank_t core_rank, ucp_ep_h *ep)
 {
     ucc_tl_ucp_context_t *ctx = UCC_TL_UCP_TEAM_CTX(team);
     void                 *addr;

--- a/src/components/tl/ucp/tl_ucp_ep.c
+++ b/src/components/tl/ucp/tl_ucp_ep.c
@@ -40,15 +40,14 @@ static inline ucc_status_t ucc_tl_ucp_connect_ep(ucc_tl_ucp_context_t *ctx,
 }
 
 ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t         *team,
-                                        ucc_rank_t                 team_rank,
+                                        ucc_rank_t                 core_rank,
                                         ucp_ep_h                  *ep)
 {
     ucc_tl_ucp_context_t *ctx = UCC_TL_UCP_TEAM_CTX(team);
     void                 *addr;
 
     addr = ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), team->super.super.team,
-                                ucc_ep_map_eval(team->map, team_rank),
-                                ucc_tl_ucp.super.super.id);
+                                core_rank, ucc_tl_ucp.super.super.id);
     return ucc_tl_ucp_connect_ep(ctx, ep, addr);
 }
 

--- a/src/components/tl/ucp/tl_ucp_ep.h
+++ b/src/components/tl/ucp/tl_ucp_ep.h
@@ -22,17 +22,11 @@ ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t         *team,
 void ucc_tl_ucp_close_eps(ucc_tl_ucp_context_t *ctx);
 
 static inline ucc_context_addr_header_t *
-ucc_tl_ucp_get_team_ep_header(ucc_tl_ucp_team_t *team, ucc_rank_t rank)
+ucc_tl_ucp_get_team_ep_header(ucc_tl_ucp_team_t *team, ucc_rank_t core_rank)
 
 {
     return ucc_get_team_ep_header(UCC_TL_CORE_CTX(team), team->super.super.team,
-                                  ucc_ep_map_eval(team->map, rank));
-}
-
-static inline ucc_context_id_t
-ucc_tl_ucp_get_rank_key(ucc_tl_ucp_team_t *team, ucc_rank_t rank)
-{
-    return ucc_tl_ucp_get_team_ep_header(team, rank)->ctx_id;
+                                  core_rank);
 }
 
 static inline ucc_status_t ucc_tl_ucp_get_ep(ucc_tl_ucp_team_t *team, ucc_rank_t rank,
@@ -42,22 +36,24 @@ static inline ucc_status_t ucc_tl_ucp_get_ep(ucc_tl_ucp_team_t *team, ucc_rank_t
     ucc_context_addr_header_t *h        = NULL;
     ucc_rank_t                 ctx_rank = 0;
     ucc_status_t               status;
+    ucc_rank_t                 core_rank;
 
+    core_rank = ucc_ep_map_eval(team->map, rank);
     if (ctx->eps) {
         /* Core super.super.team ptr is NULL for service_team
            which has scope == UCC_CL_LAST + 1*/
         ucc_assert((NULL != team->super.super.team) ||
                    IS_SERVICE_TEAM(team));
         ctx_rank = team->super.super.team ?
-            ucc_get_ctx_rank(team->super.super.team, rank) : rank;
+            ucc_get_ctx_rank(team->super.super.team, core_rank) : core_rank;
         *ep      = ctx->eps[ctx_rank];
     } else {
-        h   = ucc_tl_ucp_get_team_ep_header(team, rank);
+        h   = ucc_tl_ucp_get_team_ep_header(team, core_rank);
         *ep = tl_ucp_hash_get(ctx->ep_hash, h->ctx_id);
     }
     if (NULL == (*ep)) {
         /* Not connected yet */
-        status = ucc_tl_ucp_connect_team_ep(team, rank, ep);
+        status = ucc_tl_ucp_connect_team_ep(team, core_rank, ep);
         if (ucc_unlikely(UCC_OK != status)) {
             tl_error(UCC_TL_TEAM_LIB(team), "failed to connect team ep");
             *ep = NULL;

--- a/src/components/tl/ucp/tl_ucp_ep.h
+++ b/src/components/tl/ucp/tl_ucp_ep.h
@@ -44,8 +44,9 @@ static inline ucc_status_t ucc_tl_ucp_get_ep(ucc_tl_ucp_team_t *team, ucc_rank_t
            which has scope == UCC_CL_LAST + 1*/
         ucc_assert((NULL != team->super.super.team) ||
                    IS_SERVICE_TEAM(team));
-        ctx_rank = team->super.super.team ?
-            ucc_get_ctx_rank(team->super.super.team, core_rank) : core_rank;
+        ctx_rank = team->super.super.team
+                       ? ucc_get_ctx_rank(team->super.super.team, core_rank)
+                       : core_rank;
         *ep      = ctx->eps[ctx_rank];
     } else {
         h   = ucc_tl_ucp_get_team_ep_header(team, core_rank);

--- a/src/core/ucc_sbgp.h
+++ b/src/core/ucc_sbgp.h
@@ -9,14 +9,27 @@
 #include "utils/ucc_coll_utils.h"
 
 typedef enum ucc_sbgp_type_t {
-    UCC_SBGP_NUMA,
-    UCC_SBGP_SOCKET,
-    UCC_SBGP_NODE,
-    UCC_SBGP_NODE_LEADERS,
-    UCC_SBGP_NET,
-    UCC_SBGP_SOCKET_LEADERS,
-    UCC_SBGP_NUMA_LEADERS,
-    UCC_SBGP_FLAT,
+    UCC_SBGP_NUMA, /* Group of ranks on the same NUMA domain.
+                      This group does not exist if processes are
+                      not bound to a single NUMA node. */
+    UCC_SBGP_SOCKET,/* Group of ranks on the same SOCKET.
+                      This group does not exist if processes are
+                      not bound to a single SOCKET node. */
+    UCC_SBGP_NODE, /* Group of ranks on the same NODE. */
+    UCC_SBGP_NODE_LEADERS, /* Group of ranks with local_node_rank = 0.
+                              This group EXISTS when team spans at least 2 nodes.
+                              This group is ENABLED for procs with local_node_rank = 0.
+                              This group is DISABLED but EXISTS for procs with local_node_rank != 0*/
+    UCC_SBGP_NET, /* Group of ranks with the same local_node_rank.
+                     This group EXISTS when team spans at least 2 nodes AND
+                     the team has equal PPN across all the nodes.
+                     If EXISTS this group is ENABLED for all procs. */
+    UCC_SBGP_SOCKET_LEADERS, /* Group of ranks with local_socket_rank = 0.
+                              This group EXISTS when team spans at least 2 sockets.
+                              This group is ENABLED for procs with local_socket_rank = 0.
+                              This group is DISABLED but EXISTS for procs with local_socket_rank != 0 */
+    UCC_SBGP_NUMA_LEADERS, /* same as SOCKET_LEADERS but for NUMA node grouping */
+    UCC_SBGP_FLAT, /* Group contains ALL the ranks of the team */
     UCC_SBGP_LAST
 } ucc_sbgp_type_t;
 

--- a/src/core/ucc_sbgp.h
+++ b/src/core/ucc_sbgp.h
@@ -9,27 +9,30 @@
 #include "utils/ucc_coll_utils.h"
 
 typedef enum ucc_sbgp_type_t {
-    UCC_SBGP_NUMA, /* Group of ranks on the same NUMA domain.
-                      This group does not exist if processes are
-                      not bound to a single NUMA node. */
-    UCC_SBGP_SOCKET,/* Group of ranks on the same SOCKET.
-                      This group does not exist if processes are
-                      not bound to a single SOCKET node. */
-    UCC_SBGP_NODE, /* Group of ranks on the same NODE. */
-    UCC_SBGP_NODE_LEADERS, /* Group of ranks with local_node_rank = 0.
-                              This group EXISTS when team spans at least 2 nodes.
-                              This group is ENABLED for procs with local_node_rank = 0.
-                              This group is DISABLED but EXISTS for procs with local_node_rank != 0*/
-    UCC_SBGP_NET, /* Group of ranks with the same local_node_rank.
-                     This group EXISTS when team spans at least 2 nodes AND
-                     the team has equal PPN across all the nodes.
-                     If EXISTS this group is ENABLED for all procs. */
+    UCC_SBGP_NUMA,           /* Group of ranks on the same NUMA domain.
+                                This group does not exist if processes are
+                                not bound to a single NUMA node. */
+    UCC_SBGP_SOCKET,         /* Group of ranks on the same SOCKET.
+                                This group does not exist if processes are
+                                not bound to a single SOCKET node. */
+    UCC_SBGP_NODE,           /* Group of ranks on the same NODE. */
+    UCC_SBGP_NODE_LEADERS,   /* Group of ranks with local_node_rank = 0.
+                                This group EXISTS when team spans at least 2
+                                nodes. This group is ENABLED for procs with
+                                local_node_rank = 0. This group is DISABLED but
+                                EXISTS for procs with local_node_rank != 0*/
+    UCC_SBGP_NET,            /* Group of ranks with the same local_node_rank.
+                                This group EXISTS when team spans at least 2
+                                nodes AND the team has equal PPN across all the
+                                nodes. If EXISTS this group is ENABLED for all
+                                procs. */
     UCC_SBGP_SOCKET_LEADERS, /* Group of ranks with local_socket_rank = 0.
-                              This group EXISTS when team spans at least 2 sockets.
-                              This group is ENABLED for procs with local_socket_rank = 0.
-                              This group is DISABLED but EXISTS for procs with local_socket_rank != 0 */
-    UCC_SBGP_NUMA_LEADERS, /* same as SOCKET_LEADERS but for NUMA node grouping */
-    UCC_SBGP_FLAT, /* Group contains ALL the ranks of the team */
+                                This group EXISTS when team spans at least 2
+                                sockets. This group is ENABLED for procs with
+                                local_socket_rank = 0. This group is DISABLED
+                                but EXISTS for procs with local_socket_rank != 0 */
+    UCC_SBGP_NUMA_LEADERS,   /* Same as SOCKET_LEADERS but for NUMA grouping */
+    UCC_SBGP_FLAT,           /* Group contains ALL the ranks of the team */
     UCC_SBGP_LAST
 } ucc_sbgp_type_t;
 

--- a/src/core/ucc_topo.c
+++ b/src/core/ucc_topo.c
@@ -6,6 +6,7 @@
 #include "config.h"
 #include "ucc_topo.h"
 #include "ucc_context.h"
+#include "ucc_team.h"
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_math.h"
 #include <string.h>
@@ -191,4 +192,16 @@ ucc_sbgp_t *ucc_team_topo_get_sbgp(ucc_team_topo_t *topo, ucc_sbgp_type_t type)
         }
     }
     return &topo->sbgps[type];
+}
+
+int ucc_topo_is_single_node(ucc_team_topo_t *topo)
+{
+    ucc_sbgp_t *sbgp;
+
+    sbgp = ucc_team_topo_get_sbgp(topo, UCC_SBGP_NODE);
+    if (UCC_SBGP_ENABLED == sbgp->status &&
+        sbgp->group_size == topo->team->size) {
+        return 1;
+    }
+    return 0;
 }

--- a/src/core/ucc_topo.h
+++ b/src/core/ucc_topo.h
@@ -36,6 +36,6 @@ void         ucc_topo_cleanup(ucc_topo_t *topo);
 ucc_status_t ucc_team_topo_init(ucc_team_t *team, ucc_topo_t *topo,
                                 ucc_team_topo_t **team_topo);
 void         ucc_team_topo_cleanup(ucc_team_topo_t *team_topo);
-ucc_sbgp_t  *ucc_team_topo_get_sbgp(ucc_team_topo_t *topo, ucc_sbgp_type_t type);
-int          ucc_topo_is_single_node(ucc_team_topo_t *topo);
+ucc_sbgp_t *ucc_team_topo_get_sbgp(ucc_team_topo_t *topo, ucc_sbgp_type_t type);
+int         ucc_topo_is_single_node(ucc_team_topo_t *topo);
 #endif

--- a/src/core/ucc_topo.h
+++ b/src/core/ucc_topo.h
@@ -36,6 +36,6 @@ void         ucc_topo_cleanup(ucc_topo_t *topo);
 ucc_status_t ucc_team_topo_init(ucc_team_t *team, ucc_topo_t *topo,
                                 ucc_team_topo_t **team_topo);
 void         ucc_team_topo_cleanup(ucc_team_topo_t *team_topo);
-ucc_sbgp_t *ucc_team_topo_get_sbgp(ucc_team_topo_t *topo, ucc_sbgp_type_t type);
-
+ucc_sbgp_t  *ucc_team_topo_get_sbgp(ucc_team_topo_t *topo, ucc_sbgp_type_t type);
+int          ucc_topo_is_single_node(ucc_team_topo_t *topo);
 #endif


### PR DESCRIPTION
## What
Adds the hierarchical low-latency Allreduce implemented as a sequence of innode_reduce->internode_allreduce->innode_bcast. Supports TL/SHARP as well.

Some perf numbers:

Allreduce   Latency (us), host , n32ppn40
-
msgsize, B | CL/BASIC | HIER | HIER+SHARP
--|--|--|--
4 | 15.38 | 13.48 | 11.03
8 | 15.26 | 14.9 | 12.03
16 | 15.24 | 14.72 | 11.72
32 | 16.47 | 17.65 | 13.21
64 | 18.63 | 16.34 | 14.32
128 | 23.75 | 21.55 | 18.19
256 | 25.77 | 27.92 | 22.88
512 | 32.07 | 34.42 | 23.81
1024 | 60.35 | 33.06 | 28.49
2048 | 82.8 | 37.01 | 31.88


It is still uses TL/UCP for innode reduce and bcast.
Example cmd line to use SHARP:
`nnodes=32; ppn=40; mpirun -x UCC_CL_HIER_NODE_LEADERS_SBGP_TLS=ucp,sharp   -x UCC_CL_HIER_TLS=ucp,sharp -x UCC_CL_BASIC_TLS=ucp -x UCC_CLS=basic,hier -np $((nnodes*ppn)) --map-by ppr:$ppn:node --bind-to core  ./install/bin/ucc_perftest -c allreduce -b 1 -e 512 -w 5000 -n 10000`

