### PR TITLE
TL/UCP: Fix typo to get send and receive types

### DIFF
--- a/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
@@ -41,8 +41,8 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
 
     posts    = UCC_TL_UCP_TEAM_LIB(team)->cfg.alltoallv_pairwise_num_posts;
     nreqs    = (posts > gsize || posts == 0) ? gsize : posts;
-    rdt_size = ucc_dt_size(TASK_ARGS(task).src.info_v.datatype);
-    sdt_size = ucc_dt_size(TASK_ARGS(task).dst.info_v.datatype);
+    rdt_size = ucc_dt_size(TASK_ARGS(task).dst.info_v.datatype);
+    sdt_size = ucc_dt_size(TASK_ARGS(task).src.info_v.datatype);
     while ((task->send_posted < gsize || task->recv_posted < gsize) &&
            (polls++ < task->n_polls)) {
         ucp_worker_progress(UCC_TL_UCP_TEAM_CTX(team)->ucp_worker);


### PR DESCRIPTION
## What
Fix type to get send and receive types in the context of alltoallv operations that lead to bug when the two types are not the same.

## Why ?
A typo led to a mix up while referring to send and receive types.

## How ?
N/A