### PR TITLE
TEST/MPI: adds onesided alltoall test

### DIFF
--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -15,6 +15,7 @@ static std::vector<ucc_coll_type_t> colls = {UCC_COLL_TYPE_BARRIER,
                                              UCC_COLL_TYPE_ALLTOALL,
                                              UCC_COLL_TYPE_ALLTOALLV,
                                              UCC_COLL_TYPE_REDUCE_SCATTER};
+static std::vector<ucc_coll_type_t> onesided_colls = {UCC_COLL_TYPE_ALLTOALL};
 static std::vector<ucc_memory_type_t> mtypes = {UCC_MEMORY_TYPE_HOST};
 static std::vector<ucc_datatype_t> dtypes = {UCC_DT_INT32, UCC_DT_INT64,
                                              UCC_DT_FLOAT32, UCC_DT_FLOAT64};
@@ -494,6 +495,11 @@ int main(int argc, char *argv[])
     for (auto &inpl : inplace) {
         test->set_inplace(inpl);
         test->run_all();
+    }
+    test->set_colls(onesided_colls);
+    for (auto &inpl : inplace) {
+        test->set_inplace(inpl);
+        test->run_all(true);
     }
     std::cout << std::flush;
     MPI_Iallreduce(MPI_IN_PLACE, test->results.data(), test->results.size(),

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -475,6 +475,7 @@ int main(int argc, char *argv[])
         }
     }
     test->create_teams(teams);
+    test->create_teams(teams, true);
     test->set_iter(iterations);
     test->set_num_tests(num_tests);
     test->set_colls(colls);

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -35,7 +35,7 @@ static ucc_thread_mode_t                   thread_mode  = UCC_THREAD_SINGLE;
 static int                                 iterations   = 1;
 static int                                 show_help    = 0;
 static int                                 num_tests    = 1;
-static bool                                is_onesided  = true;
+static bool                                has_onesided = true;
 #ifdef HAVE_CUDA
 static test_set_cuda_device_t test_cuda_set_device = TEST_SET_DEV_NONE;
 #endif
@@ -421,7 +421,7 @@ int ProcessArgs(int argc, char** argv)
             break;
 #endif
         case 'O':
-            is_onesided = std::stoi(optarg);
+            has_onesided = std::stoi(optarg);
             break;
         case 'h':
             show_help = 1;
@@ -472,7 +472,7 @@ int main(int argc, char *argv[])
 #ifdef HAVE_CUDA
     set_cuda_device(test_cuda_set_device);
 #endif
-    test = new UccTestMpi(argc, argv, thread_mode, 0);
+    test = new UccTestMpi(argc, argv, thread_mode, 0, has_onesided);
     for (auto &m : mtypes) {
         if (UCC_MEMORY_TYPE_HOST != m && UCC_OK != ucc_mc_available(m)) {
             std::cerr << "requested memory type " << ucc_memory_type_names[m]
@@ -482,7 +482,7 @@ int main(int argc, char *argv[])
         }
     }
     test->create_teams(teams);
-    if (is_onesided) {
+    if (has_onesided) {
         test->create_teams(teams, true);
     }
     test->set_iter(iterations);
@@ -504,7 +504,7 @@ int main(int argc, char *argv[])
         test->set_inplace(inpl);
         test->run_all();
     }
-    if (is_onesided) {
+    if (has_onesided) {
         test->set_colls(onesided_colls);
         for (auto &inpl : inplace) {
             test->set_inplace(inpl);

--- a/test/mpi/test_alltoall.cc
+++ b/test/mpi/test_alltoall.cc
@@ -14,12 +14,12 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                            size_t _max_size, void ** buffers) :
     TestCase(_team, UCC_COLL_TYPE_ALLTOALL, _mt, _msgsize, _inplace, _max_size)
 {
-    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t dt_size           = ucc_dt_size(TEST_DT);
     size_t single_rank_count = _msgsize / dt_size;
-    bool is_onesided = (buffers != nullptr);
-    void * work_buf;
-    int rank;
-    int nprocs;
+    bool   is_onesided       = (buffers != nullptr);
+    void  *work_buf          = nullptr;
+    int    rank;
+    int    nprocs;
 
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &nprocs);
@@ -41,14 +41,17 @@ TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     check_buf = ucc_malloc(_msgsize * nprocs, "check buf");
     UCC_MALLOC_CHECK(check_buf);
     if (TEST_NO_INPLACE == inplace) {
-        UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize * nprocs, _mt));
-        sbuf = sbuf_mc_header->addr;
+        if (!is_onesided) {
+            UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize * nprocs, _mt));
+            sbuf = sbuf_mc_header->addr;
+        }
     } else {
         args.mask  = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
     if (is_onesided) {
-        args.mask |= UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER;
+        args.mask =
+            UCC_COLL_ARGS_FIELD_FLAGS | UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER;
         args.flags |= UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS;
         args.global_work_buffer = work_buf;
     }
@@ -100,55 +103,6 @@ ucc_status_t TestAlltoall::reset_sbuf()
         init_buffer(sbuf, single_rank_count * nprocs, TEST_DT, mem_type, 0);
     }
     return UCC_OK;
-}
-
-TestAlltoall::TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
-                           ucc_memory_type_t _mt, ucc_test_team_t &_team,
-                           size_t _max_size, void * buffers[3]) :
-    TestCase(_team, _mt, _msgsize, _inplace, _max_size)
-{
-    size_t dt_size           = ucc_dt_size(TEST_DT);
-    size_t single_rank_count = _msgsize / dt_size;
-    void * work_buf          = buffers[2];
-    int    rank;
-    int    nprocs;
-
-    MPI_Comm_rank(team.comm, &rank);
-    MPI_Comm_size(team.comm, &nprocs);
-
-    args.coll_type = UCC_COLL_TYPE_ALLTOALL;
-    args.mask =
-        UCC_COLL_ARGS_FIELD_FLAGS | UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER;
-    args.flags = UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS;
-    sbuf       = buffers[0];
-    rbuf       = buffers[1];
-    if (TEST_SKIP_NONE != skip_reduce(test_max_size < (_msgsize * nprocs),
-                                      TEST_SKIP_MEM_LIMIT, team.comm)) {
-        return;
-    }
-    check_rbuf = ucc_malloc(_msgsize * nprocs, "check rbuf");
-    UCC_MALLOC_CHECK(check_rbuf);
-    if (TEST_NO_INPLACE == inplace) {
-        init_buffer(sbuf, single_rank_count * nprocs, TEST_DT, _mt, rank);
-        UCC_ALLOC_COPY_BUF(check_sbuf_mc_header, UCC_MEMORY_TYPE_HOST, sbuf,
-                           _mt, _msgsize * nprocs);
-        check_sbuf = check_sbuf_mc_header->addr;
-    } else {
-        args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
-        init_buffer(rbuf, single_rank_count * nprocs, TEST_DT, _mt, rank);
-        init_buffer(check_rbuf, single_rank_count * nprocs, TEST_DT,
-                    UCC_MEMORY_TYPE_HOST, rank);
-    }
-    args.src.info.buffer    = sbuf;
-    args.src.info.count     = single_rank_count * nprocs;
-    args.src.info.datatype  = TEST_DT;
-    args.src.info.mem_type  = _mt;
-    args.dst.info.buffer    = rbuf;
-    args.dst.info.count     = single_rank_count * nprocs;
-    args.dst.info.datatype  = TEST_DT;
-    args.dst.info.mem_type  = _mt;
-    args.global_work_buffer = work_buf;
-    UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
 }
 
 ucc_status_t TestAlltoall::check()

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -11,13 +11,14 @@ TestCase::init(ucc_coll_type_t _type, ucc_test_team_t &_team, int num_tests,
                int root, size_t msgsize, ucc_test_mpi_inplace_t inplace,
                ucc_memory_type_t mt, size_t max_size, ucc_datatype_t dt,
                ucc_reduction_op_t op, ucc_test_vsize_flag_t count_bits,
-               ucc_test_vsize_flag_t displ_bits, void ** onesided_buffers)
+               ucc_test_vsize_flag_t displ_bits, void **onesided_buffers)
 {
     std::vector<std::shared_ptr<TestCase>> tcs;
 
     for (int i = 0; i < num_tests; i++) {
-        auto tc = init_single(_type, _team, root, msgsize, inplace, mt,
-                              max_size, dt, op, count_bits, displ_bits, onesided_buffers);
+        auto tc =
+            init_single(_type, _team, root, msgsize, inplace, mt, max_size, dt,
+                        op, count_bits, displ_bits, onesided_buffers);
         if (!tc) {
             tcs.clear();
             return tcs;

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -11,13 +11,13 @@ TestCase::init(ucc_coll_type_t _type, ucc_test_team_t &_team, int num_tests,
                int root, size_t msgsize, ucc_test_mpi_inplace_t inplace,
                ucc_memory_type_t mt, size_t max_size, ucc_datatype_t dt,
                ucc_reduction_op_t op, ucc_test_vsize_flag_t count_bits,
-               ucc_test_vsize_flag_t displ_bits)
+               ucc_test_vsize_flag_t displ_bits, void ** onesided_buffers)
 {
     std::vector<std::shared_ptr<TestCase>> tcs;
 
     for (int i = 0; i < num_tests; i++) {
         auto tc = init_single(_type, _team, root, msgsize, inplace, mt,
-                              max_size, dt, op, count_bits, displ_bits);
+                              max_size, dt, op, count_bits, displ_bits, onesided_buffers);
         if (!tc) {
             tcs.clear();
             return tcs;
@@ -39,8 +39,7 @@ std::shared_ptr<TestCase> TestCase::init_single(
         ucc_reduction_op_t op,
         ucc_test_vsize_flag_t count_bits,
         ucc_test_vsize_flag_t displ_bits,
-        void * onesided_buffers[3],
-        bool is_onesided)
+        void ** onesided_buffers)
 {
     switch(_type) {
     case UCC_COLL_TYPE_BARRIER:
@@ -64,7 +63,7 @@ std::shared_ptr<TestCase> TestCase::init_single(
         return std::make_shared<TestReduce>(msgsize, inplace, dt, op, mt, root,
                                            _team, max_size);
     case UCC_COLL_TYPE_ALLTOALL:
-        if (is_onesided) {
+        if (onesided_buffers) {
             return std::make_shared<TestAlltoall>(msgsize, inplace, mt, _team,
                                                   max_size, onesided_buffers);
         } else {
@@ -114,9 +113,14 @@ void TestCase::mpi_progress(void)
 }
 
 std::string TestCase::str() {
-    std::string _str = std::string("tc=") + ucc_coll_type_str(args.coll_type) +
-        " team=" + team_str(team.type) + " mtype=" + ucc_memory_type_names[mem_type] +
-        " msgsize=" + std::to_string(msgsize);
+    std::string _str = std::string("tc=");
+    if (args.flags & UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS) {
+        _str += std::string("Onesided ");
+    }
+    _str += std::string(ucc_coll_type_str(args.coll_type)) +
+            " team=" + team_str(team.type) +
+            " mtype=" + ucc_memory_type_names[mem_type] +
+            " msgsize=" + std::to_string(msgsize);
     if (ucc_coll_inplace_supported(args.coll_type)) {
         _str += std::string(" inplace=") + (inplace == TEST_INPLACE ? "1" : "0");
     }
@@ -166,6 +170,11 @@ test_skip_cause_t TestCase::skip_reduce(test_skip_cause_t cause, MPI_Comm comm)
     return skip_reduce(1, cause, comm);
 }
 
+void TestCase::tc_progress_ctx()
+{
+    ucc_context_progress(team.ctx);
+}
+
 TestCase::TestCase(ucc_test_team_t &_team, ucc_coll_type_t ct,
                    ucc_memory_type_t _mem_type,
                    size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
@@ -173,17 +182,16 @@ TestCase::TestCase(ucc_test_team_t &_team, ucc_coll_type_t ct,
     team(_team), mem_type(_mem_type),  msgsize(_msgsize), inplace(_inplace),
     test_max_size(_max_size)
 {
+    int rank;
+
     sbuf           = NULL;
     rbuf           = NULL;
+    check_buf      = NULL;
     sbuf_mc_header = NULL;
     rbuf_mc_header = NULL;
-    check_sbuf     = NULL;
-    check_rbuf     = NULL;
     test_skip      = TEST_SKIP_NONE;
     args.flags     = 0;
     args.mask      = 0;
-    int rank;
-
     args.coll_type = ct;
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -209,15 +209,11 @@ TestCase::~TestCase()
     if (TEST_SKIP_NONE == test_skip) {
         UCC_CHECK(ucc_collective_finalize(req));
     }
-    if (sbuf) {
-        if (sbuf_mc_header) {
-            UCC_CHECK(ucc_mc_free(sbuf_mc_header));
-        }
+    if (sbuf_mc_header) {
+        UCC_CHECK(ucc_mc_free(sbuf_mc_header));
     }
-    if (rbuf) {
-        if (rbuf_mc_header) {
-            UCC_CHECK(ucc_mc_free(rbuf_mc_header));
-        }
+    if (rbuf_mc_header) {
+        UCC_CHECK(ucc_mc_free(rbuf_mc_header));
     }
     if (check_buf) {
         ucc_free(check_buf);

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -39,9 +39,11 @@ static ucc_status_t oob_allgather_free(void *req)
 }
 
 UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t _tm, int is_local) {
-    ucc_lib_config_h lib_config;
+    std::string          env = "UCC_TL_UCP_TUNE=alltoall:0-inf:@1";
+    ucc_lib_config_h     lib_config;
     ucc_context_config_h ctx_config;
-    int size, rank;
+    int                  size, rank;
+    ucc_mem_map_t        segments[3];
 
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -56,6 +58,8 @@ UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t _tm, int is_loc
     /* Init ucc context for a specified UCC_TEST_TLS */
     ucc_context_params_t ctx_params = {
     };
+    ucc_context_params_t onesided_ctx_params = {
+    };
     if (!is_local) {
         ctx_params.mask            |= UCC_CONTEXT_PARAM_FIELD_OOB;
         ctx_params.oob.allgather = oob_allgather;
@@ -64,13 +68,35 @@ UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t _tm, int is_loc
         ctx_params.oob.coll_info = (void*)(uintptr_t)MPI_COMM_WORLD;
         ctx_params.oob.n_oob_eps = size;
         ctx_params.oob.oob_ep    = rank;
+
+        onesided_ctx_params = ctx_params;
+        for (auto i = 0; i < 3; i++) {
+            /* FIXME: what's the correct number here.. */
+            onesided_buffers[i] = ucc_malloc((1<<21) * size);
+            UCC_MALLOC_CHECK(onesided_buffers[i]);
+            segments[i].address = onesided_buffers[i];
+            segments[i].len     = (1<<21) * size;
+        }
+        onesided_ctx_params.mask |= UCC_CONTEXT_PARAM_FIELD_MEM_PARAMS;
+        onesided_ctx_params.mem_params.segments   = segments;
+        onesided_ctx_params.mem_params.n_segments = 3;
+    } else {
+        for (auto i = 0; i < 3; i++) {
+            onesided_buffers[i] = NULL;
+        }
     }
     UCC_CHECK(ucc_lib_config_read(NULL, NULL, &lib_config));
     UCC_CHECK(ucc_init(&lib_params, lib_config, &lib));
     ucc_lib_config_release(lib_config);
-
     UCC_CHECK(ucc_context_config_read(lib, NULL, &ctx_config));
     UCC_CHECK(ucc_context_create(lib, &ctx_params, ctx_config, &ctx));
+
+    putenv((char *)env.c_str());
+    UCC_CHECK(ucc_lib_config_read(NULL, NULL, &lib_config));
+    UCC_CHECK(ucc_init(&lib_params, lib_config, &onesided_lib));
+    ucc_lib_config_release(lib_config);
+    UCC_CHECK(ucc_context_config_read(onesided_lib, NULL, &ctx_config));
+    UCC_CHECK(ucc_context_create(onesided_lib, &onesided_ctx_params, ctx_config, &onesided_ctx));
     ucc_context_config_release(ctx_config);
     set_msgsizes(8, ((1ULL) << 21), 8);
     dtypes = {UCC_DT_INT32, UCC_DT_INT64, UCC_DT_FLOAT32, UCC_DT_FLOAT64};
@@ -88,7 +114,8 @@ void UccTestMpi::set_iter(int iter)
     iterations = iter;
 }
 
-void UccTestMpi::create_teams(std::vector<ucc_test_mpi_team_t> &test_teams)
+void UccTestMpi::create_teams(std::vector<ucc_test_mpi_team_t> &test_teams,
+                              bool                              is_onesided)
 {
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -102,7 +129,7 @@ void UccTestMpi::create_teams(std::vector<ucc_test_mpi_team_t> &test_teams)
             }
             continue;
         }
-        create_team(t);
+        create_team(t, is_onesided);
     }
 }
 
@@ -111,8 +138,18 @@ UccTestMpi::~UccTestMpi()
     for (auto &t : teams) {
         destroy_team(t);
     }
+    for (auto &t : onesided_teams) {
+        destroy_team(t);
+    }
+    if (onesided_buffers[0]) {
+        for (auto i = 0; i < 3; i++) {
+            ucc_free(onesided_buffers[i]);
+        }
+    }
     UCC_CHECK(ucc_context_destroy(ctx));
+    UCC_CHECK(ucc_context_destroy(onesided_ctx));
     UCC_CHECK(ucc_finalize(lib));
+    UCC_CHECK(ucc_finalize(onesided_lib));
 }
 
 ucc_team_h UccTestMpi::create_ucc_team(MPI_Comm comm)
@@ -154,12 +191,57 @@ ucc_team_h UccTestMpi::create_ucc_team(MPI_Comm comm)
     return team;
 }
 
-
-void UccTestMpi::create_team(ucc_test_mpi_team_t t)
+ucc_team_h UccTestMpi::create_onesided_ucc_team(MPI_Comm comm)
 {
+    int               rank, size;
+    ucc_team_h        team;
+    ucc_team_params_t team_params;
+    ucc_status_t      status;
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+
+    /* Create UCC TEAM for comm world */
+    team_params.mask               = UCC_TEAM_PARAM_FIELD_EP       |
+        UCC_TEAM_PARAM_FIELD_EP_RANGE |
+        UCC_TEAM_PARAM_FIELD_OOB | UCC_TEAM_PARAM_FIELD_FLAGS;
+    team_params.oob.allgather = oob_allgather;
+    team_params.oob.req_test  = oob_allgather_test;
+    team_params.oob.req_free  = oob_allgather_free;
+    team_params.oob.coll_info = (void*)comm;
+    team_params.oob.n_oob_eps = size;
+    team_params.oob.oob_ep    = rank;
+    team_params.ep            = rank;
+    team_params.ep_range      = UCC_COLLECTIVE_EP_RANGE_CONTIG;
+    team_params.flags = UCC_TEAM_FLAG_COLL_WORK_BUFFER;
+
+    UCC_CHECK(ucc_team_create_post(&onesided_ctx, 1, &team_params, &team));
+    MPI_Request req;
+    int tmp;
+    int completed;
+    MPI_Irecv(&tmp, 1, MPI_INT, rank, 123, comm, &req);
+    while (UCC_INPROGRESS == (status = ucc_team_create_test(team))) {
+        ucc_context_progress(onesided_ctx);
+        MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
+    };
+    MPI_Send(&tmp, 1, MPI_INT, rank, 123, comm);
+    if (status < 0) {
+        std::cerr << "*** UCC TEST FAIL: ucc_team_create_onesided_test failed\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+    return team;
+}
+
+void UccTestMpi::create_team(ucc_test_mpi_team_t t, bool is_onesided)
+{
+    ucc_team_h team;
     MPI_Comm comm = create_mpi_comm(t);
-    ucc_team_h team = create_ucc_team(comm);
-    teams.push_back(ucc_test_team_t(t, comm, team, ctx));
+    if (is_onesided) {
+        team = create_onesided_ucc_team(comm);
+        onesided_teams.push_back(ucc_test_team_t(t, comm, team, onesided_ctx));
+    } else {
+        team = create_ucc_team(comm);
+        teams.push_back(ucc_test_team_t(t, comm, team, ctx));
+    }
 }
 
 void UccTestMpi::destroy_team(ucc_test_team_t &team)
@@ -381,10 +463,21 @@ void UccTestMpi::run_all_at_team(ucc_test_team_t &          team,
                                 switch (c) {
                                 case UCC_COLL_TYPE_ALLTOALL:
                                 {
-                                    auto tcs = TestCase::init(c, team, nt, r, m,
-                                                              inplace, mt, s);
-                                    auto res = exec_tests(tcs);
-                                    rst.insert(rst.end(), res.begin(), res.end());
+                                    if (team.ctx == ctx) { 
+                                        auto tcs = TestCase::init(c, team, nt, r, m,
+                                                                 inplace, mt, s);
+                                        auto res = exec_tests(tcs);
+                                        rst.insert(rst.end(), res.begin(), res.end());
+                                    } else {
+                                        auto tc_onesided = TestCase::init(
+                                            c, team, r, m, inplace, mt, s,
+                                            UCC_DT_UINT32, UCC_OP_LAST,
+                                            TEST_FLAG_VSIZE_64BIT,
+                                            TEST_FLAG_VSIZE_64BIT,
+                                            onesided_buffers, true);
+                                        rst.push_back(
+                                            tc_onesided.get()->exec());
+                                    }
                                     break;
                                 }
                                 case UCC_COLL_TYPE_ALLTOALLV:
@@ -456,6 +549,9 @@ void UccTestMpi::run_all()
         }
     } else {
         for (auto &t : teams) {
+            run_all_at_team(t, results);
+        }
+        for (auto &t : onesided_teams) {
             run_all_at_team(t, results);
         }
     }

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -38,7 +38,8 @@ static ucc_status_t oob_allgather_free(void *req)
     return UCC_OK;
 }
 
-UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t _tm, int is_local)
+UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t _tm,
+                       int is_local)
 {
     ucc_lib_config_h     lib_config;
     ucc_context_config_h ctx_config;
@@ -430,11 +431,12 @@ void UccTestMpi::run_all_at_team(ucc_test_team_t &          team,
                                 switch (c) {
                                 case UCC_COLL_TYPE_ALLTOALL:
                                 {
-                                    if (team.ctx == ctx) { 
-                                        auto tcs = TestCase::init(c, team, nt, r, m,
-                                                                 inplace, mt, s);
+                                    if (team.ctx == ctx) {
+                                        auto tcs = TestCase::init(
+                                            c, team, nt, r, m, inplace, mt, s);
                                         auto res = exec_tests(tcs);
-                                        rst.insert(rst.end(), res.begin(), res.end());
+                                        rst.insert(rst.end(), res.begin(),
+                                                   res.end());
                                     } else {
                                         if (mt != UCC_MEMORY_TYPE_HOST) {
                                             continue;
@@ -446,7 +448,8 @@ void UccTestMpi::run_all_at_team(ucc_test_team_t &          team,
                                             TEST_FLAG_VSIZE_64BIT,
                                             onesided_buffers);
                                         auto res = exec_tests(tc_onesided);
-                                        rst.insert(rst.end(), res.begin(), res.end());
+                                        rst.insert(rst.end(), res.begin(),
+                                                   res.end());
                                     }
                                     break;
                                 }

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -43,6 +43,7 @@ UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t _tm, int is_loc
     ucc_lib_config_h     lib_config;
     ucc_context_config_h ctx_config;
     int                  size, rank;
+    long *               work_buf;
     ucc_mem_map_t        segments[3];
 
     MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -77,6 +78,8 @@ UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t _tm, int is_loc
             segments[i].address = onesided_buffers[i];
             segments[i].len     = (1<<21) * size;
         }
+        work_buf = (long *)onesided_buffers[2];
+        work_buf[0] = -1;
         onesided_ctx_params.mask |= UCC_CONTEXT_PARAM_FIELD_MEM_PARAMS;
         onesided_ctx_params.mem_params.segments   = segments;
         onesided_ctx_params.mem_params.n_segments = 3;

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -200,7 +200,8 @@ public:
             ucc_datatype_t dt = UCC_DT_INT32,
             ucc_reduction_op_t op = UCC_OP_SUM,
             ucc_test_vsize_flag_t count_vsize = TEST_FLAG_VSIZE_64BIT,
-            ucc_test_vsize_flag_t displ_vsize = TEST_FLAG_VSIZE_64BIT);
+            ucc_test_vsize_flag_t displ_vsize = TEST_FLAG_VSIZE_64BIT,
+            void ** onesided_buffers = nullptr);
     static std::vector<std::shared_ptr<TestCase>> init(
             ucc_coll_type_t _type,
             ucc_test_team_t &_team,
@@ -214,8 +215,7 @@ public:
             ucc_reduction_op_t op = UCC_OP_SUM,
             ucc_test_vsize_flag_t count_vsize = TEST_FLAG_VSIZE_64BIT,
             ucc_test_vsize_flag_t displ_vsize = TEST_FLAG_VSIZE_64BIT,
-            void * onesided_buffers[3] = {0},
-            bool is_onesided = false);
+            void ** onesided_buffers = nullptr);
     TestCase(ucc_test_team_t &_team, ucc_coll_type_t ct,
              ucc_memory_type_t _mem_type = UCC_MEMORY_TYPE_UNKNOWN,
              size_t _msgsize = 0, ucc_test_mpi_inplace_t _inplace = TEST_NO_INPLACE,
@@ -228,6 +228,7 @@ public:
     virtual std::string str();
     virtual ucc_status_t test();
     void wait();
+    void tc_progress_ctx();
     ucc_status_t exec();
     test_skip_cause_t skip_reduce(test_skip_cause_t cause, MPI_Comm comm);
     test_skip_cause_t skip_reduce(int skip_cond, test_skip_cause_t cause,
@@ -290,7 +291,6 @@ public:
     void set_num_tests(int num_tests) {
         nt = num_tests;
     }
-    void create_teams(std::vector<ucc_test_mpi_team_t> &test_teams);
     void create_teams(std::vector<ucc_test_mpi_team_t> &test_teams, bool is_onesided = false);
     void progress_ctx() {
         ucc_context_progress(ctx);

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -204,7 +204,9 @@ public:
             ucc_datatype_t dt = UCC_DT_INT32,
             ucc_reduction_op_t op = UCC_OP_SUM,
             ucc_test_vsize_flag_t count_vsize = TEST_FLAG_VSIZE_64BIT,
-            ucc_test_vsize_flag_t displ_vsize = TEST_FLAG_VSIZE_64BIT);
+            ucc_test_vsize_flag_t displ_vsize = TEST_FLAG_VSIZE_64BIT,
+            void * onesided_buffers[3] = {0},
+            bool is_onesided = false);
     TestCase(ucc_test_team_t &_team, ucc_coll_type_t ct,
              ucc_memory_type_t _mem_type = UCC_MEMORY_TYPE_UNKNOWN,
              size_t _msgsize = 0, ucc_test_mpi_inplace_t _inplace = TEST_NO_INPLACE,
@@ -226,15 +228,19 @@ public:
 class UccTestMpi {
     ucc_thread_mode_t      tm;
     ucc_context_h          ctx;
+    ucc_context_h          onesided_ctx;
     ucc_lib_h              lib;
     int                    nt;
+    ucc_lib_h              onesided_lib;
     ucc_test_mpi_inplace_t inplace;
     ucc_test_mpi_root_t    root_type;
     int                    root_value;
     int                    iterations;
-    void create_team(ucc_test_mpi_team_t t);
+    void *                 onesided_buffers[3];
+    void create_team(ucc_test_mpi_team_t t, bool is_onesided = false);
     void destroy_team(ucc_test_team_t &team);
     ucc_team_h create_ucc_team(MPI_Comm comm);
+    ucc_team_h create_onesided_ucc_team(MPI_Comm comm);
     std::vector<size_t> msgsizes;
     std::vector<ucc_memory_type_t> mtypes;
     std::vector<ucc_datatype_t> dtypes;
@@ -248,6 +254,7 @@ class UccTestMpi {
             std::vector<std::shared_ptr<TestCase>> tcs);
 public:
     std::vector<ucc_test_team_t> teams;
+    std::vector<ucc_test_team_t> onesided_teams;
     void run_all_at_team(ucc_test_team_t &team, std::vector<ucc_status_t> &rst);
     std::vector<ucc_status_t> results;
     UccTestMpi(int argc, char *argv[], ucc_thread_mode_t tm, int is_local);
@@ -276,6 +283,7 @@ public:
         nt = num_tests;
     }
     void create_teams(std::vector<ucc_test_mpi_team_t> &test_teams);
+    void create_teams(std::vector<ucc_test_mpi_team_t> &test_teams, bool is_onesided = false);
     void progress_ctx() {
         ucc_context_progress(ctx);
     }
@@ -357,7 +365,7 @@ class TestAlltoall : public TestCase {
 public:
     TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                  ucc_memory_type_t _mt, ucc_test_team_t &_team,
-                 size_t _max_size);
+                 size_t _max_size, void * buffers[3]);
     ucc_status_t set_input() override;
     ucc_status_t reset_sbuf() override;
     ucc_status_t check();

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -75,6 +75,15 @@ extern int test_rand_seed;
 }
 #endif
 
+#define UCC_TEST_N_MEM_SEGMENTS   3
+#define UCC_TEST_MEM_SEGMENT_SIZE (1 << 21)
+
+typedef enum {
+    MEM_SEND_SEGMENT,
+    MEM_RECV_SEGMENT,
+    MEM_WORK_SEGMENT
+} ucc_test_mem_segments;
+
 typedef enum {
     TEAM_WORLD,
     TEAM_REVERSE,
@@ -239,8 +248,7 @@ class UccTestMpi {
     void *                 onesided_buffers[3];
     void create_team(ucc_test_mpi_team_t t, bool is_onesided = false);
     void destroy_team(ucc_test_team_t &team);
-    ucc_team_h create_ucc_team(MPI_Comm comm);
-    ucc_team_h create_onesided_ucc_team(MPI_Comm comm);
+    ucc_team_h create_ucc_team(MPI_Comm comm, bool is_onesided = false);
     std::vector<size_t> msgsizes;
     std::vector<ucc_memory_type_t> mtypes;
     std::vector<ucc_datatype_t> dtypes;
@@ -271,7 +279,7 @@ public:
     }
     void set_count_vsizes(std::vector<ucc_test_vsize_flag_t> &_counts_vsize);
     void set_displ_vsizes(std::vector<ucc_test_vsize_flag_t> &_displs_vsize);
-    void run_all();
+    void run_all(bool is_onesided = false);
     void set_root(ucc_test_mpi_root_t _root_type, int _root_value) {
         root_type = _root_type;
         root_value = _root_value;
@@ -365,7 +373,7 @@ class TestAlltoall : public TestCase {
 public:
     TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                  ucc_memory_type_t _mt, ucc_test_team_t &_team,
-                 size_t _max_size, void * buffers[3]);
+                 size_t _max_size, void ** buffers = nullptr);
     ucc_status_t set_input() override;
     ucc_status_t reset_sbuf() override;
     ucc_status_t check();

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -201,7 +201,7 @@ public:
             ucc_reduction_op_t op = UCC_OP_SUM,
             ucc_test_vsize_flag_t count_vsize = TEST_FLAG_VSIZE_64BIT,
             ucc_test_vsize_flag_t displ_vsize = TEST_FLAG_VSIZE_64BIT,
-            void ** onesided_buffers = nullptr);
+            void **onesided_buffers = nullptr);
     static std::vector<std::shared_ptr<TestCase>> init(
             ucc_coll_type_t _type,
             ucc_test_team_t &_team,
@@ -215,7 +215,7 @@ public:
             ucc_reduction_op_t op = UCC_OP_SUM,
             ucc_test_vsize_flag_t count_vsize = TEST_FLAG_VSIZE_64BIT,
             ucc_test_vsize_flag_t displ_vsize = TEST_FLAG_VSIZE_64BIT,
-            void ** onesided_buffers = nullptr);
+            void **onesided_buffers = nullptr);
     TestCase(ucc_test_team_t &_team, ucc_coll_type_t ct,
              ucc_memory_type_t _mem_type = UCC_MEMORY_TYPE_UNKNOWN,
              size_t _msgsize = 0, ucc_test_mpi_inplace_t _inplace = TEST_NO_INPLACE,
@@ -291,7 +291,8 @@ public:
     void set_num_tests(int num_tests) {
         nt = num_tests;
     }
-    void create_teams(std::vector<ucc_test_mpi_team_t> &test_teams, bool is_onesided = false);
+    void create_teams(std::vector<ucc_test_mpi_team_t> &test_teams,
+                      bool                              is_onesided = false);
     void progress_ctx() {
         ucc_context_progress(ctx);
     }
@@ -372,8 +373,8 @@ public:
 class TestAlltoall : public TestCase {
 public:
     TestAlltoall(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
-                 ucc_memory_type_t _mt, ucc_test_team_t &_team,
-                 size_t _max_size, void ** buffers = nullptr);
+                 ucc_memory_type_t _mt, ucc_test_team_t &_team, size_t _max_size,
+                 void **buffers = nullptr);
     ucc_status_t set_input() override;
     ucc_status_t reset_sbuf() override;
     ucc_status_t check();

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -266,7 +266,8 @@ public:
     std::vector<ucc_test_team_t> onesided_teams;
     void run_all_at_team(ucc_test_team_t &team, std::vector<ucc_status_t> &rst);
     std::vector<ucc_status_t> results;
-    UccTestMpi(int argc, char *argv[], ucc_thread_mode_t tm, int is_local);
+    UccTestMpi(int argc, char *argv[], ucc_thread_mode_t tm, int is_local,
+               bool with_onesided);
     ~UccTestMpi();
     void set_msgsizes(size_t min, size_t max, size_t power);
     void set_dtypes(std::vector<ucc_datatype_t> &_dtypes);


### PR DESCRIPTION
## What
Adds onesided alltoall MPI tests 

## Why ?
This adds the missing MPI tests that should have been included in PR #309  and #323 
