### PR TITLE
CORE: automatic TLs build discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 
+# TLs generated Makefile
+config/m4/tls_list.m4
+src/components/tl/makefile.am
+
 # TL plugins generated Makefile
 config/m4/tl_coll_plugins_list.m4
 src/components/tl/ucp/makefile.coll_plugins.am

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,28 @@
 #!/bin/sh
 
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+if [ $SCRIPT_DIR != `pwd` ]; then
+    echo "autogen.sh script must be launched from the top of the source tree"
+    exit 1
+fi
+
 rm -rf config/m4/tl_coll_plugins_list.m4
+rm -rf config/m4/tls_list.m4
+rm -rf src/components/tl/makefile.am
+
 touch config/m4/tl_coll_plugins_list.m4
+touch config/m4/tls_list.m4
+
+# Detect and generate TLs makefiles
+for t in $(ls -d src/components/tl/*/); do
+    echo "m4_include([$t/configure.m4])" >> config/m4/tls_list.m4
+    plugin=$(basename $t)
+    echo "SUBDIRS += components/tl/$plugin" >> src/components/tl/makefile.am
+done
+
+# Detect and generate TL coll plugins makefiles
 for t in $(ls -d src/components/tl/*/); do
     if [ -d $t/coll_plugins ]; then
         rm -rf $t/makefile.coll_plugins.am

--- a/config/m4/check_tls.m4
+++ b/config/m4/check_tls.m4
@@ -1,0 +1,22 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+AC_DEFUN([CHECK_TLS],[
+    AC_ARG_WITH([tls],
+        [AS_HELP_STRING([--with-tls=(tl1,tl2 | all)], [Enable build of TLs])],
+        [TLS_REQUIRED=${with_tls}], [TLS_REQUIRED=all])
+    m4_include([config/m4/tls_list.m4])
+])
+
+AC_DEFUN([CHECK_TLS_REQUIRED], [
+    tl_name=$1
+    CHECKED_TL_REQUIRED=n
+    AS_IF([ test "$TLS_REQUIRED" = "all" ], [CHECKED_TL_REQUIRED=y],
+    [
+       for t in $(echo ${TLS_REQUIRED} | tr "," " "); do
+           AS_IF([ test "$t" == "$tl_name" ], [CHECKED_TL_REQUIRED=y], [])
+       done
+    ])
+])

--- a/config/m4/nccl.m4
+++ b/config/m4/nccl.m4
@@ -90,6 +90,5 @@ AS_IF([test "x$nccl_checked" != "xyes"],[
     ])
 
     nccl_checked=yes
-    AM_CONDITIONAL([HAVE_NCCL], [test "x$nccl_happy" != xno])
 ])
 ])

--- a/config/m4/sharp.m4
+++ b/config/m4/sharp.m4
@@ -56,7 +56,5 @@ AS_IF([test "x$with_sharp" != "xno"],
     [AC_MSG_WARN([SHARP was explicitly disabled])])
 
 sharp_checked=yes
-AM_CONDITIONAL([HAVE_SHARP], [test "x$sharp_happy" != xno])
 ])
-
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -140,8 +140,6 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_AARCH64_HI1620], [false])
      AM_CONDITIONAL([HAVE_UCX], [false])
      AM_CONDITIONAL([HAVE_CUDA], [false])
-     AM_CONDITIONAL([HAVE_NCCL], [false])
-     AM_CONDITIONAL([HAVE_SHARP], [false])
      AM_CONDITIONAL([HAVE_MPI], [false])
      AM_CONDITIONAL([HAVE_MPIRUN], [false])
      AM_CONDITIONAL([HAVE_MPICC], [false])
@@ -160,6 +158,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/mpi.m4])
      m4_include([config/m4/configure.m4])
      m4_include([config/m4/tl_coll_plugins.m4])
+     m4_include([config/m4/check_tls.m4])
      m4_include([test/gtest/configure.m4])
 
      mc_modules=":cpu"
@@ -171,8 +170,6 @@ AS_IF([test "x$with_docs_only" = xyes],
      AC_MSG_RESULT([UCX support: $ucx_happy])
      if test $ucx_happy != "yes"; then
          AC_MSG_ERROR([UCX is not available])
-     else
-         tl_modules="${tl_modules}:ucp"
      fi
 
      CHECK_CUDA
@@ -181,18 +178,11 @@ AS_IF([test "x$with_docs_only" = xyes],
          mc_modules="${mc_modules}:cuda"
      fi
 
-     CHECK_NCCL
-     AC_MSG_RESULT([NCCL support: $nccl_happy])
-     if test $nccl_happy = "yes"; then
-         tl_modules="${tl_modules}:nccl"
-     fi
 
-     CHECK_SHARP
-     AC_MSG_RESULT([SHARP support: $sharp_happy])
-     if test $sharp_happy = "yes"; then
-         tl_modules="${tl_modules}:sharp"
-     fi
+     CHECK_TLS
     ]) # Docs only
+
+
 
 CFLAGS="$CFLAGS -std=gnu11"
 CPPFLAGS="$CPPFLAGS $UCS_CPPFLAGS $includes"
@@ -206,9 +196,6 @@ AC_CONFIG_FILES([
                  src/core/ucc_version.c
                  src/components/cl/basic/Makefile
                  src/components/cl/hier/Makefile
-                 src/components/tl/ucp/Makefile
-                 src/components/tl/nccl/Makefile
-                 src/components/tl/sharp/Makefile
                  src/components/mc/cpu/Makefile
                  src/components/mc/cuda/Makefile
                  src/components/mc/cuda/kernel/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,26 +4,17 @@
 
 cl_dirs = components/cl/basic \
 		  components/cl/hier
-tl_dirs =
-mc_dirs = components/mc/cpu
 
-if HAVE_UCX
-tl_dirs += components/tl/ucp
-endif
+mc_dirs = components/mc/cpu
 
 if HAVE_CUDA
 mc_dirs += components/mc/cuda
 endif
 
-if HAVE_NCCL
-tl_dirs += components/tl/nccl
-endif
+SUBDIRS = . $(cl_dirs) $(mc_dirs)
 
-if HAVE_SHARP
-tl_dirs += components/tl/sharp
-endif
+include components/tl/makefile.am
 
-SUBDIRS = . $(cl_dirs) $(tl_dirs) $(mc_dirs)
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =
 

--- a/src/components/tl/nccl/Makefile.am
+++ b/src/components/tl/nccl/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
 #
+if TL_NCCL_ENABLED
 
 allgatherv =                      \
 	allgatherv/allgatherv.h       \
@@ -24,3 +25,5 @@ libucc_tl_nccl_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLA
 libucc_tl_nccl_la_LIBADD   = $(CUDA_LIBS) $(NCCL_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 include $(top_srcdir)/config/module.am
+
+endif

--- a/src/components/tl/nccl/configure.m4
+++ b/src/components/tl/nccl/configure.m4
@@ -1,0 +1,18 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+
+tl_nccl_enabled=n
+CHECK_TLS_REQUIRED(["nccl"])
+AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
+[
+    CHECK_NCCL
+    AC_MSG_RESULT([NCCL support: $nccl_happy])
+    if test $nccl_happy = "yes"; then
+        tl_modules="${tl_modules}:nccl"
+        tl_nccl_enabled=y
+    fi
+], [])
+
+AM_CONDITIONAL([TL_NCCL_ENABLED], [test "$tl_nccl_enabled" = "y"])
+AC_CONFIG_FILES([src/components/tl/nccl/Makefile])

--- a/src/components/tl/sharp/Makefile.am
+++ b/src/components/tl/sharp/Makefile.am
@@ -2,6 +2,8 @@
 # Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
 #
 
+if TL_SHARP_ENABLED
+
 sources =             \
         tl_sharp.h         \
         tl_sharp.c         \
@@ -19,3 +21,5 @@ libucc_tl_sharp_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(SHARP_LDF
 libucc_tl_sharp_la_LIBADD   = $(SHARP_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 include $(top_srcdir)/config/module.am
+
+endif

--- a/src/components/tl/sharp/configure.m4
+++ b/src/components/tl/sharp/configure.m4
@@ -1,0 +1,18 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+
+tl_sharp_enabled=n
+CHECK_TLS_REQUIRED(["sharp"])
+AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
+[
+    CHECK_SHARP
+    AC_MSG_RESULT([SHARP support: $sharp_happy])
+    if test $sharp_happy = "yes"; then
+       tl_modules="${tl_modules}:sharp"
+       tl_sharp_enabled=y
+    fi
+], [])
+
+AM_CONDITIONAL([TL_SHARP_ENABLED], [test "$tl_sharp_enabled" = "y"])
+AC_CONFIG_FILES([src/components/tl/sharp/Makefile])

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -1,10 +1,13 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
 #
+if TL_UCP_ENABLED
+
 if BUILD_TL_COLL_PLUGINS
 SUBDIRS = .
 include makefile.coll_plugins.am
 endif
+
 barrier =                     \
 	barrier/barrier.h         \
 	barrier/barrier.c         \
@@ -87,3 +90,5 @@ libucc_tl_ucp_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(UCX_LDFLAGS
 libucc_tl_ucp_la_LIBADD   = $(UCX_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 include $(top_srcdir)/config/module.am
+
+endif

--- a/src/components/tl/ucp/configure.m4
+++ b/src/components/tl/ucp/configure.m4
@@ -1,0 +1,16 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+
+tl_ucp_enabled=n
+if test $ucx_happy = "yes"; then
+   CHECK_TLS_REQUIRED(["ucp"])
+   AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
+         [
+           tl_modules="${tl_modules}:ucp"
+           tl_ucp_enabled=y
+         ], [])
+fi
+
+AM_CONDITIONAL([TL_UCP_ENABLED], [test "$tl_ucp_enabled" = "y"])
+AC_CONFIG_FILES([src/components/tl/ucp/Makefile])


### PR DESCRIPTION
## What
Automatic TLs discovery during build process.
new (optional) configure parameter --with-tls= to specify list of tls to build.

## Why ?
When 3rd party implements custom TL integration should be entirely independent from open-source upstream UCC cude, including build. 

