### PR TITLE
TOPO: fix is single node

### DIFF
--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -204,7 +204,7 @@ ucc_sbgp_t *ucc_topo_get_sbgp(ucc_topo_t *topo, ucc_sbgp_type_t type)
     return &topo->sbgps[type];
 }
 
-int ucc_context_topo_is_single_node(ucc_topo_t *topo)
+int ucc_topo_is_single_node(ucc_topo_t *topo)
 {
     ucc_sbgp_t *sbgp;
 


### PR DESCRIPTION
## What
fixes 
```
libucc_cl_hier.so: undefined symbol: ucc_topo_is_single_node
```