### PR TITLE
TL/NCCL: allgatherv algs bcopy and bcast

### DIFF
--- a/src/components/tl/nccl/Makefile.am
+++ b/src/components/tl/nccl/Makefile.am
@@ -2,6 +2,10 @@
 # Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
 #
 
+allgatherv =                      \
+	allgatherv/allgatherv.h       \
+	allgatherv/allgatherv.c
+
 sources =             \
 	tl_nccl.h         \
 	tl_nccl.c         \
@@ -9,7 +13,8 @@ sources =             \
 	tl_nccl_context.c \
 	tl_nccl_team.c    \
 	tl_nccl_coll.h    \
-	tl_nccl_coll.c
+	tl_nccl_coll.c    \
+	$(allgatherv)
 
 module_LTLIBRARIES = libucc_tl_nccl.la
 libucc_tl_nccl_la_SOURCES  = $(sources)

--- a/src/components/tl/nccl/allgatherv/allgatherv.c
+++ b/src/components/tl/nccl/allgatherv/allgatherv.c
@@ -1,0 +1,270 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_nccl.h"
+#include "allgatherv.h"
+#include "core/ucc_mc.h"
+#include "core/ucc_ee.h"
+
+ucc_base_coll_alg_info_t
+    ucc_tl_nccl_allgatherv_algs[UCC_TL_NCCL_ALLGATHERV_ALG_LAST + 1] = {
+        [UCC_TL_NCCL_ALLGATHERV_ALG_P2P] =
+            {.id   = UCC_TL_NCCL_ALLGATHERV_ALG_P2P,
+             .name = "p2p",
+             .desc = "allgatherv based nccl on point to point"},
+        [UCC_TL_NCCL_ALLGATHERV_ALG_BCOPY] =
+            {.id   = UCC_TL_NCCL_ALLGATHERV_ALG_BCOPY,
+             .name = "bcopy",
+             .desc = "allgatherv with buffered copy"},
+        [UCC_TL_NCCL_ALLGATHERV_ALG_BCAST] =
+            {.id   = UCC_TL_NCCL_ALLGATHERV_ALG_BCAST,
+             .name = "bcast",
+             .desc = "allgatherv based on nccl bcast"},
+        [UCC_TL_NCCL_ALLGATHERV_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};
+
+#define CHECK_INPLACE(_args, _team)                                            \
+    do {                                                                       \
+        if (UCC_IS_INPLACE((_args))) {                                         \
+            tl_error(UCC_TL_TEAM_LIB((_team)),                                 \
+                     "inplace allgatherv is not supported");                   \
+            status = UCC_ERR_NOT_SUPPORTED;                                    \
+            goto out;                                                          \
+        }                                                                      \
+    } while(0)
+
+#define CHECK_USERDEFINED_DT(_args, _team)                                     \
+    do {                                                                       \
+        if (((_args).src.info.datatype == UCC_DT_USERDEFINED) ||               \
+            ((_args).dst.info_v.datatype == UCC_DT_USERDEFINED)) {             \
+            tl_error(UCC_TL_TEAM_LIB((_team)),                                 \
+                     "user defined datatype is not supported");                \
+            status = UCC_ERR_NOT_SUPPORTED;                                    \
+            goto out;                                                          \
+        }                                                                      \
+    } while(0)
+
+ucc_status_t ucc_tl_nccl_allgatherv_p2p_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
+    ucc_rank_t          size   = UCC_TL_TEAM_SIZE(team);
+    ucc_ee_h            ee     = coll_task->ee;
+    cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context :
+                                                       team->stream;
+    ucc_status_t        status = UCC_OK;
+    void               *sbuf   = args->src.info.buffer;
+    ptrdiff_t           rbuf   = (ptrdiff_t)args->dst.info_v.buffer;
+    size_t sdt_size, rdt_size, count, displ;
+    ucc_rank_t peer;
+
+    task->super.super.status = UCC_INPROGRESS;
+    sdt_size                 = ucc_dt_size(args->src.info.datatype);
+    rdt_size                 = ucc_dt_size(args->dst.info_v.datatype);
+    UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_allgatherv_start", 0);
+    NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    count = args->src.info.count;
+    if (count != 0) {
+        for (peer = 0; peer < size; peer++) {
+            NCCLCHECK_GOTO(ncclSend(sbuf, count * sdt_size, ncclChar, peer,
+                                    team->nccl_comm, stream),
+                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+        }
+    }
+    for (peer = 0; peer < size; peer++) {
+        count = ucc_coll_args_get_count(args, args->dst.info_v.counts, peer);
+        if (count != 0) {
+            displ = ucc_coll_args_get_displacement(
+                args, args->dst.info_v.displacements, peer);
+            NCCLCHECK_GOTO(ncclRecv((void *)(rbuf + displ * rdt_size),
+                                    count * rdt_size, ncclChar, peer,
+                                    team->nccl_comm, stream),
+                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+        }
+    }
+    NCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_nccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_nccl_allgatherv_p2p_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t *     team,
+                                             ucc_coll_task_t **    task_h)
+{
+    ucc_tl_nccl_team_t *nccl_team = ucc_derived_of(team, ucc_tl_nccl_team_t);
+    ucc_coll_args_t    *args      = &coll_args->args;
+    ucc_status_t        status    = UCC_OK;
+    ucc_tl_nccl_task_t *task;
+
+    CHECK_INPLACE(*args, nccl_team);
+    CHECK_USERDEFINED_DT(*args, nccl_team);
+    task = ucc_tl_nccl_init_task(coll_args, team);
+    if (!task) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    task->super.post     = ucc_tl_nccl_allgatherv_p2p_start;
+    *task_h = &task->super;
+out:
+    return status;
+}
+
+ucc_status_t ucc_tl_nccl_allgatherv_bcopy_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
+    ucc_rank_t          size   = UCC_TL_TEAM_SIZE(team);
+    ucc_ee_h            ee     = coll_task->ee;
+    cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context :
+                                                       team->stream;
+    ucc_status_t        status = UCC_OK;
+    void               *sbuf   = args->src.info.buffer;
+    ptrdiff_t           rbuf   = (ptrdiff_t)args->dst.info_v.buffer;
+    size_t              max_count, rdt_size, sdt_size, displ, scount, rcount;
+    ucc_rank_t          peer;
+
+    task->super.super.status = UCC_INPROGRESS;
+    UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_allgatherv_start", 0);
+    scount    = args->src.info.count;
+    rdt_size  = ucc_dt_size(args->dst.info_v.datatype);
+    sdt_size  = ucc_dt_size(args->src.info.datatype);
+    max_count = ucc_coll_args_get_count(args, args->dst.info_v.counts, 0);
+    for (peer = 1; peer < size; peer++) {
+        max_count = ucc_max(ucc_coll_args_get_count(args,
+                            args->dst.info_v.counts, 0), max_count);
+    }
+    if (max_count * rdt_size > scount * sdt_size) {
+        CUDACHECK_GOTO(cudaMemcpyAsync(PTR_OFFSET(task->scratch->addr,
+                                       max_count * rdt_size * size), sbuf,
+                                       scount * sdt_size,
+                                       cudaMemcpyDeviceToDevice, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
+        sbuf = PTR_OFFSET(task->scratch->addr, max_count * rdt_size * size);
+    }
+    NCCLCHECK_GOTO(ncclAllGather(sbuf, task->scratch->addr, max_count * rdt_size,
+                                 ncclChar, team->nccl_comm, stream),
+                   exit_coll, status, UCC_TL_TEAM_LIB(team));
+    for (peer = 0; peer < size; peer++) {
+        rcount = ucc_coll_args_get_count(args,
+                                         args->dst.info_v.counts, peer);
+        displ  = ucc_coll_args_get_displacement(args,
+                                                args->dst.info_v.displacements,
+                                                peer);
+        CUDACHECK_GOTO(cudaMemcpyAsync(PTR_OFFSET(rbuf, displ * rdt_size),
+                                       PTR_OFFSET(task->scratch->addr,
+                                                  peer * max_count * rdt_size),
+                                       rcount * rdt_size,
+                                       cudaMemcpyDeviceToDevice, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
+    }
+    status = ucc_tl_nccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_nccl_allgatherv_bcopy_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t *     team,
+                                               ucc_coll_task_t **    task_h)
+{
+    ucc_tl_nccl_team_t *nccl_team = ucc_derived_of(team, ucc_tl_nccl_team_t);
+    ucc_coll_args_t    *args      = &coll_args->args;
+    ucc_status_t        status    = UCC_OK;
+    ucc_tl_nccl_task_t *task;
+    size_t              max_count, sdt_size, rdt_size;
+    ucc_rank_t          peer;
+
+    CHECK_INPLACE(*args, nccl_team);
+    CHECK_USERDEFINED_DT(*args, nccl_team);
+    task = ucc_tl_nccl_init_task(coll_args, team);
+    if (ucc_unlikely(!task)) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    sdt_size = ucc_dt_size(args->src.info.datatype);
+    rdt_size = ucc_dt_size(args->dst.info_v.datatype);
+    max_count = ucc_coll_args_get_count(args, args->dst.info_v.counts, 0);
+    for (peer = 1; peer < team->params.size; peer++) {
+        max_count = ucc_max(ucc_coll_args_get_count(args,
+                            args->dst.info_v.counts, 0), max_count);
+    }
+    if (max_count * rdt_size > args->src.info.count * sdt_size) {
+        status = ucc_mc_alloc(&task->scratch, (team->params.size + 1) *
+                              max_count *
+                              ucc_dt_size(args->dst.info_v.datatype),
+                              UCC_MEMORY_TYPE_CUDA);
+
+    } else {
+        status = ucc_mc_alloc(&task->scratch, max_count * team->params.size *
+                              ucc_dt_size(args->dst.info_v.datatype),
+                              UCC_MEMORY_TYPE_CUDA);
+    }
+    if (ucc_unlikely(status != UCC_OK)) {
+        ucc_tl_nccl_free_task(task);
+        return status;
+    }
+    task->super.post = ucc_tl_nccl_allgatherv_bcopy_start;
+    *task_h = &task->super;
+out:
+    return status;
+}
+
+ucc_status_t ucc_tl_nccl_allgatherv_bcast_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
+    ucc_rank_t          size   = UCC_TL_TEAM_SIZE(team);
+    ucc_ee_h            ee     = coll_task->ee;
+    cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context :
+                                                       team->stream;
+    ucc_status_t        status = UCC_OK;
+    void               *sbuf   = args->src.info.buffer;
+    ptrdiff_t           rbuf   = (ptrdiff_t)args->dst.info_v.buffer;
+    size_t rdt_size, count, displ;
+    ucc_rank_t peer;
+
+    task->super.super.status = UCC_INPROGRESS;
+    rdt_size                 = ucc_dt_size(args->dst.info_v.datatype);
+    UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_allgatherv_start", 0);
+    NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    for (peer = 0; peer < size; peer++) {
+        count = ucc_coll_args_get_count(args, args->dst.info_v.counts, peer);
+        displ = ucc_coll_args_get_displacement(args,
+                                               args->dst.info_v.displacements,
+                                               peer);
+        NCCLCHECK_GOTO(ncclBroadcast(sbuf, PTR_OFFSET(rbuf, displ * rdt_size),
+                                     count * rdt_size, ncclChar, peer,
+                                     team->nccl_comm, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
+    }
+    NCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_nccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_nccl_allgatherv_bcast_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t *     team,
+                                               ucc_coll_task_t **    task_h)
+{
+    ucc_tl_nccl_team_t *nccl_team = ucc_derived_of(team, ucc_tl_nccl_team_t);
+    ucc_coll_args_t    *args      = &coll_args->args;
+    ucc_status_t        status    = UCC_OK;
+    ucc_tl_nccl_task_t *task;
+
+    CHECK_INPLACE(*args, nccl_team);
+    CHECK_USERDEFINED_DT(*args, nccl_team);
+    task = ucc_tl_nccl_init_task(coll_args, team);
+    if (!task) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    task->super.post = ucc_tl_nccl_allgatherv_bcast_start;
+    *task_h = &task->super;
+out:
+    return status;
+}

--- a/src/components/tl/nccl/allgatherv/allgatherv.h
+++ b/src/components/tl/nccl/allgatherv/allgatherv.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef ALLGATHERV_H_
+#define ALLGATHERV_H_
+
+#include "tl_nccl_coll.h"
+
+enum {
+    UCC_TL_NCCL_ALLGATHERV_ALG_P2P,
+    UCC_TL_NCCL_ALLGATHERV_ALG_BCOPY,
+    UCC_TL_NCCL_ALLGATHERV_ALG_BCAST,
+    UCC_TL_NCCL_ALLGATHERV_ALG_LAST
+};
+
+#define UCC_TL_NCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR                          \
+    "allgatherv:0-16k:@0#allgatherv:16k-1M:@1#allgatherv:1M-inf:@2"
+
+extern ucc_base_coll_alg_info_t
+             ucc_tl_nccl_allgatherv_algs[UCC_TL_NCCL_ALLGATHERV_ALG_LAST + 1];
+
+ucc_status_t ucc_tl_nccl_allgatherv_p2p_start(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_nccl_allgatherv_p2p_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t *     team,
+                                             ucc_coll_task_t **    task_h);
+
+ucc_status_t ucc_tl_nccl_allgatherv_bcopy_start(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_nccl_allgatherv_bcopy_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t *     team,
+                                               ucc_coll_task_t **    task_h);
+
+ucc_status_t ucc_tl_nccl_allgatherv_bcast_start(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_nccl_allgatherv_bcast_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t *     team,
+                                               ucc_coll_task_t **    task_h);
+
+static inline int ucc_tl_nccl_allgatherv_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_TL_NCCL_ALLGATHERV_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_tl_nccl_allgatherv_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
+
+#endif

--- a/src/components/tl/nccl/tl_nccl.c
+++ b/src/components/tl/nccl/tl_nccl.c
@@ -6,6 +6,7 @@
 
 #include "tl_nccl.h"
 #include "components/mc/base/ucc_mc_base.h"
+#include "allgatherv/allgatherv.h"
 
 ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib,
                                       ucc_base_lib_attr_t  *base_attr);
@@ -64,3 +65,9 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
 ucc_status_t ucc_tl_nccl_team_get_scores(ucc_base_team_t   *tl_team,
                                          ucc_coll_score_t **score_p);
 UCC_TL_IFACE_DECLARE(nccl, NCCL);
+
+__attribute__((constructor)) static void tl_ucp_iface_init(void)
+{
+    ucc_tl_nccl.super.alg_info[ucc_ilog2(UCC_COLL_TYPE_ALLGATHERV)] =
+        ucc_tl_nccl_allgatherv_algs;
+}

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -89,10 +89,11 @@ typedef struct ucc_tl_nccl_team {
 } ucc_tl_nccl_team_t;
 
 typedef struct ucc_tl_nccl_task {
-    ucc_coll_task_t     super;
-    ucc_status_t        host_status;
-    ucc_status_t       *dev_status;
-    void               *completed;
+    ucc_coll_task_t         super;
+    ucc_status_t            host_status;
+    ucc_status_t           *dev_status;
+    void                   *completed;
+    ucc_mc_buffer_header_t *scratch;
 } ucc_tl_nccl_task_t;
 
 #define TASK_TEAM(_task)                                                       \

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -93,7 +93,12 @@ typedef struct ucc_tl_nccl_task {
     ucc_status_t            host_status;
     ucc_status_t           *dev_status;
     void                   *completed;
-    ucc_mc_buffer_header_t *scratch;
+    union {
+        struct {
+            ucc_mc_buffer_header_t *scratch;
+            size_t                  max_count;
+        } allgatherv_bcopy;
+    };
 } ucc_tl_nccl_task_t;
 
 #define TASK_TEAM(_task)                                                       \

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -85,10 +85,10 @@ ucc_tl_nccl_task_t * ucc_tl_nccl_init_task(ucc_base_coll_args_t *coll_args,
     task = ucc_mpool_get(&nccl_ctx->req_mp);
     ucc_coll_task_init(&task->super, coll_args, team);
     UCC_TL_NCCL_PROFILE_REQUEST_NEW(task, "tl_nccl_task", 0);
-    task->super.finalize       = ucc_tl_nccl_coll_finalize;
-    task->super.triggered_post = ucc_tl_nccl_triggered_post;
-    task->completed            = NULL;
-    task->scratch              = NULL;
+    task->super.finalize           = ucc_tl_nccl_coll_finalize;
+    task->super.triggered_post     = ucc_tl_nccl_triggered_post;
+    task->completed                = NULL;
+    task->allgatherv_bcopy.scratch = NULL;
     if (nccl_ctx->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT) {
         status = ucc_mc_ee_create_event(&task->completed, UCC_EE_CUDA_STREAM);
         if (ucc_unlikely(status != UCC_OK)) {
@@ -143,8 +143,8 @@ ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
     if (task->completed) {
         ucc_mc_ee_destroy_event(task->completed, UCC_EE_CUDA_STREAM);
     }
-    if (task->scratch) {
-        ucc_mc_free(task->scratch);
+    if (task->allgatherv_bcopy.scratch) {
+        ucc_mc_free(task->allgatherv_bcopy.scratch);
     }
     ucc_tl_nccl_free_task(task);
     return status;

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -11,6 +11,7 @@
 #include "utils/ucc_compiler_def.h"
 #include "utils/ucc_math.h"
 #include "utils/ucc_coll_utils.h"
+#include "allgatherv/allgatherv.h"
 
 #define ncclOpUnsupported (ncclNumOps + 1)
 #define ncclDataTypeUnsupported (ncclNumTypes + 1)
@@ -59,6 +60,10 @@ ncclRedOp_t ucc_to_nccl_reduce_op[] = {
     [UCC_OP_MINLOC]      = (ncclRedOp_t)ncclOpUnsupported,
 };
 
+const char
+    *ucc_tl_nccl_default_alg_select_str[UCC_TL_NCCL_N_DEFAULT_ALG_SELECT_STR] = {
+        UCC_TL_NCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR};
+
 static inline ucc_status_t ucc_nccl_check_dt_supported(ucc_datatype_t dt1,
                                                        ucc_datatype_t dt2)
 {
@@ -67,6 +72,82 @@ static inline ucc_status_t ucc_nccl_check_dt_supported(ucc_datatype_t dt1,
         return UCC_ERR_NOT_SUPPORTED;
     }
     return UCC_OK;
+}
+
+ucc_tl_nccl_task_t * ucc_tl_nccl_init_task(ucc_base_coll_args_t *coll_args,
+                                           ucc_base_team_t *team)
+{
+    ucc_tl_nccl_context_t *nccl_ctx  = ucc_derived_of(team->context,
+                                                      ucc_tl_nccl_context_t);
+    ucc_tl_nccl_task_t    *task;
+    ucc_status_t           status;
+
+    task = ucc_mpool_get(&nccl_ctx->req_mp);
+    ucc_coll_task_init(&task->super, coll_args, team);
+    UCC_TL_NCCL_PROFILE_REQUEST_NEW(task, "tl_nccl_task", 0);
+    task->super.finalize       = ucc_tl_nccl_coll_finalize;
+    task->super.triggered_post = ucc_tl_nccl_triggered_post;
+    task->completed            = NULL;
+    task->scratch              = NULL;
+    if (nccl_ctx->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT) {
+        status = ucc_mc_ee_create_event(&task->completed, UCC_EE_CUDA_STREAM);
+        if (ucc_unlikely(status != UCC_OK)) {
+            ucc_mpool_put(task);
+            return NULL;
+        }
+    }
+    return task;
+}
+
+void ucc_tl_nccl_free_task(ucc_tl_nccl_task_t *task)
+{
+    UCC_TL_NCCL_PROFILE_REQUEST_FREE(task);
+    ucc_mpool_put(task);
+}
+
+ucc_status_t ucc_tl_nccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
+                                        ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task  = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_status_t status;
+    ucc_ev_t *post_event;
+
+    ucc_assert(ee->ee_type == UCC_EE_CUDA_STREAM);
+    coll_task->ee = ee;
+    tl_info(UCC_TASK_LIB(task), "triggered post. task:%p", coll_task);
+
+    status = coll_task->post(coll_task);
+    if (ucc_likely(status == UCC_OK)) {
+        /* TODO: mpool */
+        post_event = ucc_malloc(sizeof(ucc_ev_t), "event");
+        if (ucc_unlikely(post_event == NULL)) {
+            tl_error(UCC_TASK_LIB(task), "failed to allocate memory for event");
+            return UCC_ERR_NO_MEMORY;
+        }
+
+        post_event->ev_type = UCC_EVENT_COLLECTIVE_POST;
+        post_event->ev_context_size = 0;
+        post_event->req = &coll_task->super;
+        ucc_ee_set_event_internal(coll_task->ee, post_event,
+                                  &coll_task->ee->event_out_queue);
+    }
+    return status;
+}
+
+ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task  = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_status_t       status = UCC_OK ;
+
+    tl_info(UCC_TASK_LIB(task), "finalizing coll task %p", task);
+    if (task->completed) {
+        ucc_mc_ee_destroy_event(task->completed, UCC_EE_CUDA_STREAM);
+    }
+    if (task->scratch) {
+        ucc_mc_free(task->scratch);
+    }
+    ucc_tl_nccl_free_task(task);
+    return status;
 }
 
 ucc_status_t ucc_tl_nccl_collective_sync(ucc_tl_nccl_task_t *task,
@@ -305,50 +386,6 @@ ucc_status_t ucc_tl_nccl_allgather_init(ucc_tl_nccl_task_t *task)
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_nccl_allgatherv_start(ucc_coll_task_t *coll_task)
-{
-    ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_coll_args_t    *args   = &TASK_ARGS(task);
-    ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
-    ucc_rank_t          size   = UCC_TL_TEAM_SIZE(team);
-    ucc_ee_h            ee     = coll_task->ee;
-    cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
-    ucc_status_t        status = UCC_OK;
-    void               *sbuf   = args->src.info.buffer;
-    ptrdiff_t           rbuf   = (ptrdiff_t)args->dst.info_v.buffer;
-    size_t sdt_size, rdt_size, count, displ;
-    ucc_rank_t peer;
-
-    task->super.super.status = UCC_INPROGRESS;
-    sdt_size                 = ucc_dt_size(args->src.info.datatype);
-    rdt_size                 = ucc_dt_size(args->dst.info_v.datatype);
-    UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_allgatherv_start", 0);
-    NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
-    count = args->src.info.count;
-    if (count != 0) {
-        for (peer = 0; peer < size; peer++) {
-            NCCLCHECK_GOTO(ncclSend(sbuf, count * sdt_size, ncclChar, peer,
-                                    team->nccl_comm, stream),
-                        exit_coll, status, UCC_TL_TEAM_LIB(team));
-        }
-    }
-    for (peer = 0; peer < size; peer++) {
-        count = ucc_coll_args_get_count(args, args->dst.info_v.counts, peer);
-        if (count != 0) {
-            displ = ucc_coll_args_get_displacement(
-                args, args->dst.info_v.displacements, peer);
-            NCCLCHECK_GOTO(ncclRecv((void *)(rbuf + displ * rdt_size),
-                                    count * rdt_size, ncclChar, peer,
-                                    team->nccl_comm, stream),
-                        exit_coll, status, UCC_TL_TEAM_LIB(team));
-        }
-    }
-    NCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
-    status = ucc_tl_nccl_collective_sync(task, stream);
-exit_coll:
-    return status;
-}
-
 ucc_status_t ucc_tl_nccl_allgatherv_init(ucc_tl_nccl_task_t *task)
 {
     if (UCC_IS_INPLACE(TASK_ARGS(task))) {
@@ -360,7 +397,7 @@ ucc_status_t ucc_tl_nccl_allgatherv_init(ucc_tl_nccl_task_t *task)
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    task->super.post     = ucc_tl_nccl_allgatherv_start;
+    task->super.post = ucc_tl_nccl_allgatherv_p2p_start;
     return UCC_OK;
 }
 
@@ -525,4 +562,49 @@ ucc_status_t ucc_tl_nccl_barrier_init(ucc_tl_nccl_task_t *task)
     task->super.post = ucc_tl_nccl_allreduce_start;
 
     return UCC_OK;
+}
+
+static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
+{
+    switch (coll_type) {
+    case UCC_COLL_TYPE_ALLGATHERV:
+        return ucc_tl_nccl_allgatherv_alg_from_str(str);
+    default:
+        break;
+    }
+    return -1;
+}
+
+ucc_status_t ucc_tl_nccl_alg_id_to_init(int alg_id, const char *alg_id_str,
+                                        ucc_coll_type_t   coll_type,
+                                        ucc_memory_type_t mem_type, //NOLINT
+                                        ucc_base_coll_init_fn_t *init)
+{
+    ucc_status_t status = UCC_OK;
+    if (alg_id_str) {
+        alg_id = alg_id_from_str(coll_type, alg_id_str);
+    }
+
+    switch (coll_type) {
+    case UCC_COLL_TYPE_ALLGATHERV:
+        switch (alg_id) {
+        case UCC_TL_NCCL_ALLGATHERV_ALG_P2P:
+            *init = ucc_tl_nccl_allgatherv_p2p_init;
+            break;
+        case UCC_TL_NCCL_ALLGATHERV_ALG_BCOPY:
+            *init = ucc_tl_nccl_allgatherv_bcopy_init;
+            break;
+        case UCC_TL_NCCL_ALLGATHERV_ALG_BCAST:
+            *init = ucc_tl_nccl_allgatherv_bcast_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    default:
+        status = UCC_ERR_NOT_SUPPORTED;
+        break;
+    }
+    return status;
 }

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -88,7 +88,6 @@ ucc_tl_nccl_task_t * ucc_tl_nccl_init_task(ucc_base_coll_args_t *coll_args,
     task->super.finalize           = ucc_tl_nccl_coll_finalize;
     task->super.triggered_post     = ucc_tl_nccl_triggered_post;
     task->completed                = NULL;
-    task->allgatherv_bcopy.scratch = NULL;
     if (nccl_ctx->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT) {
         status = ucc_mc_ee_create_event(&task->completed, UCC_EE_CUDA_STREAM);
         if (ucc_unlikely(status != UCC_OK)) {
@@ -142,9 +141,6 @@ ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
     tl_info(UCC_TASK_LIB(task), "finalizing coll task %p", task);
     if (task->completed) {
         ucc_mc_ee_destroy_event(task->completed, UCC_EE_CUDA_STREAM);
-    }
-    if (task->allgatherv_bcopy.scratch) {
-        ucc_mc_free(task->allgatherv_bcopy.scratch);
     }
     ucc_tl_nccl_free_task(task);
     return status;

--- a/src/components/tl/nccl/tl_nccl_coll.h
+++ b/src/components/tl/nccl/tl_nccl_coll.h
@@ -10,6 +10,28 @@
 
 #include "tl_nccl.h"
 
+#define UCC_TL_NCCL_N_DEFAULT_ALG_SELECT_STR 1
+extern const char
+    *ucc_tl_nccl_default_alg_select_str[UCC_TL_NCCL_N_DEFAULT_ALG_SELECT_STR];
+
+ucc_status_t ucc_tl_nccl_alg_id_to_init(int alg_id, const char *alg_id_str,
+                                        ucc_coll_type_t   coll_type,
+                                        ucc_memory_type_t mem_type,
+                                        ucc_base_coll_init_fn_t *init);
+
+ucc_tl_nccl_task_t * ucc_tl_nccl_init_task(ucc_base_coll_args_t *coll_args,
+                                           ucc_base_team_t *team);
+
+void ucc_tl_nccl_free_task(ucc_tl_nccl_task_t *task);
+
+ucc_status_t ucc_tl_nccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
+                                        ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_nccl_collective_sync(ucc_tl_nccl_task_t *task,
+                                         cudaStream_t stream);
+
 ucc_status_t ucc_tl_nccl_allgather_init(ucc_tl_nccl_task_t *task);
 
 ucc_status_t ucc_tl_nccl_allgatherv_init(ucc_tl_nccl_task_t *task);

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -9,13 +9,37 @@
 
 #define TEST_DT UCC_DT_UINT32
 
+static void fill_counts_and_displacements(int size, int count,
+                                          int *counts, int *displs)
+{
+    int bias = count / 2;
+    int i;
+
+    counts[0] = count - bias;
+    displs[0] = 0;
+    for (i = 1; i < size - 1; i++) {
+        if (i % 2 == 0) {
+            counts[i] = count - bias;
+        } else {
+            counts[i] = count + bias;
+        }
+        displs[i] = displs[i - 1] + counts[i - 1];
+    }
+    if (size % 2 == 0) {
+        counts[size - 1] = count + bias;
+    } else {
+        counts[size - 1] = count;
+    }
+    displs[size - 1] = displs[size - 2] + counts[size - 2];
+}
+
 TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                                ucc_memory_type_t _mt, ucc_test_team_t &_team,
                                size_t _max_size) :
     TestCase(_team, _mt, _msgsize, _inplace, _max_size)
 {
     size_t dt_size = ucc_dt_size(TEST_DT);
-    size_t count = _msgsize/dt_size;
+    size_t count = _msgsize / dt_size;
     int rank, size;
     counts = NULL;
     displacements = NULL;
@@ -36,31 +60,29 @@ TestAllgatherv::TestAllgatherv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     rbuf       = rbuf_mc_header->addr;
     check_rbuf = ucc_malloc(_msgsize*size, "check rbuf");
     UCC_MALLOC_CHECK(check_rbuf);
-    for (int i = 0; i < size; i++) {
-        counts[i] = count;
-        displacements[i] = i * count;
-    }
+    fill_counts_and_displacements(size, count, counts, displacements);
+
     if (TEST_NO_INPLACE == inplace) {
         args.mask = 0;
-        UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
+        UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, counts[rank] * dt_size, _mt));
         sbuf = sbuf_mc_header->addr;
-        init_buffer(sbuf, count, TEST_DT, _mt, rank);
+        init_buffer(sbuf, counts[rank], TEST_DT, _mt, rank);
         UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
-                           _mt, _msgsize);
+                           _mt, counts[rank] * dt_size);
         check_sbuf = check_sbuf_mc_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
-        init_buffer((void*)((ptrdiff_t)rbuf + rank*count*dt_size),
-                    count, TEST_DT, _mt, rank);
-        init_buffer((void*)((ptrdiff_t)check_rbuf + rank*count*dt_size),
-                    count, TEST_DT, UCC_MEMORY_TYPE_HOST, rank);
+        init_buffer((void*)((ptrdiff_t)rbuf + displacements[rank] * dt_size),
+                    counts[rank], TEST_DT, _mt, rank);
+        init_buffer((void*)((ptrdiff_t)check_rbuf + displacements[rank] * dt_size),
+                    counts[rank], TEST_DT, UCC_MEMORY_TYPE_HOST, rank);
     }
     if (TEST_NO_INPLACE == inplace) {
         args.src.info.buffer          = sbuf;
         args.src.info.datatype        = TEST_DT;
         args.src.info.mem_type        = _mt;
-        args.src.info.count           = count;
+        args.src.info.count           = counts[rank];
     }
     args.dst.info_v.buffer        = rbuf;
     args.dst.info_v.counts        = (ucc_count_t*)counts;
@@ -81,18 +103,24 @@ TestAllgatherv::~TestAllgatherv() {
 
 ucc_status_t TestAllgatherv::check()
 {
-    size_t       count = counts[0];
-    MPI_Datatype dt    = ucc_dt_to_mpi(TEST_DT);
-    int          size, completed;
+    MPI_Datatype dt          = ucc_dt_to_mpi(TEST_DT);
+    int          total_count = 0;
+    int          size, rank, completed, count, i;
     MPI_Request  req;
 
     MPI_Comm_size(team.comm, &size);
-    MPI_Iallgatherv((inplace == TEST_INPLACE) ? MPI_IN_PLACE : check_sbuf, count, dt,
-                    check_rbuf, (int*)counts, (int*)displacements, dt, team.comm, &req);
+    MPI_Comm_rank(team.comm, &rank);
+    count  = counts[rank];
+    for (i = 0 ; i < size; i++) {
+        total_count += counts[i];
+    }
+    MPI_Iallgatherv((inplace == TEST_INPLACE) ? MPI_IN_PLACE : check_sbuf,
+                    count, dt, check_rbuf, (int*)counts, (int*)displacements,
+                    dt, team.comm, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
     } while(!completed);
 
-    return compare_buffers(rbuf, check_rbuf, count*size, TEST_DT, mem_type);
+    return compare_buffers(rbuf, check_rbuf, total_count, TEST_DT, mem_type);
 }


### PR DESCRIPTION
## What
Add 2 new allgatherv algorithms in TL NCCL
* bcast based: allgatherv is split into series of broadcasts
* bcopy: run allgather with msg size equal to max size in dst.info_v.count to local scratch space and then do local copy to dst buffer
* p2p: original allgatherv in TL NCCL

Performance on 1 Node 8PPN
|allgather size, bytes                | time, us |         |         |
|----------------|:--------:|:-------:|:-------:|
|  | p2p      | bcopy   | bcast   |
| 8192           | 138.7    | 133     | 110.8   |
| 16384          | 131      | 140.5   | 104.8   |
| 32768          | 135.5    | 134.8   | 107.6   |
| 65536          | 138.1    | 141.6   | 109.7   |
| 131072         | 127.3    | 140.2   | 113.3   |
| 262144         | 133.1    | 146.8   | 124.9   |
| 524288         | 141.3    | 150     | 141.4   |
| 1048576        | 144.4    | 157.3   | 167.3   |
| 2097152        | 169.4    | 189.6   | 198     |
| 4194304        | 203.4    | 216.9   | 217.6   |
| 8388608        | 290.3    | 263     | 266.5   |
| 16777216       | 441.8    | 331     | 378.2   |
| 33554432       | 746.7    | 502.9   | 601.5   |
| 67108864       | 1411.1   | 827.3   | 1019.3  |
| 134217728      | 2675.2   | 1464    | 1880.2  |
| 268435456      | 5336.2   | 2786.1  | 3574.3  |
| 536870912      | 10463.2  | 5378.6  | 5685.1  |
| 1073741824     | 20698.9  | 10614.4 | 11014.1 |
