### PR TITLE
CORE: cache params on base_team

### DIFF
--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -99,15 +99,16 @@ typedef struct ucc_base_team_params {
     ucc_rank_t        rank; /* Rank of a calling process in the TL/CL team. It is a uniq
                                process identifier within a team (not job) but it has the
                                property: it is always contig and in the range [0, team_size).*/
+    ucc_rank_t        size; /* Size of the TL team. size <= team->size (tl can be a subset of
+                               the core team) */
     uint16_t          id;   /* core level team id */
     ucc_team_t *      team; /* core team pointer */
-    ucc_ep_map_t      map;
+    ucc_ep_map_t      map;  /* ranks map to the core ucc team */
 } ucc_base_team_params_t;
 
 typedef struct ucc_base_team {
-    ucc_base_context_t *context;
-    ucc_team_t *        team; /* core team pointer is stored on a CL/TL team
-                                 (which inherit from base) during class init. */
+    ucc_base_context_t    *context;
+    ucc_base_team_params_t params;
 } ucc_base_team_t;
 
 typedef struct ucc_base_team_iface {

--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -16,7 +16,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_team_t, ucc_base_context_t *cl_context,
     int                     i;
     ucc_status_t            status;
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_team_t, &ctx->super, params->team);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_team_t, &ctx->super, params);
     self->tl_teams = ucc_malloc(sizeof(ucc_tl_team_t *) * ctx->n_tl_ctxs,
                                 "cl_basic_tl_teams");
     if (!self->tl_teams) {
@@ -174,7 +174,7 @@ ucc_status_t ucc_cl_basic_team_get_scores(ucc_base_team_t   *cl_team,
     }
     if (strlen(lib->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->score_str, *score, cl_team->team->size, NULL, cl_team,
+            lib->score_str, *score, UCC_CL_TEAM_SIZE(team), NULL, cl_team,
             UCC_CL_BASIC_DEFAULT_SCORE, NULL);
 
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -49,7 +49,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
         return UCC_ERR_INVALID_PARAM;
     }
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_team_t, &ctx->super, params->team);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_team_t, &ctx->super, params);
 
     ucc_cl_hier_enable_sbgps(self);
     n_sbgp_teams = 0;
@@ -108,7 +108,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
                 d                         = &self->team_create_req->descs[j];
                 d->param.team             = params->team;
                 d->param.rank             = hs->sbgp->group_rank;
-                d->param.params.team_size = hs->sbgp->group_size;
+                d->param.size             = hs->sbgp->group_size;
                 d->param.params.mask =
                     UCC_TEAM_PARAM_FIELD_EP_RANGE | UCC_TEAM_PARAM_FIELD_EP |
                     UCC_TEAM_PARAM_FIELD_TEAM_SIZE | UCC_TEAM_PARAM_FIELD_OOB;
@@ -322,7 +322,8 @@ ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
 
     if (strlen(lib->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->score_str, score, cl_team->team->size, ucc_cl_hier_coll_init,
+            lib->score_str, score, UCC_CL_TEAM_SIZE(team),
+            ucc_cl_hier_coll_init,
             cl_team, UCC_CL_HIER_DEFAULT_SCORE, NULL);
 
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -171,11 +171,11 @@ ucc_status_t ucc_cl_lib_config_read(ucc_cl_iface_t *iface,
 }
 
 UCC_CLASS_INIT_FUNC(ucc_cl_team_t, ucc_cl_context_t *cl_context,
-                    ucc_team_t *team)
+                    const ucc_base_team_params_t *params)
 {
     UCC_CLASS_CALL_BASE_INIT();
     self->super.context = &cl_context->super;
-    self->super.team    = team;
+    self->super.params  = *params;
     return UCC_OK;
 }
 

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -85,7 +85,8 @@ UCC_CLASS_DECLARE(ucc_cl_context_t, ucc_cl_lib_t *, ucc_context_t *);
 typedef struct ucc_cl_team {
     ucc_base_team_t super;
 } ucc_cl_team_t;
-UCC_CLASS_DECLARE(ucc_cl_team_t, ucc_cl_context_t *, ucc_team_t *);
+UCC_CLASS_DECLARE(ucc_cl_team_t, ucc_cl_context_t *,
+                  const ucc_base_team_params_t *);
 
 typedef struct ucc_cl_lib_attr {
     ucc_base_lib_attr_t       super;
@@ -106,4 +107,9 @@ typedef struct ucc_cl_lib_attr {
     (ucc_derived_of((_cl_team)->super.context->lib, ucc_cl_lib_t))->iface
 
 #define UCC_CL_TEAM_LIB(_cl_team) (_cl_team)->super.super.context->lib
+
+#define UCC_CL_TEAM_SIZE(_cl_team) (_cl_team)->super.super.params.size
+
+#define UCC_CL_TEAM_RANK(_cl_team) (_cl_team)->super.super.params.rank
+
 #endif

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -73,10 +73,7 @@ typedef struct ucc_tl_nccl_team {
     ucc_tl_team_t        super;
     ncclUniqueId        *unique_id;
     void                *oob_req;
-    ucc_team_oob_coll_t  oob;
     ncclComm_t           nccl_comm;
-    ucc_rank_t           rank;
-    ucc_rank_t           size;
     cudaStream_t         stream;
 } ucc_tl_nccl_team_t;
 

--- a/src/components/tl/sharp/tl_sharp.h
+++ b/src/components/tl/sharp/tl_sharp.h
@@ -86,10 +86,7 @@ UCC_CLASS_DECLARE(ucc_tl_sharp_context_t, const ucc_base_context_params_t *,
 typedef struct ucc_tl_sharp_team {
     ucc_tl_team_t          super;
     void                  *oob_req;
-    ucc_team_oob_coll_t    oob;
     struct sharp_coll_comm *sharp_comm;
-    ucc_rank_t             rank;
-    ucc_rank_t             size;
     ucc_tl_sharp_oob_ctx_t oob_ctx;
 } ucc_tl_sharp_team_t;
 

--- a/src/components/tl/sharp/tl_sharp_team.c
+++ b/src/components/tl/sharp/tl_sharp_team.c
@@ -23,17 +23,14 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_team_t, ucc_base_context_t *tl_context,
         return UCC_ERR_INVALID_PARAM;
     }
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params->team);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
 
-    self->oob              = params->params.oob;
-    self->size             = self->oob.n_oob_eps;
-    self->rank             = params->rank;
     self->oob_ctx.ctx      = self;
     self->oob_ctx.ctx_oob  = NULL;
-    self->oob_ctx.team_oob = &self->oob;
+    self->oob_ctx.team_oob = &UCC_TL_TEAM_OOB(self);
 
-    comm_spec.rank              = self->rank;;
-    comm_spec.size              = self->size;
+    comm_spec.rank              = UCC_TL_TEAM_RANK(self);
+    comm_spec.size              = UCC_TL_TEAM_SIZE(self);
     comm_spec.group_world_ranks = NULL;
     comm_spec.oob_ctx           = &self->oob_ctx;
 
@@ -151,7 +148,7 @@ ucc_status_t ucc_tl_sharp_team_get_scores(ucc_base_team_t   *tl_team,
 
     if (strlen(lib->super.super.score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->super.super.score_str, score, team->size,
+            lib->super.super.score_str, score, UCC_TL_TEAM_SIZE(team),
             ucc_tl_sharp_coll_init, &team->super.super,
             UCC_TL_SHARP_DEFAULT_SCORE, NULL);
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -178,11 +178,11 @@ ucc_status_t ucc_tl_team_destroy_multiple(ucc_team_multiple_req_t *req)
 }
 
 UCC_CLASS_INIT_FUNC(ucc_tl_team_t, ucc_tl_context_t *tl_context,
-                    ucc_team_t *team)
+                    const ucc_base_team_params_t *params)
 {
     UCC_CLASS_CALL_BASE_INIT();
     self->super.context = &tl_context->super;
-    self->super.team    = team;
+    self->super.params  = *params;
     return UCC_OK;
 }
 

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -84,7 +84,8 @@ UCC_CLASS_DECLARE(ucc_tl_context_t, ucc_tl_lib_t *, ucc_context_t *);
 typedef struct ucc_tl_team {
     ucc_base_team_t super;
 } ucc_tl_team_t;
-UCC_CLASS_DECLARE(ucc_tl_team_t, ucc_tl_context_t *, ucc_team_t *);
+UCC_CLASS_DECLARE(ucc_tl_team_t, ucc_tl_context_t *,
+                  const ucc_base_team_params_t *);
 
 #define UCC_TL_IFACE_DECLARE(_name, _NAME)                                     \
     UCC_BASE_IFACE_DECLARE(TL_, tl_, _name, _NAME)
@@ -130,4 +131,13 @@ typedef struct ucc_tl_lib_attr {
 
 #define UCC_TL_CTX_OOB(_ctx) ((_ctx)->super.super.ucc_context->params.oob)
 
+#define UCC_TL_TEAM_SIZE(_tl_team) (_tl_team)->super.super.params.size
+
+#define UCC_TL_TEAM_RANK(_tl_team) (_tl_team)->super.super.params.rank
+
+#define UCC_TL_CORE_TEAM(_tl_team) (_tl_team)->super.super.params.team
+
+#define UCC_TL_TEAM_MAP(_tl_team) (_tl_team)->super.super.params.map
+
+#define UCC_TL_TEAM_OOB(_tl_team) (_tl_team)->super.super.params.params.oob
 #endif

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -33,8 +33,8 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_datatype_t         dt         = args->dst.info.datatype;
     size_t                 dt_size    = ucc_dt_size(dt);
     size_t                 data_size  = count * dt_size;
-    ucc_rank_t             size       = team->size;
-    ucc_rank_t             rank       = team->rank;
+    ucc_rank_t             rank       = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t             size       = UCC_TL_TEAM_SIZE(team);
     ucc_rank_t             broot      = 0;
     void                  *sbuf;
     ptrdiff_t              peer_seg_offset, local_seg_offset;
@@ -142,8 +142,8 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_coll_args_t   *args  = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
-    ucc_rank_t         size  = team->size;
-    ucc_rank_t         rank  = team->rank;
+    ucc_rank_t         rank       = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         size       = UCC_TL_TEAM_SIZE(team);
     ucc_kn_radix_t     radix = task->allgather_kn.p.radix;
     ucc_rank_t         broot = 0;
     ucc_status_t       status;
@@ -187,8 +187,8 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_init_r(
     ucc_coll_task_t **task_h, ucc_kn_radix_t radix)
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_rank_t         size    = tl_team->size;
-    ucc_rank_t         rank    = tl_team->rank;
+    ucc_rank_t         rank    = UCC_TL_TEAM_RANK(tl_team);
+    ucc_rank_t         size    = UCC_TL_TEAM_SIZE(tl_team);
     ucc_rank_t         broot   = 0;
     ucc_tl_ucp_task_t *task;
 
@@ -210,7 +210,7 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_init(ucc_base_coll_args_t *coll_args,
                                                ucc_coll_task_t     **task_h)
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_rank_t         size    = tl_team->size;
+    ucc_rank_t         size    = UCC_TL_TEAM_SIZE(tl_team);
     ucc_kn_radix_t     radix;
 
     radix = ucc_min(UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allgather_kn_radix, size);

--- a/src/components/tl/ucp/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv_ring.c
@@ -17,8 +17,8 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task     = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_coll_args_t   *args     = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team     = TASK_TEAM(task);
-    ucc_rank_t         grank    = team->rank;
-    ucc_rank_t         gsize    = team->size;
+    ucc_rank_t         grank    = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         gsize    = UCC_TL_TEAM_SIZE(team);
     ptrdiff_t          rbuf     = (ptrdiff_t)args->dst.info_v.buffer;
     ucc_memory_type_t  rmem     = args->dst.info_v.mem_type;
     size_t             rdt_size = ucc_dt_size(args->dst.info_v.datatype);
@@ -69,7 +69,7 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *coll_task)
     ptrdiff_t          rbuf  = (ptrdiff_t)TASK_ARGS(task).dst.info_v.buffer;
     ucc_memory_type_t  smem  = TASK_ARGS(task).src.info.mem_type;
     ucc_memory_type_t  rmem  = TASK_ARGS(task).dst.info_v.mem_type;
-    ucc_rank_t         grank = team->rank;
+    ucc_rank_t         grank = UCC_TL_TEAM_RANK(team);
     size_t             data_size, data_displ, rdt_size;
     ucc_status_t       status;
 

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -106,7 +106,8 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
 
     ucc_schedule_init(schedule, coll_args, team);
     cfg_radix = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_radix;
-    radix = ucc_knomial_pattern_get_min_radix(cfg_radix, tl_team->size, count);
+    radix = ucc_knomial_pattern_get_min_radix(cfg_radix,
+                                              UCC_TL_TEAM_SIZE(tl_team), count);
 
     /* 1st step of allreduce: knomial reduce_scatter */
     status = ucc_tl_ucp_reduce_scatter_knomial_init_r(&args, team, &task, radix);

--- a/src/components/tl/ucp/alltoall/alltoall_pairwise.c
+++ b/src/components/tl/ucp/alltoall/alltoall_pairwise.c
@@ -31,8 +31,8 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *coll_task)
     ptrdiff_t          rbuf  = (ptrdiff_t)TASK_ARGS(task).dst.info.buffer;
     ucc_memory_type_t  smem  = TASK_ARGS(task).src.info.mem_type;
     ucc_memory_type_t  rmem  = TASK_ARGS(task).dst.info.mem_type;
-    ucc_rank_t         grank = team->rank;
-    ucc_rank_t         gsize = team->size;
+    ucc_rank_t         grank = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         gsize = UCC_TL_TEAM_SIZE(team);
     ucc_rank_t         peer;
     int                polls = 0;
     int                posts, nreqs;

--- a/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
@@ -32,8 +32,8 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
     ptrdiff_t          rbuf  = (ptrdiff_t)TASK_ARGS(task).dst.info_v.buffer;
     ucc_memory_type_t  smem  = TASK_ARGS(task).src.info_v.mem_type;
     ucc_memory_type_t  rmem  = TASK_ARGS(task).dst.info_v.mem_type;
-    ucc_rank_t         grank = team->rank;
-    ucc_rank_t         gsize = team->size;
+    ucc_rank_t         grank = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         gsize = UCC_TL_TEAM_SIZE(team);
     int                polls = 0;
     ucc_rank_t         peer;
     int                posts, nreqs;//, count_stride, displ_stride;
@@ -112,6 +112,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_start(ucc_coll_task_t *coll_task)
 ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task)
 {
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+    ucc_rank_t         size = UCC_TL_TEAM_SIZE(team);
     ucc_coll_args_t   *args = &TASK_ARGS(task);
 
     task->super.post     = ucc_tl_ucp_alltoallv_pairwise_start;
@@ -123,7 +124,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task)
             ucc_tl_ucp_pre_register_mem(
                 team, args->src.info_v.buffer,
                 (ucc_coll_args_get_total_count(args, args->src.info_v.counts,
-                                               team->size) *
+                                               size) *
                  ucc_dt_size(args->src.info_v.datatype)),
                 args->src.info_v.mem_type);
         }
@@ -132,7 +133,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task)
             ucc_tl_ucp_pre_register_mem(
                 team, args->dst.info_v.buffer,
                 (ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
-                                               team->size) *
+                                               size) *
                  ucc_dt_size(args->dst.info_v.datatype)),
                 args->dst.info_v.mem_type);
         }

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -15,11 +15,11 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
-    ucc_rank_t         myrank    = team->rank;
-    ucc_rank_t         team_size = team->size;
+    ucc_rank_t         rank       = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         size       = UCC_TL_TEAM_SIZE(team);
     ucc_rank_t         root      = (uint32_t)TASK_ARGS(task).root;
     uint32_t           radix     = task->bcast_kn.radix;
-    ucc_rank_t         vrank     = (myrank - root + team_size) % team_size;
+    ucc_rank_t         vrank     = (rank - root + size) % size;
     ucc_rank_t         dist      = task->bcast_kn.dist;
     void              *buffer    = TASK_ARGS(task).src.info.buffer;
     ucc_memory_type_t  mtype     = TASK_ARGS(task).src.info.mem_type;
@@ -37,8 +37,8 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
             if (pos == 0) {
                 for (i = radix - 1; i >= 1; i--) {
                     vpeer = vrank + i * dist;
-                    if (vpeer < team_size) {
-                        peer = (vpeer + root) % team_size;
+                    if (vpeer < size) {
+                        peer = (vpeer + root) % size;
                         UCPCHECK_GOTO(ucc_tl_ucp_send_nb(buffer, data_size,
                                                          mtype, peer, team,
                                                          task),
@@ -47,7 +47,7 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
                 }
             } else {
                 vroot_at_level = vrank - pos * dist;
-                root_at_level  = (vroot_at_level + root) % team_size;
+                root_at_level  = (vroot_at_level + root) % size;
                 UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(buffer, data_size, mtype,
                                                  root_at_level, team, task),
                               task, out);
@@ -71,14 +71,15 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+    ucc_rank_t         size = UCC_TL_TEAM_SIZE(team);
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_bcast_kn_start", 0);
     ucc_tl_ucp_task_reset(task);
 
     task->bcast_kn.radix =
-        ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.bcast_kn_radix, team->size);
-    CALC_KN_TREE_DIST(team->size, task->bcast_kn.radix, task->bcast_kn.dist);
+        ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.bcast_kn_radix, size);
+    CALC_KN_TREE_DIST(size, task->bcast_kn.radix, task->bcast_kn.dist);
 
     status = ucc_tl_ucp_bcast_knomial_progress(&task->super);
     if (UCC_INPROGRESS == status) {

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -70,7 +70,8 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
     ucc_kn_radix_t       radix, cfg_radix;
 
     cfg_radix = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.bcast_sag_kn_radix;
-    radix = ucc_knomial_pattern_get_min_radix(cfg_radix, tl_team->size, count);
+    radix = ucc_knomial_pattern_get_min_radix(cfg_radix,
+                                              UCC_TL_TEAM_SIZE(tl_team), count);
 
     /* 1st step of bcast: knomial scatter */
     args.args.dst.info.buffer   = args.args.src.info.buffer;

--- a/src/components/tl/ucp/reduce/reduce.c
+++ b/src/components/tl/ucp/reduce/reduce.c
@@ -14,8 +14,8 @@ ucc_status_t ucc_tl_ucp_reduce_init(ucc_tl_ucp_task_t *task)
 {
     ucc_coll_args_t   *args      = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
-    ucc_rank_t         myrank    = team->rank;
-    ucc_rank_t         team_size = team->size;
+    ucc_rank_t         myrank    = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         team_size = UCC_TL_TEAM_SIZE(team);
     ucc_rank_t         root      = args->root;
     ucc_rank_t         vrank     = (myrank - root + team_size) % team_size;
     ucc_status_t       status    = UCC_OK;
@@ -34,8 +34,8 @@ ucc_status_t ucc_tl_ucp_reduce_init(ucc_tl_ucp_task_t *task)
     task->super.progress  = ucc_tl_ucp_reduce_knomial_progress;
     task->super.finalize  = ucc_tl_ucp_reduce_knomial_finalize;
     task->reduce_kn.radix =
-        ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_kn_radix, team->size);
-    CALC_KN_TREE_DIST(team->size, task->reduce_kn.radix,
+        ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_kn_radix, team_size);
+    CALC_KN_TREE_DIST(team_size, task->reduce_kn.radix,
                       task->reduce_kn.max_dist);
     isleaf = (vrank % task->reduce_kn.radix != 0 || vrank == team_size - 1);
     task->reduce_kn.scratch_mc_header = NULL;

--- a/src/components/tl/ucp/reduce/reduce_knomial.c
+++ b/src/components/tl/ucp/reduce/reduce_knomial.c
@@ -17,16 +17,18 @@
 
 ucc_status_t ucc_tl_ucp_reduce_knomial_progress(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_task_t *task       = ucc_derived_of(coll_task,
+                                                   ucc_tl_ucp_task_t);
     ucc_coll_args_t   *args       = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team       = TASK_TEAM(task);
-    int                avg_pre_op = UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
-    ucc_rank_t         myrank     = team->rank;
-    ucc_rank_t         team_size  = team->size;
+    int                avg_pre_op =
+        UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
+    ucc_rank_t         rank       = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         size       = UCC_TL_TEAM_SIZE(team);
     ucc_rank_t         root       = (ucc_rank_t)args->root;
     uint32_t           radix      = task->reduce_kn.radix;
-    ucc_rank_t         vrank      = (myrank - root + team_size) % team_size;
-    void              *rbuf       = (myrank == root) ? args->dst.info.buffer :
+    ucc_rank_t         vrank      = (rank - root + size) % size;
+    void              *rbuf       = (rank == root) ? args->dst.info.buffer :
                                                       task->reduce_kn.scratch;
     ucc_memory_type_t  mtype;
     ucc_datatype_t     dt;
@@ -37,7 +39,7 @@ ucc_status_t ucc_tl_ucp_reduce_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_status_t       status;
     int                is_avg;
 
-    if (root == myrank) {
+    if (root == rank) {
         count = args->dst.info.count;
         data_size = count * ucc_dt_size(args->dst.info.datatype);
         mtype = args->dst.info.mem_type;
@@ -67,11 +69,11 @@ UCC_REDUCE_KN_PHASE_INIT:
                 task->reduce_kn.children_per_cycle = 0;
                 for (i = 1; i < radix; i++) {
                     vpeer = vrank + i * task->reduce_kn.dist;
-                    if (vpeer >= team_size) {
+                    if (vpeer >= size) {
                     	break;
                     } else {
                         task->reduce_kn.children_per_cycle += 1;
-                        peer = (vpeer + root) % team_size;
+                        peer = (vpeer + root) % size;
                         UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(scratch_offset,
                                           data_size, mtype, peer, team, task),
                                           task, out);
@@ -102,7 +104,7 @@ UCC_REDUCE_KN_PHASE_MULTI:
                 }
             } else {
                 vroot_at_level = vrank - pos * task->reduce_kn.dist;
-                root_at_level  = (vroot_at_level + root) % team_size;
+                root_at_level  = (vroot_at_level + root) % size;
                 UCPCHECK_GOTO(ucc_tl_ucp_send_nb(task->reduce_kn.scratch,
                                   data_size, mtype, root_at_level, team, task),
                                   task, out);
@@ -128,17 +130,17 @@ ucc_status_t ucc_tl_ucp_reduce_knomial_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
     uint32_t           radix     = task->reduce_kn.radix;
     ucc_rank_t         root      = (ucc_rank_t)args->root;
-    ucc_rank_t         myrank    = team->rank;
-    ucc_rank_t         team_size = team->size;
-    ucc_rank_t         vrank     = (myrank - root + team_size) % team_size;
+    ucc_rank_t         rank       = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         size       = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t         vrank     = (rank - root + size) % size;
     int                isleaf    =
-        (vrank % radix != 0 || vrank == team_size - 1);
+        (vrank % radix != 0 || vrank == size - 1);
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_reduce_kn_start", 0);
     ucc_tl_ucp_task_reset(task);
 
-    if (UCC_IS_INPLACE(*args) && (team->rank == root)) {
+    if (UCC_IS_INPLACE(*args) && (rank == root)) {
         args->src.info.buffer = args->dst.info.buffer;
     }
 

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -24,7 +24,8 @@ ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_coll_args_t       *args  = &TASK_ARGS(task);
     ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
     ucc_kn_radix_t         radix = task->reduce_scatter_kn.p.radix;
-    int                    avg_pre_op = UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
+    int                    avg_pre_op =
+        UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
     uint8_t                node_type  = task->reduce_scatter_kn.p.node_type;
     ucc_knomial_pattern_t *p          = &task->reduce_scatter_kn.p;
     void                  *scratch    = task->reduce_scatter_kn.scratch;
@@ -36,8 +37,8 @@ ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
         rbuf : args->src.info.buffer;
     size_t                 dt_size    = ucc_dt_size(dt);
     size_t                 data_size  = count * dt_size;
-    ucc_rank_t             size       = team->size;
-    ucc_rank_t             rank       = team->rank;
+    ucc_rank_t             rank       = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t             size       = UCC_TL_TEAM_SIZE(team);
     ptrdiff_t              peer_seg_offset, local_seg_offset, offset;
     ucc_rank_t             peer, step_radix, peer_seg_index, local_seg_index;
     ucc_status_t           status;
@@ -186,6 +187,8 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_coll_args_t   *args = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+    ucc_rank_t         rank = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         size = UCC_TL_TEAM_SIZE(team);
     ucc_status_t       status;
     uint8_t            node_type;
 
@@ -193,8 +196,7 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
                                      0);
     ucc_tl_ucp_task_reset(task);
 
-    ucc_knomial_pattern_init(team->size, team->rank,
-                             task->reduce_scatter_kn.p.radix,
+    ucc_knomial_pattern_init(size, rank, task->reduce_scatter_kn.p.radix,
                              &task->reduce_scatter_kn.p);
     node_type = task->reduce_scatter_kn.p.node_type;
     if (!(UCC_IS_INPLACE(*args) || (KN_NODE_PROXY == node_type))) {
@@ -227,8 +229,8 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
     ucc_coll_task_t **task_h, ucc_kn_radix_t radix)
 {
     ucc_tl_ucp_team_t *tl_team   = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_rank_t         size      = tl_team->size;
-    ucc_rank_t         rank      = tl_team->rank;
+    ucc_rank_t         rank      = UCC_TL_TEAM_RANK(tl_team);
+    ucc_rank_t         size      = UCC_TL_TEAM_SIZE(tl_team);
     size_t             count     = coll_args->args.dst.info.count;
     ucc_datatype_t     dt        = coll_args->args.dst.info.datatype;
     size_t             dt_size   = ucc_dt_size(dt);
@@ -267,7 +269,7 @@ ucc_tl_ucp_reduce_scatter_knomial_init(ucc_base_coll_args_t *coll_args,
                                        ucc_coll_task_t **    task_h)
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_rank_t         size    = tl_team->size;
+    ucc_rank_t         size    = UCC_TL_TEAM_SIZE(tl_team);
     size_t             count   = coll_args->args.dst.info.count;
     ucc_kn_radix_t     radix, cfg_radix;
 

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -91,14 +91,8 @@ typedef struct ucc_tl_ucp_task ucc_tl_ucp_task_t;
 typedef struct ucc_tl_ucp_team {
     ucc_tl_team_t              super;
     ucc_status_t               status;
-    ucc_rank_t                 size;
-    ucc_rank_t                 rank;
-    uint32_t                   id;
-    uint32_t                   scope;
-    uint32_t                   scope_id;
     uint32_t                   seq_num;
     ucc_tl_ucp_task_t         *preconnect_task;
-    ucc_ep_map_t               map; /*< map to the core ucc team */
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
@@ -122,7 +116,7 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
 
 #define UCC_TL_CTX_OOB(_ctx) ((_ctx)->super.super.ucc_context->params.oob)
 
-#define IS_SERVICE_TEAM(_team) ((_team)->scope == UCC_CL_LAST + 1)
+#define IS_SERVICE_TEAM(_team) ((_team)->super.super.params.scope == UCC_CL_LAST + 1)
 
 
 void ucc_tl_ucp_pre_register_mem(ucc_tl_ucp_team_t *team, void *addr,

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -112,8 +112,8 @@ static inline ucc_tl_ucp_task_t *ucc_tl_ucp_get_task(ucc_tl_ucp_team_t *team)
     task->n_polls            = ctx->cfg.n_polls;
     task->super.team         = &team->super.super;
     task->subset.map.type    = UCC_EP_MAP_FULL;
-    task->subset.map.ep_num  = team->size;
-    task->subset.myrank      = team->rank;
+    task->subset.map.ep_num  = UCC_TL_TEAM_SIZE(team);
+    task->subset.myrank      = UCC_TL_TEAM_RANK(team);
     ucc_tl_ucp_task_reset(task);
     return task;
 }

--- a/src/components/tl/ucp/tl_ucp_ep.c
+++ b/src/components/tl/ucp/tl_ucp_ep.c
@@ -45,7 +45,7 @@ ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t *team,
     ucc_tl_ucp_context_t *ctx = UCC_TL_UCP_TEAM_CTX(team);
     void                 *addr;
 
-    addr = ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), team->super.super.team,
+    addr = ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), UCC_TL_CORE_TEAM(team),
                                 core_rank, ucc_tl_ucp.super.super.id);
     return ucc_tl_ucp_connect_ep(ctx, ep, addr);
 }

--- a/src/components/tl/ucp/tl_ucp_ep.h
+++ b/src/components/tl/ucp/tl_ucp_ep.h
@@ -25,7 +25,7 @@ static inline ucc_context_addr_header_t *
 ucc_tl_ucp_get_team_ep_header(ucc_tl_ucp_team_t *team, ucc_rank_t core_rank)
 
 {
-    return ucc_get_team_ep_header(UCC_TL_CORE_CTX(team), team->super.super.team,
+    return ucc_get_team_ep_header(UCC_TL_CORE_CTX(team), UCC_TL_CORE_TEAM(team),
                                   core_rank);
 }
 
@@ -38,14 +38,13 @@ static inline ucc_status_t ucc_tl_ucp_get_ep(ucc_tl_ucp_team_t *team, ucc_rank_t
     ucc_status_t               status;
     ucc_rank_t                 core_rank;
 
-    core_rank = ucc_ep_map_eval(team->map, rank);
+    core_rank = ucc_ep_map_eval(UCC_TL_TEAM_MAP(team), rank);
     if (ctx->eps) {
+        ucc_team_t *core_team = UCC_TL_CORE_TEAM(team);
         /* Core super.super.team ptr is NULL for service_team
            which has scope == UCC_CL_LAST + 1*/
-        ucc_assert((NULL != team->super.super.team) ||
-                   IS_SERVICE_TEAM(team));
-        ctx_rank = team->super.super.team
-                       ? ucc_get_ctx_rank(team->super.super.team, core_rank)
+        ucc_assert((NULL != core_team) || IS_SERVICE_TEAM(team));
+        ctx_rank = core_team ? ucc_get_ctx_rank(core_team, core_rank)
                        : core_rank;
         *ep      = ctx->eps[ctx_rank];
     } else {

--- a/src/components/tl/ucp/tl_ucp_reduce.h
+++ b/src/components/tl/ucp/tl_ucp_reduce.h
@@ -18,7 +18,7 @@ ucc_tl_ucp_reduce_multi(void *src1, void *src2, void *dst, size_t n_vectors,
     if (is_avg) {
         return ucc_dt_reduce_multi_alpha(
             src1, src2, dst, n_vectors, count, stride, dt, UCC_OP_PROD,
-            (double)1 / (double)TASK_TEAM(task)->size, mem_type,
+            (double)1 / (double)UCC_TL_TEAM_SIZE(TASK_TEAM(task)), mem_type,
             &TASK_ARGS(task));
     }
     return ucc_dt_reduce_multi(src1, src2, dst, n_vectors, count, stride,

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -49,7 +49,7 @@ void ucc_tl_ucp_recv_completion_cb(void *request, ucs_status_t status,
         if (ucc_unlikely(UCS_PTR_IS_ERR(ucp_status))) {                        \
             tl_error(UCC_TL_TEAM_LIB(team),                                    \
                      "tag %u; dest %d; team_id %u; errmsg %s", task->tag,      \
-                     dest_group_rank, team->id,                                \
+                     dest_group_rank, team->super.super.params.id,             \
                      ucs_status_string(UCS_PTR_STATUS(ucp_status)));           \
             ucp_request_cancel(UCC_TL_UCP_WORKER(team), ucp_status);           \
             ucp_request_free(ucp_status);                                      \
@@ -73,8 +73,10 @@ static inline ucc_status_t ucc_tl_ucp_send_nb(void *buffer, size_t msglen,
     if (ucc_unlikely(UCC_OK != status)) {
         return status;
     }
-    ucp_tag = UCC_TL_UCP_MAKE_SEND_TAG(task->tag, team->rank, team->id,
-                                       team->scope_id, team->scope);
+    ucp_tag = UCC_TL_UCP_MAKE_SEND_TAG(task->tag, UCC_TL_TEAM_RANK(team),
+                                       team->super.super.params.id,
+                                       team->super.super.params.scope_id,
+                                       team->super.super.params.scope);
     req_param.op_attr_mask =
         UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_DATATYPE |
         UCP_OP_ATTR_FIELD_USER_DATA | UCP_OP_ATTR_FIELD_MEMORY_TYPE;
@@ -103,7 +105,9 @@ static inline ucc_status_t ucc_tl_ucp_recv_nb(void *buffer, size_t msglen,
     ucp_tag_t           ucp_tag, ucp_tag_mask;
 
     UCC_TL_UCP_MAKE_RECV_TAG(ucp_tag, ucp_tag_mask, task->tag, dest_group_rank,
-                             team->id, team->scope_id, team->scope);
+                             team->super.super.params.id,
+                             team->super.super.params.scope_id,
+                             team->super.super.params.scope);
     req_param.op_attr_mask =
         UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_DATATYPE |
         UCP_OP_ATTR_FIELD_USER_DATA | UCP_OP_ATTR_FIELD_MEMORY_TYPE;

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -119,5 +119,6 @@ free_task:
 
 void ucc_tl_ucp_service_update_id(ucc_base_team_t *team, uint16_t id) {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    tl_team->id                = id;
+
+    tl_team->super.super.params.id  = id;
 }

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -615,6 +615,7 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
                 t_params.params.ep_range = UCC_COLLECTIVE_EP_RANGE_CONTIG;
                 t_params.params.ep       = ctx->rank;
                 t_params.rank            = ctx->rank;
+                t_params.size            = ctx->params.oob.n_oob_eps;
                 /* CORE scope id - never overlaps with CL type */
                 t_params.scope    = UCC_CL_LAST + 1;
                 t_params.scope_id = 0;

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -56,6 +56,7 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
         return UCC_ERR_NO_MEMORY;
     }
     team->bp.rank                 = team->rank;
+    team->bp.size                 = team->size;
     team->bp.team                 = team;
     team->bp.map.type             = UCC_EP_MAP_FULL;
     team->state                   = UCC_TEAM_ADDR_EXCHANGE;


### PR DESCRIPTION
## What
Cache common params on base_team struct so it is available outside
of TL as well. Additionally remove redundancy in different
TLs. E.g., stuff like "rank, size, map, scope, oob" - all TLs used
to cache it inside ucc_tl_<name>_t struct. Now it is all stored in
base_team. 

## Why ?
Allows different UCC frameworks (e.g. future TOPO framework) to access basic information about TL team (base_team): size, rank, map to ctx, etc. Removes redundant caching at TL levels.


