### PR TITLE
BUILD: fixes build with intel mpi

### DIFF
--- a/config/m4/mpi.m4
+++ b/config/m4/mpi.m4
@@ -26,9 +26,9 @@ AC_ARG_WITH([mpi],
 AS_IF([test "x$with_mpi" = xyes],
         [
         AC_ARG_VAR(MPICC,[MPI C compiler command])
-        AC_PATH_PROGS(MPICC,mpicc mpiicc,"",$mpi_path)
+        AC_PATH_PROGS(MPICC,mpiicc mpicc,"",$mpi_path)
         AC_ARG_VAR(MPICXX,[MPI CXX compiler command])
-        AC_PATH_PROGS(MPICXX,mpicxx mpiicpc,"",$mpi_path)
+        AC_PATH_PROGS(MPICXX,mpiicpc mpicxx,"",$mpi_path)
         AC_ARG_VAR(MPIRUN,[MPI launch command])
         AC_PATH_PROGS(MPIRUN,mpirun mpiexec aprun orterun,"",$mpi_path)
         AS_IF([test -z "$MPIRUN"],

--- a/src/components/tl/sharp/tl_sharp_coll.c
+++ b/src/components/tl/sharp/tl_sharp_coll.c
@@ -13,7 +13,7 @@
 #include <sharp/api/version.h>
 #include <sharp/api/sharp_coll.h>
 
-int ucc_to_sharp_dtype[] = {
+enum sharp_datatype ucc_to_sharp_dtype[] = {
     [UCC_DT_PREDEFINED_ID(UCC_DT_INT8)]     = SHARP_DTYPE_NULL,
     [UCC_DT_PREDEFINED_ID(UCC_DT_INT16)]    = SHARP_DTYPE_SHORT,
     [UCC_DT_PREDEFINED_ID(UCC_DT_INT32)]    = SHARP_DTYPE_INT,
@@ -31,7 +31,7 @@ int ucc_to_sharp_dtype[] = {
     [UCC_DT_PREDEFINED_ID(UCC_DT_BFLOAT16)] = SHARP_DTYPE_NULL,
 };
 
-int ucc_to_sharp_reduce_op[] = {
+enum sharp_reduce_op ucc_to_sharp_reduce_op[] = {
     [UCC_OP_SUM]         = SHARP_OP_SUM,
     [UCC_OP_PROD]        = SHARP_OP_NULL,
     [UCC_OP_MAX]         = SHARP_OP_MAX,
@@ -47,7 +47,7 @@ int ucc_to_sharp_reduce_op[] = {
     [UCC_OP_AVG]         = SHARP_OP_NULL,
 };
 
-int ucc_to_sharp_memtype[] = {
+enum sharp_data_memory_type ucc_to_sharp_memtype[] = {
     [UCC_MEMORY_TYPE_HOST]         = SHARP_MEM_TYPE_HOST,
     [UCC_MEMORY_TYPE_CUDA]         = SHARP_MEM_TYPE_CUDA,
     [UCC_MEMORY_TYPE_CUDA_MANAGED] = SHARP_MEM_TYPE_LAST,

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -136,7 +136,7 @@ ucc_status_t ucc_tl_ucp_team_get_scores(ucc_base_team_t   *tl_team,
             tl_debug(tl_team->context->lib,
                      "enable support for memory type %s",
                      ucc_memory_type_names[i]);
-            mem_types[mt_n++] = i;
+            mem_types[mt_n++] = (ucc_memory_type_t)i;
         }
     }
 

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -17,17 +17,17 @@ END_C_DECLS
 static ucc_status_t oob_allgather(void *sbuf, void *rbuf, size_t msglen,
                                   void *coll_info, void **req)
 {
-    MPI_Comm    comm = (MPI_Comm)coll_info;
+    MPI_Comm    comm = (MPI_Comm)(uintptr_t)coll_info;
     MPI_Request request;
     MPI_Iallgather(sbuf, msglen, MPI_BYTE, rbuf, msglen, MPI_BYTE, comm,
                    &request);
-    *req = (void *)request;
+    *req = (void *)(uintptr_t)request;
     return UCC_OK;
 }
 
 static ucc_status_t oob_allgather_test(void *req)
 {
-    MPI_Request request = (MPI_Request)req;
+    MPI_Request request = (MPI_Request)(uintptr_t)req;
     int         completed;
     MPI_Test(&request, &completed, MPI_STATUS_IGNORE);
     return completed ? UCC_OK : UCC_INPROGRESS;
@@ -61,7 +61,7 @@ UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t _tm, int is_loc
         ctx_params.oob.allgather = oob_allgather;
         ctx_params.oob.req_test  = oob_allgather_test;
         ctx_params.oob.req_free  = oob_allgather_free;
-        ctx_params.oob.coll_info = (void*)MPI_COMM_WORLD;
+        ctx_params.oob.coll_info = (void*)(uintptr_t)MPI_COMM_WORLD;
         ctx_params.oob.n_oob_eps = size;
         ctx_params.oob.oob_ep    = rank;
     }
@@ -131,7 +131,7 @@ ucc_team_h UccTestMpi::create_ucc_team(MPI_Comm comm)
     team_params.oob.allgather = oob_allgather;
     team_params.oob.req_test  = oob_allgather_test;
     team_params.oob.req_free  = oob_allgather_free;
-    team_params.oob.coll_info = (void*)comm;
+    team_params.oob.coll_info = (void*)(uintptr_t)comm;
     team_params.oob.n_oob_eps = size;
     team_params.oob.oob_ep    = rank;
     team_params.ep            = rank;

--- a/tools/perf/ucc_pt_bootstrap_mpi.cc
+++ b/tools/perf/ucc_pt_bootstrap_mpi.cc
@@ -3,17 +3,17 @@
 static ucc_status_t mpi_oob_allgather(void *sbuf, void *rbuf, size_t msglen,
                                       void *coll_info, void **req)
 {
-    MPI_Comm    comm = (MPI_Comm)coll_info;
+    MPI_Comm    comm = (MPI_Comm)(uintptr_t)coll_info;
     MPI_Request request;
     MPI_Iallgather(sbuf, msglen, MPI_BYTE, rbuf, msglen, MPI_BYTE, comm,
                    &request);
-    *req = (void *)request;
+    *req = (void *)(uintptr_t)request;
     return UCC_OK;
 }
 
 static ucc_status_t mpi_oob_allgather_test(void *req)
 {
-    MPI_Request request = (MPI_Request)req;
+    MPI_Request request = (MPI_Request)(uintptr_t)req;
     int         completed;
     MPI_Test(&request, &completed, MPI_STATUS_IGNORE);
     return completed ? UCC_OK : UCC_INPROGRESS;
@@ -30,14 +30,14 @@ ucc_pt_bootstrap_mpi::ucc_pt_bootstrap_mpi()
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
-    context_oob.coll_info = (void*)MPI_COMM_WORLD;
+    context_oob.coll_info = (void*)(uintptr_t)MPI_COMM_WORLD;
     context_oob.allgather = mpi_oob_allgather;
     context_oob.req_test  = mpi_oob_allgather_test;
     context_oob.req_free  = mpi_oob_allgather_free;
     context_oob.n_oob_eps = size;
     context_oob.oob_ep    = rank;
 
-    team_oob.coll_info = (void*)MPI_COMM_WORLD;
+    team_oob.coll_info = (void*)(uintptr_t)MPI_COMM_WORLD;
     team_oob.allgather = mpi_oob_allgather;
     team_oob.req_test  = mpi_oob_allgather_test;
     team_oob.req_free  = mpi_oob_allgather_free;


### PR DESCRIPTION
## Why ?
IMPI/ICC may be used for perf comparison/evaluation

## How ?
- When detecting MPICC/MPICXX check for mpiicc mpicpc first (mpicxx wrapper of impi uses gcc by default)
- fix compile errors thrown by ICC
