### PR TITLE
TL/UCP: reduce_scatter

### DIFF
--- a/src/coll_patterns/sra_knomial.h
+++ b/src/coll_patterns/sra_knomial.h
@@ -136,4 +136,15 @@ static inline ptrdiff_t ucc_sra_kn_get_offset(size_t count, size_t dt_size,
     return offset;
 }
 
+static inline void ucc_sra_kn_peer_block_seg(ucc_knomial_pattern_t *p,
+                                             ucc_rank_t peer, ucc_rank_t step_radix,
+                                             size_t block_count, size_t *count,
+                                             size_t *offset)
+{
+    ucc_rank_t seg_index;
+
+    seg_index = ucc_sra_kn_compute_seg_index(peer, p->radix_pow, p);
+    *count = ucc_sra_kn_compute_seg_size(block_count, step_radix, seg_index);
+    *offset = ucc_sra_kn_compute_seg_offset(block_count, step_radix, seg_index);
+}
 #endif

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -47,7 +47,9 @@ reduce =	                 \
 
 reduce_scatter =	                        \
 	reduce_scatter/reduce_scatter.h         \
-	reduce_scatter/reduce_scatter_knomial.c
+	reduce_scatter/reduce_scatter.c         \
+	reduce_scatter/reduce_scatter_knomial.c \
+	reduce_scatter/reduce_scatter_ring.c
 
 scatter =	                   \
 	scatter/scatter.h          \

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter.c
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#include "tl_ucp.h"
+#include "reduce_scatter.h"
+#include "utils/ucc_coll_utils.h"
+
+ucc_base_coll_alg_info_t
+    ucc_tl_ucp_reduce_scatter_algs[UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST + 1] = {
+        [UCC_TL_UCP_REDUCE_SCATTER_ALG_KNOMIAL] =
+            {.id   = UCC_TL_UCP_REDUCE_SCATTER_ALG_KNOMIAL,
+             .name = "knomial",
+             .desc = "recursive k-ing with arbitrary radix "},
+        [UCC_TL_UCP_REDUCE_SCATTER_ALG_RING] =
+            {.id   = UCC_TL_UCP_REDUCE_SCATTER_ALG_RING,
+             .name = "ring",
+             .desc = "O(N) ring"},
+        [UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter.h
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter.h
@@ -7,12 +7,40 @@
 #define REDUCE_SCATTER_H_
 #include "../tl_ucp_reduce.h"
 
+enum {
+    UCC_TL_UCP_REDUCE_SCATTER_ALG_KNOMIAL,
+    UCC_TL_UCP_REDUCE_SCATTER_ALG_RING,
+    UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST
+};
+
+extern ucc_base_coll_alg_info_t
+             ucc_tl_ucp_reduce_scatter_algs[UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST + 1];
+
+#define UCC_TL_UCP_REDUCE_SCATTER_DEFAULT_ALG_SELECT_STR                            \
+    "reduce_scatter:@0"
+
+static inline int ucc_tl_ucp_reduce_scatter_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_tl_ucp_reduce_scatter_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
+
 /* Base interface signature: uses reduce_scatter_kn_radix from config. */
 
 ucc_status_t
 ucc_tl_ucp_reduce_scatter_knomial_init(ucc_base_coll_args_t *coll_args,
                                        ucc_base_team_t      *team,
                                        ucc_coll_task_t     **task_h);
+
+ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_args,
+                                    ucc_base_team_t      *team,
+                                    ucc_coll_task_t     **task_h);
 
 /* Internal interface to KN reduce scatter with custom radix */
 ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -17,6 +17,93 @@
         task->reduce_scatter_kn.phase = _phase;                                \
     } while (0)
 
+
+#define GET_COUNT(_args, _size)                                         \
+    ((_args).coll_type == UCC_COLL_TYPE_ALLREDUCE ?                     \
+     (_args).dst.info.count : (_args).dst.info.count * (_size))
+
+
+/* Buffer for send operations at given iteration of main knomial loop.
+   On the first iteration send data can be in several locations:
+   - If the calling rank served another "extra" rank then the result of first
+   reduction is in the "user dst" buffer.
+   - INPLACE case: the data is originally in "user dst"
+   After first iteration the data to send (the result of reduction from previous
+   iteration) will be in the beginning of the scratch buffer.
+   Note, scratch can point to "user dst" if NON_EXTRA case && NON_INPLACE.
+   This is the only case when scratch allocation is not required. */
+#define GET_SBUF(_task, _node_type, _args)                                    \
+    ((ucc_knomial_pattern_loop_first_iteration(&(_task)->reduce_scatter_kn.p)) \
+        ? ((KN_NODE_PROXY ==  (_node_type) || UCC_IS_INPLACE(*(_args)))       \
+            ? (_args)->dst.info.buffer                                        \
+            : (_args)->src.info.buffer)                                       \
+     : (_task)->reduce_scatter_kn.scratch)
+
+/* Buffer for recv operations at given iteration of main knomial loop.
+   On the first iteration it points the beginning of the scratch.
+   On all subsequent iterations we store the result of the reduction from
+   previous iterations in the beginning of the scratch. It occupies
+   block_count * dt_size bytes - we need to offset. */
+#define GET_RBUF(_task, _block_size)                                          \
+    ((!ucc_knomial_pattern_loop_first_iteration(&(_task)->reduce_scatter_kn.p)) \
+        ? PTR_OFFSET((_task)->reduce_scatter_kn.scratch,                      \
+                 (_block_size))                                               \
+    : (_task)->reduce_scatter_kn.scratch)
+
+static inline ucc_status_t reduce_blocks(ucc_tl_ucp_task_t *task)
+{
+    ucc_coll_args_t       *args  = &TASK_ARGS(task);
+    ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
+    ucc_kn_radix_t         radix = task->reduce_scatter_kn.p.radix;
+    int                    avg_pre_op =
+        UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
+    ucc_knomial_pattern_t *p          = &task->reduce_scatter_kn.p;
+    uint8_t                node_type  = p->node_type;
+    ucc_memory_type_t      mem_type   = args->dst.info.mem_type;
+    ucc_datatype_t         dt         = args->dst.info.datatype;
+    size_t                 dt_size    = ucc_dt_size(dt);
+    ucc_rank_t             rank       = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t             size       = UCC_TL_TEAM_SIZE(team);
+    size_t                 count      = GET_COUNT(*args, size);
+    size_t                 block_count, local_seg_count, local_seg_offset;
+    void                  *local_block, *recv_blocks, *reduce_target;
+    int                    n_recv, is_avg;
+    ucc_rank_t             step_radix;
+
+    n_recv = task->send_posted - p->iteration * (radix - 1);
+    if (n_recv > 0) {
+        block_count = ucc_sra_kn_compute_block_count(count, rank, p);
+        step_radix  = ucc_sra_kn_compute_step_radix(rank, size, p);
+
+        ucc_sra_kn_peer_block_seg(p, rank, step_radix, block_count,
+                                  &local_seg_count, &local_seg_offset);
+
+        local_block  = PTR_OFFSET(GET_SBUF(task, node_type, args),
+                                  local_seg_offset * dt_size);
+        recv_blocks  = GET_RBUF(task, block_count * dt_size);
+        reduce_target = task->reduce_scatter_kn.scratch;
+        if (task->reduce_scatter_kn.scratch != args->dst.info.buffer &&
+                ucc_knomial_pattern_loop_last_iteration(p)) {
+            if (args->coll_type != UCC_COLL_TYPE_ALLREDUCE) {
+                local_seg_offset = 0;
+            } else {
+                ucc_sra_kn_get_offset_and_seglen(count, dt_size, rank, size, radix,
+                                                 &local_seg_offset, &local_seg_count);
+            }
+            reduce_target = PTR_OFFSET(args->dst.info.buffer, local_seg_offset);
+        }
+
+        is_avg = args->reduce.predefined_op == UCC_OP_AVG &&
+            (avg_pre_op ? ucc_knomial_pattern_loop_first_iteration(p)
+             : ucc_knomial_pattern_loop_last_iteration(p));
+
+        return ucc_tl_ucp_reduce_multi(local_block, recv_blocks, reduce_target,
+                                       n_recv, local_seg_count, local_seg_count * dt_size,
+                                       dt, mem_type, task, is_avg);
+    }
+    return UCC_OK;
+}
+
 ucc_status_t
 ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 {
@@ -24,44 +111,37 @@ ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_coll_args_t       *args  = &TASK_ARGS(task);
     ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
     ucc_kn_radix_t         radix = task->reduce_scatter_kn.p.radix;
-    int                    avg_pre_op =
-        UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
-    uint8_t                node_type  = task->reduce_scatter_kn.p.node_type;
-    ucc_knomial_pattern_t *p          = &task->reduce_scatter_kn.p;
+    ucc_knomial_pattern_t *p     = &task->reduce_scatter_kn.p;
+    uint8_t                node_type  = p->node_type;
     void                  *scratch    = task->reduce_scatter_kn.scratch;
-    void                  *rbuf       = args->dst.info.buffer;
     ucc_memory_type_t      mem_type   = args->dst.info.mem_type;
-    size_t                 count      = args->dst.info.count;
     ucc_datatype_t         dt         = args->dst.info.datatype;
-    void                  *sbuf       = UCC_IS_INPLACE(*args) ?
-        rbuf : args->src.info.buffer;
     size_t                 dt_size    = ucc_dt_size(dt);
-    size_t                 data_size  = count * dt_size;
     ucc_rank_t             rank       = UCC_TL_TEAM_RANK(team);
     ucc_rank_t             size       = UCC_TL_TEAM_SIZE(team);
-    ptrdiff_t              peer_seg_offset, local_seg_offset, offset;
-    ucc_rank_t             peer, step_radix, peer_seg_index, local_seg_index;
+    size_t                 count      = GET_COUNT(*args, size);
+    void                  *rbuf       = args->dst.info.buffer;
+    void                  *sbuf       = UCC_IS_INPLACE(*args)
+        ? args->dst.info.buffer : args->src.info.buffer;
+    ptrdiff_t              peer_seg_offset, local_seg_offset;
+    ucc_rank_t             peer, step_radix;
     ucc_status_t           status;
     ucc_kn_radix_t         loop_step;
     size_t                 block_count, peer_seg_count, local_seg_count;
-    void                  *reduce_data, *local_data;
-    int                    is_avg;
 
-    local_seg_count = 0;
-    block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
     UCC_KN_GOTO_PHASE(task->reduce_scatter_kn.phase);
 
     if (KN_NODE_EXTRA == node_type) {
         peer = ucc_knomial_pattern_get_proxy(p, rank);
         UCPCHECK_GOTO(
-            ucc_tl_ucp_send_nb(sbuf, data_size, mem_type, peer, team, task),
+            ucc_tl_ucp_send_nb(sbuf, count * dt_size, mem_type, peer, team, task),
             task, out);
     }
 
     if (KN_NODE_PROXY == node_type) {
         peer = ucc_knomial_pattern_get_extra(p, rank);
         UCPCHECK_GOTO(
-            ucc_tl_ucp_recv_nb(scratch, data_size, mem_type, peer, team, task),
+            ucc_tl_ucp_recv_nb(scratch, count * dt_size, mem_type, peer, team, task),
             task, out);
     }
 
@@ -85,22 +165,15 @@ UCC_KN_PHASE_EXTRA:
     while (!ucc_knomial_pattern_loop_done(p)) {
         step_radix  = ucc_sra_kn_compute_step_radix(rank, size, p);
         block_count = ucc_sra_kn_compute_block_count(count, rank, p);
-        sbuf        = (ucc_knomial_pattern_loop_first_iteration(p))
-                          ? ((KN_NODE_PROXY == node_type || UCC_IS_INPLACE(*args))
-                                 ? args->dst.info.buffer
-                                 : args->src.info.buffer)
-                          : task->reduce_scatter_kn.scratch;
+        sbuf        = GET_SBUF(task, node_type, args);
+
         for (loop_step = 1; loop_step < radix; loop_step++) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, size, loop_step);
             if (peer == UCC_KN_PEER_NULL)
                 continue;
 
-            peer_seg_index =
-                ucc_sra_kn_compute_seg_index(peer, p->radix_pow, p);
-            peer_seg_count = ucc_sra_kn_compute_seg_size(
-                block_count, step_radix, peer_seg_index);
-            peer_seg_offset = ucc_sra_kn_compute_seg_offset(
-                block_count, step_radix, peer_seg_index);
+            ucc_sra_kn_peer_block_seg(p, peer, step_radix, block_count,
+                                      &peer_seg_count, &peer_seg_offset);
             UCPCHECK_GOTO(
                 ucc_tl_ucp_send_nb(PTR_OFFSET(sbuf, peer_seg_offset * dt_size),
                                    peer_seg_count * dt_size, mem_type, peer,
@@ -108,14 +181,10 @@ UCC_KN_PHASE_EXTRA:
                 task, out);
         }
 
-        local_seg_index = ucc_sra_kn_compute_seg_index(rank, p->radix_pow, p);
-        local_seg_count = ucc_sra_kn_compute_seg_size(block_count, step_radix,
-                                                      local_seg_index);
+        ucc_sra_kn_peer_block_seg(p, rank, step_radix, block_count,
+                                  &local_seg_count, &local_seg_offset);
 
-        rbuf = task->reduce_scatter_kn.scratch;
-        if (!ucc_knomial_pattern_loop_first_iteration(p)) {
-            rbuf = PTR_OFFSET(rbuf, block_count * dt_size);
-        }
+        rbuf = GET_RBUF(task, block_count * dt_size);
         for (loop_step = 1; loop_step < radix; loop_step++) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, size, loop_step);
             if (peer == UCC_KN_PEER_NULL)
@@ -130,49 +199,26 @@ UCC_KN_PHASE_EXTRA:
             SAVE_STATE(UCC_KN_PHASE_LOOP);
             return task->super.super.status;
         }
-        if (task->send_posted > p->iteration * (radix - 1)) {
-            sbuf       = (ucc_knomial_pattern_loop_first_iteration(p))
-                             ? ((KN_NODE_PROXY == node_type || UCC_IS_INPLACE(*args))
-                                    ? args->dst.info.buffer
-                                    : args->src.info.buffer)
-                             : task->reduce_scatter_kn.scratch;
-            rbuf       = (!ucc_knomial_pattern_loop_first_iteration(p))
-                             ? PTR_OFFSET(task->reduce_scatter_kn.scratch,
-                                    block_count * dt_size)
-                             : task->reduce_scatter_kn.scratch;
-            step_radix = ucc_sra_kn_compute_step_radix(rank, size, p);
-            local_seg_index =
-                ucc_sra_kn_compute_seg_index(rank, p->radix_pow, p);
-            local_seg_count = ucc_sra_kn_compute_seg_size(
-                block_count, step_radix, local_seg_index);
-            local_seg_offset = ucc_sra_kn_compute_seg_offset(
-                block_count, step_radix, local_seg_index);
-            local_data  = PTR_OFFSET(sbuf, local_seg_offset * dt_size);
-            reduce_data = task->reduce_scatter_kn.scratch;
-            is_avg      = args->reduce.predefined_op == UCC_OP_AVG &&
-                     (avg_pre_op ? ucc_knomial_pattern_loop_first_iteration(p)
-                                 : ucc_knomial_pattern_loop_last_iteration(p));
-
-            status = ucc_tl_ucp_reduce_multi(
-                local_data, rbuf, reduce_data,
-                task->send_posted - p->iteration * (radix - 1), local_seg_count,
-                local_seg_count * dt_size, dt, mem_type, task, is_avg);
-            if (ucc_unlikely(UCC_OK != status)) {
-                tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
-                task->super.super.status = status;
-                return status;
-            }
+        status = reduce_blocks(task);
+        if (ucc_unlikely(UCC_OK != status)) {
+            tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
+            task->super.super.status = status;
+            return status;
         }
         ucc_knomial_pattern_next_iteration(p);
     }
 
-    offset = ucc_sra_kn_get_offset(count, dt_size, rank, size, radix);
-    status = ucc_mc_memcpy(PTR_OFFSET(args->dst.info.buffer, offset),
-                           task->reduce_scatter_kn.scratch,
-                           local_seg_count * dt_size, mem_type, mem_type);
+    if (task->reduce_scatter_kn.scratch == args->dst.info.buffer) {
+        ucc_sra_kn_get_offset_and_seglen(count, dt_size, rank, size, radix,
+                                         &local_seg_offset, &local_seg_count);
 
-    if (UCC_OK != status) {
-        return status;
+        status = ucc_mc_memcpy(PTR_OFFSET(args->dst.info.buffer, local_seg_offset),
+                               task->reduce_scatter_kn.scratch,
+                               local_seg_count * dt_size, mem_type, mem_type);
+
+        if (UCC_OK != status) {
+            return status;
+        }
     }
 UCC_KN_PHASE_PROXY: /* unused label */
 out:
@@ -190,7 +236,6 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
     ucc_rank_t         rank = UCC_TL_TEAM_RANK(team);
     ucc_rank_t         size = UCC_TL_TEAM_SIZE(team);
     ucc_status_t       status;
-    uint8_t            node_type;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_reduce_scatter_kn_start",
                                      0);
@@ -198,8 +243,7 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
 
     ucc_knomial_pattern_init(size, rank, task->reduce_scatter_kn.p.radix,
                              &task->reduce_scatter_kn.p);
-    node_type = task->reduce_scatter_kn.p.node_type;
-    if (!(UCC_IS_INPLACE(*args) || (KN_NODE_PROXY == node_type))) {
+    if (!task->reduce_scatter_kn.scratch_mc_header) {
         task->reduce_scatter_kn.scratch = args->dst.info.buffer;
     }
     task->reduce_scatter_kn.phase = UCC_KN_PHASE_INIT;
@@ -216,9 +260,8 @@ ucc_status_t
 ucc_tl_ucp_reduce_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    uint8_t            node_type = task->reduce_scatter_kn.p.node_type;
 
-    if (UCC_IS_INPLACE(TASK_ARGS(task)) || (KN_NODE_PROXY == node_type)) {
+    if (task->reduce_scatter_kn.scratch_mc_header) {
         ucc_mc_free(task->reduce_scatter_kn.scratch_mc_header);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);
@@ -231,7 +274,7 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
     ucc_tl_ucp_team_t *tl_team   = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_rank_t         rank      = UCC_TL_TEAM_RANK(tl_team);
     ucc_rank_t         size      = UCC_TL_TEAM_SIZE(tl_team);
-    size_t             count     = coll_args->args.dst.info.count;
+    size_t             count     = GET_COUNT(coll_args->args, size);
     ucc_datatype_t     dt        = coll_args->args.dst.info.datatype;
     size_t             dt_size   = ucc_dt_size(dt);
     size_t             data_size = count * dt_size;
@@ -247,9 +290,18 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
     ucc_assert(coll_args->args.src.info.mem_type ==
                coll_args->args.dst.info.mem_type);
     ucc_knomial_pattern_init(size, rank, radix, &task->reduce_scatter_kn.p);
-
-    if (UCC_IS_INPLACE(coll_args->args) ||
-        (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type)) {
+    task->reduce_scatter_kn.scratch_mc_header = NULL;
+    /* Scratch allocation can be skipped only when:
+       allreduce_sra_no_scratch params is set to "Y" - we want to try avoiding
+       scratch space allocation           &&
+       algorithm is ALLREDUCE (coll_type) &&
+       NON_INPLACE (user provided dst buffer which can be used as scratch) &&
+       i'm not a proxy rank (otherwise dst buffer already contains result of
+       communication/reduction with "extra") */
+    if (!UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_no_scratch ||
+        coll_args->args.coll_type == UCC_COLL_TYPE_REDUCE_SCATTER      ||
+        UCC_IS_INPLACE(coll_args->args)                                ||
+        KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type) {
         status = ucc_mc_alloc(&task->reduce_scatter_kn.scratch_mc_header,
                               data_size, mem_type);
         task->reduce_scatter_kn.scratch =
@@ -270,7 +322,7 @@ ucc_tl_ucp_reduce_scatter_knomial_init(ucc_base_coll_args_t *coll_args,
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_rank_t         size    = UCC_TL_TEAM_SIZE(tl_team);
-    size_t             count   = coll_args->args.dst.info.count;
+    size_t             count   = GET_COUNT(coll_args->args, size);
     ucc_kn_radix_t     radix, cfg_radix;
 
     cfg_radix = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.reduce_scatter_kn_radix;

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -20,7 +20,7 @@
 
 
 #define GET_COUNT(_args, _size)                                         \
-    ((_args).coll_type == UCC_COLL_TYPE_ALLREDUCE ?                     \
+    (((_args).coll_type == UCC_COLL_TYPE_ALLREDUCE || UCC_IS_INPLACE((_args))) ? \
      (_args).dst.info.count : (_args).dst.info.count * (_size))
 
 
@@ -296,8 +296,6 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
     task->super.progress = ucc_tl_ucp_reduce_scatter_knomial_progress;
     task->super.finalize = ucc_tl_ucp_reduce_scatter_knomial_finalize;
 
-    ucc_assert(coll_args->args.src.info.mem_type ==
-               coll_args->args.dst.info.mem_type);
     task->reduce_scatter_kn.scratch_mc_header = NULL;
     task->reduce_scatter_kn.p                 = p;
     /* Scratch allocation can be skipped only when:

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -1,0 +1,351 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "reduce_scatter.h"
+#include "tl_ucp_coll.h"
+#include "tl_ucp_sendrecv.h"
+#include "core/ucc_progress_queue.h"
+#include "core/ucc_mc.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
+
+static inline size_t ucc_ring_block_count(size_t total_count, ucc_rank_t n_blocks, ucc_rank_t block)
+{
+    size_t block_count = total_count / n_blocks;
+    size_t left        = total_count % n_blocks;
+    return (block < left) ? block_count + 1 : block_count;
+}
+
+static inline size_t ucc_ring_block_offset(size_t total_count, ucc_rank_t n_blocks, ucc_rank_t block)
+{
+    size_t block_count = total_count / n_blocks;
+    size_t left        = total_count % n_blocks;
+    size_t offset      = block * block_count + left;
+    return (block < left) ? offset - (left - block) : offset;
+}
+
+static inline void ucc_ring_frag_count(ucc_tl_ucp_task_t *task, size_t count, ucc_rank_t block,
+                                       size_t *frag_count)
+{
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+    size_t             size = UCC_TL_TEAM_SIZE(team);
+    int                n_frags, frag;
+    size_t             block_count;
+
+    n_frags = task->reduce_scatter_ring.n_frags;
+    frag    = task->reduce_scatter_ring.frag;
+
+    block_count  = ucc_ring_block_count(count, size, block);
+    *frag_count  = ucc_ring_block_count(block_count, n_frags, frag);
+}
+
+static inline void ucc_ring_frag_block_offset(ucc_tl_ucp_task_t *task, size_t count, ucc_rank_t block,
+                                              size_t *block_offset, size_t *frag_offset)
+{
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+    size_t             size = UCC_TL_TEAM_SIZE(team);
+    int                n_frags, frag;
+    size_t             block_count;
+
+    n_frags = task->reduce_scatter_ring.n_frags;
+    frag    = task->reduce_scatter_ring.frag;
+
+    block_count  = ucc_ring_block_count(count, size, block);
+    *frag_offset = ucc_ring_block_offset(block_count, n_frags, frag);
+    *block_offset = ucc_ring_block_offset(count, size, block);
+}
+
+static inline ucc_status_t ucc_tl_ucp_test_ring(ucc_tl_ucp_task_t *task)
+{
+    int polls = 0;
+    while (polls++ < task->n_polls) {
+        if (task->send_posted - task->send_completed <= 1 &&
+            task->recv_posted == task->recv_completed) {
+            return UCC_OK;
+        }
+        ucp_worker_progress(TASK_CTX(task)->ucp_worker);
+    }
+    return UCC_INPROGRESS;
+}
+
+static ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_coll_args_t       *args = &TASK_ARGS(task);
+    ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
+    ucc_rank_t             size      = task->subset.map.ep_num;
+    ucc_rank_t             rank      = task->subset.myrank;
+    void                  *sbuf      = args->src.info.buffer;
+    ucc_memory_type_t      mem_type  = args->dst.info.mem_type;
+    size_t                 count     = args->dst.info.count * size;
+    ucc_datatype_t         dt        = args->dst.info.datatype;
+    size_t                 dt_size   = ucc_dt_size(dt);
+    ucc_rank_t             sendto     = (rank + 1) % size;
+    ucc_rank_t             recvfrom   = (rank - 1 + size) % size;
+    ucc_rank_t         prevblock, recv_data_from;
+    ucc_status_t       status;
+    size_t              max_block_size, block_offset, frag_count, frag_offset;
+    int step;
+    void *tmp[3];
+
+
+    sendto   = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, sendto);
+    recvfrom = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recvfrom);
+
+    max_block_size = ucc_ring_block_count(count, size, 0) * dt_size;
+    tmp[0]         = task->reduce_scatter_ring.scratch;
+    tmp[1] = PTR_OFFSET(tmp[0], max_block_size);
+    tmp[2] = PTR_OFFSET(tmp[1], max_block_size);
+
+    if (UCC_INPROGRESS == ucc_tl_ucp_test_ring(task)) {
+        return task->super.super.status;
+    }
+    while (task->recv_posted > 0) {
+        void *reduce_target = tmp[1 + (task->recv_completed - 1) % 2];
+        step = task->send_posted;
+        prevblock = (rank - 1 - step + size) % size;
+        prevblock = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, prevblock);
+        if (task->recv_completed == size - 1) {
+            ucc_assert(prevblock == UCC_TL_TEAM_RANK(team));
+            prevblock = UCC_TL_TEAM_RANK(team);
+        }
+        /* reduction */
+        ucc_assert(task->recv_posted == task->recv_completed);
+        ucc_assert(task->recv_posted   < size);
+
+        ucc_ring_frag_count(task, count, prevblock, &frag_count);
+        ucc_ring_frag_block_offset(task, count, prevblock, &block_offset, &frag_offset);
+        if (task->recv_completed == size - 1) {
+            reduce_target = PTR_OFFSET(args->dst.info.buffer, frag_offset* dt_size);
+        }
+        if (UCC_OK != (status = ucc_dt_reduce_multi(
+                           tmp[0], PTR_OFFSET(sbuf, (block_offset + frag_offset) * dt_size),
+                           reduce_target, 1, frag_count, 0, dt,
+                           mem_type, args))) {
+            tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
+            task->super.super.status = status;
+            return status;
+        }
+        if (task->recv_completed == size - 1) {
+            task->recv_posted = task->recv_completed = 0;
+            break;
+        }
+        ucc_assert(task->send_posted  - task->send_completed <= 1);
+        ucc_assert(task->send_posted   < size);
+
+        UCPCHECK_GOTO(
+            ucc_tl_ucp_send_nb(tmp[ 1 + (task->send_posted - 1) % 2],
+                               frag_count * dt_size, mem_type, sendto, team, task),
+            task, out);
+
+
+        recv_data_from = (rank - 2- step + size) % size;
+        recv_data_from = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recv_data_from);
+
+        ucc_ring_frag_count(task, count, recv_data_from, &frag_count);
+
+        UCPCHECK_GOTO(
+            ucc_tl_ucp_recv_nb(tmp[0], frag_count * dt_size, mem_type, recvfrom, team, task),
+            task, out);
+
+
+        if (UCC_INPROGRESS == ucc_tl_ucp_test_ring(task)) {
+            return task->super.super.status;
+        }
+    }
+    if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+        return task->super.super.status;
+    }
+    task->super.super.status = UCC_OK;
+out:
+    return task->super.super.status;
+}
+
+static ucc_status_t ucc_tl_ucp_reduce_scatter_ring_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_coll_args_t   *args  = &TASK_ARGS(task);
+    ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
+    ucc_rank_t         size  = task->subset.map.ep_num;
+    ucc_rank_t         rank      = task->subset.myrank;
+    ucc_rank_t         sendto     = (rank + 1) % size;
+    ucc_rank_t         recvfrom   = (rank - 1 + size) % size;
+    size_t             count   = args->dst.info.count * size;
+    ucc_datatype_t     dt      = args->dst.info.datatype;
+    size_t             dt_size = ucc_dt_size(dt);
+    ucc_memory_type_t  mem_type  = args->dst.info.mem_type;
+    void *sbuf = args->src.info.buffer;
+    ucc_status_t       status;
+    size_t             max_block_size, block_offset, frag_count, frag_offset;
+    int step = 0;
+    void *tmp[2];
+    ucc_rank_t send_block, recv_block;
+
+
+    task->super.super.status = UCC_INPROGRESS;
+    ucc_tl_ucp_task_reset(task);
+    sendto   = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, sendto);
+    recvfrom = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recvfrom);
+
+
+    max_block_size = ucc_ring_block_count(count, size, 0) * dt_size;
+    tmp[0]         = task->reduce_scatter_ring.scratch;
+    if (size > 2) {
+        tmp[1] = PTR_OFFSET(tmp[0], max_block_size);
+    }
+
+    recv_block = (rank - 2 - step  + size) % size;
+    send_block = (rank - 1 - step  + size) % size;
+    recv_block = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recv_block);
+    send_block = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, send_block);
+
+    ucc_ring_frag_count(task, count, recv_block, &frag_count);
+    UCPCHECK_GOTO(
+        ucc_tl_ucp_recv_nb(tmp[0], frag_count * dt_size, mem_type, recvfrom, team, task),
+        task, out);
+
+
+    ucc_ring_frag_count(task, count, send_block, &frag_count);
+    ucc_ring_frag_block_offset(task, count, send_block, &block_offset, &frag_offset);
+    UCPCHECK_GOTO(
+        ucc_tl_ucp_send_nb(PTR_OFFSET(sbuf, (block_offset + frag_offset) * dt_size),
+                           frag_count * dt_size, mem_type, sendto, team, task),
+        task, out);
+
+    status = ucc_tl_ucp_reduce_scatter_ring_progress(&task->super);
+    if (UCC_INPROGRESS == status) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+        return UCC_OK;
+    }
+    return ucc_task_complete(coll_task);
+out:
+    return task->super.super.status;
+}
+
+static ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+
+    if (task->reduce_scatter_ring.inv_map.type != UCC_EP_MAP_FULL) {
+        ucc_ep_map_destroy_inverse(&task->reduce_scatter_ring.inv_map);
+    }
+    ucc_mc_free(task->reduce_scatter_ring.scratch_mc_header);
+    return ucc_tl_ucp_coll_finalize(coll_task);
+}
+
+
+static ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_init_subset(ucc_base_coll_args_t *coll_args,
+                                         ucc_base_team_t      *team,
+                                         ucc_coll_task_t     **task_h,
+                                         ucc_subset_t subset,
+                                         int n_frags, int frag)
+{
+    ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_rank_t         size    = UCC_TL_TEAM_SIZE(tl_team);
+    size_t             count   = coll_args->args.dst.info.count * size;
+    ucc_datatype_t     dt      = coll_args->args.dst.info.datatype;
+    size_t             dt_size = ucc_dt_size(dt);
+    ucc_memory_type_t  mem_type  = coll_args->args.dst.info.mem_type;
+    size_t to_alloc, max_segcount;
+    ucc_tl_ucp_task_t *task;
+    ucc_status_t       status;
+
+    task                 = ucc_tl_ucp_init_task(coll_args, team);
+    task->super.post     = ucc_tl_ucp_reduce_scatter_ring_start;
+    task->super.progress = ucc_tl_ucp_reduce_scatter_ring_progress;
+    task->super.finalize = ucc_tl_ucp_reduce_scatter_ring_finalize;
+    task->subset         = subset;
+
+    if (task->subset.map.type != UCC_EP_MAP_FULL) {
+        status = ucc_ep_map_create_inverse(task->subset.map,
+                                           &task->reduce_scatter_ring.inv_map);
+        if (UCC_OK != status) {
+            return status;
+        }
+    } else {
+        task->reduce_scatter_ring.inv_map.type = UCC_EP_MAP_FULL;
+        task->reduce_scatter_ring.inv_map.ep_num = task->subset.map.ep_num;
+    }
+    task->reduce_scatter_ring.n_frags = n_frags;
+    task->reduce_scatter_ring.frag = frag;
+
+    max_segcount = ucc_ring_block_count(count, size, 0);
+    //TODO need less mem - dvivide by n_frags
+    to_alloc = max_segcount + (size > 2 ? 2*max_segcount : 0);
+    status = ucc_mc_alloc(&task->reduce_scatter_ring.scratch_mc_header,
+                          to_alloc * dt_size, mem_type);
+
+    task->reduce_scatter_ring.scratch =
+        task->reduce_scatter_ring.scratch_mc_header->addr;
+    *task_h = &task->super;
+    return status;
+}
+
+static ucc_status_t ucc_tl_ucp_reduce_scatter_ring_sched_post(ucc_coll_task_t *coll_task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
+
+    return ucc_schedule_start(schedule);
+}
+
+static ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_sched_finalize(ucc_coll_task_t *task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
+    ucc_status_t status;
+
+    status = ucc_schedule_finalize(task);
+    ucc_tl_ucp_put_schedule(schedule);
+    return status;
+}
+
+ucc_status_t ucc_tl_ucp_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_args,
+                                                 ucc_base_team_t *     team,
+                                                 ucc_coll_task_t **    task_h)
+{
+
+    ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    int bidir = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.reduce_scatter_ring_bidirectional;
+    ucc_schedule_t *schedule;
+    ucc_coll_task_t *ctask;
+    ucc_status_t status;
+    ucc_subset_t s[2];
+    int i, n_subsets;
+
+    if (UCC_TL_TEAM_SIZE(tl_team) == 2) {
+        return ucc_tl_ucp_reduce_scatter_knomial_init(coll_args, team, task_h);
+    }
+
+    schedule = ucc_tl_ucp_get_schedule(tl_team);
+    n_subsets = bidir ? 2 : 1;
+
+    s[0].myrank = UCC_TL_TEAM_RANK(tl_team);
+    s[0].map.type = UCC_EP_MAP_FULL;
+    s[0].map.ep_num = UCC_TL_TEAM_SIZE(tl_team);
+
+    s[1].map = ucc_ep_map_create_reverse(UCC_TL_TEAM_SIZE(tl_team));
+    s[1].myrank = ucc_ep_map_eval(s[1].map, UCC_TL_TEAM_RANK(tl_team));
+
+    for (i = 0; i < n_subsets; i++) {
+        status = ucc_tl_ucp_reduce_scatter_ring_init_subset(coll_args, team, &ctask,
+                                                            s[i], n_subsets, i);
+        if (UCC_OK != status) {
+            tl_error(UCC_TL_TEAM_LIB(tl_team), "failed to allocate ring task");
+            return status;
+        }
+        ctask->n_deps = 1;
+        ucc_schedule_add_task(schedule, ctask);
+        ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
+                                    ctask, ucc_task_start_handler);
+    }
+    schedule->super.post = ucc_tl_ucp_reduce_scatter_ring_sched_post;
+    schedule->super.finalize = ucc_tl_ucp_reduce_scatter_ring_sched_finalize;
+    *task_h = &schedule->super;
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -241,7 +241,7 @@ ucc_tl_ucp_reduce_scatter_ring_finalize(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
 
     if (task->reduce_scatter_ring.inv_map.type != UCC_EP_MAP_FULL) {
-        ucc_ep_map_destroy_inverse(&task->reduce_scatter_ring.inv_map);
+        ucc_ep_map_destroy(&task->reduce_scatter_ring.inv_map);
     }
     ucc_mc_free(task->reduce_scatter_ring.scratch_mc_header);
     return ucc_tl_ucp_coll_finalize(coll_task);

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -120,6 +120,11 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_avg_pre_op),
      UCC_CONFIG_TYPE_BOOL},
 
+    {"REDUCE_SCATTER_RING_BIDIRECTIONAL", "y",
+     "Launch 2 inverted rings concurrently",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_scatter_ring_bidirectional),
+     UCC_CONFIG_TYPE_BOOL},
+
     {NULL}};
 
 static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -82,6 +82,12 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_seq),
      UCC_CONFIG_TYPE_BOOL},
 
+    {"ALLREDUCE_SRA_KN_NO_SCRATCH", "y",
+     "When possible try to perform algorithm using only user provided buffers, "
+     "avoiding scratch buffer allocation",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_no_scratch),
+     UCC_CONFIG_TYPE_BOOL},
+
     {"REDUCE_SCATTER_KN_RADIX", "4",
      "Radix of the knomial reduce-scatter algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_scatter_kn_radix),

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -55,6 +55,7 @@ typedef struct ucc_tl_ucp_lib_config {
     int                 allreduce_sra_kn_seq;
     int                 allreduce_sra_kn_no_scratch;
     int                 reduce_avg_pre_op;
+    int                 reduce_scatter_ring_bidirectional;
     size_t              allreduce_sra_kn_frag_thresh;
     size_t              allreduce_sra_kn_frag_size;
 } ucc_tl_ucp_lib_config_t;
@@ -102,7 +103,8 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
     (UCC_COLL_TYPE_ALLTOALL  | UCC_COLL_TYPE_ALLTOALLV  |  \
      UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |  \
      UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST      |  \
-     UCC_COLL_TYPE_BARRIER   | UCC_COLL_TYPE_REDUCE)
+     UCC_COLL_TYPE_BARRIER   | UCC_COLL_TYPE_REDUCE     |  \
+     UCC_COLL_TYPE_REDUCE_SCATTER)
 
 #define UCC_TL_UCP_TEAM_LIB(_team)                                             \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_ucp_lib_t))

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -53,9 +53,10 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t            allreduce_sra_kn_n_frags;
     uint32_t            allreduce_sra_kn_pipeline_depth;
     int                 allreduce_sra_kn_seq;
+    int                 allreduce_sra_kn_no_scratch;
+    int                 reduce_avg_pre_op;
     size_t              allreduce_sra_kn_frag_thresh;
     size_t              allreduce_sra_kn_frag_size;
-    int                 reduce_avg_pre_op;
 } ucc_tl_ucp_lib_config_t;
 
 typedef struct ucc_tl_ucp_context_config {

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -16,9 +16,11 @@
 #include "allgatherv/allgatherv.h"
 #include "bcast/bcast.h"
 #include "reduce/reduce.h"
+#include "reduce_scatter/reduce_scatter.h"
 const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR] = {
-        UCC_TL_UCP_ALLREDUCE_DEFAULT_ALG_SELECT_STR, UCC_TL_UCP_BCAST_DEFAULT_ALG_SELECT_STR};
+    UCC_TL_UCP_ALLREDUCE_DEFAULT_ALG_SELECT_STR, UCC_TL_UCP_BCAST_DEFAULT_ALG_SELECT_STR,
+    UCC_TL_UCP_REDUCE_SCATTER_DEFAULT_ALG_SELECT_STR,};
 
 void ucc_tl_ucp_send_completion_cb(void *request, ucs_status_t status,
                                    void *user_data)
@@ -107,6 +109,8 @@ static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
         return ucc_tl_ucp_allreduce_alg_from_str(str);
     case UCC_COLL_TYPE_BCAST:
         return ucc_tl_ucp_bcast_alg_from_str(str);
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        return ucc_tl_ucp_reduce_scatter_alg_from_str(str);
     default:
         break;
     }
@@ -148,6 +152,19 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
         default:
            status = UCC_ERR_INVALID_PARAM;
            break;
+        };
+        break;
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        switch (alg_id) {
+        case UCC_TL_UCP_REDUCE_SCATTER_ALG_KNOMIAL:
+            *init = ucc_tl_ucp_reduce_scatter_knomial_init;
+            break;
+        case UCC_TL_UCP_REDUCE_SCATTER_ALG_RING:
+            *init = ucc_tl_ucp_reduce_scatter_ring_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
         };
         break;
     default:

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -13,7 +13,7 @@
 #include "components/mc/base/ucc_mc_base.h"
 #include "tl_ucp_tag.h"
 
-#define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 2
+#define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 3
 extern const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR];
 
@@ -57,6 +57,13 @@ typedef struct ucc_tl_ucp_task {
             void                   *scratch;
             ucc_mc_buffer_header_t *scratch_mc_header;
         } reduce_scatter_kn;
+        struct {
+            void                   *scratch;
+            ucc_mc_buffer_header_t *scratch_mc_header;
+            ucc_ep_map_t            inv_map;
+            int                     n_frags;
+            int                     frag;
+        } reduce_scatter_ring;
         struct {
             int                     phase;
             ucc_knomial_pattern_t   p;

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -313,45 +313,53 @@ void ucc_coll_str(const ucc_base_coll_args_t *args, char *str, size_t len)
 }
 
 
-static uint64_t ucc_ep_map_inverse_cb(uint64_t ep, void *cb_ctx) {
-    uint64_t size = (uint64_t)cb_ctx;
-    return size - ep - 1;
-}
-
 ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size)
 {
     ucc_ep_map_t map = {
-        .type = UCC_EP_MAP_CB,
-        .ep_num = size,
-        .cb.cb = ucc_ep_map_inverse_cb,
-        .cb.cb_ctx = (void*)(uintptr_t)size
+        .type           = UCC_EP_MAP_STRIDED,
+        .ep_num         = size,
+        .strided.start  = size - 1,
+        .strided.stride = -1
     };
     return map;
+}
+
+static inline int ucc_ep_map_is_reverse(ucc_ep_map_t *map)
+{
+    return (map->type == UCC_EP_MAP_STRIDED) &&
+        (map->strided.start == map->ep_num - 1) &&
+        (map->strided.stride == -1);
 }
 
 ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map)
 {
     ucc_ep_map_t inv;
-    ucc_rank_t          i;
+    ucc_rank_t   i;
 
-    inv.type = UCC_EP_MAP_ARRAY;
-    inv.ep_num = map.ep_num;
-    inv.array.elem_size = sizeof(ucc_rank_t);
-    inv.array.map = ucc_malloc(sizeof(ucc_rank_t) * map.ep_num, "inv_map");
-    if (!inv.array.map) {
-        ucc_error("failed to allocate %zd bytes for inv map\n",
-                  sizeof(ucc_rank_t) * map.ep_num);
-        return UCC_ERR_NO_MEMORY;
-    }
-    for (i = 0; i < map.ep_num; i++) {
-        ucc_rank_t r = (ucc_rank_t)ucc_ep_map_eval(map, i);
-        *((ucc_rank_t*)PTR_OFFSET(inv.array.map, sizeof(ucc_rank_t) * r)) = i;
+    if (ucc_ep_map_is_reverse(&map)) {
+        inv = map;
+    } else {
+        inv.type = UCC_EP_MAP_ARRAY;
+        inv.ep_num = map.ep_num;
+        inv.array.elem_size = sizeof(ucc_rank_t);
+        inv.array.map = ucc_malloc(sizeof(ucc_rank_t) * map.ep_num, "inv_map");
+        if (!inv.array.map) {
+            ucc_error("failed to allocate %zd bytes for inv map\n",
+                      sizeof(ucc_rank_t) * map.ep_num);
+            return UCC_ERR_NO_MEMORY;
+        }
+        for (i = 0; i < map.ep_num; i++) {
+            ucc_rank_t r = (ucc_rank_t)ucc_ep_map_eval(map, i);
+            *((ucc_rank_t*)PTR_OFFSET(inv.array.map, sizeof(ucc_rank_t) * r)) = i;
+        }
     }
     *inv_map = inv;
     return UCC_OK;
 }
 
-void ucc_ep_map_destroy_inverse(ucc_ep_map_t *inv_map)
+void ucc_ep_map_destroy(ucc_ep_map_t *map)
 {
-    ucc_free(inv_map->array.map);
+    if (map->type == UCC_EP_MAP_ARRAY) {
+        ucc_free(map->array.map);
+    }
 }

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -129,4 +129,11 @@ ucc_ep_map_t ucc_ep_map_from_array(ucc_rank_t **array, ucc_rank_t size,
                                    ucc_rank_t full_size, int need_free);
 
 void ucc_coll_str(const ucc_base_coll_args_t *args, char *str, size_t len);
+
+ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size);
+
+ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map);
+
+void ucc_ep_map_destroy_inverse(ucc_ep_map_t *inv_map);
+
 #endif

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -130,10 +130,13 @@ ucc_ep_map_t ucc_ep_map_from_array(ucc_rank_t **array, ucc_rank_t size,
 
 void ucc_coll_str(const ucc_base_coll_args_t *args, char *str, size_t len);
 
+/* Creates a rank map that reverses rank order, ie
+   rank r -> size - 1 - r */
 ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size);
 
+/* Creates an inverse mapping for a given map */
 ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map);
 
-void ucc_ep_map_destroy_inverse(ucc_ep_map_t *inv_map);
+void ucc_ep_map_destroy(ucc_ep_map_t *map);
 
 #endif

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -82,6 +82,7 @@ gtest_SOURCES =                     \
 	core/test_allgatherv.cc         \
 	core/test_bcast.cc              \
 	core/test_reduce.cc             \
+	core/test_reduce_scatter.cc     \
 	core/test_allreduce.cc          \
 	core/test_schedule.cc           \
 	core/test_topo.cc               \

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -506,16 +506,25 @@ UccReq::UccReq(UccTeam_h _team, UccCollCtxVec ctxs) :
 {
     EXPECT_EQ(team->procs.size(), ctxs.size());
     ucc_coll_req_h req;
+    ucc_status_t   status, err_status;
+
+    err_status = UCC_OK;
     for (auto i = 0; i < team->procs.size(); i++) {
-        if (UCC_OK != ucc_collective_init(ctxs[i]->args, &req,
-                                          team->procs[i].team)) {
-            goto err;
+        if (UCC_OK != (status = ucc_collective_init(ctxs[i]->args, &req,
+                                                    team->procs[i].team))) {
+            err_status = status;
         }
         reqs.push_back(req);
+    }
+    if (UCC_OK != err_status) {
+        goto err;
     }
     return;
 err:
     reqs.clear();
+    if (err_status == UCC_ERR_NOT_SUPPORTED) {
+        UCC_TEST_SKIP_R("coll_init: not supported");
+    }
 }
 
 UccReq::~UccReq()

--- a/test/gtest/core/test_reduce_scatter.cc
+++ b/test/gtest/core/test_reduce_scatter.cc
@@ -1,0 +1,358 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "test_mc_reduce.h"
+#include "common/test_ucc.h"
+#include "utils/ucc_math.h"
+
+#include <array>
+
+template<typename T>
+class test_reduce_scatter : public UccCollArgs, public testing::Test {
+  public:
+    void data_init(int nprocs, ucc_datatype_t dt, size_t count,
+                   UccCollCtxVec &ctxs)
+    {
+        size_t rcount;
+        ctxs.resize(nprocs);
+        if (count < nprocs) {
+            count = nprocs;
+        }
+        count = count - (count % nprocs);
+        rcount = count / nprocs;
+        if (TEST_INPLACE == inplace) {
+            rcount = count;
+        }
+
+        for (int r = 0; r < nprocs; r++) {
+            ucc_coll_args_t *coll = (ucc_coll_args_t*)
+                    calloc(1, sizeof(ucc_coll_args_t));
+
+            ctxs[r] = (gtest_ucc_coll_ctx_t*)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
+            ctxs[r]->args = coll;
+
+            coll->mask = UCC_COLL_ARGS_FIELD_PREDEFINED_REDUCTIONS;
+            coll->coll_type = UCC_COLL_TYPE_REDUCE_SCATTER;
+            coll->reduce.predefined_op = T::redop;
+
+            ctxs[r]->init_buf = ucc_malloc(ucc_dt_size(dt) * count, "init buf");
+            EXPECT_NE(ctxs[r]->init_buf, nullptr);
+            for (int i = 0; i < count; i++) {
+                typename T::type * ptr;
+                ptr = (typename T::type *)ctxs[r]->init_buf;
+                /* need to limit the init value so that "prod" operation
+                   would not grow too large. We have teams up to 16 procs
+                   in gtest, this would result in prod ~2**48 */
+                ptr[i] = (typename T::type)((i + r + 1) % 8);
+            }
+
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_mc_header,
+                                   ucc_dt_size(dt) * rcount, mem_type));
+            coll->dst.info.buffer = ctxs[r]->dst_mc_header->addr;
+            if (TEST_INPLACE == inplace) {
+                coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
+                coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+                UCC_CHECK(ucc_mc_memcpy(coll->dst.info.buffer, ctxs[r]->init_buf,
+                                        ucc_dt_size(dt) * rcount, mem_type,
+                                        UCC_MEMORY_TYPE_HOST));
+                coll->src.info.mem_type = UCC_MEMORY_TYPE_UNKNOWN;
+                coll->src.info.count    = SIZE_MAX;
+                coll->src.info.datatype = (ucc_datatype_t)-1;
+            } else {
+                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_mc_header,
+                                       ucc_dt_size(dt) * count, mem_type));
+                coll->src.info.buffer = ctxs[r]->src_mc_header->addr;
+                UCC_CHECK(ucc_mc_memcpy(coll->src.info.buffer, ctxs[r]->init_buf,
+                                        ucc_dt_size(dt) * count, mem_type,
+                                        UCC_MEMORY_TYPE_HOST));
+                coll->src.info.mem_type = mem_type;
+                coll->src.info.count    = (ucc_count_t)count;
+                coll->src.info.datatype = dt;
+            }
+            coll->dst.info.mem_type = mem_type;
+            coll->dst.info.count    = (ucc_count_t)rcount;
+            coll->dst.info.datatype = dt;
+        }
+    }
+    void data_fini(UccCollCtxVec ctxs) {
+        for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
+            ucc_coll_args_t* coll = ctx->args;
+            if (coll->src.info.buffer) { /* no inplace */
+                UCC_CHECK(ucc_mc_free(ctx->src_mc_header));
+            }
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header));
+            ucc_free(ctx->init_buf);
+            free(coll);
+            free(ctx);
+        }
+        ctxs.clear();
+    }
+    void reset(UccCollCtxVec ctxs)
+    {
+        for (auto r = 0; r < ctxs.size(); r++) {
+            ucc_coll_args_t *coll  = ctxs[r]->args;
+            size_t           count = coll->dst.info.count;
+            ucc_datatype_t   dtype = coll->dst.info.datatype;
+            clear_buffer(coll->dst.info.buffer, count * ucc_dt_size(dtype),
+                         mem_type, 0);
+
+            if (TEST_INPLACE == inplace) {
+                UCC_CHECK(ucc_mc_memcpy(coll->dst.info.buffer,
+                                        ctxs[r]->init_buf,
+                                        ucc_dt_size(dtype) * count, mem_type,
+                                        UCC_MEMORY_TYPE_HOST));
+            }
+        }
+    }
+    bool data_validate(UccCollCtxVec ctxs)
+    {
+        size_t total_count, rcount;
+        std::vector<typename T::type *> dsts(ctxs.size());
+
+        if (TEST_INPLACE != inplace) {
+            total_count = (ctxs[0])->args->src.info.count;
+            rcount = (ctxs[0])->args->dst.info.count;
+        } else {
+            total_count = (ctxs[0])->args->dst.info.count;
+            rcount = total_count / ctxs.size();
+        }
+
+        ucc_assert(rcount * ctxs.size() == total_count);
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                dsts[r] = (typename T::type *) ucc_malloc(rcount * sizeof(typename T::type), "dsts buf");
+                EXPECT_NE(dsts[r], nullptr);
+                UCC_CHECK(ucc_mc_memcpy(dsts[r], ctxs[r]->args->dst.info.buffer,
+                                        rcount * sizeof(typename T::type), UCC_MEMORY_TYPE_HOST,
+                                        mem_type));
+            }
+        } else {
+            for (int r = 0; r < ctxs.size(); r++) {
+                dsts[r] = (typename T::type *)(ctxs[r]->args->dst.info.buffer);
+            }
+        }
+
+        for (int i = 0; i < total_count; i++) {
+            typename T::type res =
+                    ((typename T::type *)((ctxs[0])->init_buf))[i];
+            for (int r = 1; r < ctxs.size(); r++) {
+                res = T::do_op(res, ((typename T::type *)((ctxs[r])->init_buf))[i]);
+            }
+            if (T::redop == UCC_OP_AVG) {
+                res = res / (typename T::type)ctxs.size();
+            }
+            T::assert_equal(res, dsts[i/rcount][i % rcount]);
+        }
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                ucc_free(dsts[r]);
+            }
+        }
+        return true;
+    }
+};
+
+TYPED_TEST_CASE(test_reduce_scatter, ReductionTypesOps);
+
+#define TEST_DECLARE(_mem_type, _inplace, _repeat)                             \
+    {                                                                          \
+        std::array<int, 3> counts{4, 256, 65536};                              \
+        for (int tid = 0; tid < UccJob::nStaticTeams; tid++) {                 \
+            for (int count : counts) {                                         \
+                UccTeam_h     team = UccJob::getStaticTeams()[tid];            \
+                int           size = team->procs.size();                       \
+                UccCollCtxVec ctxs;                                            \
+                this->set_mem_type(_mem_type);                                 \
+                this->set_inplace(_inplace);                                   \
+                this->data_init(size, TypeParam::dt, count, ctxs);             \
+                try {\
+                UccReq req(team, ctxs);                                        \
+                for (auto i = 0; i < _repeat; i++) {                    \
+                    req.start();                                        \
+                    req.wait();                                         \
+                    EXPECT_EQ(true, this->data_validate(ctxs));         \
+                    this->reset(ctxs);                                  \
+                }                                                       \
+                }\
+                catch (const std::exception & e) {\
+                    std::cerr << e.what() << std::endl; \
+                }\
+                this->data_fini(ctxs);                                  \
+            }                                                                  \
+        }                                                                      \
+    }
+
+TYPED_TEST(test_reduce_scatter, single_host) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_NO_INPLACE, 1);
+}
+
+
+TYPED_TEST(test_reduce_scatter, single_host_persistent)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_NO_INPLACE, 3);
+}
+
+TYPED_TEST(test_reduce_scatter, single_host_inplace) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_INPLACE, 1);
+}
+
+
+TYPED_TEST(test_reduce_scatter, single_host_persistent_inplace)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_INPLACE, 3);
+}
+
+#ifdef HAVE_CUDA
+TYPED_TEST(test_reduce_scatter, single_cuda) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_NO_INPLACE, 1);
+}
+
+TYPED_TEST(test_reduce_scatter, single_cuda_persistent)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_NO_INPLACE, 3);
+}
+
+TYPED_TEST(test_reduce_scatter, single_cuda_inplace) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE, 1);
+}
+
+TYPED_TEST(test_reduce_scatter, single_cuda_persistent_inplace)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE, 3);
+}
+#endif
+
+
+#define TEST_DECLARE_MULTIPLE(_mem_type, _inplace)                             \
+    {                                                                          \
+        std::array<int, 3> counts{4, 256, 65536};                              \
+        for (int count : counts) {                                             \
+            std::vector<UccReq>        reqs;                                   \
+            std::vector<UccCollCtxVec> ctxs;                                   \
+            try {\
+            for (int tid = 0; tid < UccJob::nStaticTeams; tid++) {             \
+                UccTeam_h     team = UccJob::getStaticTeams()[tid];            \
+                int           size = team->procs.size();                       \
+                UccCollCtxVec ctx;                                             \
+                this->set_inplace(_inplace);                                   \
+                this->set_mem_type(_mem_type);                                 \
+                this->data_init(size, TypeParam::dt, count, ctx);              \
+                ctxs.push_back(ctx);                                           \
+                reqs.push_back(UccReq(team, ctx));                             \
+            }                                                                  \
+                UccReq::startall(reqs);                                        \
+                UccReq::waitall(reqs);                                         \
+                for (auto ctx : ctxs) {                                        \
+                    EXPECT_EQ(true, this->data_validate(ctx));                 \
+                }                                                              \
+                }\
+                catch (const std::exception & e) {\
+                    std::cerr << e.what() << std::endl; \
+                }\
+            for (auto ctx : ctxs) {                                            \
+                this->data_fini(ctx);                                          \
+            }                                                                  \
+        }                                                                      \
+    }
+
+TYPED_TEST(test_reduce_scatter, multiple) {
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_HOST, TEST_NO_INPLACE);
+}
+
+
+TYPED_TEST(test_reduce_scatter, multiple_inplace) {
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_HOST, TEST_INPLACE);
+}
+
+#ifdef HAVE_CUDA
+TYPED_TEST(test_reduce_scatter, multiple_cuda) {
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_NO_INPLACE);
+}
+
+TYPED_TEST(test_reduce_scatter, multiple_cuda_inplace) {
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE);
+}
+#endif
+
+template<typename T>
+class test_reduce_scatter_alg : public test_reduce_scatter<T>
+{};
+
+using test_reduce_scatter_alg_type = ::testing::Types<ReductionTest<UCC_DT_INT32, sum>>;
+TYPED_TEST_CASE(test_reduce_scatter_alg, test_reduce_scatter_alg_type);
+
+TYPED_TEST(test_reduce_scatter_alg, knomial) {
+    int           n_procs = 15;
+    ucc_job_env_t env     = {{"UCC_CL_BASIC_TUNE", "inf"},
+                             {"UCC_TL_UCP_TUNE", "reduce_scatter:@knomial:inf"}};
+    UccJob        job(n_procs, UccJob::UCC_JOB_CTX_GLOBAL, env);
+    UccTeam_h     team   = job.create_team(n_procs);
+    int           repeat = 3;
+    UccCollCtxVec ctxs;
+    std::vector<ucc_memory_type_t> mt = {UCC_MEMORY_TYPE_HOST};
+
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
+        mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+
+    for (auto count : {65536, 123567}) {
+        for (auto inplace : {TEST_NO_INPLACE, TEST_INPLACE}) {
+            for (auto m : mt) {
+                this->set_mem_type(m);
+                this->set_inplace(inplace);
+                this->data_init(n_procs, TypeParam::dt, count, ctxs);
+                UccReq req(team, ctxs);
+
+                for (auto i = 0; i < repeat; i++) {
+                    req.start();
+                    req.wait();
+                    EXPECT_EQ(true, this->data_validate(ctxs));
+                    this->reset(ctxs);
+                }
+                this->data_fini(ctxs);
+            }
+        }
+    }
+}
+
+TYPED_TEST(test_reduce_scatter_alg, ring) {
+    int           n_procs = 15;
+    ucc_job_env_t env     = {{"UCC_CL_BASIC_TUNE", "inf"},
+                             {"UCC_TL_UCP_TUNE", "reduce_scatter:@ring:inf"}};
+    UccJob        job(n_procs, UccJob::UCC_JOB_CTX_GLOBAL, env);
+    UccTeam_h     team   = job.create_team(n_procs);
+    int           repeat = 3;
+    UccCollCtxVec ctxs;
+    std::vector<ucc_memory_type_t> mt = {UCC_MEMORY_TYPE_HOST};
+
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
+        mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+
+    for (auto count : {65536, 123567}) {
+        for (auto inplace : {TEST_NO_INPLACE, TEST_INPLACE}) {
+            for (auto m : mt) {
+                this->set_mem_type(m);
+                this->set_inplace(inplace);
+                this->data_init(n_procs, TypeParam::dt, count, ctxs);
+                UccReq req(team, ctxs);
+
+                for (auto i = 0; i < repeat; i++) {
+                    req.start();
+                    req.wait();
+                    EXPECT_EQ(true, this->data_validate(ctxs));
+                    this->reset(ctxs);
+                }
+                this->data_fini(ctxs);
+            }
+        }
+    }
+}

--- a/test/gtest/utils/test_ep_map.cc
+++ b/test/gtest/utils/test_ep_map.cc
@@ -10,17 +10,22 @@ extern "C" {
 #include <vector>
 
 class EpMap {
-    ucc_ep_map_t map;
 public:
-    ucc_rank_t *array;
+    ucc_ep_map_t map;
+    ucc_rank_t  *array;
+    EpMap() {};
     EpMap(ucc_ep_map_t _map) {
         array = NULL;
         map   = _map;
     };
-    EpMap(uint64_t full) {
-        map.type   = UCC_EP_MAP_FULL;
-        map.ep_num = full;
+    EpMap(uint64_t full, bool reverse = false) {
         array      = NULL;
+        if (reverse) {
+            map = ucc_ep_map_create_reverse(full);
+        } else {
+            map.type   = UCC_EP_MAP_FULL;
+            map.ep_num = full;
+        }
     };
     EpMap(uint64_t start, int64_t stride, uint64_t num, uint64_t full) {
         map.type           = ((num == full)  && (stride == 1)) ?
@@ -84,4 +89,50 @@ UCC_TEST_F(test_ep_map, from_array_free)
 
     /* FULL pattern found - array is released */
     EXPECT_EQ((void*)NULL, EpMap({1, 2, 3, 4, 5}, 5, 1).array);
+}
+
+UCC_TEST_F(test_ep_map, reverse)
+{
+    const int    size = 10;
+    ucc_ep_map_t map  = ucc_ep_map_create_reverse(size);
+
+    for (int i = 0; i < size; i++) {
+        EXPECT_EQ(size - 1 - i, ucc_ep_map_eval(map, i));
+    }
+}
+
+class test_ep_map_inv : public test_ep_map {
+public:
+    void check_inv(EpMap map) {
+        ucc_ep_map_t inv;
+        EXPECT_EQ(UCC_OK, ucc_ep_map_create_inverse(map.map, &inv));
+        for (int i = 0; i < map.map.ep_num; i++) {
+            EXPECT_EQ(i, ucc_ep_map_eval(inv, ucc_ep_map_eval(map.map, i)));
+        }
+        ucc_ep_map_destroy(&inv);
+    };
+};
+
+UCC_TEST_F(test_ep_map_inv, contig)
+{
+    /* reverse of FULL */
+    check_inv(EpMap(10));
+
+    /* reverse of INVERSE */
+    check_inv(EpMap(10, true));
+}
+
+UCC_TEST_F(test_ep_map_inv, strided)
+{
+    /* stride positive */
+    check_inv(EpMap(1, 30, 5, 150));
+
+    /* stride negative */
+    check_inv(EpMap(100, -10, 5, 150));
+}
+
+
+UCC_TEST_F(test_ep_map_inv, random)
+{
+    check_inv(EpMap({4, 0, 1, 2, 3}, 5));
 }

--- a/test/mpi/test_reduce_scatter.cc
+++ b/test/mpi/test_reduce_scatter.cc
@@ -24,13 +24,16 @@ TestReduceScatter::TestReduceScatter(size_t _msgsize,
     dt = _dt;
     args.coll_type = UCC_COLL_TYPE_REDUCE_SCATTER;
 
+
     if (skip_reduce(test_max_size < _msgsize, TEST_SKIP_MEM_LIMIT,
                     team.comm) ||
-        skip_reduce((count % comm_size != 0), TEST_SKIP_NOT_SUPPORTED,
+        skip_reduce((count < comm_size), TEST_SKIP_NOT_SUPPORTED,
                     team.comm)) {
         return;
     }
 
+    count   = count - (count % comm_size);
+    msgsize = _msgsize = count * dt_size;
     if (TEST_NO_INPLACE == inplace) {
         args.dst.info.count = count / comm_size;
 


### PR DESCRIPTION
## What
Enables reduce-scatter implementation in TL/UCP.

## Why ?
Main API. Also RS is needed for 2lvl Allreduce.

## How ?
- Enables Knomial RS to be used directly for reduce-scatter (not only as part of sra knomial allreduce)
- Implements ring reduce-scatter. Bi or uni-directional (option, default bi-directional). 
- RS knomial falls back to ring for non-power K case
- Adds gtests