### PR TITLE
BUILD: fix clang tidy warnings

### DIFF
--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -35,10 +35,10 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
                          ucc_coll_task_t **task)
 {
     ucc_cl_hier_team_t  *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_coll_task_t     *tasks[MAX_AR_RAB_TASKS] = {NULL};
     ucc_schedule_t      *schedule;
     ucc_status_t         status;
     ucc_base_coll_args_t args;
-    ucc_coll_task_t     *tasks[MAX_AR_RAB_TASKS];
     int                  n_tasks, i;
 
     schedule = &ucc_cl_hier_get_schedule(cl_team)->super.super;

--- a/src/components/tl/ucp/scatter/scatter_knomial.c
+++ b/src/components/tl/ucp/scatter/scatter_knomial.c
@@ -58,7 +58,6 @@ ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_kn_radix_t         radix     = task->scatter_kn.p.radix;
     uint8_t                node_type = task->scatter_kn.p.node_type;
     ucc_knomial_pattern_t *p         = &task->scatter_kn.p;
-    void                  *sbuf      = args->src.info.buffer;
     void                  *rbuf      = args->dst.info.buffer;
     ucc_memory_type_t      mem_type  = args->src.info.mem_type;
     size_t                 count     = args->src.info.count;
@@ -67,6 +66,7 @@ ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_rank_t             root      = (ucc_rank_t)args->root;
     ucc_rank_t             size      = team->size;
     ucc_rank_t             rank      = VRANK(team->rank, root, size);
+    void                  *sbuf;
     ucc_rank_t             team_size = team->size - p->n_extra;
     ucc_rank_t             peer, vroot, vpeer, peer_recv_dist;
     ucc_rank_t             step_radix, peer_seg_index, local_seg_index;

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -317,6 +317,10 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
     ucc_coll_task_t *ev_task;
     ucc_status_t     status;
 
+    if (ev->ev_type != UCC_EVENT_COMPUTE_COMPLETE) {
+        ucc_error("event type %d is not supported", ev->ev_type);
+        return UCC_ERR_NOT_IMPLEMENTED;
+    }
     task->ee = ee;
     ev_task = ucc_malloc(sizeof(*ev_task), "ev_task");
     if (!ev_task) {

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -165,6 +165,7 @@ ucc_status_t ucc_context_config_modify(ucc_context_config_t *config,
             if (!cl_cfg) {
                 ucc_error("required CL %s is not part of the context",
                           ucc_cl_names[required_cls[i]]);
+                ucc_free(required_cls);
                 return UCC_ERR_INVALID_PARAM;
             }
             status = ucc_config_parser_set_value(
@@ -174,6 +175,7 @@ ucc_status_t ucc_context_config_modify(ucc_context_config_t *config,
                 ucc_error("failed to modify CL \"%s\" configuration, name %s, "
                           "value %s",
                           cl_cfg->cl_lib->iface->super.name, name, value);
+                ucc_free(required_cls);
                 return status;
             }
         }


### PR DESCRIPTION
## What
Fixing following clang-tidy warnings

-  allreduce/allreduce_rab.c: 100:5: warning: 3rd function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
- scatter/scatter_knomial.c:61:28:  warning: Value stored to 'sbuf' during its initialization is never read [clang-analyzer-deadcode.DeadStores]
- core/ucc_coll.c:314:56: warning: parameter 'ev' is unused [misc-unused-parameters]
- coll_score/ucc_coll_score.c:123:9: warning: Potential memory leak [clang-analyzer-unix.Malloc]
