### PR TITLE
TL/NCCL: fix completed event

### DIFF
--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -74,7 +74,7 @@ typedef struct ucc_mc_cuda {
     ucc_mc_cuda_task_post_fn       post_strm_task;
 } ucc_mc_cuda_t;
 
-typedef struct ucc_cuda_mc_event {
+typedef struct ucc_mc_cuda_event {
     cudaEvent_t    event;
 } ucc_mc_cuda_event_t;
 

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -84,7 +84,7 @@ typedef struct ucc_tl_nccl_task {
     ucc_coll_task_t     super;
     ucc_status_t        host_status;
     ucc_status_t       *dev_status;
-    cudaEvent_t         completed;
+    void               *completed;
 } ucc_tl_nccl_task_t;
 
 #define TASK_TEAM(_task)                                                       \

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -177,8 +177,7 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
     task->super.triggered_post = ucc_tl_nccl_triggered_post;
     task->completed            = NULL;
     if (nccl_ctx->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT) {
-        status = ucc_mc_ee_create_event((void **)&task->completed,
-                                         UCC_EE_CUDA_STREAM);
+        status = ucc_mc_ee_create_event(&task->completed, UCC_EE_CUDA_STREAM);
         if (ucc_unlikely(status != UCC_OK)) {
             goto free_task;
         }


### PR DESCRIPTION
## What
Change type of completed event

## Why ?
ucc_mc_ee_create_event returns ucc_mc_cuda_event_t, not cudaEvent_t
