### PR TITLE
CORE: new dt/op proposal #1

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,8 @@ noinst_HEADERS =                      \
 	core/ucc_topo.h                   \
 	core/ucc_sbgp.h                   \
 	core/ucc_service_coll.h           \
+	core/ucc_dt.h	                  \
+	core/ucc_op.h	                  \
 	schedule/ucc_schedule.h           \
 	schedule/ucc_schedule_pipelined.h \
 	coll_score/ucc_coll_score.h       \
@@ -97,6 +99,8 @@ libucc_la_SOURCES =                   \
 	core/ucc_topo.c                   \
 	core/ucc_sbgp.c                   \
 	core/ucc_service_coll.c           \
+	core/ucc_dt.c                     \
+	core/ucc_op.c                     \
 	schedule/ucc_schedule.c           \
 	schedule/ucc_schedule_pipelined.c \
 	coll_score/ucc_coll_score.c       \

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -196,7 +196,8 @@ static ucc_status_t ucc_mc_cpu_reduce_multi(const void *src1, const void *src2,
         return ucc_mc_cpu_reduce_multi_double(src1, src2, dst, n_vectors,
                                               count, stride, op);
     default:
-        mc_error(&ucc_mc_cpu.super, "unsupported reduction type (%d)", dt);
+        mc_error(&ucc_mc_cpu.super, "unsupported reduction type (%s)",
+                 ucc_datatype_str(dt));
         return UCC_ERR_NOT_SUPPORTED;
     }
     return UCC_OK;

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce.h
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce.h
@@ -125,8 +125,8 @@
         default:                                                               \
             mc_error(&ucc_mc_cpu.super,                                        \
                      "int dtype does not support "                             \
-                     "requested reduce op: %d",                                \
-                     op);                                                      \
+                     "requested reduce op: %s",                                \
+                     ucc_reduction_op_str(op));                                \
             return UCC_ERR_NOT_SUPPORTED;                                      \
         }                                                                      \
     } while (0)
@@ -156,8 +156,8 @@
         default:                                                               \
             mc_error(&ucc_mc_cpu.super,                                        \
                      "float dtype does not support "                           \
-                     "requested reduce op: %d",                                \
-                     op);                                                      \
+                     "requested reduce op: %s",                                \
+                     ucc_reduction_op_str(op));                                \
             return UCC_ERR_NOT_SUPPORTED;                                      \
         }                                                                      \
     } while (0)

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -16,49 +16,47 @@
 #define ncclDataTypeUnsupported (ncclNumTypes + 1)
 
 ncclDataType_t ucc_to_nccl_dtype[] = {
-    [UCC_DT_INT8]        = (ncclDataType_t)ncclInt8,
-    [UCC_DT_INT16]       = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_INT32]       = (ncclDataType_t)ncclInt32,
-    [UCC_DT_INT64]       = (ncclDataType_t)ncclInt64,
-    [UCC_DT_INT128]      = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_UINT8]       = (ncclDataType_t)ncclUint8,
-    [UCC_DT_UINT16]      = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_UINT32]      = (ncclDataType_t)ncclUint32,
-    [UCC_DT_UINT64]      = (ncclDataType_t)ncclUint64,
-    [UCC_DT_UINT128]     = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_FLOAT16]     = (ncclDataType_t)ncclFloat16,
-    [UCC_DT_FLOAT32]     = (ncclDataType_t)ncclFloat32,
-    [UCC_DT_FLOAT64]     = (ncclDataType_t)ncclFloat64,
-    [UCC_DT_USERDEFINED] = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_OPAQUE]      = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT8)]        = (ncclDataType_t)ncclInt8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT16)]       = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT32)]       = (ncclDataType_t)ncclInt32,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT64)]       = (ncclDataType_t)ncclInt64,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT128)]      = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT8)]       = (ncclDataType_t)ncclUint8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT16)]      = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT32)]      = (ncclDataType_t)ncclUint32,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT64)]      = (ncclDataType_t)ncclUint64,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT128)]     = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT16)]     = (ncclDataType_t)ncclFloat16,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT32)]     = (ncclDataType_t)ncclFloat32,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT64)]     = (ncclDataType_t)ncclFloat64,
 };
 
 ncclRedOp_t ucc_to_nccl_reduce_op[] = {
-    [UCC_OP_USERDEFINED] = (ncclRedOp_t)ncclOpUnsupported,
-    [UCC_OP_SUM]         = (ncclRedOp_t)ncclSum,
-    [UCC_OP_PROD]        = (ncclRedOp_t)ncclProd,
-    [UCC_OP_MAX]         = (ncclRedOp_t)ncclMax,
-    [UCC_OP_MIN]         = (ncclRedOp_t)ncclMin,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_SUM)]         = (ncclRedOp_t)ncclSum,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_PROD)]        = (ncclRedOp_t)ncclProd,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_MAX)]         = (ncclRedOp_t)ncclMax,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_MIN)]         = (ncclRedOp_t)ncclMin,
 #if NCCL_VERSION_CODE < NCCL_VERSION(2,10,3)
-    [UCC_OP_AVG]         = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_AVG)]         = (ncclRedOp_t)ncclOpUnsupported,
 #else
-    [UCC_OP_AVG]         = (ncclRedOp_t)ncclAvg,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_AVG)]         = (ncclRedOp_t)ncclAvg,
 #endif
-    [UCC_OP_LAND]        = (ncclRedOp_t)ncclOpUnsupported,
-    [UCC_OP_LOR]         = (ncclRedOp_t)ncclOpUnsupported,
-    [UCC_OP_LXOR]        = (ncclRedOp_t)ncclOpUnsupported,
-    [UCC_OP_BAND]        = (ncclRedOp_t)ncclOpUnsupported,
-    [UCC_OP_BOR]         = (ncclRedOp_t)ncclOpUnsupported,
-    [UCC_OP_BXOR]        = (ncclRedOp_t)ncclOpUnsupported,
-    [UCC_OP_MAXLOC]      = (ncclRedOp_t)ncclOpUnsupported,
-    [UCC_OP_MINLOC]      = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_LAND)]        = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_LOR)]         = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_LXOR)]        = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_BAND)]        = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_BOR)]         = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_BXOR)]        = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_MAXLOC)]      = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_MINLOC)]      = (ncclRedOp_t)ncclOpUnsupported,
 };
 
 static inline ucc_status_t ucc_nccl_check_dt_supported(ucc_datatype_t dt1,
                                                        ucc_datatype_t dt2)
 {
-    if (ucc_unlikely((dt1 != dt2) ||
-                     (ucc_to_nccl_dtype[dt1] == ncclDataTypeUnsupported))) {
+    if (ucc_unlikely((dt1 != dt2) || !UCC_DT_IS_PREDEFINED(dt1) ||
+                     (ucc_to_nccl_dtype[UCC_DT_PREDEFINED_ID(dt1)]
+                      == ncclDataTypeUnsupported))) {
         return UCC_ERR_NOT_SUPPORTED;
     }
     return UCC_OK;
@@ -140,8 +138,8 @@ ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task)
         tl_error(UCC_TASK_LIB(task), "inplace alltoallv is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((TASK_ARGS(task).src.info.datatype == UCC_DT_USERDEFINED) ||
-        (TASK_ARGS(task).dst.info.datatype == UCC_DT_USERDEFINED)) {
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info.datatype))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -199,8 +197,8 @@ ucc_status_t ucc_tl_nccl_alltoallv_init(ucc_tl_nccl_task_t *task)
         tl_error(UCC_TASK_LIB(task), "inplace alltoall is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((TASK_ARGS(task).src.info_v.datatype == UCC_DT_USERDEFINED) ||
-        (TASK_ARGS(task).dst.info_v.datatype == UCC_DT_USERDEFINED)) {
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info_v.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info_v.datatype))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -220,7 +218,7 @@ ucc_status_t ucc_tl_nccl_allreduce_start(ucc_coll_task_t *coll_task)
         UCC_IS_INPLACE(*args) ? args->dst.info.buffer : args->src.info.buffer;
     ucc_status_t        status = UCC_OK;
     ncclDataType_t      dt     = ucc_to_nccl_dtype[args->dst.info.datatype];
-    ncclRedOp_t         op = ucc_to_nccl_reduce_op[args->reduce.predefined_op];
+    ncclRedOp_t         op = ucc_to_nccl_reduce_op[UCC_OP_PREDEFINED_ID(args->op)];
     size_t              count = args->dst.info.count;
 
     task->super.super.status = UCC_INPROGRESS;
@@ -239,8 +237,8 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_allreduce_init(ucc_tl_nccl_task_t *task)
 {
-    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
-        (ucc_to_nccl_reduce_op[TASK_ARGS(task).reduce.predefined_op] ==
+    if (!UCC_OP_IS_PREDEFINED(TASK_ARGS(task).op) ||
+         (ucc_to_nccl_reduce_op[UCC_OP_PREDEFINED_ID(TASK_ARGS(task).op)] ==
          ncclOpUnsupported)) {
         tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
@@ -347,8 +345,8 @@ ucc_status_t ucc_tl_nccl_allgatherv_init(ucc_tl_nccl_task_t *task)
         tl_error(UCC_TASK_LIB(task), "inplace allgatherv is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((TASK_ARGS(task).src.info_v.datatype == UCC_DT_USERDEFINED) ||
-        (TASK_ARGS(task).dst.info_v.datatype == UCC_DT_USERDEFINED)) {
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info_v.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info_v.datatype))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -404,7 +402,7 @@ ucc_status_t ucc_tl_nccl_reduce_scatter_start(ucc_coll_task_t *coll_task)
     ucc_status_t        status = UCC_OK;
     ncclDataType_t      dt     = ucc_to_nccl_dtype[args->dst.info.datatype];
     ncclRedOp_t         op     = ucc_to_nccl_reduce_op[
-                                    args->reduce.predefined_op];
+        UCC_OP_PREDEFINED_ID(args->op)];
     size_t              count  = args->dst.info.count;
 
     task->super.super.status = UCC_INPROGRESS;
@@ -424,8 +422,8 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_reduce_scatter_init(ucc_tl_nccl_task_t *task)
 {
-    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
-        (ucc_to_nccl_reduce_op[TASK_ARGS(task).reduce.predefined_op] ==
+    if ((!UCC_OP_IS_PREDEFINED(TASK_ARGS(task).op)) ||
+        (ucc_to_nccl_reduce_op[UCC_OP_PREDEFINED_ID(TASK_ARGS(task).op)] ==
          ncclOpUnsupported)) {
         tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
@@ -452,7 +450,7 @@ ucc_status_t ucc_tl_nccl_reduce_start(ucc_coll_task_t *coll_task)
     ucc_datatype_t      ucc_dt  = args->src.info.datatype;
     size_t              count   = args->src.info.count;
     ncclRedOp_t         op      = ucc_to_nccl_reduce_op[
-                                     args->reduce.predefined_op];
+        UCC_OP_PREDEFINED_ID(args->op)];
     ucc_status_t        status  = UCC_OK;
     ncclDataType_t      nccl_dt;
 
@@ -480,8 +478,8 @@ ucc_status_t ucc_tl_nccl_reduce_init(ucc_tl_nccl_task_t *task)
                            TASK_ARGS(task).dst.info.datatype:
                            TASK_ARGS(task).src.info.datatype;
 
-    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
-        (ucc_to_nccl_reduce_op[TASK_ARGS(task).reduce.predefined_op] ==
+    if ((!UCC_OP_IS_PREDEFINED(TASK_ARGS(task).op)) ||
+        (ucc_to_nccl_reduce_op[UCC_OP_PREDEFINED_ID(TASK_ARGS(task).op)] ==
          ncclOpUnsupported)) {
         tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
@@ -501,10 +499,9 @@ ucc_status_t ucc_tl_nccl_barrier_init(ucc_tl_nccl_task_t *task)
     /* use 4-byte allreduce to accomplish barrier */
     ucc_coll_args_t *args   = &TASK_ARGS(task);
 
-    args->mask |= (UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS |
-                   UCC_COLL_ARGS_FIELD_FLAGS);
+    args->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
     args->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
-    args->reduce.predefined_op = UCC_OP_SUM;
+    args->op     = UCC_OP_SUM;
 
     args->dst.info.buffer   = TASK_CTX(task)->scratch_buf;
     args->src.info.buffer   = args->dst.info.buffer;

--- a/src/components/tl/sharp/tl_sharp_coll.c
+++ b/src/components/tl/sharp/tl_sharp_coll.c
@@ -14,38 +14,35 @@
 #include <sharp/api/sharp_coll.h>
 
 int ucc_to_sharp_dtype[] = {
-    [UCC_DT_INT8]        = SHARP_DTYPE_NULL,
-    [UCC_DT_INT16]       = SHARP_DTYPE_SHORT,
-    [UCC_DT_INT32]       = SHARP_DTYPE_INT,
-    [UCC_DT_INT64]       = SHARP_DTYPE_LONG,
-    [UCC_DT_INT128]      = SHARP_DTYPE_NULL,
-    [UCC_DT_UINT8]       = SHARP_DTYPE_NULL,
-    [UCC_DT_UINT16]      = SHARP_DTYPE_UNSIGNED_SHORT,
-    [UCC_DT_UINT32]      = SHARP_DTYPE_UNSIGNED,
-    [UCC_DT_UINT64]      = SHARP_DTYPE_UNSIGNED_LONG,
-    [UCC_DT_UINT128]     = SHARP_DTYPE_NULL,
-    [UCC_DT_FLOAT16]     = SHARP_DTYPE_FLOAT_SHORT,
-    [UCC_DT_FLOAT32]     = SHARP_DTYPE_FLOAT,
-    [UCC_DT_FLOAT64]     = SHARP_DTYPE_DOUBLE,
-    [UCC_DT_USERDEFINED] = SHARP_DTYPE_NULL,
-    [UCC_DT_OPAQUE]      = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT8)]        = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT16)]       = SHARP_DTYPE_SHORT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT32)]       = SHARP_DTYPE_INT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT64)]       = SHARP_DTYPE_LONG,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT128)]      = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT8)]       = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT16)]      = SHARP_DTYPE_UNSIGNED_SHORT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT32)]      = SHARP_DTYPE_UNSIGNED,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT64)]      = SHARP_DTYPE_UNSIGNED_LONG,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT128)]     = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT16)]     = SHARP_DTYPE_FLOAT_SHORT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT32)]     = SHARP_DTYPE_FLOAT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT64)]     = SHARP_DTYPE_DOUBLE,
 };
 
 int ucc_to_sharp_reduce_op[] = {
-    [UCC_OP_USERDEFINED] = SHARP_OP_NULL,
-    [UCC_OP_SUM]         = SHARP_OP_SUM,
-    [UCC_OP_PROD]        = SHARP_OP_NULL,
-    [UCC_OP_MAX]         = SHARP_OP_MAX,
-    [UCC_OP_MIN]         = SHARP_OP_MIN,
-    [UCC_OP_LAND]        = SHARP_OP_LAND,
-    [UCC_OP_LOR]         = SHARP_OP_LOR,
-    [UCC_OP_LXOR]        = SHARP_OP_LXOR,
-    [UCC_OP_BAND]        = SHARP_OP_BAND,
-    [UCC_OP_BOR]         = SHARP_OP_BOR,
-    [UCC_OP_BXOR]        = SHARP_OP_BXOR,
-    [UCC_OP_MAXLOC]      = SHARP_OP_MAXLOC,
-    [UCC_OP_MINLOC]      = SHARP_OP_MINLOC,
-    [UCC_OP_AVG]         = SHARP_OP_NULL,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_SUM)]         = SHARP_OP_SUM,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_PROD)]        = SHARP_OP_NULL,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_MAX)]         = SHARP_OP_MAX,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_MIN)]         = SHARP_OP_MIN,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_LAND)]        = SHARP_OP_LAND,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_LOR)]         = SHARP_OP_LOR,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_LXOR)]        = SHARP_OP_LXOR,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_BAND)]        = SHARP_OP_BAND,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_BOR)]         = SHARP_OP_BOR,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_BXOR)]        = SHARP_OP_BXOR,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_MAXLOC)]      = SHARP_OP_MAXLOC,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_MINLOC)]      = SHARP_OP_MINLOC,
+    [UCC_OP_PREDEFINED_ID(UCC_OP_AVG)]         = SHARP_OP_NULL,
 };
 
 int ucc_to_sharp_memtype[] = {
@@ -181,8 +178,8 @@ ucc_status_t ucc_tl_sharp_allreduce_start(ucc_coll_task_t *coll_task)
     task->super.super.status = UCC_INPROGRESS;
     UCC_TL_SHARP_PROFILE_REQUEST_EVENT(coll_task, "sharp_allreduce_start", 0);
 
-    sharp_type = ucc_to_sharp_dtype[dt];
-    op_type    = ucc_to_sharp_reduce_op[args->reduce.predefined_op];
+    sharp_type = ucc_to_sharp_dtype[UCC_DT_PREDEFINED_ID(dt)];
+    op_type    = ucc_to_sharp_reduce_op[UCC_OP_PREDEFINED_ID(args->op)];
     data_size  = ucc_dt_size(dt) * count;
 
     if (!UCC_IS_INPLACE(*args)) {
@@ -234,14 +231,15 @@ ucc_status_t ucc_tl_sharp_allreduce_init(ucc_tl_sharp_task_t *task)
 {
     ucc_coll_args_t *args = &TASK_ARGS(task);
 
-    if (args->mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) {
+    if (!UCC_OP_IS_PREDEFINED(args->op) ||
+        !UCC_DT_IS_PREDEFINED(args->dst.info.datatype)) {
         return UCC_ERR_NOT_SUPPORTED;
     }
 
     if (ucc_to_sharp_memtype[args->src.info.mem_type] == SHARP_MEM_TYPE_LAST ||
         ucc_to_sharp_memtype[args->dst.info.mem_type] == SHARP_MEM_TYPE_LAST ||
-        ucc_to_sharp_dtype[args->dst.info.datatype] == SHARP_DTYPE_NULL ||
-        ucc_to_sharp_reduce_op[args->reduce.predefined_op] == SHARP_OP_NULL) {
+        ucc_to_sharp_dtype[UCC_DT_PREDEFINED_ID(args->dst.info.datatype)] == SHARP_DTYPE_NULL ||
+        ucc_to_sharp_reduce_op[UCC_OP_PREDEFINED_ID(args->op)] == SHARP_OP_NULL) {
         return UCC_ERR_NOT_SUPPORTED;
     }
 

--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -12,8 +12,8 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
 {
-    if ((TASK_ARGS(task).src.info.datatype == UCC_DT_USERDEFINED) ||
-        (TASK_ARGS(task).dst.info.datatype == UCC_DT_USERDEFINED)) {
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info.datatype))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/ucp/allgatherv/allgatherv.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv.c
@@ -14,9 +14,9 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task)
 {
-    if ((TASK_ARGS(task).dst.info_v.datatype == UCC_DT_USERDEFINED) ||
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info_v.datatype)) ||
         (!UCC_IS_INPLACE(TASK_ARGS(task)) &&
-         (TASK_ARGS(task).src.info.datatype == UCC_DT_USERDEFINED))) {
+         (!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info.datatype)))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/ucp/allreduce/allreduce.h
+++ b/src/components/tl/ucp/allreduce/allreduce.h
@@ -24,7 +24,7 @@ ucc_status_t ucc_tl_ucp_allreduce_init(ucc_tl_ucp_task_t *task);
 
 #define CHECK_USERDEFINED_OP(_args, _team)                                     \
     do {                                                                       \
-        if (_args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) {         \
+        if (!UCC_OP_IS_PREDEFINED((_args).op)) {                               \
             tl_error(UCC_TL_TEAM_LIB(_team),                                   \
                      "userdefined reductions are not supported yet");          \
             status = UCC_ERR_NOT_SUPPORTED;                                    \
@@ -44,7 +44,6 @@ ucc_status_t ucc_tl_ucp_allreduce_init(ucc_tl_ucp_task_t *task);
     } while (0)
 
 #define ALLREDUCE_TASK_CHECK(_args, _team)                                     \
-    CHECK_USERDEFINED_OP((_args), (_team));                                    \
     CHECK_SAME_MEMTYPE((_args), (_team));                                      \
     CHECK_AVG_OP((_args), (_team));
 

--- a/src/components/tl/ucp/alltoall/alltoall.h
+++ b/src/components/tl/ucp/alltoall/alltoall.h
@@ -28,15 +28,15 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_init_common(ucc_tl_ucp_task_t *task);
         }                                                   \
     } while (0)
 
-#define ALLTOALL_CHECK_USERDEFINED_DT(_args, _team)             \
-    do {                                                        \
-        if ((_args.src.info.datatype == UCC_DT_USERDEFINED) ||  \
-            (_args.dst.info.datatype == UCC_DT_USERDEFINED)) {  \
-            tl_error(UCC_TL_TEAM_LIB(_team),                    \
-                     "user defined datatype is not supported"); \
-            status = UCC_ERR_NOT_SUPPORTED;                     \
-            goto out;                                           \
-        }                                                       \
+#define ALLTOALL_CHECK_USERDEFINED_DT(_args, _team  )             \
+    do {                                                          \
+        if (!UCC_DT_IS_PREDEFINED((_args).src.info.datatype) ||   \
+            !UCC_DT_IS_PREDEFINED((_args).dst.info.datatype)) {   \
+            tl_error(UCC_TL_TEAM_LIB(_team),                      \
+                     "user defined datatype is not supported");   \
+            status = UCC_ERR_NOT_SUPPORTED;                       \
+            goto out;                                             \
+        }                                                         \
     } while (0)
 
 #define ALLTOALL_TASK_CHECK(_args, _team)              \

--- a/src/components/tl/ucp/alltoallv/alltoallv.h
+++ b/src/components/tl/ucp/alltoallv/alltoallv.h
@@ -30,8 +30,8 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task);
 
 #define ALLTOALLV_CHECK_USERDEFINED_DT(_args, _team)                \
     do {                                                            \
-        if ((_args.src.info_v.datatype == UCC_DT_USERDEFINED) ||    \
-            (_args.dst.info_v.datatype == UCC_DT_USERDEFINED)) {    \
+        if (!UCC_DT_IS_PREDEFINED((_args).src.info_v.datatype) ||   \
+            !UCC_DT_IS_PREDEFINED((_args).dst.info_v.datatype)) {   \
             tl_error(UCC_TL_TEAM_LIB(_team),                        \
                      "user defined datatype is not supported");     \
             status = UCC_ERR_NOT_SUPPORTED;                         \

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -126,7 +126,7 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
 // TODO remove once AVG is implemented
 #define CHECK_AVG_OP(_args, _team)                                             \
     do {                                                                       \
-        if (_args.reduce.predefined_op == UCC_OP_AVG) {                        \
+        if ((_args).op == UCC_OP_AVG) {                                        \
             tl_error(UCC_TL_TEAM_LIB(_team),                                   \
                      "Average reduction is not supported yet");                \
             status = UCC_ERR_NOT_SUPPORTED;                                    \

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -20,9 +20,8 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
     ucc_tl_ucp_task_t   *task    = ucc_tl_ucp_get_task(tl_team);
     ucc_base_coll_args_t bargs   = {
         .args = {
-            .coll_type            = UCC_COLL_TYPE_ALLREDUCE,
-            .mask                 = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS,
-            .reduce.predefined_op = op,
+            .coll_type    = UCC_COLL_TYPE_ALLREDUCE,
+            .op           = op,
             .src.info = {
                 .buffer   = sbuf,
                 .count    = count,
@@ -43,8 +42,8 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
     if (status != UCC_OK) {
         goto free_task;
     }
-    task->subset = subset;
-    task->tag  = UCC_TL_UCP_SERVICE_TAG;
+    task->subset         = subset;
+    task->tag            = UCC_TL_UCP_SERVICE_TAG;
     task->n_polls        = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;

--- a/src/core/ucc_dt.c
+++ b/src/core/ucc_dt.c
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_dt.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_math.h"
+
+size_t ucc_dt_predefined_sizes[UCC_DT_PREDEFINED_LAST] = {
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT8)]    = 1,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT8)]   = 1,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT16)]   = 2,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT16)]  = 2,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT16)] = 2,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT32)]   = 4,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT32)]  = 4,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT32)] = 4,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT64)]   = 8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT64)]  = 8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT64)] = 8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT128)]  = 16,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT128)] = 16,
+};
+
+ucc_status_t ucc_dt_create_generic(const ucc_generic_dt_ops_t *ops, void *context,
+                                   ucc_datatype_t *datatype_p)
+{
+    ucc_dt_generic_t *dt_gen;
+    int ret;
+
+    ret = ucc_posix_memalign((void **)&dt_gen,
+                             ucc_max(sizeof(void *), UCC_BIT(UCC_DATATYPE_SHIFT)),
+                             sizeof(*dt_gen), "generic_dt");
+    if (ret != 0) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    dt_gen->ops     = *ops;
+    dt_gen->context = context;
+    *datatype_p     = ucc_dt_from_generic(dt_gen);
+    return UCC_OK;
+}
+
+void ucc_dt_destroy(ucc_datatype_t datatype)
+{
+    ucc_dt_generic_t *dt_gen;
+
+    switch (datatype & UCC_DATATYPE_CLASS_MASK) {
+    case UCC_DATATYPE_PREDEFINED:
+    case UCC_DATATYPE_CONTIG:
+        break;
+    case UCC_DATATYPE_GENERIC:
+        dt_gen = ucc_dt_to_generic(datatype);
+        ucc_free(dt_gen);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/core/ucc_dt.h
+++ b/src/core/ucc_dt.h
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_DT_H_
+#define UCC_DT_H_
+#include "config.h"
+#include "ucc/api/ucc.h"
+
+typedef struct ucc_dt_generic {
+    void                     *context;
+    ucc_generic_dt_ops_t     ops;
+} ucc_dt_generic_t;
+
+#define UCC_DT_PREDEFINED_ID(_dt) ((_dt) >> UCC_DATATYPE_SHIFT)
+
+#define UCC_DT_IS_GENERIC(_datatype)                                    \
+    (((_datatype) & UCC_DATATYPE_CLASS_MASK) == UCC_DATATYPE_GENERIC)
+
+#define UCC_DT_IS_PREDEFINED(_dt) \
+    (((_dt) & UCC_DATATYPE_CLASS_MASK) == UCC_DATATYPE_PREDEFINED)
+
+#define UCC_DT_IS_CONTIG(_dt) \
+          (((_dt) & UCC_DATATYPE_CLASS_MASK) == UCC_DATATYPE_CONTIG)
+
+static inline
+ucc_dt_generic_t* ucc_dt_to_generic(ucc_datatype_t datatype)
+{
+    return (ucc_dt_generic_t*)(void*)(datatype & ~UCC_DATATYPE_CLASS_MASK);
+}
+
+static inline
+ucc_datatype_t ucc_dt_from_generic(ucc_dt_generic_t* dt_gen)
+{
+    return ((uintptr_t)dt_gen) | UCC_DATATYPE_GENERIC;
+}
+
+static inline size_t ucc_contig_dt_elem_size(ucc_datatype_t datatype)
+{
+    return datatype >> UCC_DATATYPE_SHIFT;
+}
+
+extern size_t ucc_dt_predefined_sizes[UCC_DT_PREDEFINED_LAST];
+
+static inline size_t ucc_dt_size(ucc_datatype_t dt)
+{
+    if (UCC_DT_IS_PREDEFINED(dt)) {
+        return ucc_dt_predefined_sizes[UCC_DT_PREDEFINED_ID(dt)];
+    } else if (UCC_DT_IS_CONTIG(dt)) {
+        return ucc_contig_dt_elem_size(dt);
+    }
+    // GENERIC callck pack/unpack
+    // TODO remove ucc_likely once custom datatype is implemented
+    return 0;
+}
+
+
+
+#endif

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -49,8 +49,6 @@ static inline void ucc_copy_lib_params(ucc_lib_params_t *dst,
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_LIB_PARAM_FIELD_REDUCTION_TYPES,
                             reduction_types);
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_LIB_PARAM_FIELD_SYNC_TYPE, sync_type);
-    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_LIB_PARAM_FIELD_REDUCTION_WRAPPER,
-                            reduction_wrapper);
 }
 
 /* Core logic for the selection of CL components:

--- a/src/core/ucc_mc.h
+++ b/src/core/ucc_mc.h
@@ -8,6 +8,8 @@
 
 #include "ucc/api/ucc.h"
 #include "components/mc/base/ucc_mc_base.h"
+#include "core/ucc_dt.h"
+#include "utils/ucc_math.h"
 
 ucc_status_t ucc_mc_init(const ucc_mc_params_t *mc_params);
 
@@ -88,12 +90,27 @@ static inline ucc_status_t ucc_dt_reduce(const void *src1, const void *src2,
                                          ucc_memory_type_t mem_type,
                                          ucc_coll_args_t *args)
 {
-    if (args->mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) {
+    if (!UCC_OP_IS_PREDEFINED(args->op) || !UCC_DT_IS_PREDEFINED(dt)) {
         return UCC_ERR_NOT_SUPPORTED; //TODO
     } else {
-        return ucc_mc_reduce(src1, src2, dst, count, dt,
-                             args->reduce.predefined_op, mem_type);
+        return ucc_mc_reduce(src1, src2, dst, count,
+                             dt, args->op, mem_type);
     }
+}
+
+
+static inline ucc_status_t ucc_mc_reduce_userdefined(void *src1, void *src2,
+                                                     void *dst, size_t n_vectors,
+                                                     size_t count, size_t stride,
+                                                     ucc_op_userdefined_t *op)
+{
+    int i;
+
+    op->ops.reduce(src1, src2, dst, count, op->context);
+    for (i = 1; i < n_vectors; i++) {
+        op->ops.reduce(PTR_OFFSET(src2, stride*i), dst, dst, count, op->context);
+    }
+    return UCC_OK;
 }
 
 static inline ucc_status_t ucc_dt_reduce_multi(void *src1, void *src2,
@@ -103,11 +120,12 @@ static inline ucc_status_t ucc_dt_reduce_multi(void *src1, void *src2,
                                                ucc_memory_type_t mem_type,
                                                ucc_coll_args_t *args)
 {
-    if (args->mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) {
-        return UCC_ERR_NOT_SUPPORTED; //TODO
+    if (!UCC_OP_IS_PREDEFINED(args->op) || !UCC_DT_IS_PREDEFINED(dt)) {
+        return ucc_mc_reduce_userdefined(src1, src2, dst, n_vectors, count, stride,
+                                         ucc_op_to_userdefined(args->op));
     } else {
         return ucc_mc_reduce_multi(src1, src2, dst, n_vectors, count, stride,
-                                   dt, args->reduce.predefined_op, mem_type);
+                                   dt, args->op, mem_type);
     }
 }
 

--- a/src/core/ucc_op.c
+++ b/src/core/ucc_op.c
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_op.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_math.h"
+
+ucc_status_t ucc_op_create_userdefined(const ucc_userdefined_op_ops_t *ops, void *context,
+                                   ucc_reduction_op_t *op_p)
+{
+    ucc_op_userdefined_t *op_u;
+    int ret;
+
+    ret = ucc_posix_memalign((void **)&op_u,
+                             ucc_max(sizeof(void *), UCC_BIT(UCC_REDUCTION_OP_SHIFT)),
+                             sizeof(*op_u), "userdefined_op");
+    if (ret != 0) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    op_u->ops     = *ops;
+    op_u->context = context;
+    *op_p     = ucc_op_from_userdefined(op_u);
+    return UCC_OK;
+}
+
+void ucc_op_destroy(ucc_reduction_op_t op)
+{
+    ucc_op_userdefined_t *op_u;
+
+    switch (op & UCC_REDUCTION_OP_CLASS_MASK) {
+    case UCC_REDUCTION_OP_PREDEFINED:
+        break;
+    case UCC_REDUCTION_OP_USERDEFINED:
+        op_u = ucc_op_to_userdefined(op);
+        ucc_free(op_u);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/core/ucc_op.h
+++ b/src/core/ucc_op.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_DT_GENERIC_H_
+#define UCC_DT_GENERIC_H_
+#include "config.h"
+#include "ucc/api/ucc.h"
+
+typedef struct ucc_op_userdefined {
+    void                     *context;
+    ucc_userdefined_op_ops_t     ops;
+} ucc_op_userdefined_t;
+
+#define UCC_OP_PREDEFINED_ID(_op) \
+    ucc_ilog2((_op) >> UCC_REDUCTION_OP_SHIFT)
+
+#define UCC_OP_IS_USERDEFINED(_op)                                    \
+    (((_op) & UCC_REDUCTION_OP_CLASS_MASK) == UCC_REDUCTINO_OP_USERDEFINED)
+
+#define UCC_OP_IS_PREDEFINED(_dt) \
+    (((_dt) & UCC_REDUCTION_OP_CLASS_MASK) == UCC_REDUCTION_OP_PREDEFINED)
+
+static inline
+ucc_op_userdefined_t* ucc_op_to_userdefined(ucc_reduction_op_t op)
+{
+    return (ucc_op_userdefined_t*)(void*)(op & ~UCC_REDUCTION_OP_CLASS_MASK);
+}
+
+
+static inline
+ucc_reduction_op_t ucc_op_from_userdefined(ucc_op_userdefined_t* op_u)
+{
+    return ((uintptr_t)op_u) | UCC_REDUCTION_OP_USERDEFINED;
+}
+
+#endif

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -555,7 +555,8 @@ static ucc_status_t ucc_team_alloc_id(ucc_team_t *team)
                                     .map.ep_num = team->size,
                                     .myrank     = team->rank};
         status = ucc_service_allreduce(team, local, global, UCC_DT_UINT64,
-                                       ctx->ids.pool_size, UCC_OP_BAND, subset,
+                                       ctx->ids.pool_size,
+                                       UCC_OP_BAND, subset,
                                        &team->sreq);
         if (status < 0) {
             return status;

--- a/src/ucc/api/ucc_def.h
+++ b/src/ucc/api/ucc_def.h
@@ -114,6 +114,8 @@ typedef uint64_t ucc_aint_t;
 /* Reflects the definition in UCS - The i-th bit */
 #define UCC_BIT(i)               (1ul << (i))
 
+#define UCC_MASK(i)              (UCC_BIT(i) - 1)
+
 /* Reflects the definition in UCS */
 /**
  * @ingroup UCC_UTILS
@@ -156,6 +158,5 @@ typedef size_t ucc_context_addr_len_t;
  * the execution context and related queues.
  */
 typedef struct ucc_ee*      ucc_ee_h;
-
 
 #endif

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -158,7 +158,7 @@ size_t ucc_coll_args_msgsize(const ucc_base_coll_args_t *bargs)
     case UCC_COLL_TYPE_REDUCE_SCATTERV:
         return ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
                                              team->size) *
-               ucc_dt_size(args->dst.info.datatype);
+               ucc_dt_size(args->dst.info_v.datatype);
     case UCC_COLL_TYPE_ALLTOALLV:
     case UCC_COLL_TYPE_GATHERV:
     case UCC_COLL_TYPE_SCATTERV:
@@ -306,8 +306,7 @@ void ucc_coll_str(const ucc_base_coll_args_t *args, char *str, size_t len)
         ct == UCC_COLL_TYPE_REDUCE) {
         ucc_snprintf_safe(tmp, sizeof(tmp), " %s %s",
                           ucc_datatype_str(args->args.src.info.datatype),
-                          (args->args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ?
-                          "userdefined" : ucc_reduction_op_str(args->args.reduce.predefined_op));
+                          ucc_reduction_op_str(args->args.op));
         left = len - strlen(str);
         strncat(str, tmp, left);
     }

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -7,7 +7,7 @@
 #define UCC_COMPILER_DEF_H_
 
 #include "config.h"
-#include "ucc/api/ucc_status.h"
+#include "ucc/api/ucc.h"
 #include <ucs/type/status.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/preprocessor.h>
@@ -32,8 +32,8 @@ typedef int                        ucc_score_t;
 #define _UCC_PP_MAKE_STRING(x) #x
 #define UCC_PP_MAKE_STRING(x)  _UCC_PP_MAKE_STRING(x)
 #define UCC_PP_QUOTE UCS_PP_QUOTE
-#define UCC_MASK     UCS_MASK
 #define UCC_EMPTY_STATEMENT {}
+
 
 #define UCC_COPY_PARAM_BY_FIELD(_dst, _src, _FIELD, _field)                    \
     do {                                                                       \

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -8,6 +8,8 @@
 
 #include "config.h"
 #include "core/ucc_global_opts.h"
+#include "core/ucc_op.h"
+#include "core/ucc_dt.h"
 #include <ucs/debug/log_def.h>
 
 #define UCC_LOG_LEVEL_ERROR UCS_LOG_LEVEL_ERROR
@@ -113,10 +115,6 @@ static inline const char* ucc_datatype_str(ucc_datatype_t dt)
         return "int128";
     case UCC_DT_UINT128:
         return "uint128";
-    case UCC_DT_USERDEFINED:
-        return "userdefined";
-    case UCC_DT_OPAQUE:
-        return "opaque";
     default:
         return NULL;
     }
@@ -124,33 +122,36 @@ static inline const char* ucc_datatype_str(ucc_datatype_t dt)
 
 static inline const char* ucc_reduction_op_str(ucc_reduction_op_t op)
 {
-    switch(op) {
-    case UCC_OP_SUM:
-        return "sum";
-    case UCC_OP_PROD:
-        return "prod";
-    case UCC_OP_MAX:
-        return "max";
-    case UCC_OP_MIN:
-        return "min";
-    case UCC_OP_LAND:
-        return "land";
-    case UCC_OP_LOR:
-        return "lor";
-    case UCC_OP_LXOR:
-        return "lxor";
-    case UCC_OP_BAND:
-        return "band";
-    case UCC_OP_BOR:
-        return "bor";
-    case UCC_OP_BXOR:
-        return "bxor";
-    case UCC_OP_MAXLOC:
-        return "maxloc";
-    case UCC_OP_MINLOC:
-        return "minloc";
-    default:
-        return NULL;
+    if (UCC_OP_IS_PREDEFINED(op)) {
+        switch(op) {
+        case UCC_OP_SUM:
+            return "sum";
+        case UCC_OP_PROD:
+            return "prod";
+        case UCC_OP_MAX:
+            return "max";
+        case UCC_OP_MIN:
+            return "min";
+        case UCC_OP_LAND:
+            return "land";
+        case UCC_OP_LOR:
+            return "lor";
+        case UCC_OP_LXOR:
+            return "lxor";
+        case UCC_OP_BAND:
+            return "band";
+        case UCC_OP_BOR:
+            return "bor";
+        case UCC_OP_BXOR:
+            return "bxor";
+        case UCC_OP_MAXLOC:
+            return "maxloc";
+        case UCC_OP_MINLOC:
+            return "minloc";
+        default:
+            return NULL;
+        }
     }
+    return "userdefined";
 }
 #endif

--- a/src/utils/ucc_malloc.h
+++ b/src/utils/ucc_malloc.h
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 
 #define ucc_malloc(_s, ...) malloc(_s)
+#define ucc_posix_memalign(_ptr, _align, _size, ...) posix_memalign(_ptr, _align, _size)
 #define ucc_calloc(_n, _s, ...) calloc(_n, _s)
 #define ucc_realloc(_p, _s, ...) realloc(_p, _s)
 #define ucc_free(_p) free(_p)

--- a/src/utils/ucc_math.c
+++ b/src/utils/ucc_math.c
@@ -6,22 +6,6 @@
 #include "ucc/api/ucc.h"
 #include "ucc_math.h"
 
-size_t ucc_dt_sizes[UCC_DT_USERDEFINED] = {
-    [UCC_DT_INT8]    = 1,
-    [UCC_DT_UINT8]   = 1,
-    [UCC_DT_INT16]   = 2,
-    [UCC_DT_UINT16]  = 2,
-    [UCC_DT_FLOAT16] = 2,
-    [UCC_DT_INT32]   = 4,
-    [UCC_DT_UINT32]  = 4,
-    [UCC_DT_FLOAT32] = 4,
-    [UCC_DT_INT64]   = 8,
-    [UCC_DT_UINT64]  = 8,
-    [UCC_DT_FLOAT64] = 8,
-    [UCC_DT_INT128]  = 16,
-    [UCC_DT_UINT128] = 16,
-};
-
 static int _compare(const void *a, const void *b)
 {
     return (*(int *)a - *(int *)b);

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -26,17 +26,6 @@
 #define DO_OP_LXOR(_v1, _v2) ((!_v1) != (!_v2))
 #define DO_OP_BXOR(_v1, _v2) (_v1 ^ _v2)
 
-extern size_t ucc_dt_sizes[UCC_DT_USERDEFINED];
-static inline size_t ucc_dt_size(ucc_datatype_t dt)
-{
-    if (ucc_likely(dt < UCC_DT_USERDEFINED)) {
-        return ucc_dt_sizes[dt];
-    }
-    // TODO remove ucc_likely once custom datatype is implemented
-    return 0;
-}
-
-
 #define PTR_OFFSET(_ptr, _offset)                                              \
     ((void *)((ptrdiff_t)(_ptr) + (size_t)(_offset)))
 

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -236,4 +236,9 @@ public:
 
 void clear_buffer(void *_buf, size_t size, ucc_memory_type_t mt, uint8_t value);
 
+#define PREDEFINED_DTYPES \
+    ::testing::Values(UCC_DT_INT8, UCC_DT_INT16, UCC_DT_INT32, UCC_DT_INT64, UCC_DT_INT128,\
+                      UCC_DT_UINT8, UCC_DT_UINT16, UCC_DT_UINT32, UCC_DT_UINT64, UCC_DT_UINT128,\
+                      UCC_DT_FLOAT16, UCC_DT_FLOAT32, UCC_DT_FLOAT64)
+
 #endif

--- a/test/gtest/core/test_allgather.cc
+++ b/test/gtest/core/test_allgather.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
-using Param_1 = std::tuple<int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_0 = std::tuple<int, ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
 
 class test_allgather : public UccCollArgs, public ucc::test
 {
@@ -140,7 +140,7 @@ class test_allgather_0 : public test_allgather,
 UCC_TEST_P(test_allgather_0, single)
 {
     const int                 team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype    = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
@@ -162,7 +162,7 @@ UCC_TEST_P(test_allgather_0, single)
 UCC_TEST_P(test_allgather_0, single_persistent)
 {
     const int                 team_id = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype   = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype   = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
@@ -191,7 +191,7 @@ INSTANTIATE_TEST_CASE_P(
     , test_allgather_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1, 4), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
@@ -206,7 +206,7 @@ class test_allgather_1 : public test_allgather,
 
 UCC_TEST_P(test_allgather_1, multiple_host)
 {
-    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_datatype_t      dtype    = std::get<0>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<1>(GetParam());
     const int                 count    = std::get<2>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<3>(GetParam());
@@ -221,7 +221,7 @@ UCC_TEST_P(test_allgather_1, multiple_host)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        data_init(size, dtype, count, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -237,7 +237,7 @@ UCC_TEST_P(test_allgather_1, multiple_host)
 INSTANTIATE_TEST_CASE_P(
     , test_allgather_1,
     ::testing::Combine(
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1, 4), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
-using Param_1 = std::tuple<int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_0 = std::tuple<int, ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
 
 class test_allgatherv : public UccCollArgs, public ucc::test
 {
@@ -159,7 +159,7 @@ class test_allgatherv_0 : public test_allgatherv,
 UCC_TEST_P(test_allgatherv_0, single)
 {
     const int                 team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype    = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
@@ -170,7 +170,7 @@ UCC_TEST_P(test_allgatherv_0, single)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -181,7 +181,7 @@ UCC_TEST_P(test_allgatherv_0, single)
 UCC_TEST_P(test_allgatherv_0, single_persistent)
 {
     const int                 team_id = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype   = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype   = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
@@ -193,7 +193,7 @@ UCC_TEST_P(test_allgatherv_0, single_persistent)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq req(team, ctxs);
 
     for (auto i = 0; i < n_calls; i++) {
@@ -209,7 +209,7 @@ INSTANTIATE_TEST_CASE_P(
     , test_allgatherv_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_INT64 + 1), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
@@ -223,7 +223,7 @@ class test_allgatherv_1 : public test_allgatherv,
 
 UCC_TEST_P(test_allgatherv_1, multiple)
 {
-    const ucc_datatype_t       dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_datatype_t       dtype    = std::get<0>(GetParam());
     const ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     const int                  count    = std::get<2>(GetParam());
     const gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
@@ -238,7 +238,7 @@ UCC_TEST_P(test_allgatherv_1, multiple)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        data_init(size, dtype, count, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -254,7 +254,7 @@ UCC_TEST_P(test_allgatherv_1, multiple)
 INSTANTIATE_TEST_CASE_P(
     , test_allgatherv_1,
     ::testing::Combine(
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_INT64 + 1), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else

--- a/test/gtest/core/test_allreduce.cc
+++ b/test/gtest/core/test_allreduce.cc
@@ -29,9 +29,8 @@ class test_allreduce : public UccCollArgs, public testing::Test {
             ctxs[r] = (gtest_ucc_coll_ctx_t*)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
             ctxs[r]->args = coll;
 
-            coll->mask = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
             coll->coll_type = UCC_COLL_TYPE_ALLREDUCE;
-            coll->reduce.predefined_op = T::redop;
+            coll->op        = T::redop;
 
             ctxs[r]->init_buf = ucc_malloc(ucc_dt_size(dt) * count, "init buf");
             EXPECT_NE(ctxs[r]->init_buf, nullptr);

--- a/test/gtest/core/test_alltoall.cc
+++ b/test/gtest/core/test_alltoall.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
-using Param_1 = std::tuple<int, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
+using Param_0 = std::tuple<int, ucc_datatype_t, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
+using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
 
 class test_alltoall : public UccCollArgs, public ucc::test
 {
@@ -143,7 +143,7 @@ class test_alltoall_0 : public test_alltoall,
 UCC_TEST_P(test_alltoall_0, single)
 {
     const int            team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t dtype    = std::get<1>(GetParam());
     ucc_memory_type_t    mem_type = std::get<2>(GetParam());
     gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
     const int            count    = std::get<4>(GetParam());
@@ -154,7 +154,7 @@ UCC_TEST_P(test_alltoall_0, single)
     this->set_inplace(inplace);
     this->set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -165,7 +165,7 @@ UCC_TEST_P(test_alltoall_0, single)
 UCC_TEST_P(test_alltoall_0, single_persistent)
 {
     const int            team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t dtype    = std::get<1>(GetParam());
     ucc_memory_type_t    mem_type = std::get<2>(GetParam());
     gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
     const int            count    = std::get<4>(GetParam());
@@ -177,7 +177,7 @@ UCC_TEST_P(test_alltoall_0, single_persistent)
     this->set_inplace(inplace);
     this->set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq req(team, ctxs);
 
     for (auto i = 0; i < n_calls; i++) {
@@ -193,7 +193,7 @@ INSTANTIATE_TEST_CASE_P(
     , test_alltoall_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
@@ -207,7 +207,7 @@ class test_alltoall_1 : public test_alltoall,
 
 UCC_TEST_P(test_alltoall_1, multiple)
 {
-    const ucc_datatype_t       dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_datatype_t       dtype    = std::get<0>(GetParam());
     ucc_memory_type_t          mem_type = std::get<1>(GetParam());
     gtest_ucc_inplace_t        inplace  = std::get<2>(GetParam());
     const int                  count    = std::get<3>(GetParam());
@@ -222,7 +222,7 @@ UCC_TEST_P(test_alltoall_1, multiple)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        data_init(size, dtype, count, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -238,7 +238,7 @@ UCC_TEST_P(test_alltoall_1, multiple)
 INSTANTIATE_TEST_CASE_P(
     , test_alltoall_1,
     ::testing::Combine(
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
-using Param_1 = std::tuple<ucc_memory_type_t, gtest_ucc_inplace_t, int>;
+using Param_0 = std::tuple<int, ucc_memory_type_t, gtest_ucc_inplace_t, ucc_datatype_t>;
+using Param_1 = std::tuple<ucc_memory_type_t, gtest_ucc_inplace_t, ucc_datatype_t>;
 
 template <class T>
 class test_alltoallv : public UccCollArgs, public ucc::test
@@ -155,7 +155,7 @@ UCC_TEST_P(test_alltoallv_0, single)
     const int            team_id = std::get<0>(GetParam());
     ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     gtest_ucc_inplace_t  inplace = std::get<2>(GetParam());
-    const ucc_datatype_t dtype   = (ucc_datatype_t)std::get<3>(GetParam());
+    const ucc_datatype_t dtype   = std::get<3>(GetParam());
     UccTeam_h            team    = UccJob::getStaticTeams()[team_id];
     int                  size    = team->procs.size();
     UccCollCtxVec        ctxs;
@@ -166,7 +166,7 @@ UCC_TEST_P(test_alltoallv_0, single)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, 1, ctxs);
+    data_init(size, dtype, 1, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -180,7 +180,7 @@ UCC_TEST_P(test_alltoallv_0, single_persistent)
     const int            team_id  = std::get<0>(GetParam());
     ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     gtest_ucc_inplace_t  inplace  = std::get<2>(GetParam());
-    const ucc_datatype_t dtype    = (ucc_datatype_t)std::get<3>(GetParam());
+    const ucc_datatype_t dtype    = std::get<3>(GetParam());
     UccTeam_h            team     = UccJob::getStaticTeams()[team_id];
     int                  size     = team->procs.size();
     const int            n_calls  = 3;
@@ -192,7 +192,7 @@ UCC_TEST_P(test_alltoallv_0, single_persistent)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, 1, ctxs);
+    data_init(size, dtype, 1, ctxs);
     UccReq req(team, ctxs);
 
     for (auto i = 0; i < n_calls; i++) {
@@ -212,7 +212,7 @@ UCC_TEST_P(test_alltoallv_1, single)
     const int            team_id = std::get<0>(GetParam());
     ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     gtest_ucc_inplace_t  inplace = std::get<2>(GetParam());
-    const ucc_datatype_t dtype   = (ucc_datatype_t)std::get<3>(GetParam());
+    const ucc_datatype_t dtype   = std::get<3>(GetParam());
     UccTeam_h            team    = UccJob::getStaticTeams()[team_id];
     int                  size    = team->procs.size();
     UccCollCtxVec        ctxs;
@@ -220,7 +220,7 @@ UCC_TEST_P(test_alltoallv_1, single)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, 1, ctxs);
+    data_init(size, dtype, 1, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -239,7 +239,7 @@ INSTANTIATE_TEST_CASE_P(
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
             ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
-            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+            PREDEFINED_DTYPES)); // dtype
 
 
 INSTANTIATE_TEST_CASE_P(
@@ -252,7 +252,7 @@ INSTANTIATE_TEST_CASE_P(
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
             ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
-            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+            PREDEFINED_DTYPES)); // dtype
 
 class test_alltoallv_2 : public test_alltoallv<uint64_t>,
         public ::testing::WithParamInterface<Param_1> {};
@@ -265,7 +265,7 @@ UCC_TEST_P(test_alltoallv_2, multiple)
 {
     ucc_memory_type_t           mem_type = std::get<0>(GetParam());
     gtest_ucc_inplace_t         inplace  = std::get<1>(GetParam());
-    const ucc_datatype_t        dtype    = (ucc_datatype_t)std::get<2>(GetParam());
+    const ucc_datatype_t        dtype    = std::get<2>(GetParam());
     std::vector<UccReq>         reqs;
     std::vector<UccCollCtxVec>  ctxs;
 
@@ -281,7 +281,7 @@ UCC_TEST_P(test_alltoallv_2, multiple)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, 1, ctx);
+        data_init(size, dtype, 1, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -298,7 +298,7 @@ UCC_TEST_P(test_alltoallv_3, multiple)
 {
     ucc_memory_type_t           mem_type = std::get<0>(GetParam());
     gtest_ucc_inplace_t         inplace  = std::get<1>(GetParam());
-    const ucc_datatype_t        dtype    = (ucc_datatype_t)std::get<2>(GetParam());
+    const ucc_datatype_t        dtype    = std::get<2>(GetParam());
     std::vector<UccReq>         reqs;
     std::vector<UccCollCtxVec>  ctxs;
 
@@ -310,7 +310,7 @@ UCC_TEST_P(test_alltoallv_3, multiple)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, 1, ctx);
+        data_init(size, dtype, 1, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -332,7 +332,7 @@ INSTANTIATE_TEST_CASE_P(
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
             ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
-            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+            PREDEFINED_DTYPES)); // dtype
 
 INSTANTIATE_TEST_CASE_P(
         32, test_alltoallv_3,
@@ -343,4 +343,4 @@ INSTANTIATE_TEST_CASE_P(
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
             ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
-            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+            PREDEFINED_DTYPES)); // dtype

--- a/test/gtest/core/test_bcast.cc
+++ b/test/gtest/core/test_bcast.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, int>;
-using Param_1 = std::tuple<int, ucc_memory_type_t, int, int>;
+using Param_0 = std::tuple<int, ucc_datatype_t, ucc_memory_type_t, int, int>;
+using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, int, int>;
 
 class test_bcast : public UccCollArgs, public ucc::test
 {
@@ -119,7 +119,7 @@ class test_bcast_0 : public test_bcast,
 UCC_TEST_P(test_bcast_0, single)
 {
     const int                 team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype    = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const int                 root     = std::get<4>(GetParam());
@@ -130,7 +130,7 @@ UCC_TEST_P(test_bcast_0, single)
     set_mem_type(mem_type);
     set_root(root);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -141,7 +141,7 @@ UCC_TEST_P(test_bcast_0, single)
 UCC_TEST_P(test_bcast_0, single_persistent)
 {
     const int               team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t    dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t    dtype    = std::get<1>(GetParam());
     const ucc_memory_type_t mem_type = std::get<2>(GetParam());
     const int               count    = std::get<3>(GetParam());
     const int               root     = std::get<4>(GetParam());
@@ -153,7 +153,7 @@ UCC_TEST_P(test_bcast_0, single_persistent)
     set_mem_type(mem_type);
     set_root(root);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq req(team, ctxs);
 
     for (auto i = 0; i < n_calls; i++) {
@@ -170,7 +170,7 @@ INSTANTIATE_TEST_CASE_P(
     , test_bcast_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_UINT32 + 1, 3), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
@@ -184,7 +184,7 @@ class test_bcast_1 : public test_bcast,
 
 UCC_TEST_P(test_bcast_1, multiple)
 {
-    const ucc_datatype_t       dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_datatype_t       dtype    = std::get<0>(GetParam());
     const ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     const int                  count    = std::get<2>(GetParam());
     const int                  root     = std::get<3>(GetParam());
@@ -199,7 +199,7 @@ UCC_TEST_P(test_bcast_1, multiple)
         set_mem_type(mem_type);
         set_root(root);
 
-        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        data_init(size, dtype, count, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -215,7 +215,7 @@ UCC_TEST_P(test_bcast_1, multiple)
 INSTANTIATE_TEST_CASE_P(
     , test_bcast_1,
     ::testing::Combine(
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_UINT32 + 1, 3), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else

--- a/test/gtest/core/test_reduce.cc
+++ b/test/gtest/core/test_reduce.cc
@@ -27,12 +27,11 @@ class test_reduce : public UccCollArgs, public testing::Test {
                           sizeof(gtest_ucc_coll_ctx_t));
             ctxs[r]->args = coll;
 
-            coll->mask = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
             coll->coll_type = UCC_COLL_TYPE_REDUCE;
-            coll->reduce.predefined_op = T::redop;
-            coll->root = root;
+            coll->op        = T::redop;
+            coll->root      = root;
             coll->src.info.mem_type = mem_type;
-            coll->src.info.count = (ucc_count_t)count;
+            coll->src.info.count    = (ucc_count_t)count;
             coll->src.info.datatype = dt;
 
             ctxs[r]->init_buf = ucc_malloc(ucc_dt_size(dt) * count,

--- a/test/mpi/test_allreduce.cc
+++ b/test/mpi/test_allreduce.cc
@@ -55,9 +55,7 @@ TestAllreduce::TestAllreduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         args.src.info.mem_type    = UCC_MEMORY_TYPE_UNKNOWN;
     }
 
-    args.mask                |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    args.reduce.predefined_op = _op;
-
+    args.op                   = _op;
     args.dst.info.buffer      = rbuf;
     args.dst.info.count       = count;
     args.dst.info.datatype    = _dt;

--- a/test/mpi/test_reduce.cc
+++ b/test/mpi/test_reduce.cc
@@ -50,9 +50,7 @@ TestReduce::TestReduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                        (inplace && rank == root) ? rbuf : sbuf, _mt, _msgsize);
     check_sbuf = check_sbuf_mc_header->addr;
 
-    args.mask                |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    args.reduce.predefined_op = _op;
-
+    args.op                   = _op;
     args.src.info.buffer      = sbuf;
     args.src.info.count       = count;
     args.src.info.datatype    = _dt;

--- a/test/mpi/test_reduce_scatter.cc
+++ b/test/mpi/test_reduce_scatter.cc
@@ -57,8 +57,6 @@ TestReduceScatter::TestReduceScatter(size_t _msgsize,
         init_buffer(check_rbuf, count, dt, UCC_MEMORY_TYPE_HOST, rank);
     }
 
-    args.mask                |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    args.reduce.predefined_op = _op;
 
     if (inplace == TEST_NO_INPLACE) {
         args.src.info.buffer      = sbuf;
@@ -66,7 +64,7 @@ TestReduceScatter::TestReduceScatter(size_t _msgsize,
         args.src.info.datatype    = _dt;
         args.src.info.mem_type    = _mt;
     }
-
+    args.op                   = _op;
     args.dst.info.buffer      = rbuf;
     args.dst.info.datatype    = _dt;
     args.dst.info.mem_type    = _mt;

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -20,8 +20,7 @@ ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
         coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
-    coll_args.mask |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    coll_args.reduce.predefined_op = op;
+    coll_args.op                = op;
     coll_args.src.info.datatype = dt;
     coll_args.dst.info.datatype = dt;
     coll_args.src.info.mem_type = mt;

--- a/tools/perf/ucc_pt_coll_reduce.cc
+++ b/tools/perf/ucc_pt_coll_reduce.cc
@@ -20,8 +20,7 @@ ucc_pt_coll_reduce::ucc_pt_coll_reduce(ucc_datatype_t dt, ucc_memory_type mt,
         coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
 
-    coll_args.mask |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    coll_args.reduce.predefined_op = op;
+    coll_args.op   = op;
     coll_args.root = 0;
     coll_args.src.info.datatype = dt;
     coll_args.src.info.mem_type = mt;

--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -149,9 +149,8 @@ ucc_status_t ucc_pt_comm::allreduce(float* in, float* out, size_t size,
     ucc_coll_args_t args;
     ucc_coll_req_h req;
 
-    args.mask                 = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
     args.coll_type            = UCC_COLL_TYPE_ALLREDUCE;
-    args.reduce.predefined_op = op;
+    args.op                   = op;
     args.src.info.buffer      = in;
     args.src.info.count       = size;
     args.src.info.datatype    = UCC_DT_FLOAT32;


### PR DESCRIPTION
## What
Changes the UCC.h datatype and reduce_op definitions to support custom dtypes

## Why ?
Current API does not allow support for derived types. 

## How ?
dtype and op are 8bytes (uint64_t) values. 
Predefined dtypes are still the same from the user perspective (UCC_DT_INT32, etc).
ucc_dt_make_contig, ucc_dt_make_generic

custom op: ucc_op_make_userdefined

Required OMPI change: https://github.com/vspetrov/ompi/commit/9746d0cd80e7b3854b8f1f4b663cb5091ab96b2d - MINIMAL

Example of Working code that does UCC_allreduce over custom dtype (struct of fields int+float) and custom reduce op: https://gist.github.com/vspetrov/55c375c7013727ad26a7928e6362bd10
