### PR TITLE
BUILD: fix autogen for non bash shell

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,7 +2,7 @@
 
 # Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
 
-SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE:-$0}" )" &> /dev/null && pwd )"
 if [ $SCRIPT_DIR != `pwd` ]; then
     echo "autogen.sh script must be launched from the top of the source tree"
     exit 1


### PR DESCRIPTION
## What
Fixes "./autogen.sh: 5: Bad substitution"

## How ?
For non bash shell use $0 instead of ${BASH_SOURCE}