### PR TITLE
CORE: new dt/op proposal #2

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,7 @@ noinst_HEADERS =                      \
 	core/ucc_topo.h                   \
 	core/ucc_sbgp.h                   \
 	core/ucc_service_coll.h           \
+	core/ucc_dt.h	                  \
 	schedule/ucc_schedule.h           \
 	schedule/ucc_schedule_pipelined.h \
 	coll_score/ucc_coll_score.h       \
@@ -97,6 +98,7 @@ libucc_la_SOURCES =                   \
 	core/ucc_topo.c                   \
 	core/ucc_sbgp.c                   \
 	core/ucc_service_coll.c           \
+	core/ucc_dt.c                     \
 	schedule/ucc_schedule.c           \
 	schedule/ucc_schedule_pipelined.c \
 	coll_score/ucc_coll_score.c       \

--- a/src/components/mc/cpu/mc_cpu.c
+++ b/src/components/mc/cpu/mc_cpu.c
@@ -196,7 +196,8 @@ static ucc_status_t ucc_mc_cpu_reduce_multi(const void *src1, const void *src2,
         return ucc_mc_cpu_reduce_multi_double(src1, src2, dst, n_vectors,
                                               count, stride, op);
     default:
-        mc_error(&ucc_mc_cpu.super, "unsupported reduction type (%d)", dt);
+        mc_error(&ucc_mc_cpu.super, "unsupported reduction type (%s)",
+                 ucc_datatype_str(dt));
         return UCC_ERR_NOT_SUPPORTED;
     }
     return UCC_OK;

--- a/src/components/mc/cpu/reduce/mc_cpu_reduce.h
+++ b/src/components/mc/cpu/reduce/mc_cpu_reduce.h
@@ -125,8 +125,8 @@
         default:                                                               \
             mc_error(&ucc_mc_cpu.super,                                        \
                      "int dtype does not support "                             \
-                     "requested reduce op: %d",                                \
-                     op);                                                      \
+                     "requested reduce op: %s",                                \
+                     ucc_reduction_op_str(op));                                \
             return UCC_ERR_NOT_SUPPORTED;                                      \
         }                                                                      \
     } while (0)
@@ -156,8 +156,8 @@
         default:                                                               \
             mc_error(&ucc_mc_cpu.super,                                        \
                      "float dtype does not support "                           \
-                     "requested reduce op: %d",                                \
-                     op);                                                      \
+                     "requested reduce op: %s",                                \
+                     ucc_reduction_op_str(op));                                \
             return UCC_ERR_NOT_SUPPORTED;                                      \
         }                                                                      \
     } while (0)

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -16,25 +16,22 @@
 #define ncclDataTypeUnsupported (ncclNumTypes + 1)
 
 ncclDataType_t ucc_to_nccl_dtype[] = {
-    [UCC_DT_INT8]        = (ncclDataType_t)ncclInt8,
-    [UCC_DT_INT16]       = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_INT32]       = (ncclDataType_t)ncclInt32,
-    [UCC_DT_INT64]       = (ncclDataType_t)ncclInt64,
-    [UCC_DT_INT128]      = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_UINT8]       = (ncclDataType_t)ncclUint8,
-    [UCC_DT_UINT16]      = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_UINT32]      = (ncclDataType_t)ncclUint32,
-    [UCC_DT_UINT64]      = (ncclDataType_t)ncclUint64,
-    [UCC_DT_UINT128]     = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_FLOAT16]     = (ncclDataType_t)ncclFloat16,
-    [UCC_DT_FLOAT32]     = (ncclDataType_t)ncclFloat32,
-    [UCC_DT_FLOAT64]     = (ncclDataType_t)ncclFloat64,
-    [UCC_DT_USERDEFINED] = (ncclDataType_t)ncclDataTypeUnsupported,
-    [UCC_DT_OPAQUE]      = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT8)]        = (ncclDataType_t)ncclInt8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT16)]       = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT32)]       = (ncclDataType_t)ncclInt32,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT64)]       = (ncclDataType_t)ncclInt64,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT128)]      = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT8)]       = (ncclDataType_t)ncclUint8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT16)]      = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT32)]      = (ncclDataType_t)ncclUint32,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT64)]      = (ncclDataType_t)ncclUint64,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT128)]     = (ncclDataType_t)ncclDataTypeUnsupported,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT16)]     = (ncclDataType_t)ncclFloat16,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT32)]     = (ncclDataType_t)ncclFloat32,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT64)]     = (ncclDataType_t)ncclFloat64,
 };
 
 ncclRedOp_t ucc_to_nccl_reduce_op[] = {
-    [UCC_OP_USERDEFINED] = (ncclRedOp_t)ncclOpUnsupported,
     [UCC_OP_SUM]         = (ncclRedOp_t)ncclSum,
     [UCC_OP_PROD]        = (ncclRedOp_t)ncclProd,
     [UCC_OP_MAX]         = (ncclRedOp_t)ncclMax,
@@ -57,8 +54,9 @@ ncclRedOp_t ucc_to_nccl_reduce_op[] = {
 static inline ucc_status_t ucc_nccl_check_dt_supported(ucc_datatype_t dt1,
                                                        ucc_datatype_t dt2)
 {
-    if (ucc_unlikely((dt1 != dt2) ||
-                     (ucc_to_nccl_dtype[dt1] == ncclDataTypeUnsupported))) {
+    if (ucc_unlikely((dt1 != dt2) || !UCC_DT_IS_PREDEFINED(dt1) ||
+                     (ucc_to_nccl_dtype[UCC_DT_PREDEFINED_ID(dt1)]
+                      == ncclDataTypeUnsupported))) {
         return UCC_ERR_NOT_SUPPORTED;
     }
     return UCC_OK;
@@ -140,8 +138,8 @@ ucc_status_t ucc_tl_nccl_alltoall_init(ucc_tl_nccl_task_t *task)
         tl_error(UCC_TASK_LIB(task), "inplace alltoallv is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((TASK_ARGS(task).src.info.datatype == UCC_DT_USERDEFINED) ||
-        (TASK_ARGS(task).dst.info.datatype == UCC_DT_USERDEFINED)) {
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info.datatype))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -199,8 +197,8 @@ ucc_status_t ucc_tl_nccl_alltoallv_init(ucc_tl_nccl_task_t *task)
         tl_error(UCC_TASK_LIB(task), "inplace alltoall is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((TASK_ARGS(task).src.info_v.datatype == UCC_DT_USERDEFINED) ||
-        (TASK_ARGS(task).dst.info_v.datatype == UCC_DT_USERDEFINED)) {
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info_v.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info_v.datatype))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -220,7 +218,7 @@ ucc_status_t ucc_tl_nccl_allreduce_start(ucc_coll_task_t *coll_task)
         UCC_IS_INPLACE(*args) ? args->dst.info.buffer : args->src.info.buffer;
     ucc_status_t        status = UCC_OK;
     ncclDataType_t      dt     = ucc_to_nccl_dtype[args->dst.info.datatype];
-    ncclRedOp_t         op = ucc_to_nccl_reduce_op[args->reduce.predefined_op];
+    ncclRedOp_t         op = ucc_to_nccl_reduce_op[args->op];
     size_t              count = args->dst.info.count;
 
     task->super.super.status = UCC_INPROGRESS;
@@ -239,9 +237,7 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_allreduce_init(ucc_tl_nccl_task_t *task)
 {
-    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
-        (ucc_to_nccl_reduce_op[TASK_ARGS(task).reduce.predefined_op] ==
-         ncclOpUnsupported)) {
+    if (ucc_to_nccl_reduce_op[TASK_ARGS(task).op] == ncclOpUnsupported) {
         tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -347,8 +343,8 @@ ucc_status_t ucc_tl_nccl_allgatherv_init(ucc_tl_nccl_task_t *task)
         tl_error(UCC_TASK_LIB(task), "inplace allgatherv is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((TASK_ARGS(task).src.info_v.datatype == UCC_DT_USERDEFINED) ||
-        (TASK_ARGS(task).dst.info_v.datatype == UCC_DT_USERDEFINED)) {
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info_v.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info_v.datatype))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -403,8 +399,7 @@ ucc_status_t ucc_tl_nccl_reduce_scatter_start(ucc_coll_task_t *coll_task)
     void               *src    = args->src.info.buffer;
     ucc_status_t        status = UCC_OK;
     ncclDataType_t      dt     = ucc_to_nccl_dtype[args->dst.info.datatype];
-    ncclRedOp_t         op     = ucc_to_nccl_reduce_op[
-                                    args->reduce.predefined_op];
+    ncclRedOp_t         op     = ucc_to_nccl_reduce_op[args->op];
     size_t              count  = args->dst.info.count;
 
     task->super.super.status = UCC_INPROGRESS;
@@ -424,9 +419,7 @@ exit_coll:
 
 ucc_status_t ucc_tl_nccl_reduce_scatter_init(ucc_tl_nccl_task_t *task)
 {
-    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
-        (ucc_to_nccl_reduce_op[TASK_ARGS(task).reduce.predefined_op] ==
-         ncclOpUnsupported)) {
+    if (ucc_to_nccl_reduce_op[TASK_ARGS(task).op] == ncclOpUnsupported) {
         tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -451,8 +444,7 @@ ucc_status_t ucc_tl_nccl_reduce_start(ucc_coll_task_t *coll_task)
     void               *src     = args->src.info.buffer;
     ucc_datatype_t      ucc_dt  = args->src.info.datatype;
     size_t              count   = args->src.info.count;
-    ncclRedOp_t         op      = ucc_to_nccl_reduce_op[
-                                     args->reduce.predefined_op];
+    ncclRedOp_t         op      = ucc_to_nccl_reduce_op[args->op];
     ucc_status_t        status  = UCC_OK;
     ncclDataType_t      nccl_dt;
 
@@ -480,9 +472,7 @@ ucc_status_t ucc_tl_nccl_reduce_init(ucc_tl_nccl_task_t *task)
                            TASK_ARGS(task).dst.info.datatype:
                            TASK_ARGS(task).src.info.datatype;
 
-    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ||
-        (ucc_to_nccl_reduce_op[TASK_ARGS(task).reduce.predefined_op] ==
-         ncclOpUnsupported)) {
+    if (ucc_to_nccl_reduce_op[TASK_ARGS(task).op] == ncclOpUnsupported) {
         tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -501,10 +491,9 @@ ucc_status_t ucc_tl_nccl_barrier_init(ucc_tl_nccl_task_t *task)
     /* use 4-byte allreduce to accomplish barrier */
     ucc_coll_args_t *args   = &TASK_ARGS(task);
 
-    args->mask |= (UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS |
-                   UCC_COLL_ARGS_FIELD_FLAGS);
+    args->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
     args->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
-    args->reduce.predefined_op = UCC_OP_SUM;
+    args->op     = UCC_OP_SUM;
 
     args->dst.info.buffer   = TASK_CTX(task)->scratch_buf;
     args->src.info.buffer   = args->dst.info.buffer;

--- a/src/components/tl/sharp/tl_sharp_coll.c
+++ b/src/components/tl/sharp/tl_sharp_coll.c
@@ -14,25 +14,22 @@
 #include <sharp/api/sharp_coll.h>
 
 int ucc_to_sharp_dtype[] = {
-    [UCC_DT_INT8]        = SHARP_DTYPE_NULL,
-    [UCC_DT_INT16]       = SHARP_DTYPE_SHORT,
-    [UCC_DT_INT32]       = SHARP_DTYPE_INT,
-    [UCC_DT_INT64]       = SHARP_DTYPE_LONG,
-    [UCC_DT_INT128]      = SHARP_DTYPE_NULL,
-    [UCC_DT_UINT8]       = SHARP_DTYPE_NULL,
-    [UCC_DT_UINT16]      = SHARP_DTYPE_UNSIGNED_SHORT,
-    [UCC_DT_UINT32]      = SHARP_DTYPE_UNSIGNED,
-    [UCC_DT_UINT64]      = SHARP_DTYPE_UNSIGNED_LONG,
-    [UCC_DT_UINT128]     = SHARP_DTYPE_NULL,
-    [UCC_DT_FLOAT16]     = SHARP_DTYPE_FLOAT_SHORT,
-    [UCC_DT_FLOAT32]     = SHARP_DTYPE_FLOAT,
-    [UCC_DT_FLOAT64]     = SHARP_DTYPE_DOUBLE,
-    [UCC_DT_USERDEFINED] = SHARP_DTYPE_NULL,
-    [UCC_DT_OPAQUE]      = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT8)]        = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT16)]       = SHARP_DTYPE_SHORT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT32)]       = SHARP_DTYPE_INT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT64)]       = SHARP_DTYPE_LONG,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT128)]      = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT8)]       = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT16)]      = SHARP_DTYPE_UNSIGNED_SHORT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT32)]      = SHARP_DTYPE_UNSIGNED,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT64)]      = SHARP_DTYPE_UNSIGNED_LONG,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT128)]     = SHARP_DTYPE_NULL,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT16)]     = SHARP_DTYPE_FLOAT_SHORT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT32)]     = SHARP_DTYPE_FLOAT,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT64)]     = SHARP_DTYPE_DOUBLE,
 };
 
 int ucc_to_sharp_reduce_op[] = {
-    [UCC_OP_USERDEFINED] = SHARP_OP_NULL,
     [UCC_OP_SUM]         = SHARP_OP_SUM,
     [UCC_OP_PROD]        = SHARP_OP_NULL,
     [UCC_OP_MAX]         = SHARP_OP_MAX,
@@ -181,8 +178,8 @@ ucc_status_t ucc_tl_sharp_allreduce_start(ucc_coll_task_t *coll_task)
     task->super.super.status = UCC_INPROGRESS;
     UCC_TL_SHARP_PROFILE_REQUEST_EVENT(coll_task, "sharp_allreduce_start", 0);
 
-    sharp_type = ucc_to_sharp_dtype[dt];
-    op_type    = ucc_to_sharp_reduce_op[args->reduce.predefined_op];
+    sharp_type = ucc_to_sharp_dtype[UCC_DT_PREDEFINED_ID(dt)];
+    op_type    = ucc_to_sharp_reduce_op[args->op];
     data_size  = ucc_dt_size(dt) * count;
 
     if (!UCC_IS_INPLACE(*args)) {
@@ -234,14 +231,14 @@ ucc_status_t ucc_tl_sharp_allreduce_init(ucc_tl_sharp_task_t *task)
 {
     ucc_coll_args_t *args = &TASK_ARGS(task);
 
-    if (args->mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) {
+    if (!UCC_DT_IS_PREDEFINED(args->dst.info.datatype)) {
         return UCC_ERR_NOT_SUPPORTED;
     }
 
     if (ucc_to_sharp_memtype[args->src.info.mem_type] == SHARP_MEM_TYPE_LAST ||
         ucc_to_sharp_memtype[args->dst.info.mem_type] == SHARP_MEM_TYPE_LAST ||
-        ucc_to_sharp_dtype[args->dst.info.datatype] == SHARP_DTYPE_NULL ||
-        ucc_to_sharp_reduce_op[args->reduce.predefined_op] == SHARP_OP_NULL) {
+        ucc_to_sharp_dtype[UCC_DT_PREDEFINED_ID(args->dst.info.datatype)] == SHARP_DTYPE_NULL ||
+        ucc_to_sharp_reduce_op[args->op] == SHARP_OP_NULL) {
         return UCC_ERR_NOT_SUPPORTED;
     }
 

--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -12,8 +12,8 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
 {
-    if ((TASK_ARGS(task).src.info.datatype == UCC_DT_USERDEFINED) ||
-        (TASK_ARGS(task).dst.info.datatype == UCC_DT_USERDEFINED)) {
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info.datatype))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/ucp/allgatherv/allgatherv.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv.c
@@ -14,9 +14,9 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task)
 {
-    if ((TASK_ARGS(task).dst.info_v.datatype == UCC_DT_USERDEFINED) ||
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info_v.datatype)) ||
         (!UCC_IS_INPLACE(TASK_ARGS(task)) &&
-         (TASK_ARGS(task).src.info.datatype == UCC_DT_USERDEFINED))) {
+         (!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info.datatype)))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/ucp/allreduce/allreduce.h
+++ b/src/components/tl/ucp/allreduce/allreduce.h
@@ -22,16 +22,6 @@ ucc_status_t ucc_tl_ucp_allreduce_init(ucc_tl_ucp_task_t *task);
 #define UCC_TL_UCP_ALLREDUCE_DEFAULT_ALG_SELECT_STR                            \
     "allreduce:0-4k:@0#allreduce:4k-inf:@1"
 
-#define CHECK_USERDEFINED_OP(_args, _team)                                     \
-    do {                                                                       \
-        if (_args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) {         \
-            tl_error(UCC_TL_TEAM_LIB(_team),                                   \
-                     "userdefined reductions are not supported yet");          \
-            status = UCC_ERR_NOT_SUPPORTED;                                    \
-            goto out;                                                          \
-        }                                                                      \
-    } while (0)
-
 #define CHECK_SAME_MEMTYPE(_args, _team)                                       \
     do {                                                                       \
         if (!UCC_IS_INPLACE(_args) &&                                          \
@@ -44,7 +34,6 @@ ucc_status_t ucc_tl_ucp_allreduce_init(ucc_tl_ucp_task_t *task);
     } while (0)
 
 #define ALLREDUCE_TASK_CHECK(_args, _team)                                     \
-    CHECK_USERDEFINED_OP((_args), (_team));                                    \
     CHECK_SAME_MEMTYPE((_args), (_team));                                      \
     CHECK_AVG_OP((_args), (_team));
 

--- a/src/components/tl/ucp/alltoall/alltoall.h
+++ b/src/components/tl/ucp/alltoall/alltoall.h
@@ -28,15 +28,15 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_init_common(ucc_tl_ucp_task_t *task);
         }                                                   \
     } while (0)
 
-#define ALLTOALL_CHECK_USERDEFINED_DT(_args, _team)             \
-    do {                                                        \
-        if ((_args.src.info.datatype == UCC_DT_USERDEFINED) ||  \
-            (_args.dst.info.datatype == UCC_DT_USERDEFINED)) {  \
-            tl_error(UCC_TL_TEAM_LIB(_team),                    \
-                     "user defined datatype is not supported"); \
-            status = UCC_ERR_NOT_SUPPORTED;                     \
-            goto out;                                           \
-        }                                                       \
+#define ALLTOALL_CHECK_USERDEFINED_DT(_args, _team  )             \
+    do {                                                          \
+        if (!UCC_DT_IS_PREDEFINED((_args).src.info.datatype) ||   \
+            !UCC_DT_IS_PREDEFINED((_args).dst.info.datatype)) {   \
+            tl_error(UCC_TL_TEAM_LIB(_team),                      \
+                     "user defined datatype is not supported");   \
+            status = UCC_ERR_NOT_SUPPORTED;                       \
+            goto out;                                             \
+        }                                                         \
     } while (0)
 
 #define ALLTOALL_TASK_CHECK(_args, _team)              \

--- a/src/components/tl/ucp/alltoallv/alltoallv.h
+++ b/src/components/tl/ucp/alltoallv/alltoallv.h
@@ -30,8 +30,8 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task);
 
 #define ALLTOALLV_CHECK_USERDEFINED_DT(_args, _team)                \
     do {                                                            \
-        if ((_args.src.info_v.datatype == UCC_DT_USERDEFINED) ||    \
-            (_args.dst.info_v.datatype == UCC_DT_USERDEFINED)) {    \
+        if (!UCC_DT_IS_PREDEFINED((_args).src.info_v.datatype) ||   \
+            !UCC_DT_IS_PREDEFINED((_args).dst.info_v.datatype)) {   \
             tl_error(UCC_TL_TEAM_LIB(_team),                        \
                      "user defined datatype is not supported");     \
             status = UCC_ERR_NOT_SUPPORTED;                         \

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -126,7 +126,7 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
 // TODO remove once AVG is implemented
 #define CHECK_AVG_OP(_args, _team)                                             \
     do {                                                                       \
-        if (_args.reduce.predefined_op == UCC_OP_AVG) {                        \
+        if ((_args).op == UCC_OP_AVG) {                                        \
             tl_error(UCC_TL_TEAM_LIB(_team),                                   \
                      "Average reduction is not supported yet");                \
             status = UCC_ERR_NOT_SUPPORTED;                                    \

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -20,9 +20,8 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
     ucc_tl_ucp_task_t   *task    = ucc_tl_ucp_get_task(tl_team);
     ucc_base_coll_args_t bargs   = {
         .args = {
-            .coll_type            = UCC_COLL_TYPE_ALLREDUCE,
-            .mask                 = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS,
-            .reduce.predefined_op = op,
+            .coll_type    = UCC_COLL_TYPE_ALLREDUCE,
+            .op           = op,
             .src.info = {
                 .buffer   = sbuf,
                 .count    = count,
@@ -43,8 +42,8 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
     if (status != UCC_OK) {
         goto free_task;
     }
-    task->subset = subset;
-    task->tag  = UCC_TL_UCP_SERVICE_TAG;
+    task->subset         = subset;
+    task->tag            = UCC_TL_UCP_SERVICE_TAG;
     task->n_polls        = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;

--- a/src/core/ucc_dt.c
+++ b/src/core/ucc_dt.c
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_dt.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_math.h"
+
+size_t ucc_dt_predefined_sizes[UCC_DT_PREDEFINED_LAST] = {
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT8)]    = 1,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT8)]   = 1,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT16)]   = 2,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT16)]  = 2,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT16)] = 2,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT32)]   = 4,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT32)]  = 4,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT32)] = 4,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT64)]   = 8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT64)]  = 8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT64)] = 8,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_INT128)]  = 16,
+     [UCC_DT_PREDEFINED_ID(UCC_DT_UINT128)] = 16,
+};
+
+ucc_status_t ucc_dt_create_generic(const ucc_generic_dt_ops_t *ops, void *context,
+                                   ucc_datatype_t *datatype_p)
+{
+    ucc_dt_generic_t *dt_gen;
+    int ret;
+
+    ret = ucc_posix_memalign((void **)&dt_gen,
+                             ucc_max(sizeof(void *), UCC_BIT(UCC_DATATYPE_SHIFT)),
+                             sizeof(*dt_gen), "generic_dt");
+    if (ret != 0) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    dt_gen->ops     = *ops;
+    dt_gen->context = context;
+    *datatype_p     = ucc_dt_from_generic(dt_gen);
+    return UCC_OK;
+}
+
+void ucc_dt_destroy(ucc_datatype_t datatype)
+{
+    ucc_dt_generic_t *dt_gen;
+
+    switch (datatype & UCC_DATATYPE_CLASS_MASK) {
+    case UCC_DATATYPE_PREDEFINED:
+        break;
+    case UCC_DATATYPE_GENERIC:
+        dt_gen = ucc_dt_to_generic(datatype);
+        ucc_free(dt_gen);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/core/ucc_dt.h
+++ b/src/core/ucc_dt.h
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_DT_H_
+#define UCC_DT_H_
+#include "config.h"
+#include "ucc/api/ucc.h"
+
+typedef struct ucc_dt_generic {
+    void                     *context;
+    ucc_generic_dt_ops_t     ops;
+} ucc_dt_generic_t;
+
+#define UCC_DT_PREDEFINED_ID(_dt) ((_dt) >> UCC_DATATYPE_SHIFT)
+
+#define UCC_DT_IS_GENERIC(_datatype)                                    \
+    (((_datatype) & UCC_DATATYPE_CLASS_MASK) == UCC_DATATYPE_GENERIC)
+
+#define UCC_DT_IS_PREDEFINED(_dt) \
+    (((_dt) & UCC_DATATYPE_CLASS_MASK) == UCC_DATATYPE_PREDEFINED)
+
+#define UCC_DT_GENERIC_IS_CONTIG(_dt) (((_dt)->ops.mask & UCC_GENERIC_DT_OPS_FIELD_FLAGS) && \
+                                       ((_dt)->ops.flags & UCC_GENERIC_DT_OPS_FLAG_CONTIG))
+
+#define UCC_DT_GENERIC_HAS_REDUCE(_dt) (((_dt)->ops.mask & UCC_GENERIC_DT_OPS_FIELD_FLAGS) && \
+                                       ((_dt)->ops.flags & UCC_GENERIC_DT_OPS_FLAG_REDUCE))
+
+#define UCC_DT_IS_CONTIG(_dt) (UCC_DT_IS_GENERIC(_dt) && \
+                               UCC_DT_GENERIC_IS_CONTIG(ucc_dt_to_generic(_dt)))
+
+#define UCC_DT_HAS_REDUCE(_dt) (UCC_DT_IS_GENERIC(_dt) && \
+                                UCC_DT_GENERIC_HAS_REDUCE(ucc_dt_to_generic(_dt)))
+
+static inline
+ucc_dt_generic_t* ucc_dt_to_generic(ucc_datatype_t datatype)
+{
+    return (ucc_dt_generic_t*)(void*)(datatype & ~UCC_DATATYPE_CLASS_MASK);
+}
+
+static inline
+ucc_datatype_t ucc_dt_from_generic(ucc_dt_generic_t* dt_gen)
+{
+    return ((uintptr_t)dt_gen) | UCC_DATATYPE_GENERIC;
+}
+
+static inline size_t ucc_contig_dt_size(ucc_datatype_t datatype)
+{
+    return ucc_dt_to_generic(datatype)->ops.contig_size;
+}
+
+extern size_t ucc_dt_predefined_sizes[UCC_DT_PREDEFINED_LAST];
+
+static inline size_t ucc_dt_size(ucc_datatype_t dt)
+{
+    if (UCC_DT_IS_PREDEFINED(dt)) {
+        return ucc_dt_predefined_sizes[UCC_DT_PREDEFINED_ID(dt)];
+    } else if (UCC_DT_IS_CONTIG(dt)) {
+        return ucc_contig_dt_size(dt);
+    }
+    // GENERIC callck pack/unpack
+    // TODO remove ucc_likely once custom datatype is implemented
+    return 0;
+}
+
+
+
+#endif

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -49,8 +49,6 @@ static inline void ucc_copy_lib_params(ucc_lib_params_t *dst,
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_LIB_PARAM_FIELD_REDUCTION_TYPES,
                             reduction_types);
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_LIB_PARAM_FIELD_SYNC_TYPE, sync_type);
-    UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_LIB_PARAM_FIELD_REDUCTION_WRAPPER,
-                            reduction_wrapper);
 }
 
 /* Core logic for the selection of CL components:

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -555,7 +555,8 @@ static ucc_status_t ucc_team_alloc_id(ucc_team_t *team)
                                     .map.ep_num = team->size,
                                     .myrank     = team->rank};
         status = ucc_service_allreduce(team, local, global, UCC_DT_UINT64,
-                                       ctx->ids.pool_size, UCC_OP_BAND, subset,
+                                       ctx->ids.pool_size,
+                                       UCC_OP_BAND, subset,
                                        &team->sreq);
         if (status < 0) {
             return status;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -115,46 +115,6 @@ BEGIN_C_DECLS
  *
  *  @ingroup UCC_LIB_INIT_DT
  *
- *  @brief Enumeration representing the UCC reduction operations
- *
- *  @parblock
- *
- *
- *  Description
- *
- *  @ref ucc_reduction_op_t  represents the UCC reduction operations. It is used by the
- *  library initialization routine @ref ucc_init to request the operations expected by the user.
- *  It is used by the @ref ucc_lib_attr_t to communicate the operations supported by
- *  the library. The user-defined reductions are represented by
- *  UCC_OP_USERDEFINED.
- *
- *  @endparblock
- *
- */
-typedef enum {
-    UCC_OP_USERDEFINED      = UCC_BIT(0), /*!< User defined reduction operation */
-    UCC_OP_SUM              = UCC_BIT(1), /*!< Predefined addition operation */
-    UCC_OP_PROD             = UCC_BIT(2),
-    UCC_OP_MAX              = UCC_BIT(3),
-    UCC_OP_MIN              = UCC_BIT(4),
-    UCC_OP_LAND             = UCC_BIT(5),
-    UCC_OP_LOR              = UCC_BIT(6),
-    UCC_OP_LXOR             = UCC_BIT(7),
-    UCC_OP_BAND             = UCC_BIT(8),
-    UCC_OP_BOR              = UCC_BIT(9),
-    UCC_OP_BXOR             = UCC_BIT(10),
-    UCC_OP_MAXLOC           = UCC_BIT(11),
-    UCC_OP_MINLOC           = UCC_BIT(12),
-    UCC_OP_AVG              = UCC_BIT(13) /*!< Perform an average operation, i.e.
-                                               a sum across all ranks, divided by
-                                               the number of ranks.
-                                               Supported only for floating-point values */
-} ucc_reduction_op_t;
-
-/**
- *
- *  @ingroup UCC_LIB_INIT_DT
- *
  *  @brief Enumeration representing the collective operations
  *
  *  @parblock
@@ -209,23 +169,232 @@ typedef enum {
  *  @endparblock
  *
  */
+typedef uint64_t ucc_datatype_t;
+
 typedef enum {
-    UCC_DT_INT8           = 0,
-    UCC_DT_INT16,
-    UCC_DT_INT32,
-    UCC_DT_INT64,
-    UCC_DT_INT128,
-    UCC_DT_UINT8,
-    UCC_DT_UINT16,
-    UCC_DT_UINT32,
-    UCC_DT_UINT64,
-    UCC_DT_UINT128,
-    UCC_DT_FLOAT16,
-    UCC_DT_FLOAT32,
-    UCC_DT_FLOAT64,
-    UCC_DT_USERDEFINED,
-    UCC_DT_OPAQUE
-} ucc_datatype_t;
+    UCC_DATATYPE_PREDEFINED = 0,
+    UCC_DATATYPE_GENERIC    = UCC_BIT(0),
+    UCC_DATATYPE_SHIFT      = 1,
+    UCC_DATATYPE_CLASS_MASK = UCC_MASK(UCC_DATATYPE_SHIFT)
+} ucc_dt_type_t;
+
+#define UCC_PREDEFINED_DT(_id) \
+    (ucc_datatype_t)((((uint64_t)(_id)) << UCC_DATATYPE_SHIFT) | (UCC_DATATYPE_PREDEFINED))
+
+#define   UCC_DT_INT8     UCC_PREDEFINED_DT(0)
+#define   UCC_DT_INT16    UCC_PREDEFINED_DT(1)
+#define   UCC_DT_INT32    UCC_PREDEFINED_DT(2)
+#define   UCC_DT_INT64    UCC_PREDEFINED_DT(3)
+#define   UCC_DT_INT128   UCC_PREDEFINED_DT(4)
+#define   UCC_DT_UINT8    UCC_PREDEFINED_DT(5)
+#define   UCC_DT_UINT16   UCC_PREDEFINED_DT(6)
+#define   UCC_DT_UINT32   UCC_PREDEFINED_DT(7)
+#define   UCC_DT_UINT64   UCC_PREDEFINED_DT(8)
+#define   UCC_DT_UINT128  UCC_PREDEFINED_DT(9)
+#define   UCC_DT_FLOAT16  UCC_PREDEFINED_DT(10)
+#define   UCC_DT_FLOAT32  UCC_PREDEFINED_DT(11)
+#define   UCC_DT_FLOAT64  UCC_PREDEFINED_DT(12)
+#define   UCC_DT_PREDEFINED_LAST  13
+
+
+
+/**
+ * @ingroup UCC_DATATYPE
+ * @brief UCC generic data type descriptor
+ *
+ * This structure provides a generic datatype descriptor that
+ * is used for definition of application defined datatypes.
+
+ * Typically, the descriptor is used for an integration with datatype
+ * engines implemented within MPI and SHMEM implementations.
+ *
+ * @note In case of partial receive, any amount of received data is acceptable
+ *       which matches buffer size.
+ */
+
+enum ucc_generic_dt_ops_field {
+    UCC_GENERIC_DT_OPS_FIELD_FLAGS             = UCC_BIT(0),
+};
+
+typedef enum {
+    UCC_GENERIC_DT_OPS_FLAG_CONTIG             = UCC_BIT(0),
+    UCC_GENERIC_DT_OPS_FLAG_REDUCE             = UCC_BIT(1),
+} ucc_generic_dt_ops_flags_t;
+
+typedef struct ucc_generic_dt_ops {
+    uint64_t mask;
+    uint64_t flags;
+    size_t   contig_size;
+    /**
+     * @ingroup UCC_DATATYPE
+     * @brief Start a packing request.
+     *
+     * The pointer refers to application defined start-to-pack routine. It will
+     * be called from the @ref ucc_tag_send_nb routine.
+     *
+     * @param [in]  context        User-defined context.
+     * @param [in]  buffer         Buffer to pack.
+     * @param [in]  count          Number of elements to pack into the buffer.
+     *
+     * @return  A custom state that is passed to the following
+     *          @ref ucc_generic_dt_ops::pack "pack()" routine.
+     */
+    void* (*start_pack)(void *context, const void *buffer, size_t count);
+
+    /**
+     * @ingroup UCC_DATATYPE
+     * @brief Start an unpacking request.
+     *
+     * The pointer refers to application defined start-to-unpack routine. It will
+     * be called from the @ref ucc_tag_recv_nb routine.
+     *
+     * @param [in]  context        User-defined context.
+     * @param [in]  buffer         Buffer to unpack to.
+     * @param [in]  count          Number of elements to unpack in the buffer.
+     *
+     * @return  A custom state that is passed later to the following
+     *          @ref ucc_generic_dt_ops::unpack "unpack()" routine.
+     */
+    void* (*start_unpack)(void *context, void *buffer, size_t count);
+
+    /**
+     * @ingroup UCC_DATATYPE
+     * @brief Get the total size of packed data.
+     *
+     * The pointer refers to user defined routine that returns the size of data
+     * in a packed format.
+     *
+     * @param [in]  state          State as returned by
+     *                             @ref ucc_generic_dt_ops::start_pack
+     *                             "start_pack()" routine.
+     *
+     * @return  The size of the data in a packed form.
+     */
+    size_t (*packed_size)(void *state);
+
+    /**
+     * @ingroup UCC_DATATYPE
+     * @brief Pack data.
+     *
+     * The pointer refers to application defined pack routine.
+     *
+     * @param [in]  state          State as returned by
+     *                             @ref ucc_generic_dt_ops::start_pack
+     *                             "start_pack()" routine.
+     * @param [in]  offset         Virtual offset in the output stream.
+     * @param [in]  dest           Destination buffer to pack the data.
+     * @param [in]  max_length     Maximum length to pack.
+     *
+     * @return The size of the data that was written to the destination buffer.
+     *         Must be less than or equal to @e max_length.
+     */
+    size_t (*pack) (void *state, size_t offset, void *dest, size_t max_length);
+
+    /**
+     * @ingroup UCC_DATATYPE
+     * @brief Unpack data.
+     *
+     * The pointer refers to application defined unpack routine.
+     *
+     * @param [in]  state          State as returned by
+     *                             @ref ucc_generic_dt_ops::start_unpack
+     *                             "start_unpack()" routine.
+     * @param [in]  offset         Virtual offset in the input stream.
+     * @param [in]  src            Source to unpack the data from.
+     * @param [in]  length         Length to unpack.
+     *
+     * @return UCS_OK or an error if unpacking failed.
+     */
+    ucc_status_t (*unpack)(void *state, size_t offset, const void *src, size_t length);
+
+    /**
+     * @ingroup UCC_DATATYPE
+     * @brief Finish packing/unpacking.
+     *
+     * The pointer refers to application defined finish routine.
+     *
+     * @param [in]  state          State as returned by
+     *                             @ref ucc_generic_dt_ops::start_pack
+     *                             "start_pack()"
+     *                             and
+     *                             @ref ucc_generic_dt_ops::start_unpack
+     *                             "start_unpack()"
+     *                             routines.
+     */
+    void (*finish)(void *state);
+
+    struct {
+        void (*cb)(void *src1, void *src2, void *dst,
+                   ucc_count_t count, void *context);
+        void *ctx;
+    } reduce;
+} ucc_generic_dt_ops_t;
+
+
+/**
+ * @ingroup UCC_DATATYPE
+ * @brief Create a generic datatype.
+ *
+ * This routine create a generic datatype object.
+ * The generic datatype is described by the @a ops @ref ucc_generic_dt_ops_t
+ * "object" which provides a table of routines defining the operations for
+ * generic datatype manipulation. Typically, generic datatypes are used for
+ * integration with datatype engines provided with MPI implementations (MPICH,
+ * Open MPI, etc).
+ * The application is responsible for releasing the @a datatype_p  object using
+ * @ref ucc_dt_destroy "ucc_dt_destroy()" routine.
+ *
+ * @param [in]  ops          Generic datatype function table as defined by
+ *                           @ref ucc_generic_dt_ops_t .
+ * @param [in]  context      Application defined context passed to this
+ *                           routine.  The context is passed as a parameter
+ *                           to the routines in the @a ops table.
+ * @param [out] datatype_p   A pointer to datatype object.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucc_status_t ucc_dt_create_generic(const ucc_generic_dt_ops_t *ops, void *context,
+                                   ucc_datatype_t *datatype_p);
+
+void ucc_dt_destroy(ucc_datatype_t datatype);
+
+
+/**
+ *
+ *  @ingroup UCC_LIB_INIT_DT
+ *
+ *  @brief Enumeration representing the UCC reduction operations
+ *
+ *  @parblock
+ *
+ *
+ *  Description
+ *
+ *  @ref ucc_reduction_op_t  represents the UCC reduction operations. It is used by the
+ *  library initialization routine @ref ucc_init to request the operations expected by the user.
+ *  It is used by the @ref ucc_lib_attr_t to communicate the operations supported by
+ *  the library. The user-defined reductions are represented by
+ *  UCC_OP_USERDEFINED.
+ *
+ *  @endparblock
+ *
+ */
+typedef enum {
+    UCC_OP_SUM,
+    UCC_OP_PROD,
+    UCC_OP_MAX,
+    UCC_OP_MIN,
+    UCC_OP_LAND,
+    UCC_OP_LOR,
+    UCC_OP_LXOR,
+    UCC_OP_BAND,
+    UCC_OP_BOR,
+    UCC_OP_BXOR,
+    UCC_OP_MAXLOC,
+    UCC_OP_MINLOC,
+    UCC_OP_AVG,
+   UCC_OP_LAST
+} ucc_reduction_op_t;
 
 /**
  *
@@ -284,32 +453,6 @@ typedef enum {
 
 
 /**
- *  @ingroup UCC_COLLECTIVES
- *
- *  @brief The reduction wrapper provides an interface for the UCC library to invoke
- *         user-defined custom reduction callback
- *
- *  @param [in]  invec          The input elements to be reduced by the user function
- *  @param [in]  inoutvec       The input elements to be reduced and output of the reduction
- *  @param [in]  count          The number of elements of type "dtype" to be reduced
- *  @param [in]  dtype          Datatype specified in the coll_args
- *  @param [in]  custom_op      A pointer to the user defined reduction passed to the coll_args as custom_reduction_op
- *
- *
- *  @parblock
- *
- *  @b Description
- *
- *  This function is called by the UCC library when it needs to perform a non-standard
- *  user-defined reduction operaion during allreduce/reduce collective.
- *
- *  @endparblock
- */
-typedef void(*ucc_reduction_wrapper_t)(void *invec, void *inoutvec,
-                                       ucc_count_t *count, void *dtype,
-                                       void *custom_reduction_op);
-
-/**
  * @brief UCC library initialization parameters
  */
 
@@ -321,8 +464,7 @@ enum ucc_lib_params_field{
     UCC_LIB_PARAM_FIELD_THREAD_MODE         = UCC_BIT(0),
     UCC_LIB_PARAM_FIELD_COLL_TYPES          = UCC_BIT(1),
     UCC_LIB_PARAM_FIELD_REDUCTION_TYPES     = UCC_BIT(2),
-    UCC_LIB_PARAM_FIELD_SYNC_TYPE           = UCC_BIT(3),
-    UCC_LIB_PARAM_FIELD_REDUCTION_WRAPPER   = UCC_BIT(4)
+    UCC_LIB_PARAM_FIELD_SYNC_TYPE           = UCC_BIT(3)
 };
 
 /**
@@ -362,7 +504,6 @@ typedef struct ucc_lib_params {
     uint64_t                coll_types;
     uint64_t                reduction_types;
     ucc_coll_sync_type_t    sync_type;
-    ucc_reduction_wrapper_t reduction_wrapper;
 } ucc_lib_params_t;
 
 /**
@@ -1588,10 +1729,8 @@ typedef enum {
  */
 enum ucc_coll_args_field {
     UCC_COLL_ARGS_FIELD_FLAGS                           = UCC_BIT(0),
-    UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS           = UCC_BIT(1),
-    UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS          = UCC_BIT(2),
-    UCC_COLL_ARGS_FIELD_TAG                             = UCC_BIT(3),
-    UCC_COLL_ARGS_FIELD_CB                              = UCC_BIT(4)
+    UCC_COLL_ARGS_FIELD_TAG                             = UCC_BIT(1),
+    UCC_COLL_ARGS_FIELD_CB                              = UCC_BIT(2)
 };
 
 /**
@@ -1638,14 +1777,9 @@ typedef struct ucc_coll_args {
         ucc_coll_buffer_info_t      info;   /*!< Buffer info for the collective */
         ucc_coll_buffer_info_v_t    info_v; /*!< Buffer info for the collective */
     } dst;
-    struct {
-        ucc_reduction_op_t          predefined_op; /*!< Reduction operation, if
-                                                        reduce or all-reduce
-                                                        operation selected */
-        void                       *custom_op; /*!< User defined
-                                                    reduction operation */
-        void                       *custom_dtype;
-    } reduce;
+    ucc_reduction_op_t              op; /*!< Reduction operation, if
+                                             reduce, allreduce, reduce_scatter is
+                                             operation selected */
     uint64_t                        flags;
     uint64_t                        root; /*!< Root endpoint for rooted
                                              collectives */

--- a/src/ucc/api/ucc_def.h
+++ b/src/ucc/api/ucc_def.h
@@ -114,6 +114,8 @@ typedef uint64_t ucc_aint_t;
 /* Reflects the definition in UCS - The i-th bit */
 #define UCC_BIT(i)               (1ul << (i))
 
+#define UCC_MASK(i)              (UCC_BIT(i) - 1)
+
 /* Reflects the definition in UCS */
 /**
  * @ingroup UCC_UTILS
@@ -156,6 +158,5 @@ typedef size_t ucc_context_addr_len_t;
  * the execution context and related queues.
  */
 typedef struct ucc_ee*      ucc_ee_h;
-
 
 #endif

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -158,7 +158,7 @@ size_t ucc_coll_args_msgsize(const ucc_base_coll_args_t *bargs)
     case UCC_COLL_TYPE_REDUCE_SCATTERV:
         return ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
                                              team->size) *
-               ucc_dt_size(args->dst.info.datatype);
+               ucc_dt_size(args->dst.info_v.datatype);
     case UCC_COLL_TYPE_ALLTOALLV:
     case UCC_COLL_TYPE_GATHERV:
     case UCC_COLL_TYPE_SCATTERV:
@@ -306,8 +306,7 @@ void ucc_coll_str(const ucc_base_coll_args_t *args, char *str, size_t len)
         ct == UCC_COLL_TYPE_REDUCE) {
         ucc_snprintf_safe(tmp, sizeof(tmp), " %s %s",
                           ucc_datatype_str(args->args.src.info.datatype),
-                          (args->args.mask & UCC_COLL_ARGS_FIELD_USERDEFINED_REDUCTIONS) ?
-                          "userdefined" : ucc_reduction_op_str(args->args.reduce.predefined_op));
+                          ucc_reduction_op_str(args->args.op));
         left = len - strlen(str);
         strncat(str, tmp, left);
     }

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -7,7 +7,7 @@
 #define UCC_COMPILER_DEF_H_
 
 #include "config.h"
-#include "ucc/api/ucc_status.h"
+#include "ucc/api/ucc.h"
 #include <ucs/type/status.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/preprocessor.h>
@@ -32,8 +32,8 @@ typedef int                        ucc_score_t;
 #define _UCC_PP_MAKE_STRING(x) #x
 #define UCC_PP_MAKE_STRING(x)  _UCC_PP_MAKE_STRING(x)
 #define UCC_PP_QUOTE UCS_PP_QUOTE
-#define UCC_MASK     UCS_MASK
 #define UCC_EMPTY_STATEMENT {}
+
 
 #define UCC_COPY_PARAM_BY_FIELD(_dst, _src, _FIELD, _field)                    \
     do {                                                                       \

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -8,6 +8,7 @@
 
 #include "config.h"
 #include "core/ucc_global_opts.h"
+#include "core/ucc_dt.h"
 #include <ucs/debug/log_def.h>
 
 #define UCC_LOG_LEVEL_ERROR UCS_LOG_LEVEL_ERROR
@@ -113,10 +114,6 @@ static inline const char* ucc_datatype_str(ucc_datatype_t dt)
         return "int128";
     case UCC_DT_UINT128:
         return "uint128";
-    case UCC_DT_USERDEFINED:
-        return "userdefined";
-    case UCC_DT_OPAQUE:
-        return "opaque";
     default:
         return NULL;
     }

--- a/src/utils/ucc_malloc.h
+++ b/src/utils/ucc_malloc.h
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 
 #define ucc_malloc(_s, ...) malloc(_s)
+#define ucc_posix_memalign(_ptr, _align, _size, ...) posix_memalign(_ptr, _align, _size)
 #define ucc_calloc(_n, _s, ...) calloc(_n, _s)
 #define ucc_realloc(_p, _s, ...) realloc(_p, _s)
 #define ucc_free(_p) free(_p)

--- a/src/utils/ucc_math.c
+++ b/src/utils/ucc_math.c
@@ -6,22 +6,6 @@
 #include "ucc/api/ucc.h"
 #include "ucc_math.h"
 
-size_t ucc_dt_sizes[UCC_DT_USERDEFINED] = {
-    [UCC_DT_INT8]    = 1,
-    [UCC_DT_UINT8]   = 1,
-    [UCC_DT_INT16]   = 2,
-    [UCC_DT_UINT16]  = 2,
-    [UCC_DT_FLOAT16] = 2,
-    [UCC_DT_INT32]   = 4,
-    [UCC_DT_UINT32]  = 4,
-    [UCC_DT_FLOAT32] = 4,
-    [UCC_DT_INT64]   = 8,
-    [UCC_DT_UINT64]  = 8,
-    [UCC_DT_FLOAT64] = 8,
-    [UCC_DT_INT128]  = 16,
-    [UCC_DT_UINT128] = 16,
-};
-
 static int _compare(const void *a, const void *b)
 {
     return (*(int *)a - *(int *)b);

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -26,17 +26,6 @@
 #define DO_OP_LXOR(_v1, _v2) ((!_v1) != (!_v2))
 #define DO_OP_BXOR(_v1, _v2) (_v1 ^ _v2)
 
-extern size_t ucc_dt_sizes[UCC_DT_USERDEFINED];
-static inline size_t ucc_dt_size(ucc_datatype_t dt)
-{
-    if (ucc_likely(dt < UCC_DT_USERDEFINED)) {
-        return ucc_dt_sizes[dt];
-    }
-    // TODO remove ucc_likely once custom datatype is implemented
-    return 0;
-}
-
-
 #define PTR_OFFSET(_ptr, _offset)                                              \
     ((void *)((ptrdiff_t)(_ptr) + (size_t)(_offset)))
 

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -236,4 +236,9 @@ public:
 
 void clear_buffer(void *_buf, size_t size, ucc_memory_type_t mt, uint8_t value);
 
+#define PREDEFINED_DTYPES \
+    ::testing::Values(UCC_DT_INT8, UCC_DT_INT16, UCC_DT_INT32, UCC_DT_INT64, UCC_DT_INT128,\
+                      UCC_DT_UINT8, UCC_DT_UINT16, UCC_DT_UINT32, UCC_DT_UINT64, UCC_DT_UINT128,\
+                      UCC_DT_FLOAT16, UCC_DT_FLOAT32, UCC_DT_FLOAT64)
+
 #endif

--- a/test/gtest/core/test_allgather.cc
+++ b/test/gtest/core/test_allgather.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
-using Param_1 = std::tuple<int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_0 = std::tuple<int, ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
 
 class test_allgather : public UccCollArgs, public ucc::test
 {
@@ -140,7 +140,7 @@ class test_allgather_0 : public test_allgather,
 UCC_TEST_P(test_allgather_0, single)
 {
     const int                 team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype    = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
@@ -162,7 +162,7 @@ UCC_TEST_P(test_allgather_0, single)
 UCC_TEST_P(test_allgather_0, single_persistent)
 {
     const int                 team_id = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype   = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype   = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
@@ -191,7 +191,7 @@ INSTANTIATE_TEST_CASE_P(
     , test_allgather_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1, 4), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
@@ -206,7 +206,7 @@ class test_allgather_1 : public test_allgather,
 
 UCC_TEST_P(test_allgather_1, multiple_host)
 {
-    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_datatype_t      dtype    = std::get<0>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<1>(GetParam());
     const int                 count    = std::get<2>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<3>(GetParam());
@@ -221,7 +221,7 @@ UCC_TEST_P(test_allgather_1, multiple_host)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        data_init(size, dtype, count, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -237,7 +237,7 @@ UCC_TEST_P(test_allgather_1, multiple_host)
 INSTANTIATE_TEST_CASE_P(
     , test_allgather_1,
     ::testing::Combine(
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1, 4), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else

--- a/test/gtest/core/test_allgatherv.cc
+++ b/test/gtest/core/test_allgatherv.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
-using Param_1 = std::tuple<int, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_0 = std::tuple<int, ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
 
 class test_allgatherv : public UccCollArgs, public ucc::test
 {
@@ -159,7 +159,7 @@ class test_allgatherv_0 : public test_allgatherv,
 UCC_TEST_P(test_allgatherv_0, single)
 {
     const int                 team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype    = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
@@ -170,7 +170,7 @@ UCC_TEST_P(test_allgatherv_0, single)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -181,7 +181,7 @@ UCC_TEST_P(test_allgatherv_0, single)
 UCC_TEST_P(test_allgatherv_0, single_persistent)
 {
     const int                 team_id = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype   = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype   = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const gtest_ucc_inplace_t inplace  = std::get<4>(GetParam());
@@ -193,7 +193,7 @@ UCC_TEST_P(test_allgatherv_0, single_persistent)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq req(team, ctxs);
 
     for (auto i = 0; i < n_calls; i++) {
@@ -209,7 +209,7 @@ INSTANTIATE_TEST_CASE_P(
     , test_allgatherv_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_INT64 + 1), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
@@ -223,7 +223,7 @@ class test_allgatherv_1 : public test_allgatherv,
 
 UCC_TEST_P(test_allgatherv_1, multiple)
 {
-    const ucc_datatype_t       dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_datatype_t       dtype    = std::get<0>(GetParam());
     const ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     const int                  count    = std::get<2>(GetParam());
     const gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
@@ -238,7 +238,7 @@ UCC_TEST_P(test_allgatherv_1, multiple)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        data_init(size, dtype, count, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -254,7 +254,7 @@ UCC_TEST_P(test_allgatherv_1, multiple)
 INSTANTIATE_TEST_CASE_P(
     , test_allgatherv_1,
     ::testing::Combine(
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_INT64 + 1), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else

--- a/test/gtest/core/test_allreduce.cc
+++ b/test/gtest/core/test_allreduce.cc
@@ -29,9 +29,8 @@ class test_allreduce : public UccCollArgs, public testing::Test {
             ctxs[r] = (gtest_ucc_coll_ctx_t*)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
             ctxs[r]->args = coll;
 
-            coll->mask = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
             coll->coll_type = UCC_COLL_TYPE_ALLREDUCE;
-            coll->reduce.predefined_op = T::redop;
+            coll->op        = T::redop;
 
             ctxs[r]->init_buf = ucc_malloc(ucc_dt_size(dt) * count, "init buf");
             EXPECT_NE(ctxs[r]->init_buf, nullptr);

--- a/test/gtest/core/test_alltoall.cc
+++ b/test/gtest/core/test_alltoall.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
-using Param_1 = std::tuple<int, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
+using Param_0 = std::tuple<int, ucc_datatype_t, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
+using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
 
 class test_alltoall : public UccCollArgs, public ucc::test
 {
@@ -143,7 +143,7 @@ class test_alltoall_0 : public test_alltoall,
 UCC_TEST_P(test_alltoall_0, single)
 {
     const int            team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t dtype    = std::get<1>(GetParam());
     ucc_memory_type_t    mem_type = std::get<2>(GetParam());
     gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
     const int            count    = std::get<4>(GetParam());
@@ -154,7 +154,7 @@ UCC_TEST_P(test_alltoall_0, single)
     this->set_inplace(inplace);
     this->set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -165,7 +165,7 @@ UCC_TEST_P(test_alltoall_0, single)
 UCC_TEST_P(test_alltoall_0, single_persistent)
 {
     const int            team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t dtype    = std::get<1>(GetParam());
     ucc_memory_type_t    mem_type = std::get<2>(GetParam());
     gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
     const int            count    = std::get<4>(GetParam());
@@ -177,7 +177,7 @@ UCC_TEST_P(test_alltoall_0, single_persistent)
     this->set_inplace(inplace);
     this->set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq req(team, ctxs);
 
     for (auto i = 0; i < n_calls; i++) {
@@ -193,7 +193,7 @@ INSTANTIATE_TEST_CASE_P(
     , test_alltoall_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
@@ -207,7 +207,7 @@ class test_alltoall_1 : public test_alltoall,
 
 UCC_TEST_P(test_alltoall_1, multiple)
 {
-    const ucc_datatype_t       dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_datatype_t       dtype    = std::get<0>(GetParam());
     ucc_memory_type_t          mem_type = std::get<1>(GetParam());
     gtest_ucc_inplace_t        inplace  = std::get<2>(GetParam());
     const int                  count    = std::get<3>(GetParam());
@@ -222,7 +222,7 @@ UCC_TEST_P(test_alltoall_1, multiple)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        data_init(size, dtype, count, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -238,7 +238,7 @@ UCC_TEST_P(test_alltoall_1, multiple)
 INSTANTIATE_TEST_CASE_P(
     , test_alltoall_1,
     ::testing::Combine(
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else

--- a/test/gtest/core/test_alltoallv.cc
+++ b/test/gtest/core/test_alltoallv.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, ucc_memory_type_t, gtest_ucc_inplace_t, int>;
-using Param_1 = std::tuple<ucc_memory_type_t, gtest_ucc_inplace_t, int>;
+using Param_0 = std::tuple<int, ucc_memory_type_t, gtest_ucc_inplace_t, ucc_datatype_t>;
+using Param_1 = std::tuple<ucc_memory_type_t, gtest_ucc_inplace_t, ucc_datatype_t>;
 
 template <class T>
 class test_alltoallv : public UccCollArgs, public ucc::test
@@ -155,7 +155,7 @@ UCC_TEST_P(test_alltoallv_0, single)
     const int            team_id = std::get<0>(GetParam());
     ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     gtest_ucc_inplace_t  inplace = std::get<2>(GetParam());
-    const ucc_datatype_t dtype   = (ucc_datatype_t)std::get<3>(GetParam());
+    const ucc_datatype_t dtype   = std::get<3>(GetParam());
     UccTeam_h            team    = UccJob::getStaticTeams()[team_id];
     int                  size    = team->procs.size();
     UccCollCtxVec        ctxs;
@@ -166,7 +166,7 @@ UCC_TEST_P(test_alltoallv_0, single)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, 1, ctxs);
+    data_init(size, dtype, 1, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -180,7 +180,7 @@ UCC_TEST_P(test_alltoallv_0, single_persistent)
     const int            team_id  = std::get<0>(GetParam());
     ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     gtest_ucc_inplace_t  inplace  = std::get<2>(GetParam());
-    const ucc_datatype_t dtype    = (ucc_datatype_t)std::get<3>(GetParam());
+    const ucc_datatype_t dtype    = std::get<3>(GetParam());
     UccTeam_h            team     = UccJob::getStaticTeams()[team_id];
     int                  size     = team->procs.size();
     const int            n_calls  = 3;
@@ -192,7 +192,7 @@ UCC_TEST_P(test_alltoallv_0, single_persistent)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, 1, ctxs);
+    data_init(size, dtype, 1, ctxs);
     UccReq req(team, ctxs);
 
     for (auto i = 0; i < n_calls; i++) {
@@ -212,7 +212,7 @@ UCC_TEST_P(test_alltoallv_1, single)
     const int            team_id = std::get<0>(GetParam());
     ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     gtest_ucc_inplace_t  inplace = std::get<2>(GetParam());
-    const ucc_datatype_t dtype   = (ucc_datatype_t)std::get<3>(GetParam());
+    const ucc_datatype_t dtype   = std::get<3>(GetParam());
     UccTeam_h            team    = UccJob::getStaticTeams()[team_id];
     int                  size    = team->procs.size();
     UccCollCtxVec        ctxs;
@@ -220,7 +220,7 @@ UCC_TEST_P(test_alltoallv_1, single)
     set_inplace(inplace);
     set_mem_type(mem_type);
 
-    data_init(size, (ucc_datatype_t)dtype, 1, ctxs);
+    data_init(size, dtype, 1, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -239,7 +239,7 @@ INSTANTIATE_TEST_CASE_P(
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
             ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
-            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+            PREDEFINED_DTYPES)); // dtype
 
 
 INSTANTIATE_TEST_CASE_P(
@@ -252,7 +252,7 @@ INSTANTIATE_TEST_CASE_P(
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
             ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
-            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+            PREDEFINED_DTYPES)); // dtype
 
 class test_alltoallv_2 : public test_alltoallv<uint64_t>,
         public ::testing::WithParamInterface<Param_1> {};
@@ -265,7 +265,7 @@ UCC_TEST_P(test_alltoallv_2, multiple)
 {
     ucc_memory_type_t           mem_type = std::get<0>(GetParam());
     gtest_ucc_inplace_t         inplace  = std::get<1>(GetParam());
-    const ucc_datatype_t        dtype    = (ucc_datatype_t)std::get<2>(GetParam());
+    const ucc_datatype_t        dtype    = std::get<2>(GetParam());
     std::vector<UccReq>         reqs;
     std::vector<UccCollCtxVec>  ctxs;
 
@@ -281,7 +281,7 @@ UCC_TEST_P(test_alltoallv_2, multiple)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, 1, ctx);
+        data_init(size, dtype, 1, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -298,7 +298,7 @@ UCC_TEST_P(test_alltoallv_3, multiple)
 {
     ucc_memory_type_t           mem_type = std::get<0>(GetParam());
     gtest_ucc_inplace_t         inplace  = std::get<1>(GetParam());
-    const ucc_datatype_t        dtype    = (ucc_datatype_t)std::get<2>(GetParam());
+    const ucc_datatype_t        dtype    = std::get<2>(GetParam());
     std::vector<UccReq>         reqs;
     std::vector<UccCollCtxVec>  ctxs;
 
@@ -310,7 +310,7 @@ UCC_TEST_P(test_alltoallv_3, multiple)
         this->set_inplace(inplace);
         this->set_mem_type(mem_type);
 
-        data_init(size, (ucc_datatype_t)dtype, 1, ctx);
+        data_init(size, dtype, 1, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -332,7 +332,7 @@ INSTANTIATE_TEST_CASE_P(
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
             ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
-            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+            PREDEFINED_DTYPES)); // dtype
 
 INSTANTIATE_TEST_CASE_P(
         32, test_alltoallv_3,
@@ -343,4 +343,4 @@ INSTANTIATE_TEST_CASE_P(
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
             ::testing::Values(/*TEST_INPLACE,*/ TEST_NO_INPLACE), // inplace
-            ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_FLOAT64 + 1))); // dtype
+            PREDEFINED_DTYPES)); // dtype

--- a/test/gtest/core/test_bcast.cc
+++ b/test/gtest/core/test_bcast.cc
@@ -6,8 +6,8 @@
 #include "common/test_ucc.h"
 #include "utils/ucc_math.h"
 
-using Param_0 = std::tuple<int, int, ucc_memory_type_t, int, int>;
-using Param_1 = std::tuple<int, ucc_memory_type_t, int, int>;
+using Param_0 = std::tuple<int, ucc_datatype_t, ucc_memory_type_t, int, int>;
+using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, int, int>;
 
 class test_bcast : public UccCollArgs, public ucc::test
 {
@@ -119,7 +119,7 @@ class test_bcast_0 : public test_bcast,
 UCC_TEST_P(test_bcast_0, single)
 {
     const int                 team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t      dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t      dtype    = std::get<1>(GetParam());
     const ucc_memory_type_t   mem_type = std::get<2>(GetParam());
     const int                 count    = std::get<3>(GetParam());
     const int                 root     = std::get<4>(GetParam());
@@ -130,7 +130,7 @@ UCC_TEST_P(test_bcast_0, single)
     set_mem_type(mem_type);
     set_root(root);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq    req(team, ctxs);
     req.start();
     req.wait();
@@ -141,7 +141,7 @@ UCC_TEST_P(test_bcast_0, single)
 UCC_TEST_P(test_bcast_0, single_persistent)
 {
     const int               team_id  = std::get<0>(GetParam());
-    const ucc_datatype_t    dtype    = (ucc_datatype_t)std::get<1>(GetParam());
+    const ucc_datatype_t    dtype    = std::get<1>(GetParam());
     const ucc_memory_type_t mem_type = std::get<2>(GetParam());
     const int               count    = std::get<3>(GetParam());
     const int               root     = std::get<4>(GetParam());
@@ -153,7 +153,7 @@ UCC_TEST_P(test_bcast_0, single_persistent)
     set_mem_type(mem_type);
     set_root(root);
 
-    data_init(size, (ucc_datatype_t)dtype, count, ctxs);
+    data_init(size, dtype, count, ctxs);
     UccReq req(team, ctxs);
 
     for (auto i = 0; i < n_calls; i++) {
@@ -170,7 +170,7 @@ INSTANTIATE_TEST_CASE_P(
     , test_bcast_0,
     ::testing::Combine(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_UINT32 + 1, 3), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else
@@ -184,7 +184,7 @@ class test_bcast_1 : public test_bcast,
 
 UCC_TEST_P(test_bcast_1, multiple)
 {
-    const ucc_datatype_t       dtype    = (ucc_datatype_t)std::get<0>(GetParam());
+    const ucc_datatype_t       dtype    = std::get<0>(GetParam());
     const ucc_memory_type_t    mem_type = std::get<1>(GetParam());
     const int                  count    = std::get<2>(GetParam());
     const int                  root     = std::get<3>(GetParam());
@@ -199,7 +199,7 @@ UCC_TEST_P(test_bcast_1, multiple)
         set_mem_type(mem_type);
         set_root(root);
 
-        data_init(size, (ucc_datatype_t)dtype, count, ctx);
+        data_init(size, dtype, count, ctx);
         reqs.push_back(UccReq(team, ctx));
         ctxs.push_back(ctx);
     }
@@ -215,7 +215,7 @@ UCC_TEST_P(test_bcast_1, multiple)
 INSTANTIATE_TEST_CASE_P(
     , test_bcast_1,
     ::testing::Combine(
-        ::testing::Range((int)UCC_DT_INT8, (int)UCC_DT_UINT32 + 1, 3), // dtype
+        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
         ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
 #else

--- a/test/gtest/core/test_reduce.cc
+++ b/test/gtest/core/test_reduce.cc
@@ -27,12 +27,11 @@ class test_reduce : public UccCollArgs, public testing::Test {
                           sizeof(gtest_ucc_coll_ctx_t));
             ctxs[r]->args = coll;
 
-            coll->mask = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
             coll->coll_type = UCC_COLL_TYPE_REDUCE;
-            coll->reduce.predefined_op = T::redop;
-            coll->root = root;
+            coll->op        = T::redop;
+            coll->root      = root;
             coll->src.info.mem_type = mem_type;
-            coll->src.info.count = (ucc_count_t)count;
+            coll->src.info.count    = (ucc_count_t)count;
             coll->src.info.datatype = dt;
 
             ctxs[r]->init_buf = ucc_malloc(ucc_dt_size(dt) * count,

--- a/test/mpi/test_allreduce.cc
+++ b/test/mpi/test_allreduce.cc
@@ -55,9 +55,7 @@ TestAllreduce::TestAllreduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         args.src.info.mem_type    = UCC_MEMORY_TYPE_UNKNOWN;
     }
 
-    args.mask                |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    args.reduce.predefined_op = _op;
-
+    args.op                   = _op;
     args.dst.info.buffer      = rbuf;
     args.dst.info.count       = count;
     args.dst.info.datatype    = _dt;

--- a/test/mpi/test_reduce.cc
+++ b/test/mpi/test_reduce.cc
@@ -50,9 +50,7 @@ TestReduce::TestReduce(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                        (inplace && rank == root) ? rbuf : sbuf, _mt, _msgsize);
     check_sbuf = check_sbuf_mc_header->addr;
 
-    args.mask                |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    args.reduce.predefined_op = _op;
-
+    args.op                   = _op;
     args.src.info.buffer      = sbuf;
     args.src.info.count       = count;
     args.src.info.datatype    = _dt;

--- a/test/mpi/test_reduce_scatter.cc
+++ b/test/mpi/test_reduce_scatter.cc
@@ -57,8 +57,6 @@ TestReduceScatter::TestReduceScatter(size_t _msgsize,
         init_buffer(check_rbuf, count, dt, UCC_MEMORY_TYPE_HOST, rank);
     }
 
-    args.mask                |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    args.reduce.predefined_op = _op;
 
     if (inplace == TEST_NO_INPLACE) {
         args.src.info.buffer      = sbuf;
@@ -66,7 +64,7 @@ TestReduceScatter::TestReduceScatter(size_t _msgsize,
         args.src.info.datatype    = _dt;
         args.src.info.mem_type    = _mt;
     }
-
+    args.op                   = _op;
     args.dst.info.buffer      = rbuf;
     args.dst.info.datatype    = _dt;
     args.dst.info.mem_type    = _mt;

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -20,8 +20,7 @@ ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
         coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
-    coll_args.mask |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    coll_args.reduce.predefined_op = op;
+    coll_args.op                = op;
     coll_args.src.info.datatype = dt;
     coll_args.dst.info.datatype = dt;
     coll_args.src.info.mem_type = mt;

--- a/tools/perf/ucc_pt_coll_reduce.cc
+++ b/tools/perf/ucc_pt_coll_reduce.cc
@@ -20,8 +20,7 @@ ucc_pt_coll_reduce::ucc_pt_coll_reduce(ucc_datatype_t dt, ucc_memory_type mt,
         coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
 
-    coll_args.mask |= UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
-    coll_args.reduce.predefined_op = op;
+    coll_args.op   = op;
     coll_args.root = 0;
     coll_args.src.info.datatype = dt;
     coll_args.src.info.mem_type = mt;

--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -149,9 +149,8 @@ ucc_status_t ucc_pt_comm::allreduce(float* in, float* out, size_t size,
     ucc_coll_args_t args;
     ucc_coll_req_h req;
 
-    args.mask                 = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
     args.coll_type            = UCC_COLL_TYPE_ALLREDUCE;
-    args.reduce.predefined_op = op;
+    args.op                   = op;
     args.src.info.buffer      = in;
     args.src.info.count       = size;
     args.src.info.datatype    = UCC_DT_FLOAT32;


### PR DESCRIPTION
## What
Changes the UCC.h datatype and reduce_op definitions to support custom dtypes

## Why ?
Current API does not allow support for derived types. 

## How ?
dtype and op are 8bytes (uint64_t) values. 
Predefined dtypes are still the same from the user perspective (UCC_DT_INT32, etc).
ucc_dt_make_contig, ucc_dt_make_generic

custom op: ucc_op_make_userdefined

Required OMPI change: https://github.com/vspetrov/ompi/commit/9746d0cd80e7b3854b8f1f4b663cb5091ab96b2d - MINIMAL

Example of Working code that does UCC_allreduce over custom dtype (struct of fields int+float) and custom reduce op: 
https://gist.github.com/vspetrov/1a4cb03b1018ed742e5762768da925db
