### PR TITLE
TL/CUDA: implement tl cuda

### DIFF
--- a/config/m4/configure.m4
+++ b/config/m4/configure.m4
@@ -7,11 +7,12 @@ AC_DEFUN([ENABLE_MODULE_PROFILING],
 [
     AS_IF([test "x$with_profiling" = xall],
         [
-            prof_modules=":core:mc:tl_ucp:tl_nccl:tl_sharp:cl_hier"
+            prof_modules=":core:mc:tl_ucp:tl_nccl:tl_sharp:cl_hier:tl_cuda"
             AC_DEFINE([HAVE_PROFILING_CORE], [1], [Enable profiling for CORE])
             AC_DEFINE([HAVE_PROFILING_TL_UCP], [1], [Enable profiling for TL UCP])
             AC_DEFINE([HAVE_PROFILING_TL_NCCL], [1], [Enable profiling for TL NCCL])
             AC_DEFINE([HAVE_PROFILING_TL_SHARP], [1], [Enable profiling for TL SHARP])
+            AC_DEFINE([HAVE_PROFILING_TL_CUDA], [1], [Enable profiling for TL CUDA])
             AC_DEFINE([HAVE_PROFILING_CL_HIER], [1], [Enable profiling for CL HIER])
             AC_DEFINE([HAVE_PROFILING_MC], [1], [Enable profiling for MC])
         ],
@@ -50,6 +51,12 @@ AC_DEFUN([ENABLE_MODULE_PROFILING],
             *cl_hier*)
                 prof_modules="${prof_modules}:cl_hier"
                 AC_DEFINE([HAVE_PROFILING_CL_HIER], [1], [Enable profiling for CL HIER])
+                ;;
+            esac
+            case $1 in
+            *tl_cuda*)
+                prof_modules="${prof_modules}:tl_cuda"
+                AC_DEFINE([HAVE_PROFILING_TL_CUDA], [1], [Enable profiling for TL CUDA])
                 ;;
             esac
         ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,6 +64,7 @@ noinst_HEADERS =                      \
 	utils/profile/ucc_profile_on.h    \
 	utils/profile/ucc_profile_off.h   \
 	utils/ucc_time.h                  \
+	utils/ucc_sys.h                   \
 	components/base/ucc_base_iface.h  \
 	components/cl/ucc_cl.h            \
 	components/cl/ucc_cl_log.h        \
@@ -105,6 +106,7 @@ libucc_la_SOURCES =                   \
 	utils/ucc_coll_utils.c            \
 	utils/ucc_parser.c                \
 	utils/profile/ucc_profile.c       \
+	utils/ucc_sys.c                   \
 	components/base/ucc_base_iface.c  \
 	components/cl/ucc_cl.c            \
 	components/tl/ucc_tl.c            \

--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -16,6 +16,7 @@ sources =             \
 	tl_cuda_team.c    \
 	tl_cuda_coll.c    \
 	tl_cuda_cache.c   \
+	tl_cuda_topo.c    \
 	$(alltoall)
 
 module_LTLIBRARIES = libucc_tl_cuda.la

--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -1,0 +1,30 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+
+if TL_CUDA_ENABLED
+alltoall =                       \
+	alltoall/alltoall.h          \
+	alltoall/alltoall.c          \
+	alltoall/alltoall_ce.c
+
+sources =             \
+	tl_cuda.h         \
+	tl_cuda.c         \
+	tl_cuda_lib.c     \
+	tl_cuda_context.c \
+	tl_cuda_team.c    \
+	tl_cuda_coll.c    \
+	tl_cuda_cache.c   \
+	$(alltoall)
+
+module_LTLIBRARIES = libucc_tl_cuda.la
+libucc_tl_cuda_la_SOURCES  = $(sources)
+libucc_tl_cuda_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
+libucc_tl_cuda_la_CFLAGS   = $(BASE_CFLAGS)
+libucc_tl_cuda_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLAGS)
+libucc_tl_cuda_la_LIBADD   = $(CUDA_LIBS) $(UCC_TOP_BUILDDIR)/src/libucc.la
+
+include $(top_srcdir)/config/module.am
+
+endif

--- a/src/components/tl/cuda/alltoall/alltoall.c
+++ b/src/components/tl/cuda/alltoall/alltoall.c
@@ -7,6 +7,8 @@
 #include "alltoall.h"
 #include "core/ucc_mc.h"
 
+ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task);
+
 ucc_status_t ucc_tl_cuda_alltoall_ce_start(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_cuda_alltoall_ce_progress(ucc_coll_task_t *task);
@@ -25,15 +27,10 @@ ucc_status_t ucc_tl_cuda_alltoall_init(ucc_base_coll_args_t *coll_args,
         return UCC_ERR_NO_MEMORY;
     }
 
-    status = ucc_mc_ee_create_event((void**)&task->alltoall_ce.copy_done,
-                                    UCC_EE_CUDA_STREAM);
+    status = ucc_tl_cuda_alltoall_ce_init(task);
     if (ucc_unlikely(status != UCC_OK)) {
         goto free_task;
     }
-
-    task->super.post     = ucc_tl_cuda_alltoall_ce_start;
-    task->super.progress = ucc_tl_cuda_alltoall_ce_progress;
-    task->super.finalize = ucc_tl_cuda_alltoall_ce_finalize;
 
     *task_p = &task->super;
     return UCC_OK;

--- a/src/components/tl/cuda/alltoall/alltoall.c
+++ b/src/components/tl/cuda/alltoall/alltoall.c
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "alltoall.h"
+#include "core/ucc_mc.h"
+
+ucc_status_t ucc_tl_cuda_alltoall_ce_start(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_cuda_alltoall_ce_progress(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_cuda_alltoall_ce_finalize(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_cuda_alltoall_init(ucc_base_coll_args_t *coll_args,
+                                       ucc_base_team_t *tl_team,
+                                       ucc_coll_task_t **task_p)
+{
+    ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
+    ucc_tl_cuda_task_t *task = ucc_tl_cuda_task_init(coll_args, team);
+    ucc_status_t status;
+
+    if (ucc_unlikely(!task)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    status = ucc_mc_ee_create_event((void**)&task->alltoall_ce.copy_done,
+                                    UCC_EE_CUDA_STREAM);
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto free_task;
+    }
+
+    task->super.post     = ucc_tl_cuda_alltoall_ce_start;
+    task->super.progress = ucc_tl_cuda_alltoall_ce_progress;
+    task->super.finalize = ucc_tl_cuda_alltoall_ce_finalize;
+
+    *task_p = &task->super;
+    return UCC_OK;
+
+free_task:
+    ucc_tl_cuda_task_put(task);
+    return status;
+}

--- a/src/components/tl/cuda/alltoall/alltoall.h
+++ b/src/components/tl/cuda/alltoall/alltoall.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef ALLTOALL_H_
+#define ALLTOALL_H_
+
+#include "../tl_cuda.h"
+#include "../tl_cuda_coll.h"
+
+ucc_status_t ucc_tl_cuda_alltoall_init(ucc_base_coll_args_t *coll_args,
+                                       ucc_base_team_t *tl_team,
+                                       ucc_coll_task_t **task_p);
+
+#endif

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -1,0 +1,181 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "alltoall.h"
+#include "core/ucc_mc.h"
+#include "tl_cuda_cache.h"
+
+ucc_status_t ucc_tl_cuda_alltoall_ce_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+
+    tl_trace(UCC_TASK_LIB(task), "finalizing task %p", task);
+    ucc_mc_ee_destroy_event((void*)task->alltoall_ce.copy_done,
+                            UCC_EE_CUDA_STREAM);
+    ucc_tl_cuda_task_put(task);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_cuda_alltoall_ce_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_cuda_task_t *task   = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+    ucc_tl_cuda_team_t *team   = TASK_TEAM(task);
+    ucc_tl_cuda_sync_t *sync   = TASK_SYNC(task, team->rank);
+    ucc_rank_t          n_done = 0;
+    ucc_tl_cuda_sync_t *peer_sync;
+    ucc_status_t        status;
+    ucc_rank_t          i;
+
+    status = ucc_mc_ee_event_test(task->alltoall_ce.copy_done,
+                                  UCC_EE_CUDA_STREAM);
+    if (status != UCC_OK) {
+        task->super.super.status = status;
+        goto exit;
+    }
+    sync->seq_num[1] = task->seq_num;
+    __sync_synchronize();
+    asm volatile("": : :"memory");
+    for (i = 0; i < team->size; i++) {
+        peer_sync = TASK_SYNC(task, i);
+        if (peer_sync->seq_num[1] == task->seq_num) {
+            n_done++;
+        }
+    }
+    task->super.super.status = UCC_INPROGRESS;
+    if (n_done == team->size) {
+        task->super.super.status = UCC_OK;
+    }
+exit:
+    return task->super.super.status;
+}
+
+ucc_status_t ucc_tl_cuda_alltoall_setup(ucc_tl_cuda_task_t *task)
+{
+    ucc_tl_cuda_team_t          *team = TASK_TEAM(task);
+    ucc_coll_args_t             *args = &TASK_ARGS(task);
+    ucc_tl_cuda_sync_t          *sync = TASK_SYNC(task, team->rank);
+    volatile ucc_tl_cuda_sync_t *peer_sync;
+    ucc_tl_cuda_cache_t         *cache;
+    ucc_mem_attr_t               mem_attr;
+    ucc_status_t                 status;
+    size_t                       data_len;
+    ucc_rank_t                   i;
+
+    data_len = ucc_dt_size(args->src.info.datatype) * args->src.info.count;
+    mem_attr.field_mask   = UCC_MEM_ATTR_FIELD_BASE_ADDRESS |
+                            UCC_MEM_ATTR_FIELD_ALLOC_LENGTH;
+    mem_attr.alloc_length = data_len;
+    status = ucc_mc_get_mem_attr(args->src.info.buffer, &mem_attr);
+    if (ucc_unlikely(status != UCC_OK)) {
+        return status;
+    }
+    sync->ptr    = mem_attr.base_address;
+    sync->length = mem_attr.alloc_length;
+    sync->offset = (ptrdiff_t)args->src.info.buffer - (ptrdiff_t)sync->ptr;
+    CUDACHECK_GOTO(cudaIpcGetMemHandle((cudaIpcMemHandle_t*)&sync->handle,
+                                       sync->ptr),
+                   exit_err, status, UCC_TL_TEAM_LIB(team));
+    CUDACHECK_GOTO(cudaEventRecord(sync->ipc_event_local, team->stream),
+                   exit_err, status, UCC_TL_TEAM_LIB(team));
+    __sync_synchronize();
+    asm volatile("": : :"memory");
+    sync->seq_num[0] = task->seq_num;
+    for (i = 0; i < team->size; i++) {
+        peer_sync = TASK_SYNC(task, i);
+        while (peer_sync->seq_num[0] != task->seq_num);
+    }
+
+    for (i = 0; i < team->size; i++) {
+        if (i == team->rank) {
+            continue;
+        }
+        peer_sync = TASK_SYNC(task, i);
+        cache = ucc_tl_cuda_get_cache(team, i);
+        if (ucc_unlikely(!cache)) {
+            status = UCC_ERR_NO_MESSAGE;
+            goto exit_err;
+        }
+        status = ucc_tl_cuda_map_memhandle(peer_sync->ptr, peer_sync->length,
+                                           peer_sync->handle,
+                                           &task->alltoall_ce.peer_map_addr[i],
+                                           cache);
+        if (UCC_OK != status) {
+            ucc_error("ucc_cuda_ipc_map_memhandle failed");
+            return UCC_ERR_INVALID_PARAM;
+        }
+    }
+    return UCC_OK;
+
+exit_err:
+    return status;
+}
+
+static ucc_status_t ucc_tl_cuda_alltoall_ce_post_copies(ucc_tl_cuda_task_t *task)
+{
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_coll_args_t    *args = &TASK_ARGS(task);
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, team->rank);
+    ucc_tl_cuda_sync_t *peer_sync;
+    size_t send_len;
+    ucc_rank_t i, peer;
+    void *src, *dst;
+    ucc_status_t status;
+
+    send_len = (args->src.info.count / team->size) *
+               ucc_dt_size(args->src.info.datatype);
+    for (i = 0; i < team->size; i++) {
+        peer = (team->rank + i) % team->size;
+        peer_sync = TASK_SYNC(task, peer);
+        if (peer == team->rank) {
+            src = args->src.info.buffer;
+        } else {
+            src = PTR_OFFSET(task->alltoall_ce.peer_map_addr[peer],
+                             peer_sync->offset);
+            CUDACHECK_GOTO(cudaStreamWaitEvent(team->stream,
+                                               sync->data[peer].ipc_event_remote,
+                                               0),
+                           exit, status, UCC_TASK_LIB(task));
+        }
+        src = PTR_OFFSET(src, team->rank * send_len);
+        dst = PTR_OFFSET(args->dst.info.buffer, peer * send_len);
+        CUDACHECK_GOTO(cudaMemcpyAsync(dst, src, send_len, cudaMemcpyDeviceToDevice,
+                                       team->stream),
+                       exit, status, UCC_TASK_LIB(task));
+    }
+
+    status = ucc_mc_ee_event_post(team->stream, task->alltoall_ce.copy_done,
+                                  UCC_EE_CUDA_STREAM);
+exit:
+    return status;
+
+}
+
+ucc_status_t ucc_tl_cuda_alltoall_ce_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_status_t status;
+
+    status = ucc_tl_cuda_alltoall_setup(task);
+    if (ucc_unlikely(status != UCC_OK)) {
+        task->super.super.status = status;
+        goto exit;
+    }
+
+    status = ucc_tl_cuda_alltoall_ce_post_copies(task);
+    if (ucc_unlikely(status != UCC_OK)) {
+        task->super.super.status = status;
+        goto exit;
+    }
+
+    ucc_tl_cuda_alltoall_ce_progress(coll_task);
+    if (task->super.super.status == UCC_INPROGRESS) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+        return UCC_OK;
+    }
+exit:
+    return ucc_task_complete(coll_task);
+}

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -8,6 +8,7 @@
 #include "core/ucc_mc.h"
 #include "tl_cuda_cache.h"
 #include "tl_cuda_topo.h"
+#include "utils/arch/cpu.h"
 
 enum {
     ALLTOALL_CE_STAGE_SYNC, /*< Wait for free SYNC segment */
@@ -42,6 +43,7 @@ ucc_status_t ucc_tl_cuda_alltoall_setup(ucc_tl_cuda_task_t *task)
 
     CUDACHECK_GOTO(cudaEventRecord(sync->ipc_event_local, team->stream),
                    exit_err, status, UCC_TL_TEAM_LIB(team));
+    ucc_memory_bus_fence();
     status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -28,7 +28,7 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_finalize(ucc_coll_task_t *coll_task)
 ucc_status_t ucc_tl_cuda_alltoall_setup(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t          *team = TASK_TEAM(task);
-    ucc_tl_cuda_sync_t          *sync = TASK_SYNC(task, team->rank);
+    ucc_tl_cuda_sync_t          *sync = TASK_SYNC(task, UCC_TL_TEAM_RANK(team));
     volatile ucc_tl_cuda_sync_t *peer_sync;
     ucc_tl_cuda_cache_t         *cache;
     ucc_status_t                 status;
@@ -41,17 +41,18 @@ ucc_status_t ucc_tl_cuda_alltoall_setup(ucc_tl_cuda_task_t *task)
            sizeof(cudaIpcMemHandle_t));
     CUDACHECK_GOTO(cudaEventRecord(sync->ipc_event_local, team->stream),
                    exit_err, status, UCC_TL_TEAM_LIB(team));
-    status = ucc_tl_cuda_shm_barrier_start(team->rank, task->bar);
+    status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;
     }
-    while (ucc_tl_cuda_shm_barrier_test(team->rank, task->bar) == UCC_INPROGRESS);
+    while (ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team), task->bar) ==
+           UCC_INPROGRESS);
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;
     }
 
-    for (i = 0; i < team->size; i++) {
-        if (i == team->rank) {
+    for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
+        if (i == UCC_TL_TEAM_RANK(team)) {
             continue;
         }
         peer_sync = TASK_SYNC(task, i);
@@ -79,19 +80,19 @@ static ucc_status_t ucc_tl_cuda_alltoall_ce_post_copies(ucc_tl_cuda_task_t *task
 {
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
     ucc_coll_args_t    *args = &TASK_ARGS(task);
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, team->rank);
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, UCC_TL_TEAM_RANK(team));
     ucc_tl_cuda_sync_t *peer_sync;
     size_t send_len;
     ucc_rank_t i, peer;
     void *src, *dst;
     ucc_status_t status;
 
-    send_len = (args->src.info.count / team->size) *
+    send_len = (args->src.info.count / UCC_TL_TEAM_SIZE(team)) *
                ucc_dt_size(args->src.info.datatype);
-    for (i = 0; i < team->size; i++) {
-        peer = (team->rank + i) % team->size;
+    for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
+        peer = (UCC_TL_TEAM_RANK(team) + i) % UCC_TL_TEAM_SIZE(team);
         peer_sync = TASK_SYNC(task, peer);
-        if (peer == team->rank) {
+        if (peer == UCC_TL_TEAM_RANK(team)) {
             src = args->src.info.buffer;
         } else {
             src = PTR_OFFSET(task->alltoall_ce.peer_map_addr[peer],
@@ -101,7 +102,7 @@ static ucc_status_t ucc_tl_cuda_alltoall_ce_post_copies(ucc_tl_cuda_task_t *task
                                                0),
                            exit, status, UCC_TASK_LIB(task));
         }
-        src = PTR_OFFSET(src, team->rank * send_len);
+        src = PTR_OFFSET(src, UCC_TL_TEAM_RANK(team) * send_len);
         dst = PTR_OFFSET(args->dst.info.buffer, peer * send_len);
         CUDACHECK_GOTO(cudaMemcpyAsync(dst, src, send_len,
                                        cudaMemcpyDeviceToDevice, team->stream),
@@ -119,7 +120,7 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, team->rank);
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, UCC_TL_TEAM_RANK(team));
     ucc_status_t        status;
 
     if (task->alltoall_ce.stage == ALLTOALL_CE_STAGE_SYNC) {
@@ -147,14 +148,14 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_progress(ucc_coll_task_t *coll_task)
             task->super.super.status = status;
             return task->super.super.status;
         }
-        status = ucc_tl_cuda_shm_barrier_start(team->rank, task->bar);
+        status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
         if (ucc_unlikely(status != UCC_OK)) {
             task->super.super.status = status;
             return task->super.super.status;
         }
         task->alltoall_ce.stage = ALLTOALL_CE_STAGE_BAR;
     }
-    task->super.super.status = ucc_tl_cuda_shm_barrier_test(team->rank,
+    task->super.super.status = ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team),
                                                             task->bar);
     return task->super.super.status;
 }

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -120,11 +120,10 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, UCC_TL_TEAM_RANK(team));
     ucc_status_t        status;
 
     if (task->alltoall_ce.stage == ALLTOALL_CE_STAGE_SYNC) {
-        if (sync->seq_num[0] != task->seq_num) {
+        if (ucc_tl_cuda_get_sync(task) != UCC_OK) {
             task->super.super.status = UCC_INPROGRESS;
             return task->super.super.status;
         }
@@ -157,6 +156,9 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_progress(ucc_coll_task_t *coll_task)
     }
     task->super.super.status = ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team),
                                                             task->bar);
+    if (task->super.super.status == UCC_OK) {
+        ucc_tl_cuda_put_sync(task);
+    }
     return task->super.super.status;
 }
 

--- a/src/components/tl/cuda/configure.m4
+++ b/src/components/tl/cuda/configure.m4
@@ -1,0 +1,16 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+#
+
+tl_cuda_enabled=n
+CHECK_TLS_REQUIRED(["cuda"])
+AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
+[
+    if test $cuda_happy = "yes"; then
+       tl_modules="${tl_modules}:cuda"
+       tl_cuda_enabled=y
+    fi
+], [])
+
+AM_CONDITIONAL([TL_CUDA_ENABLED], [test "$tl_cuda_enabled" = "y"])
+AC_CONFIG_FILES([src/components/tl/cuda/Makefile])

--- a/src/components/tl/cuda/tl_cuda.c
+++ b/src/components/tl/cuda/tl_cuda.c
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_cuda.h"
+#include "core/ucc_team.h"
+#include "components/mc/base/ucc_mc_base.h"
+
+static ucc_config_field_t ucc_tl_cuda_lib_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_tl_cuda_lib_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)},
+
+    {"MAX_CONCURRENT", "8",
+     "Maximum number of outstanding colls",
+     ucc_offsetof(ucc_tl_cuda_lib_config_t, max_concurrent),
+     UCC_CONFIG_TYPE_UINT},
+
+    {NULL}};
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_cuda_lib_t, ucc_base_lib_t,
+                          const ucc_base_lib_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_cuda_lib_t, ucc_base_lib_t);
+
+ucc_status_t ucc_tl_cuda_get_lib_attr(const ucc_base_lib_t *lib,
+                                      ucc_base_lib_attr_t *base_attr);
+
+static ucs_config_field_t ucc_tl_cuda_context_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_tl_cuda_context_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_tl_context_config_table)},
+
+    {NULL}};
+
+ucc_status_t ucc_tl_cuda_get_context_attr(const ucc_base_context_t *context,
+                                          ucc_base_ctx_attr_t *base_attr);
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_cuda_context_t, ucc_base_context_t,
+                          const ucc_base_context_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_cuda_context_t, ucc_base_context_t);
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_cuda_team_t, ucc_base_team_t,
+                          ucc_base_context_t *, const ucc_base_team_params_t *);
+
+ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team);
+
+ucc_status_t ucc_tl_cuda_team_destroy(ucc_base_team_t *tl_team);
+
+ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
+                                   ucc_base_team_t *team,
+                                   ucc_coll_task_t **task);
+
+ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t   *tl_team,
+                                         ucc_coll_score_t **score_p);
+
+UCC_TL_IFACE_DECLARE(cuda, CUDA);

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -31,8 +31,8 @@
     ({                                                                         \
         size_t _ctrl_size_rank = (sizeof(ucc_tl_cuda_sync_t)  +                \
                                   sizeof(ucc_tl_cuda_sync_data_t) *            \
-                                  ((_team)->size - 1)) ;                       \
-        size_t _ctrl_size = _ctrl_size_rank * (_team)->size;                   \
+                                  (UCC_TL_TEAM_SIZE(_team) - 1)) ;             \
+        size_t _ctrl_size = _ctrl_size_rank * UCC_TL_TEAM_SIZE(_team);         \
         void *_sync = PTR_OFFSET(_team->sync, _ctrl_size * (_id) +             \
                                  _ctrl_size_rank * (_rank));                   \
         (ucc_tl_cuda_sync_t*)_sync;                                            \
@@ -143,8 +143,6 @@ typedef struct ucc_tl_cuda_sync {
 
 typedef struct ucc_tl_cuda_team {
     ucc_tl_team_t              super;
-    ucc_rank_t                 rank;
-    ucc_rank_t                 size;
     uint32_t                   seq_num;
     ucc_tl_cuda_sync_t        *sync;
     ucc_tl_cuda_shm_barrier_t *bar;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -106,11 +106,14 @@ typedef struct ucc_tl_cuda_context {
 UCC_CLASS_DECLARE(ucc_tl_cuda_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
 
+typedef uint32_t ucc_tl_cuda_sync_state_t;
+
 typedef struct ucc_tl_cuda_shm_barrier {
-    ucc_rank_t size;
-    ucc_rank_t count;
-    int        sense;
-    int        local_sense[UCC_TL_CUDA_MAX_PEERS];
+    ucc_rank_t   size;
+    ucc_rank_t   count;
+    int          sense;
+    ucc_status_t state[UCC_TL_CUDA_MAX_PEERS];
+    int          local_sense[UCC_TL_CUDA_MAX_PEERS];
 } ucc_tl_cuda_shm_barrier_t;
 
 typedef struct ucc_tl_cuda_rank_id {
@@ -145,6 +148,7 @@ typedef struct ucc_tl_cuda_team {
     ucc_tl_team_t              super;
     uint32_t                   seq_num;
     ucc_tl_cuda_sync_t        *sync;
+    ucc_tl_cuda_sync_state_t  *sync_state;
     ucc_tl_cuda_shm_barrier_t *bar;
     cudaStream_t               stream;
     ucc_tl_cuda_rank_id_t     *ids;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -134,19 +134,30 @@ typedef struct ucc_tl_cuda_mem_info {
 
 typedef struct ucc_tl_cuda_sync {
     uint32_t                 seq_num[2];
-    void                    *ptr;
-    size_t                   length;
-    size_t                   offset;
-    cudaIpcMemHandle_t       handle;
+    ucc_tl_cuda_mem_info_t   mem_info_src;
+    ucc_tl_cuda_mem_info_t   mem_info_dst;
     cudaEvent_t              ipc_event_local;
     cudaIpcEventHandle_t     ev_handle;
     ucc_status_t             status;
     ucc_tl_cuda_sync_data_t  data[1];
 } ucc_tl_cuda_sync_t;
 
+typedef struct ucc_tl_cuda_proxy {
+    ucc_rank_t proxy;
+    ucc_rank_t src;
+    ucc_rank_t dst;
+} ucc_tl_cuda_proxy_t;
+
+typedef struct ucc_tl_cuda_topo {
+    ucc_rank_t           num_proxies;
+    ucc_tl_cuda_proxy_t *proxies;
+    int                 *matrix;
+} ucc_tl_cuda_topo_t;
+
 typedef struct ucc_tl_cuda_team {
     ucc_tl_team_t              super;
     uint32_t                   seq_num;
+    ucc_tl_cuda_topo_t        *topo;
     ucc_tl_cuda_sync_t        *sync;
     ucc_tl_cuda_sync_state_t  *sync_state;
     ucc_tl_cuda_shm_barrier_t *bar;
@@ -168,8 +179,10 @@ typedef struct ucc_tl_cuda_task {
     union {
         struct {
             int                     stage;
-            ucc_tl_cuda_mem_info_t  mem_info;
-            void                   *peer_map_addr[UCC_TL_CUDA_MAX_PEERS];
+            ucc_tl_cuda_mem_info_t  mem_info_src;
+            ucc_tl_cuda_mem_info_t  mem_info_dst;
+            void                   *peer_map_addr_src[UCC_TL_CUDA_MAX_PEERS];
+            void                   *peer_map_addr_dst[UCC_TL_CUDA_MAX_PEERS];
             void                   *copy_done;
         } alltoall_ce;
     };

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -138,7 +138,6 @@ typedef struct ucc_tl_cuda_sync {
     ucc_tl_cuda_mem_info_t   mem_info_dst;
     cudaEvent_t              ipc_event_local;
     cudaIpcEventHandle_t     ev_handle;
-    ucc_status_t             status;
     ucc_tl_cuda_sync_data_t  data[1];
 } ucc_tl_cuda_sync_t;
 
@@ -165,7 +164,6 @@ typedef struct ucc_tl_cuda_team {
     ucc_tl_cuda_rank_id_t     *ids;
     ucc_team_oob_coll_t        oob;
     void                      *oob_req;
-    ucc_status_t               status;
 } ucc_tl_cuda_team_t;
 
 UCC_CLASS_DECLARE(ucc_tl_cuda_team_t, ucc_base_context_t *,

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -108,6 +108,13 @@ typedef struct ucc_tl_cuda_sync_data {
     cudaEvent_t ipc_event_remote;
 } ucc_tl_cuda_sync_data_t;
 
+typedef struct ucc_tl_cuda_mem_info {
+    void               *ptr;
+    size_t              length;
+    size_t              offset;
+    cudaIpcMemHandle_t  handle;
+} ucc_tl_cuda_mem_info_t;
+
 typedef struct ucc_tl_cuda_sync {
     uint32_t                 seq_num[2];
     void                    *ptr;
@@ -142,8 +149,9 @@ typedef struct ucc_tl_cuda_task {
     uint32_t        coll_id;
     union {
         struct {
-            void *peer_map_addr[UCC_TL_CUDA_MAX_PEERS];
-            void *copy_done;
+            ucc_tl_cuda_mem_info_t mem_info;
+            void                   *peer_map_addr[UCC_TL_CUDA_MAX_PEERS];
+            void                   *copy_done;
         } alltoall_ce;
     };
 } ucc_tl_cuda_task_t;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_H_
+#define UCC_TL_CUDA_H_
+
+#include "components/tl/ucc_tl.h"
+#include "components/tl/ucc_tl_log.h"
+#include "utils/ucc_mpool.h"
+#include "tl_cuda_ep_hash.h"
+#include <cuda_runtime.h>
+
+#ifndef UCC_TL_CUDA_DEFAULT_SCORE
+#define UCC_TL_CUDA_DEFAULT_SCORE 40
+#endif
+
+#define UCC_TL_CUDA_MAX_PEERS 8
+#define UCC_TL_CUDA_SUPPORTED_COLLS                                            \
+    (UCC_COLL_TYPE_ALLTOALL)
+
+#define UCC_TL_CUDA_TEAM_LIB(_team)                                            \
+    (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_cuda_lib_t))
+
+#define UCC_TL_CUDA_TEAM_CTX(_team)                                            \
+    (ucc_derived_of((_team)->super.super.context, ucc_tl_cuda_context_t))
+
+#define UCC_TL_CUDA_TEAM_SYNC(_team, _rank, _id)                               \
+    ({                                                                         \
+        size_t _ctrl_size_rank = (sizeof(ucc_tl_cuda_sync_t)  +                \
+                                  sizeof(ucc_tl_cuda_sync_data_t) *            \
+                                  ((_team)->size - 1)) ;                       \
+        size_t _ctrl_size = _ctrl_size_rank * (_team)->size;                   \
+        void *_sync = PTR_OFFSET(_team->sync, _ctrl_size * (_id) +             \
+                                 _ctrl_size_rank * (_rank));                   \
+        (ucc_tl_cuda_sync_t*)_sync;                                            \
+    })
+
+#ifdef HAVE_PROFILING_TL_CUDA
+#include "utils/profile/ucc_profile.h"
+#else
+#include "utils/profile/ucc_profile_off.h"
+#endif
+
+#define UCC_TL_CUDA_PROFILE_FUNC UCC_PROFILE_FUNC
+#define UCC_TL_CUDA_PROFILE_REQUEST_NEW UCC_PROFILE_REQUEST_NEW
+#define UCC_TL_CUDA_PROFILE_REQUEST_EVENT UCC_PROFILE_REQUEST_EVENT
+#define UCC_TL_CUDA_PROFILE_REQUEST_FREE UCC_PROFILE_REQUEST_FREE
+
+#define CUDACHECK_GOTO(_cmd, _label, _status, _lib)                            \
+    do {                                                                       \
+        cudaError_t e = _cmd;                                                  \
+        if (ucc_unlikely(cudaSuccess != e)) {                                  \
+            tl_error(_lib, "CUDA error %d %s", e, cudaGetErrorName(e));        \
+            _status = UCC_ERR_NO_MESSAGE;                                      \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
+
+#define CUDACHECK_NORET(_cmd)                                                  \
+    do {                                                                       \
+        cudaError_t e = _cmd;                                                  \
+        if (ucc_unlikely(cudaSuccess != e)) {                                  \
+            ucc_error("CUDA error %d %s", e, cudaGetErrorName(e));             \
+        }                                                                      \
+    } while (0)
+
+typedef struct ucc_tl_cuda_iface {
+    ucc_tl_iface_t super;
+} ucc_tl_cuda_iface_t;
+
+extern ucc_tl_cuda_iface_t ucc_tl_cuda;
+
+typedef struct ucc_tl_cuda_lib_config {
+    ucc_tl_lib_config_t super;
+    uint32_t            max_concurrent;
+} ucc_tl_cuda_lib_config_t;
+
+typedef struct ucc_tl_cuda_context_config {
+    ucc_tl_context_config_t super;
+} ucc_tl_cuda_context_config_t;
+
+typedef struct ucc_tl_cuda_lib {
+    ucc_tl_lib_t             super;
+    ucc_tl_cuda_lib_config_t cfg;
+} ucc_tl_cuda_lib_t;
+UCC_CLASS_DECLARE(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_cuda_context {
+    ucc_tl_context_t              super;
+    ucc_tl_cuda_context_config_t  cfg;
+    int                           device;
+    ucc_mpool_t                   req_mp;
+    tl_cuda_ep_hash_t            *ipc_cache;
+} ucc_tl_cuda_context_t;
+UCC_CLASS_DECLARE(ucc_tl_cuda_context_t, const ucc_base_context_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_cuda_rank_id {
+    int device;
+    int shm;
+} ucc_tl_cuda_rank_id_t;
+
+typedef struct ucc_tl_cuda_sync_data {
+    cudaEvent_t ipc_event_remote;
+} ucc_tl_cuda_sync_data_t;
+
+typedef struct ucc_tl_cuda_sync {
+    uint32_t                 seq_num[2];
+    void                    *ptr;
+    size_t                   length;
+    size_t                   offset;
+    cudaIpcMemHandle_t       handle;
+    cudaEvent_t              ipc_event_local;
+    cudaIpcEventHandle_t     ev_handle;
+    ucc_status_t             status;
+    ucc_tl_cuda_sync_data_t  data[1];
+} ucc_tl_cuda_sync_t;
+
+typedef struct ucc_tl_cuda_team {
+    ucc_tl_team_t          super;
+    ucc_rank_t             rank;
+    ucc_rank_t             size;
+    uint32_t               seq_num;
+    ucc_tl_cuda_sync_t    *sync;
+    cudaStream_t           stream;
+    ucc_tl_cuda_rank_id_t *ids;
+    ucc_team_oob_coll_t    oob;
+    void                  *oob_req;
+    ucc_status_t           status;
+} ucc_tl_cuda_team_t;
+
+UCC_CLASS_DECLARE(ucc_tl_cuda_team_t, ucc_base_context_t *,
+                  const ucc_base_team_params_t *);
+
+typedef struct ucc_tl_cuda_task {
+    ucc_coll_task_t super;
+    uint32_t        seq_num;
+    uint32_t        coll_id;
+    union {
+        struct {
+            void *peer_map_addr[UCC_TL_CUDA_MAX_PEERS];
+            void *copy_done;
+        } alltoall_ce;
+    };
+} ucc_tl_cuda_task_t;
+
+#endif

--- a/src/components/tl/cuda/tl_cuda_cache.c
+++ b/src/components/tl/cuda/tl_cuda_cache.c
@@ -1,0 +1,326 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "tl_cuda.h"
+#include "tl_cuda_cache.h"
+#include "tl_cuda_ep_hash.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
+#include "core/ucc_team.h"
+#include <cuda_runtime.h>
+
+#define ENABLE_CACHE 1
+
+static ucs_pgt_dir_t*
+ucc_tl_cuda_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
+{
+    void *ptr;
+    int ret;
+
+    ret = posix_memalign(&ptr, ucs_max(sizeof(void *), UCS_PGT_ENTRY_MIN_ALIGN),
+                             sizeof(ucs_pgt_dir_t));
+    return (ret == 0) ? ptr : NULL;
+}
+
+static void ucc_tl_cuda_cache_pgt_dir_release(const ucs_pgtable_t *pgtable,
+                                              ucs_pgt_dir_t *dir)
+{
+    free(dir);
+}
+
+
+static void
+ucc_tl_cuda_cache_region_collect_callback(const ucs_pgtable_t *pgtable,
+                                           ucs_pgt_region_t *pgt_region,
+                                           void *arg)
+{
+    ucs_list_link_t *list = arg;
+    ucc_tl_cuda_cache_region_t *region;
+
+    region = ucs_derived_of(pgt_region, ucc_tl_cuda_cache_region_t);
+    ucs_list_add_tail(list, &region->list);
+}
+
+static void ucc_tl_cuda_cache_purge(ucc_tl_cuda_cache_t *cache)
+{
+    ucc_tl_cuda_cache_region_t *region, *tmp;
+    ucs_list_link_t region_list;
+
+    ucs_list_head_init(&region_list);
+    ucs_pgtable_purge(&cache->pgtable, ucc_tl_cuda_cache_region_collect_callback,
+                      &region_list);
+    ucs_list_for_each_safe(region, tmp, &region_list, list) {
+        CUDACHECK_NORET(cudaIpcCloseMemHandle(region->mapped_addr));
+        free(region);
+    }
+}
+
+ucc_status_t ucc_tl_cuda_create_cache(ucc_tl_cuda_cache_t **cache,
+                                      const char *name)
+{
+
+    ucc_status_t status;
+    ucc_tl_cuda_cache_t *cache_desc;
+    int ret;
+
+    cache_desc = ucc_malloc(sizeof(ucc_tl_cuda_cache_t), "ucc_tl_cuda_cache_t");
+    if (cache_desc == NULL) {
+        ucs_error("failed to allocate memory for tl_cuda cache");
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    ret = pthread_rwlock_init(&cache_desc->lock, NULL);
+    if (ret) {
+        ucs_error("pthread_rwlock_init() failed: %m");
+        status = UCC_ERR_INVALID_PARAM;
+        goto err;
+    }
+
+    if (UCS_OK != ucs_pgtable_init(&cache_desc->pgtable,
+                                   ucc_tl_cuda_cache_pgt_dir_alloc,
+                                   ucc_tl_cuda_cache_pgt_dir_release)) {
+        goto err_destroy_rwlock;
+    }
+
+    cache_desc->name = strdup(name);
+    if (cache_desc->name == NULL) {
+        status = UCC_ERR_NO_MEMORY;
+        goto err_destroy_rwlock;
+    }
+
+    *cache = cache_desc;
+    return UCC_OK;
+
+err_destroy_rwlock:
+    pthread_rwlock_destroy(&cache_desc->lock);
+err:
+    free(cache_desc);
+    return status;
+
+    return UCC_OK;
+}
+
+
+void ucc_tl_cuda_destroy_cache(ucc_tl_cuda_cache_t *cache)
+{
+    ucc_tl_cuda_cache_purge(cache);
+    ucs_pgtable_cleanup(&cache->pgtable);
+    pthread_rwlock_destroy(&cache->lock);
+    free(cache->name);
+    free(cache);
+}
+
+#if ENABLE_CACHE
+static void ucc_tl_cuda_cache_invalidate_regions(ucc_tl_cuda_cache_t *cache,
+                                                  void *from, void *to)
+{
+    ucs_list_link_t region_list;
+    ucs_status_t status;
+    ucc_tl_cuda_cache_region_t *region, *tmp;
+
+    ucs_list_head_init(&region_list);
+    ucs_pgtable_search_range(&cache->pgtable, (ucs_pgt_addr_t)from,
+                             (ucs_pgt_addr_t)to,
+                             ucc_tl_cuda_cache_region_collect_callback,
+                             &region_list);
+    ucs_list_for_each_safe(region, tmp, &region_list, list) {
+        status = ucs_pgtable_remove(&cache->pgtable, &region->super);
+        if (status != UCS_OK) {
+            ucs_error("failed to remove address:%p from cache (%s)",
+                      (void *)region->d_ptr, ucs_status_string(status));
+        }
+        CUDACHECK_NORET(cudaIpcCloseMemHandle(region->mapped_addr));
+        free(region);
+    }
+    ucs_trace("%s: closed memhandles in the range [%p..%p]",
+              cache->name, from, to);
+}
+#endif
+
+ucc_status_t
+ucc_tl_cuda_map_memhandle(const void *d_ptr, size_t size,
+                          cudaIpcMemHandle_t mem_handle, void **mapped_addr,
+                          ucc_tl_cuda_cache_t *cache)
+{
+#if ENABLE_CACHE
+    ucc_status_t status;
+    ucs_status_t ucs_status;
+    ucs_pgt_region_t *pgt_region;
+    ucc_tl_cuda_cache_region_t *region;
+    cudaError_t cuerr;
+    int ret;
+
+    pthread_rwlock_wrlock(&cache->lock);  //todo :is lock needed
+    pgt_region = ucs_pgtable_lookup(&cache->pgtable, (uintptr_t) d_ptr);
+    if (pgt_region != NULL) {
+        region = ucc_derived_of(pgt_region, ucc_tl_cuda_cache_region_t);
+        if (memcmp((const void *)&mem_handle, (const void *)&region->mem_handle,
+                   sizeof(cudaIpcMemHandle_t)) == 0) {
+            /*cache hit */
+            ucc_debug("%s: tl_cuda cache hit addr:%p size:%lu region:"
+                      UCS_PGT_REGION_FMT, cache->name, d_ptr,
+                      size, UCS_PGT_REGION_ARG(&region->super));
+
+            *mapped_addr = region->mapped_addr;
+            ucc_assert(region->refcount < UINT64_MAX);
+            region->refcount++;
+            pthread_rwlock_unlock(&cache->lock);
+            return UCC_OK;
+        } else {
+            ucc_debug("%s: tl_cuda cache remove stale region:"
+                      UCS_PGT_REGION_FMT " new_addr:%p new_size:%lu",
+                      cache->name, UCS_PGT_REGION_ARG(&region->super),
+                      d_ptr, size);
+
+            ucs_status = ucs_pgtable_remove(&cache->pgtable, &region->super);
+            if (ucc_unlikely(ucs_status != UCS_OK)) {
+                ucc_error("%s: failed to remove address:%p from cache",
+                          cache->name, d_ptr);
+                status = ucs_status_to_ucc_status(ucs_status);
+                goto err;
+            }
+
+            /* close memhandle */
+            cuerr = cudaIpcCloseMemHandle(region->mapped_addr);
+            if (ucc_unlikely(cuerr != cudaSuccess)) {
+                ucc_error("cudaIpcCloseMemHandle error %d %s", cuerr,
+                          cudaGetErrorName(cuerr));
+                status = UCC_ERR_NO_MESSAGE;
+                goto err;
+            }
+            free(region);
+        }
+    }
+
+    cuerr = cudaIpcOpenMemHandle(mapped_addr, mem_handle,
+                                cudaIpcMemLazyEnablePeerAccess);
+    if (cuerr != cudaSuccess) {
+        if (cuerr == cudaErrorAlreadyMapped) {
+            ucc_tl_cuda_cache_invalidate_regions(cache,
+                    (void *)ucs_align_down_pow2((uintptr_t)d_ptr,
+                    UCS_PGT_ADDR_ALIGN),
+                    (void *)ucs_align_up_pow2((uintptr_t)d_ptr + size,
+                    UCS_PGT_ADDR_ALIGN));
+            cuerr = cudaIpcOpenMemHandle(mapped_addr, mem_handle,
+                                         cudaIpcMemLazyEnablePeerAccess);
+            if (cuerr != cudaSuccess) {
+                if (cuerr == cudaErrorAlreadyMapped) {
+                    ucc_tl_cuda_cache_purge(cache);
+                    cuerr = cudaIpcOpenMemHandle(mapped_addr, mem_handle,
+                                                 cudaIpcMemLazyEnablePeerAccess);
+                    if (ucc_unlikely(cuerr != cudaSuccess)) {
+                        ucc_error("cudaIpcOpenMemHandle error %d %s", cuerr,
+                                  cudaGetErrorString(cuerr));
+                        status = UCC_ERR_INVALID_PARAM;
+                        goto err;
+                    }
+                }
+            }
+            cudaGetLastError();
+        }
+    }
+
+    /*create new cache entry */
+    ret = posix_memalign((void **)&region,
+                          ucs_max(sizeof(void *), UCS_PGT_ENTRY_MIN_ALIGN),
+                          sizeof(ucc_tl_cuda_cache_region_t));
+    if (ret != 0) {
+        ucs_warn("failed to allocate uct_tl_cuda_cache region");
+        status = UCC_ERR_NO_MEMORY;
+        goto err;
+    }
+
+    region->super.start = ucs_align_down_pow2((uintptr_t)d_ptr,
+                                               UCS_PGT_ADDR_ALIGN);
+    region->super.end   = ucs_align_up_pow2  ((uintptr_t)d_ptr + size,
+                                               UCS_PGT_ADDR_ALIGN);
+    region->d_ptr       = (void *)d_ptr;
+    region->size        = size;
+    region->mem_handle  = mem_handle;
+    region->mapped_addr = *mapped_addr;
+    region->refcount    = 1;
+
+    ucs_status = ucs_pgtable_insert(&cache->pgtable, &region->super);
+    if (ucs_status == UCS_ERR_ALREADY_EXISTS) {
+        /* overlapped region means memory freed at source. remove and try insert */
+        ucc_tl_cuda_cache_invalidate_regions(cache,
+                                              (void *)region->super.start,
+                                              (void *)region->super.end);
+        ucs_status = ucs_pgtable_insert(&cache->pgtable, &region->super);
+    }
+
+    if (ucs_status != UCS_OK) {
+
+        ucs_error("%s: failed to insert region:"UCS_PGT_REGION_FMT" size:%lu :%s",
+                  cache->name, UCS_PGT_REGION_ARG(&region->super), size,
+                  ucs_status_string(ucs_status));
+        free(region);
+        status = ucs_status_to_ucc_status(ucs_status);
+        goto err;
+    }
+
+    ucc_debug("%s: tl_cuda cache new region:"UCS_PGT_REGION_FMT" size:%lu",
+              cache->name, UCS_PGT_REGION_ARG(&region->super), size);
+
+    status = UCC_OK;
+
+err:
+    pthread_rwlock_unlock(&cache->lock);
+    return status;
+
+
+#else
+    CUDACHECK(cudaIpcOpenMemHandle(mapped_addr, mem_handle, cudaIpcMemLazyEnablePeerAccess));
+    return UCC_OK;
+#endif
+}
+
+
+ucc_status_t ucc_tl_cuda_unmap_memhandle(uintptr_t d_bptr, void *mapped_addr,
+                                         ucc_tl_cuda_cache_t *cache)
+{
+#if ENABLE_CACHE
+    ucs_pgt_region_t *pgt_region;
+    ucc_tl_cuda_cache_region_t *region;
+
+    /* use write lock because cache maybe modified */
+    pthread_rwlock_wrlock(&cache->lock);
+    pgt_region = ucs_pgtable_lookup(&cache->pgtable, d_bptr);
+    ucc_assert(pgt_region != NULL);
+    region = ucs_derived_of(pgt_region, ucc_tl_cuda_cache_region_t);
+
+    ucc_assert(region->refcount >= 1);
+    region->refcount--;
+
+    pthread_rwlock_unlock(&cache->lock);
+#else
+   CUDACHECK(cudaIpcCloseMemHandle(mapped_addr));
+#endif
+   return UCC_OK;
+}
+
+ucc_tl_cuda_cache_t* ucc_tl_cuda_get_cache(ucc_tl_cuda_team_t *team,
+                                           ucc_rank_t rank)
+{
+    ucc_tl_cuda_context_t     *ctx = UCC_TL_CUDA_TEAM_CTX(team);
+    ucc_context_addr_header_t *h   = NULL;
+    ucc_tl_cuda_cache_t *cache;
+    ucc_status_t status;
+
+    h = ucc_get_team_ep_header(UCC_TL_CORE_CTX(team), team->super.super.team,
+                               rank);
+    cache = tl_cuda_hash_get(ctx->ipc_cache, h->ctx_id);
+    if (ucc_unlikely(NULL == cache)) {
+        status =  ucc_tl_cuda_create_cache(&cache, "ipc-cache");
+        if (status != UCC_OK) {
+            tl_error(UCC_TL_TEAM_LIB(team), "failed to create ipc cache");
+            return NULL;
+        }
+        tl_cuda_hash_put(ctx->ipc_cache, h->ctx_id, cache);
+    }
+    return cache;
+}

--- a/src/components/tl/cuda/tl_cuda_cache.c
+++ b/src/components/tl/cuda/tl_cuda_cache.c
@@ -62,7 +62,6 @@ static void ucc_tl_cuda_cache_purge(ucc_tl_cuda_cache_t *cache)
 ucc_status_t ucc_tl_cuda_create_cache(ucc_tl_cuda_cache_t **cache,
                                       const char *name)
 {
-
     ucc_status_t status;
     ucc_tl_cuda_cache_t *cache_desc;
     int ret;
@@ -274,7 +273,8 @@ err:
 
 
 #else
-    CUDACHECK(cudaIpcOpenMemHandle(mapped_addr, mem_handle, cudaIpcMemLazyEnablePeerAccess));
+    CUDACHECK_NORET(cudaIpcOpenMemHandle(mapped_addr, mem_handle,
+                                         cudaIpcMemLazyEnablePeerAccess));
     return UCC_OK;
 #endif
 }
@@ -298,7 +298,7 @@ ucc_status_t ucc_tl_cuda_unmap_memhandle(uintptr_t d_bptr, void *mapped_addr,
 
     pthread_rwlock_unlock(&cache->lock);
 #else
-   CUDACHECK(cudaIpcCloseMemHandle(mapped_addr));
+   CUDACHECK_NORET(cudaIpcCloseMemHandle(mapped_addr));
 #endif
    return UCC_OK;
 }

--- a/src/components/tl/cuda/tl_cuda_cache.c
+++ b/src/components/tl/cuda/tl_cuda_cache.c
@@ -222,6 +222,7 @@ ucc_tl_cuda_map_memhandle(const void *d_ptr, size_t size,
         } else {
             ucc_error("%s: failed to open ipc mem handle. addr:%p len:%lu",
                       cache->name, d_ptr, size);
+            status = UCC_ERR_NO_MESSAGE;
             goto err;
         }
     }

--- a/src/components/tl/cuda/tl_cuda_cache.c
+++ b/src/components/tl/cuda/tl_cuda_cache.c
@@ -311,7 +311,7 @@ ucc_tl_cuda_cache_t* ucc_tl_cuda_get_cache(ucc_tl_cuda_team_t *team,
     ucc_tl_cuda_cache_t *cache;
     ucc_status_t status;
 
-    h = ucc_get_team_ep_header(UCC_TL_CORE_CTX(team), team->super.super.team,
+    h = ucc_get_team_ep_header(UCC_TL_CORE_CTX(team), UCC_TL_CORE_TEAM(team),
                                rank);
     cache = tl_cuda_hash_get(ctx->ipc_cache, h->ctx_id);
     if (ucc_unlikely(NULL == cache)) {

--- a/src/components/tl/cuda/tl_cuda_cache.c
+++ b/src/components/tl/cuda/tl_cuda_cache.c
@@ -196,9 +196,9 @@ ucc_tl_cuda_map_memhandle(const void *d_ptr, size_t size,
     if (cuerr != cudaSuccess) {
         if (cuerr == cudaErrorAlreadyMapped) {
             ucc_tl_cuda_cache_invalidate_regions(cache,
-                    (void *)ucs_align_down_pow2((uintptr_t)d_ptr,
+                    (void *)ucc_align_down_pow2((uintptr_t)d_ptr,
                     UCS_PGT_ADDR_ALIGN),
-                    (void *)ucs_align_up_pow2((uintptr_t)d_ptr + size,
+                    (void *)ucc_align_up_pow2((uintptr_t)d_ptr + size,
                     UCS_PGT_ADDR_ALIGN));
             cuerr = cudaIpcOpenMemHandle(mapped_addr, mem_handle,
                                          cudaIpcMemLazyEnablePeerAccess);
@@ -237,9 +237,9 @@ ucc_tl_cuda_map_memhandle(const void *d_ptr, size_t size,
         goto err;
     }
 
-    region->super.start = ucs_align_down_pow2((uintptr_t)d_ptr,
+    region->super.start = ucc_align_down_pow2((uintptr_t)d_ptr,
                                                UCS_PGT_ADDR_ALIGN);
-    region->super.end   = ucs_align_up_pow2  ((uintptr_t)d_ptr + size,
+    region->super.end   = ucc_align_up_pow2  ((uintptr_t)d_ptr + size,
                                                UCS_PGT_ADDR_ALIGN);
     region->d_ptr       = (void *)d_ptr;
     region->size        = size;

--- a/src/components/tl/cuda/tl_cuda_cache.h
+++ b/src/components/tl/cuda/tl_cuda_cache.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_CACHE_H_
+#define UCC_TL_CUDA_CACHE_H_
+
+#include <ucs/datastruct/pgtable.h>
+#include <ucs/datastruct/list.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+typedef struct ucc_tl_cuda_cache_region {
+    ucs_pgt_region_t    super;        /**< Base class - page table region */
+    ucs_list_link_t     list;         /**< List element */
+    void               *d_ptr;
+    size_t              size;
+    cudaIpcMemHandle_t  mem_handle;
+    void               *mapped_addr;  /**< Local mapped address */
+    uint64_t            refcount;     /**< Track inflight ops before unmapping*/
+} ucc_tl_cuda_cache_region_t;
+
+typedef struct ucc_tl_cuda_cache {
+    pthread_rwlock_t  lock;       /**< protests the page table */
+    ucs_pgtable_t     pgtable;    /**< Page table to hold the regions */
+    char             *name;       /**< Name */
+} ucc_tl_cuda_cache_t;
+
+ucc_status_t ucc_tl_cuda_create_cache(ucc_tl_cuda_cache_t **cache,
+                                      const char *name);
+
+void ucc_tl_cuda_destroy_cache(ucc_tl_cuda_cache_t *cache);
+
+ucc_status_t ucc_tl_cuda_map_memhandle(const void *dptr, size_t size,
+                                       cudaIpcMemHandle_t mem_handle,
+                                       void **mapped_addr,
+                                       ucc_tl_cuda_cache_t *cache);
+
+ucc_status_t ucc_tl_cuda_unmap_memhandle(uintptr_t d_bptr, void *mapped_addr,
+                                         ucc_tl_cuda_cache_t *cache);
+
+ucc_tl_cuda_cache_t* ucc_tl_cuda_get_cache(ucc_tl_cuda_team_t *team,
+                                           ucc_rank_t rank);
+
+#endif

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -1,6 +1,29 @@
 #include "tl_cuda_coll.h"
 #include "alltoall/alltoall.h"
 
+ucc_status_t ucc_tl_cuda_mem_info_get(void *ptr, size_t length,
+                                      ucc_tl_cuda_team_t *team,
+                                      ucc_tl_cuda_mem_info_t *mi)
+{
+    ucc_mem_attr_t mem_attr;
+    ucc_status_t   status;
+
+    mem_attr.field_mask   = UCC_MEM_ATTR_FIELD_BASE_ADDRESS |
+                            UCC_MEM_ATTR_FIELD_ALLOC_LENGTH;
+    mem_attr.alloc_length = length;
+    status = ucc_mc_get_mem_attr(ptr, &mem_attr);
+    if (ucc_unlikely(status != UCC_OK)) {
+        return status;
+    }
+    mi->ptr    = mem_attr.base_address;
+    mi->length = mem_attr.alloc_length;
+    mi->offset = (ptrdiff_t)ptr - (ptrdiff_t)mi->ptr;
+    CUDACHECK_GOTO(cudaIpcGetMemHandle(&mi->handle,mi->ptr), exit, status,
+                   UCC_TL_TEAM_LIB(team));
+exit:
+    return status;
+}
+
 ucc_status_t ucc_tl_cuda_coll_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -1,0 +1,23 @@
+#include "tl_cuda_coll.h"
+#include "alltoall/alltoall.h"
+
+ucc_status_t ucc_tl_cuda_coll_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+
+    tl_trace(UCC_TASK_LIB(task), "finalizing task %p", task);
+    ucc_tl_cuda_task_put(task);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
+                                   ucc_base_team_t *team,
+                                   ucc_coll_task_t **task_h)
+{
+    switch (coll_args->args.coll_type) {
+    case UCC_COLL_TYPE_ALLTOALL:
+        return ucc_tl_cuda_alltoall_init(coll_args, team, task_h);
+    default:
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+}

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -1,5 +1,6 @@
 #include "tl_cuda_coll.h"
 #include "alltoall/alltoall.h"
+#include "utils/arch/cpu.h"
 
 ucc_status_t ucc_tl_cuda_mem_info_get(void *ptr, size_t length,
                                       ucc_tl_cuda_team_t *team,
@@ -57,7 +58,7 @@ ucc_status_t ucc_tl_cuda_shm_barrier_start(ucc_rank_t rank,
     barrier->state[rank] = UCC_INPROGRESS;
     if (pos == barrier->size - 1) {
         barrier->count = 0;
-        __sync_synchronize();
+        ucc_memory_bus_fence();
         barrier->sense = barrier->local_sense[rank];
     }
     return UCC_OK;

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_COLL_H_
+#define UCC_TL_CUDA_COLL_H_
+
+#include "tl_cuda.h"
+
+#define TASK_TEAM(_task)                                                       \
+    (ucc_derived_of((_task)->super.team, ucc_tl_cuda_team_t))
+
+#define TASK_ARGS(_task) (_task)->super.bargs.args
+
+#define TASK_SYNC(_task, _rank)                                                \
+    ({                                                                         \
+        ucc_tl_cuda_team_t *_team = TASK_TEAM(_task);                          \
+        UCC_TL_CUDA_TEAM_SYNC(_team, _rank, (_task)->coll_id);                 \
+    })
+
+static inline void ucc_tl_cuda_task_reset(ucc_tl_cuda_task_t *task)
+{
+    task->super.super.status = UCC_INPROGRESS;
+}
+
+static inline ucc_tl_cuda_task_t *ucc_tl_cuda_task_get(ucc_tl_cuda_team_t *team)
+{
+    ucc_tl_cuda_context_t *ctx  = UCC_TL_CUDA_TEAM_CTX(team);
+    ucc_tl_cuda_task_t    *task = ucc_mpool_get(&ctx->req_mp);
+
+    UCC_TL_CUDA_PROFILE_REQUEST_NEW(task, "tl_cuda_task", 0);
+    task->super.super.status = UCC_OPERATION_INITIALIZED;
+    task->super.flags        = 0;
+    task->super.team         = &team->super.super;
+    ucc_tl_cuda_task_reset(task);
+    return task;
+}
+
+static inline void ucc_tl_cuda_task_put(ucc_tl_cuda_task_t *task)
+{
+    UCC_TL_CUDA_PROFILE_REQUEST_FREE(task);
+    ucc_mpool_put(task);
+}
+
+static inline ucc_tl_cuda_task_t *
+ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
+                      ucc_tl_cuda_team_t *team)
+{
+    ucc_tl_cuda_task_t *task = ucc_tl_cuda_task_get(team);
+    uint32_t max_concurrent;
+
+    max_concurrent = UCC_TL_CUDA_TEAM_LIB(team)->cfg.max_concurrent;
+    ucc_coll_task_init(&task->super, coll_args, &team->super.super);
+    task->seq_num = team->seq_num++;
+    task->coll_id = task->seq_num % max_concurrent;
+    return task;
+}
+
+ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
+                                    ucc_base_team_t *team,
+                                    ucc_coll_task_t **task_h);
+
+ucc_status_t ucc_tl_cuda_coll_finalize(ucc_coll_task_t *coll_task);
+
+#endif

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -8,6 +8,7 @@
 #define UCC_TL_CUDA_COLL_H_
 
 #include "tl_cuda.h"
+#include "core/ucc_mc.h"
 
 #define TASK_TEAM(_task)                                                       \
     (ucc_derived_of((_task)->super.team, ucc_tl_cuda_team_t))
@@ -57,6 +58,10 @@ ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
     task->coll_id = task->seq_num % max_concurrent;
     return task;
 }
+
+ucc_status_t ucc_tl_cuda_mem_info_get(void *ptr, size_t length,
+                                      ucc_tl_cuda_team_t *team,
+                                      ucc_tl_cuda_mem_info_t *mi);
 
 ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
                                     ucc_base_team_t *team,

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -48,7 +48,7 @@ static inline ucc_tl_cuda_task_t *ucc_tl_cuda_task_get(ucc_tl_cuda_team_t *team)
 static inline void ucc_tl_cuda_task_put(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, team->rank);
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, UCC_TL_TEAM_RANK(team));
     uint32_t max_concurrent;
 
     UCC_TL_CUDA_PROFILE_REQUEST_FREE(task);

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -47,13 +47,7 @@ static inline ucc_tl_cuda_task_t *ucc_tl_cuda_task_get(ucc_tl_cuda_team_t *team)
 
 static inline void ucc_tl_cuda_task_put(ucc_tl_cuda_task_t *task)
 {
-    // ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    // ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, UCC_TL_TEAM_RANK(team));
-    // uint32_t max_concurrent;
-
     UCC_TL_CUDA_PROFILE_REQUEST_FREE(task);
-    // max_concurrent = UCC_TL_CUDA_TEAM_LIB(team)->cfg.max_concurrent;
-    // sync->seq_num[0] += max_concurrent;
     ucc_mpool_put(task);
 }
 

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -5,6 +5,7 @@
  */
 
 #include "tl_cuda.h"
+#include "utils/arch/cpu.h"
 #include <cuda_runtime.h>
 
 static ucc_mpool_ops_t ucc_tl_cuda_req_mpool_ops = {

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_cuda.h"
+#include <cuda_runtime.h>
+
+static ucc_mpool_ops_t ucc_tl_cuda_req_mpool_ops = {
+    .chunk_alloc   = ucc_mpool_hugetlb_malloc,
+    .chunk_release = ucc_mpool_hugetlb_free,
+    .obj_init      = NULL,
+    .obj_cleanup   = NULL,
+};
+
+UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
+                    const ucc_base_context_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    ucc_tl_cuda_context_config_t *tl_cuda_config =
+        ucc_derived_of(config, ucc_tl_cuda_context_config_t);
+    ucc_status_t status;
+
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_cuda_config->super.tl_lib,
+                              params->context);
+    memcpy(&self->cfg, tl_cuda_config, sizeof(*tl_cuda_config));
+
+    status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_cuda_task_t), 0,
+                            UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
+                            &ucc_tl_cuda_req_mpool_ops, params->thread_mode,
+                            "tl_cuda_req_mp");
+    if (status != UCC_OK) {
+        tl_error(self->super.super.lib,
+                 "failed to initialize tl_cuda_req mpool");
+        return status;
+    }
+    CUDACHECK_GOTO(cudaGetDevice(&self->device), free_mpool, status,
+                   self->super.super.lib);
+    self->ipc_cache = kh_init(tl_cuda_ep_hash);
+    tl_info(self->super.super.lib, "initialized tl context: %p", self);
+
+    return UCC_OK;
+
+free_mpool:
+    ucc_mpool_cleanup(&self->req_mp, 1);
+    return status;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_context_t)
+{
+    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    ucc_mpool_cleanup(&self->req_mp, 1);
+}
+
+UCC_CLASS_DEFINE(ucc_tl_cuda_context_t, ucc_tl_context_t);
+
+ucc_status_t
+ucc_tl_cuda_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
+                             ucc_base_ctx_attr_t      *attr)
+{
+    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
+        attr->attr.ctx_addr_len = 0;
+    }
+    attr->topo_required = 1;
+    return UCC_OK;
+}

--- a/src/components/tl/cuda/tl_cuda_ep_hash.h
+++ b/src/components/tl/cuda/tl_cuda_ep_hash.h
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_EP_HASH_H_
+#define UCC_TL_CUDA_EP_HASH_H_
+
+#include "config.h"
+#include "core/ucc_context.h"
+#include "utils/khash.h"
+#include <stdint.h>
+
+/* TODO: common code with TL/UCP */
+static inline uint32_t tl_cuda_ctx_id_hash_fn_impl(uint32_t h, uint32_t k)
+{
+    uint32_t H = h & 0xf8000000;
+    h = h << 5;
+    h = h ^ ( H >> 27 );
+    h = h ^ k;
+    return h;
+}
+
+/* Collisions are handled in khash implementation */
+static inline khint32_t tl_cuda_ctx_id_hash_fn(ucc_context_id_t k)
+{
+    uint32_t h = 0;
+
+    ucc_assert(sizeof(k.pi.host_hash) == 8);
+    h = tl_cuda_ctx_id_hash_fn_impl(h,
+                                   kh_int64_hash_func(k.pi.host_hash));
+    h = tl_cuda_ctx_id_hash_fn_impl(h, k.pi.pid);
+    h = tl_cuda_ctx_id_hash_fn_impl(h, k.seq_num);
+    return (khint32_t)h;
+}
+
+#define tl_cuda_ctx_id_equal_fn(_a, _b)                                         \
+    (((_a).pi.host_hash == (_b).pi.host_hash) &&                               \
+     ((_a).pi.pid == (_b).pi.pid) && ((_a).seq_num == (_b).seq_num))
+
+KHASH_INIT(tl_cuda_ep_hash, ucc_context_id_t, void*, 1, \
+           tl_cuda_ctx_id_hash_fn, tl_cuda_ctx_id_equal_fn);
+
+#define tl_cuda_ep_hash_t khash_t(tl_cuda_ep_hash)
+
+static inline void* tl_cuda_hash_get(tl_cuda_ep_hash_t *h, ucc_context_id_t key)
+{
+    khiter_t k;
+    void    *value;
+    k = kh_get(tl_cuda_ep_hash, h , key);
+    if (k == kh_end(h)) {
+        return NULL;
+    }
+    value = kh_value(h, k);
+    return value;
+}
+
+static inline void tl_cuda_hash_put(tl_cuda_ep_hash_t *h, ucc_context_id_t key,
+                                   void *value)
+{
+    int ret;
+    khiter_t k;
+    k = kh_put(tl_cuda_ep_hash, h, key, &ret);
+    kh_value(h, k) = value;
+}
+
+static inline void* tl_cuda_hash_pop(tl_cuda_ep_hash_t *h)
+{
+    void    *ep = NULL;
+    khiter_t k;
+    k = kh_begin(h);
+    while (k != kh_end(h)) {
+        if (kh_exist(h, k)) {
+            ep = kh_value(h, k);
+            break;
+        }
+        k++;
+    }
+    if (ep) {
+        kh_del(tl_cuda_ep_hash, h, k);
+    }
+    return ep;
+}
+
+#endif

--- a/src/components/tl/cuda/tl_cuda_lib.c
+++ b/src/components/tl/cuda/tl_cuda_lib.c
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_cuda.h"
+
+/* NOLINTNEXTLINE  params is not used*/
+UCC_CLASS_INIT_FUNC(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    const ucc_tl_cuda_lib_config_t *tl_config =
+        ucc_derived_of(config, ucc_tl_cuda_lib_config_t);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_cuda.super,
+                              &tl_config->super);
+    memcpy(&self->cfg, tl_config, sizeof(*tl_config));
+    tl_info(&self->super, "initialized lib object: %p", self);
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_lib_t)
+{
+    tl_info(&self->super, "finalizing lib object: %p", self);
+}
+
+UCC_CLASS_DEFINE(ucc_tl_cuda_lib_t, ucc_tl_lib_t);
+
+ucc_status_t ucc_tl_cuda_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
+                                      ucc_base_lib_attr_t  *base_attr)
+{
+    ucc_tl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
+    attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
+    attr->super.attr.coll_types  = UCC_TL_CUDA_SUPPORTED_COLLS;
+    return UCC_OK;
+}

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -9,6 +9,7 @@
 #include "tl_cuda_topo.h"
 #include "core/ucc_team.h"
 #include "coll_score/ucc_coll_score.h"
+#include "utils/arch/cpu.h"
 #include <sys/shm.h>
 
 UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
@@ -228,6 +229,7 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
         sync->seq_num[0] = i;
     }
 
+    ucc_memory_bus_fence();
     bar = UCC_TL_CUDA_TEAM_BARRIER(team, 0);
     status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), bar);
     if (status != UCC_OK) {

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -1,0 +1,270 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_cuda.h"
+#include "tl_cuda_coll.h"
+#include "core/ucc_team.h"
+#include "coll_score/ucc_coll_score.h"
+#include <sys/shm.h>
+
+UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
+                    const ucc_base_team_params_t *params)
+{
+    ucc_tl_cuda_context_t *ctx =
+        ucc_derived_of(tl_context, ucc_tl_cuda_context_t);
+    ucc_tl_cuda_lib_t     *lib =
+        ucc_derived_of(tl_context->lib, ucc_tl_cuda_lib_t);
+    ucc_tl_cuda_sync_t *sync;
+    ucc_status_t status;
+    int shm_id, i, j;
+    size_t ctrl_size;
+
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params->team);
+
+    if (self->size > UCC_TL_CUDA_MAX_PEERS) {
+        tl_info(tl_context->lib, "team size is too large, max supported %d",
+                UCC_TL_CUDA_MAX_PEERS);
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    self->rank   = params->rank;
+    self->oob    = params->params.oob;
+    self->size   = self->oob.n_oob_eps;
+    self->stream = NULL;
+    for (i = 0; i < self->size; i++) {
+        if (!ucc_rank_on_local_node(i, params->team)) {
+            tl_info(tl_context->lib, "rank %d is on different node, "
+                    "multinode isn't supported", i);
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+    }
+
+    ctrl_size = (sizeof(ucc_tl_cuda_sync_t) + sizeof(ucc_tl_cuda_sync_data_t) *
+                (self->size - 1)) * self->size * lib->cfg.max_concurrent;
+    shm_id = -1;
+    self->sync = (void*)-1;
+    if (self->rank == 0) {
+        shm_id = shmget(IPC_PRIVATE, ctrl_size, IPC_CREAT | 0666);
+        if (shm_id < 0) {
+            tl_error(tl_context->lib, "failed to shmget with IPC_PRIVATE, "
+                     "size %zd, IPC_CREAT errno: %d(%s)", ctrl_size,
+                     errno, strerror(errno));
+            status = UCC_ERR_NO_MEMORY;
+            goto exit_err;
+        }
+        self->sync = shmat(shm_id, NULL, 0);
+        shmctl(shm_id, IPC_RMID, NULL);
+        if (self->sync == (void *)-1) {
+            tl_error(tl_context->lib, "failed to shmat errno: %d(%s)",
+                     errno, strerror(errno));
+            status = UCC_ERR_NO_MEMORY;
+            goto free_shm;
+        }
+        memset(self->sync, 0, ctrl_size);
+        for (i = 0; i < lib->cfg.max_concurrent; i++) {
+            for (j = 0; j < self->size; j++) {
+                sync = UCC_TL_CUDA_TEAM_SYNC(self, j, i);
+                sync->status = UCC_INPROGRESS;
+            }
+        }
+    }
+
+    self->ids = ucc_malloc((self->size + 1) * sizeof(*(self->ids)), "ids");
+    if (!self->ids) {
+        tl_error(tl_context->lib, "failed to alloc ranks id");
+        status = UCC_ERR_NO_MEMORY;
+        goto free_shmdt;
+    }
+    self->ids[self->size].device = ctx->device;
+    self->ids[self->size].shm    = shm_id;
+    status = self->oob.allgather(&self->ids[self->size], self->ids,
+                                 sizeof(ucc_tl_cuda_rank_id_t),
+                                 self->oob.coll_info, &self->oob_req);
+    if (UCC_OK != status) {
+        tl_error(tl_context->lib, "failed to start oob allgather");
+        goto free_devices;
+    }
+    tl_info(tl_context->lib, "posted tl team: %p", self);
+
+    self->seq_num   = 1;
+    return UCC_OK;
+
+free_devices:
+    ucc_free(self->ids);
+free_shmdt:
+    if (self->sync != (void*)-1) {
+        shmdt(self->sync);
+    }
+free_shm:
+    if (shm_id != -1) {
+        shmctl(shm_id, IPC_RMID, NULL);
+    }
+exit_err:
+    return status;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_team_t)
+{
+    ucc_tl_cuda_lib_t *lib = ucc_derived_of(self->super.super.context->lib,
+                                            ucc_tl_cuda_lib_t);
+    ucc_tl_cuda_sync_t *sync;
+    int i, j;
+
+    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    if (self->ids) {
+        if (self->sync != (void*)-1) {
+            for (i = 0; i < lib->cfg.max_concurrent; i++) {
+                for (j = 0; j < self->size; j++) {
+                    if (j == self->rank) {
+                        continue;
+                    }
+                    sync = UCC_TL_CUDA_TEAM_SYNC(self, j, i);
+                    if (sync->data[j].ipc_event_remote) {
+                        cudaEventDestroy(sync->data[j].ipc_event_remote);
+                    }
+                }
+                sync = UCC_TL_CUDA_TEAM_SYNC(self, self->rank, i);
+                if (sync->ipc_event_local) {
+                    cudaEventDestroy(sync->ipc_event_local);
+                }
+            }
+            shmdt(self->sync);
+        }
+        if (self->rank == 0) {
+            shmctl(self->ids[0].shm, IPC_RMID, NULL);
+        }
+        ucc_free(self->ids);
+    }
+    if (self->stream) {
+        cudaStreamDestroy(self->stream);
+    }
+}
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_cuda_team_t, ucc_base_team_t);
+
+UCC_CLASS_DEFINE(ucc_tl_cuda_team_t, ucc_tl_team_t);
+
+ucc_status_t ucc_tl_cuda_team_destroy(ucc_base_team_t *tl_team)
+{
+    UCC_CLASS_DELETE_FUNC_NAME(ucc_tl_cuda_team_t)(tl_team);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
+{
+    ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
+    ucc_tl_cuda_lib_t  *lib  = ucc_derived_of(tl_team->context->lib,
+                                              ucc_tl_cuda_lib_t);
+    ucc_status_t status;
+    ucc_tl_cuda_sync_t *sync;
+    volatile ucc_tl_cuda_sync_t *peer_sync;
+    int i, j, peer_access, dev, peer_dev, shm_id;
+
+    if (team->oob_req == NULL) {
+        return UCC_OK;
+    }
+    status = team->oob.req_test(team->oob_req);
+    if (status == UCC_INPROGRESS) {
+        return UCC_INPROGRESS;
+    } else if (status < 0) {
+        tl_error(tl_team->context->lib, "oob allgather failed");
+        goto exit_err;
+    }
+    team->oob.req_free(team->oob_req);
+    team->oob_req = NULL;
+    dev = team->ids[team->rank].device;
+    for (i = 0; i < team->size; i++) {
+        if (i != team->rank) {
+            peer_dev = team->ids[i].device;
+            CUDACHECK_GOTO(cudaDeviceCanAccessPeer(&peer_access, dev, peer_dev),
+                           exit_err, status, tl_team->context->lib);
+            if (!peer_access) {
+                tl_info(tl_team->context->lib,
+                        "dev %d rank %d is not accesible from dev %d rank %d",
+                        peer_dev, i, dev, team->rank);
+                status = UCC_ERR_NOT_SUPPORTED;
+                goto exit_err;
+            }
+        }
+    }
+    shm_id = team->ids[0].shm;
+    if (team->rank != 0) {
+        team->sync = shmat(shm_id, NULL, 0);
+        if (team->sync == (void *)-1) {
+            tl_error(tl_team->context->lib, "failed to shamt errno: %d (%s)",
+                     errno, strerror(errno));
+            status = UCC_ERR_NO_MEMORY;
+            goto exit_err;
+        }
+    }
+    CUDACHECK_GOTO(cudaStreamCreateWithFlags(&team->stream,
+                                             cudaStreamNonBlocking),
+                   exit_err, status, tl_team->context->lib);
+
+    for (i = 0; i < lib->cfg.max_concurrent; i++) {
+        sync = UCC_TL_CUDA_TEAM_SYNC(team, team->rank, i);
+        CUDACHECK_GOTO(cudaEventCreateWithFlags(&sync->ipc_event_local,
+                                                cudaEventDisableTiming |
+                                                cudaEventInterprocess),
+                       exit_err, status, tl_team->context->lib);
+        CUDACHECK_GOTO(cudaIpcGetEventHandle(&sync->ev_handle,
+                                             sync->ipc_event_local),
+                       exit_err, status, tl_team->context->lib);
+        sync->status = UCC_OK;
+        __sync_synchronize();
+        asm volatile("": : :"memory");
+        for (j = 0; j < team->size; j++) {
+            if (j == team->rank) {
+                continue;
+            }
+            peer_sync = UCC_TL_CUDA_TEAM_SYNC(team, j, i);
+            while (peer_sync->status != UCC_OK);
+            CUDACHECK_GOTO(cudaIpcOpenEventHandle(&sync->data[j].ipc_event_remote,
+                                                  peer_sync->ev_handle),
+                           exit_err, status, tl_team->context->lib);
+        }
+    }
+
+    tl_info(tl_team->context->lib, "initialized tl team: %p", team);
+    return UCC_OK;
+
+exit_err:
+    return status;
+}
+
+ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
+                                         ucc_coll_score_t **score_p)
+{
+    ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
+    ucc_tl_cuda_lib_t  *lib  = UCC_TL_CUDA_TEAM_LIB(team);
+    ucc_coll_score_t   *score;
+    ucc_status_t        status;
+
+    status =
+        ucc_coll_score_build_default(tl_team, UCC_TL_CUDA_DEFAULT_SCORE,
+                                     ucc_tl_cuda_coll_init,
+                                     UCC_TL_CUDA_SUPPORTED_COLLS,
+                                     NULL, 0, &score);
+    if (UCC_OK != status) {
+        return status;
+    }
+
+    if (strlen(lib->super.super.score_str) > 0) {
+        status = ucc_coll_score_update_from_str(
+            lib->super.super.score_str, score, team->size,
+            ucc_tl_cuda_coll_init, &team->super.super,
+            UCC_TL_CUDA_DEFAULT_SCORE, NULL);
+        if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
+            (status != UCC_ERR_NOT_SUPPORTED)) {
+            goto err;
+        }
+    }
+
+    *score_p = score;
+    return UCC_OK;
+err:
+    ucc_coll_score_free(score);
+    return status;
+}

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -35,6 +35,12 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
         return UCC_ERR_NOT_SUPPORTED;
     }
 
+    if (!params->team->topo) {
+        tl_info(tl_context->lib,
+                "can't create cuda team without topology data");
+        return UCC_ERR_INVALID_PARAM;
+    }
+
     if (!ucc_topo_is_single_node(params->team->topo)) {
         tl_info(tl_context->lib, "multinode team is not supported");
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -44,7 +44,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
     ctrl_size = (sizeof(ucc_tl_cuda_sync_t) + sizeof(ucc_tl_cuda_sync_data_t) *
                 (UCC_TL_TEAM_SIZE(self) - 1)) * UCC_TL_TEAM_SIZE(self) *
                 lib->cfg.max_concurrent +
-                sizeof(ucc_tl_cuda_shm_barrier_t) * lib->cfg.max_concurrent;
+                sizeof(ucc_tl_cuda_shm_barrier_t) * lib->cfg.max_concurrent +
+                sizeof(ucc_tl_cuda_sync_state_t) * lib->cfg.max_concurrent;
 
     shm_id = -1;
     self->sync = (void*)-1;
@@ -92,7 +93,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
     }
     tl_info(tl_context->lib, "posted tl team: %p", self);
 
-    self->seq_num = 0;
+    self->seq_num = 1;
     return UCC_OK;
 
 free_devices:
@@ -206,6 +207,9 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
     }
     team->bar = (ucc_tl_cuda_shm_barrier_t*)UCC_TL_CUDA_TEAM_SYNC(team, 0,
                                                        lib->cfg.max_concurrent);
+    team->sync_state = (ucc_tl_cuda_sync_state_t*)PTR_OFFSET(team->bar,
+                            sizeof(ucc_tl_cuda_shm_barrier_t) *
+                            lib->cfg.max_concurrent);
     for (i = 0; i < lib->cfg.max_concurrent; i++) {
         bar = UCC_TL_CUDA_TEAM_BARRIER(team, i);
         status = ucc_tl_cuda_shm_barrier_init(UCC_TL_TEAM_SIZE(team),

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -239,6 +239,7 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_lib_t  *lib  = UCC_TL_CUDA_TEAM_LIB(team);
+    ucc_memory_type_t   mt   = UCC_MEMORY_TYPE_CUDA;
     ucc_coll_score_t   *score;
     ucc_status_t        status;
 
@@ -246,7 +247,7 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
         ucc_coll_score_build_default(tl_team, UCC_TL_CUDA_DEFAULT_SCORE,
                                      ucc_tl_cuda_coll_init,
                                      UCC_TL_CUDA_SUPPORTED_COLLS,
-                                     NULL, 0, &score);
+                                     &mt, 1, &score);
     if (UCC_OK != status) {
         return status;
     }

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -24,15 +24,15 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params->team);
 
+    self->rank   = params->rank;
+    self->oob    = params->params.oob;
+    self->size   = self->oob.n_oob_eps;
+    self->stream = NULL;
     if (self->size > UCC_TL_CUDA_MAX_PEERS) {
         tl_info(tl_context->lib, "team size is too large, max supported %d",
                 UCC_TL_CUDA_MAX_PEERS);
         return UCC_ERR_NOT_SUPPORTED;
     }
-    self->rank   = params->rank;
-    self->oob    = params->params.oob;
-    self->size   = self->oob.n_oob_eps;
-    self->stream = NULL;
     for (i = 0; i < self->size; i++) {
         if (!ucc_rank_on_local_node(i, params->team)) {
             tl_info(tl_context->lib, "rank %d is on different node, "

--- a/src/components/tl/cuda/tl_cuda_topo.c
+++ b/src/components/tl/cuda/tl_cuda_topo.c
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_cuda_topo.h"
+
+static ucc_status_t ucc_tl_cuda_topo_init_matrix(ucc_tl_cuda_team_t *team,
+                                                 ucc_tl_cuda_topo_t *cuda_topo)
+{
+    ucc_rank_t size = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t i, j;
+    int dev, peer_dev, peer_access;
+    ucc_status_t status;
+
+    for (i = 0; i < size; i++) {
+       dev = team->ids[i].device;
+       cuda_topo->matrix[i*size + i] = 1;
+        for (j = i + 1; j < size; j++) {
+            peer_dev = team->ids[j].device;
+            CUDACHECK_GOTO(cudaDeviceCanAccessPeer(&peer_access, dev, peer_dev),
+                           exit_err, status, UCC_TL_TEAM_LIB(team));
+            cuda_topo->matrix[i*size + j] = peer_access;
+            cuda_topo->matrix[j*size + i] = peer_access;
+        }
+    }
+    return UCC_OK;
+exit_err:
+    return status;
+}
+
+static ucc_status_t ucc_tl_cuda_topo_init_proxy(ucc_tl_cuda_team_t *team,
+                                                ucc_tl_cuda_topo_t *topo)
+{
+    ucc_rank_t size        = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t num_proxies = 0;
+    ucc_rank_t i, j, k, p;
+    ucc_status_t status;
+
+    for (i = 0; i < size * size; i++) {
+        if (topo->matrix[i] == 0) {
+            num_proxies ++;
+        }
+    }
+
+    topo->num_proxies = num_proxies;
+    if (num_proxies == 0) {
+        return UCC_OK;
+    }
+    topo->proxies = (ucc_tl_cuda_proxy_t*)ucc_malloc(
+            num_proxies * sizeof(ucc_tl_cuda_proxy_t), "cuda_topo_proxies");
+    if (!topo->proxies) {
+        tl_error(UCC_TL_TEAM_LIB(team), "failed to alloc cuda topo proxy");
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    p = 0;
+    for (i = 0; i < size; i++) {
+        for (j = 0; j < size; j++) {
+            if (ucc_tl_cuda_topo_is_direct(team, topo, i, j)) {
+                continue;
+            }
+            for (k = 0; k < size; k++) {
+                if (ucc_tl_cuda_topo_is_direct(team, topo, i, k) &&
+                    ucc_tl_cuda_topo_is_direct(team, topo, k, j)) {
+                    topo->proxies[p].src   = i;
+                    topo->proxies[p].dst   = j;
+                    topo->proxies[p].proxy = k;
+                    break;
+                }
+            }
+            if (k == size) {
+                tl_info(UCC_TL_TEAM_LIB(team), "no proxy found between"
+                        "dev %d rank %d and dev %d rank %d, "
+                        "cuda topology is not supported",
+                        i, team->ids[i].device, j, team->ids[j].device);
+                status = UCC_ERR_NOT_SUPPORTED;
+                goto free_proxy;
+            }
+            p++;
+        }
+    }
+    return UCC_OK;
+
+free_proxy:
+    ucc_free(topo->proxies);
+    return status;
+}
+
+ucc_status_t ucc_tl_cuda_topo_create(ucc_tl_cuda_team_t *team,
+                                     ucc_tl_cuda_topo_t **cuda_topo)
+{
+    ucc_rank_t size = UCC_TL_TEAM_SIZE(team);
+    ucc_tl_cuda_topo_t *topo;
+    ucc_status_t status;
+
+    topo = (ucc_tl_cuda_topo_t*)ucc_malloc(sizeof(*topo), "cuda_topo");
+    if (!topo) {
+        tl_error(UCC_TL_TEAM_LIB(team), "failed to alloc cuda topo");
+        status = UCC_ERR_NO_MEMORY;
+        goto exit_err;
+    }
+
+    topo->proxies = NULL;
+    topo->matrix  = (int*)ucc_malloc(size * size * sizeof(int),
+                                     "cuda_topo_matrix");
+    if (!topo->matrix) {
+        tl_error(UCC_TL_TEAM_LIB(team), "failed to alloc cuda topo matrix");
+        status = UCC_ERR_NO_MEMORY;
+        goto free_topo;
+    }
+
+    status = ucc_tl_cuda_topo_init_matrix(team, topo);
+    if (status != UCC_OK) {
+        tl_error(UCC_TL_TEAM_LIB(team), "failed to init cuda topo matrix");
+        goto free_topo_matrix;
+    }
+
+    status = ucc_tl_cuda_topo_init_proxy(team, topo);
+    if (status != UCC_OK) {
+        if (status != UCC_ERR_NOT_SUPPORTED) {
+            tl_error(UCC_TL_TEAM_LIB(team), "failed to init cuda topo proxy");
+        }
+        goto free_topo_matrix;
+    }
+
+    *cuda_topo = topo;
+    return UCC_OK;
+free_topo_matrix:
+    ucc_free(topo->matrix);
+free_topo:
+    ucc_free(topo);
+exit_err:
+    return status;
+}
+
+void ucc_tl_cuda_topo_print(ucc_tl_cuda_team_t *team,
+                            ucc_tl_cuda_topo_t *cuda_topo)
+{
+    ucc_rank_t size = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t rank = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t i, j;
+
+    for (i = 0; i < size; i++) {
+        if (ucc_tl_cuda_topo_is_direct(team, cuda_topo, rank, i)) {
+            tl_debug(UCC_TL_TEAM_LIB(team),
+                     "dev %d rank %d to dev %d rank %d: direct",
+                     team->ids[rank].device, rank, team->ids[i].device, i);
+        } else {
+            for (j = 0 ; j < cuda_topo->num_proxies; j++) {
+                if ((cuda_topo->proxies[j].src == rank) &&
+                    (cuda_topo->proxies[j].dst == i)) {
+                    tl_debug(UCC_TL_TEAM_LIB(team),
+                             "dev %d rank %d to dev %d rank %d: "
+                             "proxy dev %d rank %d",
+                             team->ids[rank].device, rank,
+                             team->ids[i].device, i,
+                             team->ids[cuda_topo->proxies[j].proxy].device,
+                             cuda_topo->proxies[j].proxy);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+ucc_status_t ucc_tl_cuda_topo_destroy(ucc_tl_cuda_topo_t *cuda_topo)
+{
+    ucc_free(cuda_topo->matrix);
+    if (cuda_topo->proxies) {
+        ucc_free(cuda_topo->proxies);
+    }
+    ucc_free(cuda_topo);
+    return UCC_OK;
+}

--- a/src/components/tl/cuda/tl_cuda_topo.h
+++ b/src/components/tl/cuda/tl_cuda_topo.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_TOPO_H_
+#define UCC_TL_CUDA_TOPO_H_
+
+#include "tl_cuda.h"
+
+ucc_status_t ucc_tl_cuda_topo_create(ucc_tl_cuda_team_t *team,
+                                     ucc_tl_cuda_topo_t **cuda_topo);
+
+ucc_status_t ucc_tl_cuda_topo_destroy(ucc_tl_cuda_topo_t *cuda_topo);
+
+static inline int ucc_tl_cuda_topo_is_direct(ucc_tl_cuda_team_t *team,
+                                             ucc_tl_cuda_topo_t *cuda_topo,
+                                             ucc_rank_t r1, ucc_rank_t r2)
+{
+    return cuda_topo->matrix[r1 * UCC_TL_TEAM_SIZE(team) + r2] == 1;
+}
+
+void ucc_tl_cuda_topo_print(ucc_tl_cuda_team_t *team,
+                            ucc_tl_cuda_topo_t *cuda_topo);
+
+#endif

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -75,4 +75,19 @@ static inline void float32tobfloat16(float float_val, void *bfloat16_ptr)
 #endif
 }
 
+#define ucc_padding(_n, _alignment)                                            \
+    ( ((_alignment) - (_n) % (_alignment)) % (_alignment) )
+
+#define ucc_align_down(_n, _alignment)                                         \
+    ( (_n) - ((_n) % (_alignment)) )
+
+#define ucc_align_up(_n, _alignment)                                           \
+    ( (_n) + ucc_padding(_n, _alignment) )
+
+#define ucc_align_down_pow2(_n, _alignment)                                    \
+    ( (_n) & ~((_alignment) - 1) )
+
+#define ucc_align_up_pow2(_n, _alignment)                                      \
+    ucc_align_down_pow2((_n) + (_alignment) - 1, _alignment)
+
 #endif

--- a/src/utils/ucc_sys.c
+++ b/src/utils/ucc_sys.c
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_sys.h"
+#include "ucc_math.h"
+#include "ucc_log.h"
+#include <sys/shm.h>
+#include <unistd.h>
+#include <errno.h>
+
+ucc_status_t ucc_sysv_alloc(size_t *size, void **addr, int *shm_id)
+{
+    size_t alloc_size;
+    void *ptr;
+    int ret;
+
+    alloc_size = ucc_align_up(*size, getpagesize());
+
+    *shm_id = shmget(IPC_PRIVATE, alloc_size, IPC_CREAT | 0666);
+    if (*shm_id < 0) {
+        ucc_error("failed to shmget with IPC_PRIVATE, size %zd, IPC_CREAT "
+                  "errno: %d(%s)", alloc_size, errno, strerror(errno));
+        return UCC_ERR_NO_RESOURCE;
+    }
+
+    ptr = shmat(*shm_id, NULL, 0);
+    /* Remove segment, the attachment keeps a reference to the mapping */
+    /* FIXME having additional attaches to a removed segment is not portable
+    * behavior */
+    ret = shmctl(*shm_id, IPC_RMID, NULL);
+    if (ret != 0) {
+        ucc_warn("shmctl(IPC_RMID, shmid=%d) errno: %d(%s)", *shm_id, errno,
+                 strerror(errno));
+    }
+
+    if (ptr == (void*)-1) {
+        ucc_error("failed to shmat errno: %d(%s)", errno, strerror(errno));
+        if (errno == ENOMEM) {
+            return UCC_ERR_NO_MEMORY;
+        } else {
+            return UCC_ERR_NO_MESSAGE;
+        }
+    }
+    *size = alloc_size;
+    *addr = ptr;
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_sysv_free(void *addr)
+{
+    int ret;
+
+    ret = shmdt(addr);
+    if (ret) {
+        ucc_warn("failed to detach shm at %p, errno: %d(%s)", addr, errno,
+                 strerror(errno));
+        return UCC_ERR_INVALID_PARAM;
+    }
+
+    return UCC_OK;
+}

--- a/src/utils/ucc_sys.h
+++ b/src/utils/ucc_sys.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_SYS_H_
+#define UCC_SYS_H_
+
+#include "ucc/api/ucc_status.h"
+#include <stddef.h>
+
+ucc_status_t ucc_sysv_alloc(size_t *size, void **addr, int *shm_id);
+
+ucc_status_t ucc_sysv_free(void *addr);
+
+#endif

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -70,7 +70,7 @@ void PrintHelp()
        "--max_size   <value>:           maximum send/recv buffer allocation size\n"
        "--count_bits <c1,c2,..>:        list of counts bits: 32,64          (alltoallv only)\n"
        "--displ_bits <d1,d2,..>:        list of displacements bits: 32,64   (alltoallv only)\n"
-       "--set_device <value>:           0 - don't set, 1 - cuda_device = local_rank, 2 - cuda_device = local_rank % cuda_device_count"
+       "--set_device <value>:           0 - don't set, 1 - cuda_device = local_rank, 2 - cuda_device = local_rank % cuda_device_count\n"
        "--num_tests  <value>:           number of tests to run in parallel\n"
        "--help:              Show help\n";
 }
@@ -349,7 +349,7 @@ int ProcessArgs(int argc, char** argv)
                                 {"displ_bits", required_argument, nullptr, 'D'},
                                 {"iter", required_argument, nullptr, 'i'},
                                 {"thread-multiple", no_argument, nullptr, 'T'},
-                                {"num_test", no_argument, nullptr, 'N'},
+                                {"num_tests", required_argument, nullptr, 'N'},
 #ifdef HAVE_CUDA
                                 {"set_device", required_argument, nullptr, 'S'},
 #endif

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -33,6 +33,7 @@ static int root_value = 10;
 static ucc_thread_mode_t                   thread_mode  = UCC_THREAD_SINGLE;
 static int                                 iterations   = 1;
 static int                                 show_help    = 0;
+static int                                 num_tests    = 1;
 #ifdef HAVE_CUDA
 static test_set_cuda_device_t test_cuda_set_device = TEST_SET_DEV_NONE;
 #endif
@@ -70,7 +71,7 @@ void PrintHelp()
        "--count_bits <c1,c2,..>:        list of counts bits: 32,64          (alltoallv only)\n"
        "--displ_bits <d1,d2,..>:        list of displacements bits: 32,64   (alltoallv only)\n"
        "--set_device <value>:           0 - don't set, 1 - cuda_device = local_rank, 2 - cuda_device = local_rank % cuda_device_count"
-       "\n"
+       "--num_tests  <value>:           number of tests to run in parallel\n"
        "--help:              Show help\n";
 }
 
@@ -332,7 +333,7 @@ void PrintInfo()
 
 int ProcessArgs(int argc, char** argv)
 {
-    const char *const short_opts  = "c:t:m:d:o:M:I:r:s:C:D:i:Z:ThS:";
+    const char *const short_opts  = "c:t:m:d:o:M:I:N:r:s:C:D:i:Z:ThS:";
     const option      long_opts[] = {
                                 {"colls", required_argument, nullptr, 'c'},
                                 {"teams", required_argument, nullptr, 't'},
@@ -348,6 +349,7 @@ int ProcessArgs(int argc, char** argv)
                                 {"displ_bits", required_argument, nullptr, 'D'},
                                 {"iter", required_argument, nullptr, 'i'},
                                 {"thread-multiple", no_argument, nullptr, 'T'},
+                                {"num_test", no_argument, nullptr, 'N'},
 #ifdef HAVE_CUDA
                                 {"set_device", required_argument, nullptr, 'S'},
 #endif
@@ -405,6 +407,9 @@ int ProcessArgs(int argc, char** argv)
             break;
         case 'i':
             iterations = std::stoi(optarg);
+            break;
+        case 'N':
+            num_tests = std::stoi(optarg);
             break;
 #ifdef HAVE_CUDA
         case 'S':
@@ -471,6 +476,7 @@ int main(int argc, char *argv[])
     }
     test->create_teams(teams);
     test->set_iter(iterations);
+    test->set_num_tests(num_tests);
     test->set_colls(colls);
     test->set_dtypes(dtypes);
     test->set_mtypes(mtypes);

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -92,22 +92,19 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 ucc_status_t TestAllgatherv::set_input()
 {
     size_t dt_size = ucc_dt_size(TEST_DT);
-    size_t single_rank_count, single_rank_size
     int rank;
     void *buf, *check_buf;
 
     MPI_Comm_rank(team.comm, &rank);
-    single_rank_count = counts[rank];
-    single_rank_size = single_rank_count * dt_size;
     if (inplace == TEST_NO_INPLACE) {
         buf       = sbuf;
         check_buf = check_sbuf;
     } else {
-        buf       = PTR_OFFSET(rbuf, rank * single_rank_size);
-        check_buf = PTR_OFFSET(check_rbuf, rank * single_rank_size);
+        buf       = PTR_OFFSET(rbuf, displacements[rank] * dt_size);
+        check_buf = PTR_OFFSET(check_rbuf, displacements[rank] * dt_size);
     }
-    init_buffer(buf, single_rank_count, TEST_DT, mem_type, rank);
-    UCC_CHECK(ucc_mc_memcpy(check_buf, buf, single_rank_size,
+    init_buffer(buf, counts[rank], TEST_DT, mem_type, rank);
+    UCC_CHECK(ucc_mc_memcpy(check_buf, buf, counts[rank] * dt_size,
                             UCC_MEMORY_TYPE_HOST, mem_type));
     return UCC_OK;
 }

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -45,7 +45,6 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     displacements = NULL;
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
-    args.coll_type = UCC_COLL_TYPE_ALLGATHERV;
 
     if (TEST_SKIP_NONE != skip_reduce(test_max_size < (_msgsize*size),
                                       TEST_SKIP_MEM_LIMIT, team.comm)) {
@@ -65,19 +64,16 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     if (TEST_NO_INPLACE == inplace) {
         args.mask = 0;
         UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, counts[rank] * dt_size, _mt));
+        UCC_CHECK(ucc_mc_alloc(&check_sbuf_mc_header, counts[rank] * dt_size,
+                               UCC_MEMORY_TYPE_HOST));
         sbuf = sbuf_mc_header->addr;
-        init_buffer(sbuf, counts[rank], TEST_DT, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
-                           _mt, counts[rank] * dt_size);
         check_sbuf = check_sbuf_mc_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
-        init_buffer((void*)((ptrdiff_t)rbuf + displacements[rank] * dt_size),
-                    counts[rank], TEST_DT, _mt, rank);
-        init_buffer((void*)((ptrdiff_t)check_rbuf + displacements[rank] * dt_size),
-                    counts[rank], TEST_DT, UCC_MEMORY_TYPE_HOST, rank);
     }
+
+    args.coll_type = UCC_COLL_TYPE_ALLGATHERV;
     if (TEST_NO_INPLACE == inplace) {
         args.src.info.buffer          = sbuf;
         args.src.info.datatype        = TEST_DT;
@@ -89,7 +85,36 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     args.dst.info_v.displacements = (ucc_aint_t*)displacements;
     args.dst.info_v.datatype      = TEST_DT;
     args.dst.info_v.mem_type      = _mt;
+    UCC_CHECK(set_input());
     UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
+}
+
+ucc_status_t TestAllgatherv::set_input()
+{
+    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t single_rank_count, single_rank_size
+    int rank;
+    void *buf, *check_buf;
+
+    MPI_Comm_rank(team.comm, &rank);
+    single_rank_count = counts[rank];
+    single_rank_size = single_rank_count * dt_size;
+    if (inplace == TEST_NO_INPLACE) {
+        buf       = sbuf;
+        check_buf = check_sbuf;
+    } else {
+        buf       = PTR_OFFSET(rbuf, rank * single_rank_size);
+        check_buf = PTR_OFFSET(check_rbuf, rank * single_rank_size);
+    }
+    init_buffer(buf, single_rank_count, TEST_DT, mem_type, rank);
+    UCC_CHECK(ucc_mc_memcpy(check_buf, buf, single_rank_size,
+                            UCC_MEMORY_TYPE_HOST, mem_type));
+    return UCC_OK;
+}
+
+ucc_status_t TestAllgatherv::reset_sbuf()
+{
+    return UCC_OK;
 }
 
 TestAllgatherv::~TestAllgatherv() {

--- a/test/mpi/test_allreduce.cc
+++ b/test/mpi/test_allreduce.cc
@@ -33,10 +33,9 @@ TestAllreduce::TestAllreduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     UCC_MALLOC_CHECK(check_rbuf);
     if (TEST_NO_INPLACE == inplace) {
         UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
-        sbuf = sbuf_mc_header->addr;
-        init_buffer(sbuf, count, dt, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
-                           _mt, _msgsize);
+        UCC_CHECK(ucc_mc_alloc(&check_sbuf_mc_header, _msgsize,
+                               UCC_MEMORY_TYPE_HOST));
+        sbuf       = sbuf_mc_header->addr;
         check_sbuf = check_sbuf_mc_header->addr;
 
         args.src.info.buffer      = sbuf;
@@ -44,11 +43,8 @@ TestAllreduce::TestAllreduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         args.src.info.datatype    = _dt;
         args.src.info.mem_type    = _mt;
     } else {
-        args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
-        args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
-        init_buffer(rbuf, count, dt, _mt, rank);
-        init_buffer(check_rbuf, count, dt, UCC_MEMORY_TYPE_HOST, rank);
-
+        args.mask                 = UCC_COLL_ARGS_FIELD_FLAGS;
+        args.flags                = UCC_COLL_ARGS_FLAG_IN_PLACE;
         args.src.info.buffer      = NULL;
         args.src.info.count       = SIZE_MAX;
         args.src.info.datatype    = (ucc_datatype_t)-1;
@@ -60,7 +56,34 @@ TestAllreduce::TestAllreduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     args.dst.info.count       = count;
     args.dst.info.datatype    = _dt;
     args.dst.info.mem_type    = _mt;
+    UCC_CHECK(set_input());
     UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
+}
+
+ucc_status_t TestAllreduce::set_input()
+{
+    size_t dt_size = ucc_dt_size(dt);
+    size_t count   = msgsize / dt_size;
+    int rank;
+    void *buf, *check_buf;
+
+    MPI_Comm_rank(team.comm, &rank);
+    if (TEST_NO_INPLACE == inplace) {
+        buf = sbuf;
+        check_buf = check_sbuf;
+    } else {
+        buf = rbuf;
+        check_buf = check_rbuf;
+    }
+    init_buffer(buf, count, dt, mem_type, rank);
+    UCC_CHECK(ucc_mc_memcpy(check_buf, buf, count * dt_size,
+                            UCC_MEMORY_TYPE_HOST, mem_type));
+    return UCC_OK;
+}
+
+ucc_status_t TestAllreduce::reset_sbuf()
+{
+    return UCC_OK;
 }
 
 ucc_status_t TestAllreduce::check()

--- a/test/mpi/test_barrier.cc
+++ b/test/mpi/test_barrier.cc
@@ -13,6 +13,16 @@ TestBarrier::TestBarrier(ucc_test_team_t &team) : TestCase(team)
     UCC_CHECK(ucc_collective_init(&args, &req, team.team));
 }
 
+ucc_status_t TestBarrier::set_input()
+{
+    return UCC_OK;
+}
+
+ucc_status_t TestBarrier::reset_sbuf()
+{
+    return UCC_OK;
+}
+
 ucc_status_t TestBarrier::check()
 {
     return status;

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -6,17 +6,39 @@
 
 #include "test_mpi.h"
 
-std::shared_ptr<TestCase> TestCase::init(ucc_coll_type_t _type,
-                                         ucc_test_team_t &_team,
-                                         int root,
-                                         size_t msgsize,
-                                         ucc_test_mpi_inplace_t inplace,
-                                         ucc_memory_type_t mt,
-                                         size_t max_size,
-                                         ucc_datatype_t dt,
-                                         ucc_reduction_op_t op,
-                                         ucc_test_vsize_flag_t count_bits,
-                                         ucc_test_vsize_flag_t displ_bits)
+std::vector<std::shared_ptr<TestCase>>
+TestCase::init(ucc_coll_type_t _type, ucc_test_team_t &_team, int num_tests,
+               int root, size_t msgsize, ucc_test_mpi_inplace_t inplace,
+               ucc_memory_type_t mt, size_t max_size, ucc_datatype_t dt,
+               ucc_reduction_op_t op, ucc_test_vsize_flag_t count_bits,
+               ucc_test_vsize_flag_t displ_bits)
+{
+    std::vector<std::shared_ptr<TestCase>> tcs;
+
+    for (int i = 0; i < num_tests; i++) {
+        auto tc = init_single(_type, _team, root, msgsize, inplace, mt,
+                              max_size, dt, op, count_bits, displ_bits);
+        if (!tc) {
+            tcs.clear();
+            return tcs;
+        }
+        tcs.push_back(tc);
+    }
+    return tcs;
+}
+
+std::shared_ptr<TestCase> TestCase::init_single(
+        ucc_coll_type_t _type,
+        ucc_test_team_t &_team,
+        int root,
+        size_t msgsize,
+        ucc_test_mpi_inplace_t inplace,
+        ucc_memory_type_t mt,
+        size_t max_size,
+        ucc_datatype_t dt,
+        ucc_reduction_op_t op,
+        ucc_test_vsize_flag_t count_bits,
+        ucc_test_vsize_flag_t displ_bits)
 {
     switch(_type) {
     case UCC_COLL_TYPE_BARRIER:

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -329,6 +329,7 @@ std::vector<ucc_status_t> UccTestMpi::exec_tests(
         }
     } while (num_done != tcs.size());
     for (auto tc: tcs) {
+        tc->reset_sbuf();
         status = tc->check();
         if (UCC_OK != status) {
             std::cerr << "FAILURE in: " << tc->str() << std::endl;

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -212,6 +212,8 @@ public:
              size_t _max_size = TEST_UCC_RANK_BUF_SIZE_MAX);
     virtual ~TestCase();
     virtual void run();
+    virtual ucc_status_t set_input() = 0;
+    virtual ucc_status_t reset_sbuf() = 0;
     virtual ucc_status_t check() = 0;
     virtual std::string str();
     virtual ucc_status_t test();
@@ -284,6 +286,8 @@ class TestBarrier : public TestCase {
     ucc_status_t status;
 public:
     TestBarrier(ucc_test_team_t &team);
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
     ucc_status_t check();
     std::string str();
     void run();
@@ -298,6 +302,8 @@ public:
                   ucc_datatype_t _dt, ucc_reduction_op_t _op,
                   ucc_memory_type_t _mt, ucc_test_team_t &team,
                   size_t _max_size);
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
     ucc_status_t check();
     std::string str();
 };
@@ -307,6 +313,8 @@ public:
     TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t inplace,
                   ucc_memory_type_t _mt, ucc_test_team_t &team,
                   size_t _max_size);
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
     ucc_status_t check();
 };
 
@@ -318,6 +326,8 @@ public:
                    ucc_memory_type_t _mt, ucc_test_team_t &team,
                    size_t _max_size);
     ~TestAllgatherv();
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
     ucc_status_t check() override;
 };
 
@@ -326,6 +336,8 @@ public:
     TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
               ucc_memory_type_t _mt, int root, ucc_test_team_t &team,
               size_t _max_size);
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
     ucc_status_t check();
 };
 
@@ -337,6 +349,8 @@ public:
                ucc_datatype_t _dt, ucc_reduction_op_t _op,
                ucc_memory_type_t _mt, int root, ucc_test_team_t &team,
                size_t _max_size);
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
     ucc_status_t check();
 };
 
@@ -345,6 +359,8 @@ public:
     TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                  ucc_memory_type_t _mt, ucc_test_team_t &_team,
                  size_t _max_size);
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
     ucc_status_t check();
 };
 
@@ -370,6 +386,8 @@ public:
                   size_t _max_size,
                   ucc_test_vsize_flag_t count_bits,
                   ucc_test_vsize_flag_t displ_bits);
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
     ucc_status_t check();
     std::string str();
     ~TestAlltoallv();
@@ -383,6 +401,8 @@ public:
                       ucc_datatype_t _dt, ucc_reduction_op_t _op,
                       ucc_memory_type_t _mt, ucc_test_team_t &team,
                       size_t _max_size);
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
     ~TestReduceScatter();
     ucc_status_t check();
     std::string str();


### PR DESCRIPTION
## What
Implementation of new TL based on CUDA IPC transport a.k.a NVLink. This PR adds general logic to create lib, context and team objects as well as implementation of alltoall collective.
Further steps:
- support for triggered post
- support for CL HIER
- support for different NVLink topologies
- more collectives

## Why ?
In some cases we cannot use CUDA IPC through UCP TL
Performance of Alltoall on 1 Node, 4 PPN
| Size    | TL UCP (us) | TL CUDA (us) |
|---------|-------------|--------------|
| 4096    | 103.58      | 55.33        |
| 8192    | 174.51      | 55.97        |
| 16384   | 90.74       | 59.73        |
| 32768   | 91.56       | 61.60        |
| 65536   | 94.36       | 67.02        |
| 131072  | 100.62      | 72.01        |
| 262144  | 112.01      | 89.31        |
| 524288  | 144.72      | 113.65       |
| 1048576 | 233.94      | 176.28       |
| 2097152 | 384.55      | 300.24       |
| 4194304 | 716.55      | 524.44       |

