### PR TITLE
TL/CUDA: use nvml to detect topology

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -52,6 +52,21 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AC_CHECK_LIB([cudart], [cudaGetDeviceCount],
                              [CUDA_LIBS="$CUDA_LIBS -lcudart"], [cuda_happy="no"])])
+
+         # Check nvml header files
+         AC_CHECK_HEADERS([nvml.h],
+                          [cuda_happy="yes"],
+                          [AS_IF([test "x$with_cuda" != "xguess"],
+                                 [AC_MSG_ERROR([nvml header not found. Install appropriate cuda-nvml-devel package])])
+                           cuda_happy="no"])
+
+         # Check nvml library
+         AS_IF([test "x$cuda_happy" = "xyes"],
+               [AC_CHECK_LIB([nvidia-ml], [nvmlInit],
+                             [CUDA_LIBS="$CUDA_LIBS -lnvidia-ml"],
+                             [AS_IF([test "x$with_cuda" != "xguess"],
+                                    [AC_MSG_ERROR([libnvidia-ml not found. Install appropriate nvidia-driver package])])
+                              cuda_happy="no"])])
          # Check for NVCC
          AC_ARG_VAR(NVCC, [NVCC compiler command])
          AS_IF([test "x$cuda_happy" = "xyes"],

--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -8,15 +8,16 @@ alltoall =                       \
 	alltoall/alltoall.c          \
 	alltoall/alltoall_ce.c
 
-sources =             \
-	tl_cuda.h         \
-	tl_cuda.c         \
-	tl_cuda_lib.c     \
-	tl_cuda_context.c \
-	tl_cuda_team.c    \
-	tl_cuda_coll.c    \
-	tl_cuda_cache.c   \
-	tl_cuda_topo.c    \
+sources =               \
+	tl_cuda.h           \
+	tl_cuda.c           \
+	tl_cuda_lib.c       \
+	tl_cuda_context.c   \
+	tl_cuda_team.c      \
+	tl_cuda_coll.c      \
+	tl_cuda_cache.c     \
+	tl_cuda_topo.c      \
+	tl_cuda_team_topo.c \
 	$(alltoall)
 
 module_LTLIBRARIES = libucc_tl_cuda.la

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -7,7 +7,6 @@
 #include "alltoall.h"
 #include "core/ucc_mc.h"
 #include "tl_cuda_cache.h"
-#include "tl_cuda_topo.h"
 #include "utils/arch/cpu.h"
 
 enum {
@@ -67,7 +66,8 @@ ucc_status_t ucc_tl_cuda_alltoall_setup_test(ucc_tl_cuda_task_t *task)
 
     for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
         if (i == UCC_TL_TEAM_RANK(team) ||
-            !ucc_tl_cuda_topo_is_direct(team, team->topo, UCC_TL_TEAM_RANK(team), i)) {
+            !ucc_tl_cuda_team_topo_is_direct(&team->super, team->topo,
+                                             UCC_TL_TEAM_RANK(team), i)) {
             continue;
         }
         peer_sync = TASK_SYNC(task, i);
@@ -117,7 +117,8 @@ static ucc_status_t ucc_tl_cuda_alltoall_ce_post_copies(ucc_tl_cuda_task_t *task
                ucc_dt_size(args->src.info.datatype);
     for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
         peer = (rank + i) % UCC_TL_TEAM_SIZE(team);
-        if (!ucc_tl_cuda_topo_is_direct(team, team->topo, rank, peer)) {
+        if (!ucc_tl_cuda_team_topo_is_direct(&team->super, team->topo,
+                                             rank, peer)) {
             continue;
         }
         peer_sync = TASK_SYNC(task, peer);

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -85,7 +85,7 @@ typedef struct ucc_tl_cuda_context {
     ucc_tl_context_t              super;
     ucc_tl_cuda_context_config_t  cfg;
     int                           device;
-    ucc_tl_cuda_device_id_t       device_id;
+    ucc_tl_cuda_device_pci_id_t   device_id;
     ucc_tl_cuda_topo_t           *topo;
     ucc_mpool_t                   req_mp;
     tl_cuda_ep_hash_t            *ipc_cache;
@@ -104,9 +104,9 @@ typedef struct ucc_tl_cuda_shm_barrier {
 } ucc_tl_cuda_shm_barrier_t;
 
 typedef struct ucc_tl_cuda_rank_id {
-    int                     device;
-    ucc_tl_cuda_device_id_t pci_id;
-    int                     shm;
+    int                         device;
+    ucc_tl_cuda_device_pci_id_t pci_id;
+    int                         shm;
 } ucc_tl_cuda_rank_id_t;
 
 typedef struct ucc_tl_cuda_sync_data {

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -11,6 +11,9 @@
 #include "components/tl/ucc_tl_log.h"
 #include "utils/ucc_mpool.h"
 #include "tl_cuda_ep_hash.h"
+#include "tl_cuda_topo.h"
+#include "tl_cuda_team_topo.h"
+#include "tl_cuda_common.h"
 #include <cuda_runtime.h>
 
 #ifndef UCC_TL_CUDA_DEFAULT_SCORE
@@ -56,24 +59,6 @@
 #define UCC_TL_CUDA_PROFILE_REQUEST_EVENT UCC_PROFILE_REQUEST_EVENT
 #define UCC_TL_CUDA_PROFILE_REQUEST_FREE UCC_PROFILE_REQUEST_FREE
 
-#define CUDACHECK_GOTO(_cmd, _label, _status, _lib)                            \
-    do {                                                                       \
-        cudaError_t e = _cmd;                                                  \
-        if (ucc_unlikely(cudaSuccess != e)) {                                  \
-            tl_error(_lib, "CUDA error %d %s", e, cudaGetErrorName(e));        \
-            _status = UCC_ERR_NO_MESSAGE;                                      \
-            goto _label;                                                       \
-        }                                                                      \
-    } while (0)
-
-#define CUDACHECK_NORET(_cmd)                                                  \
-    do {                                                                       \
-        cudaError_t e = _cmd;                                                  \
-        if (ucc_unlikely(cudaSuccess != e)) {                                  \
-            ucc_error("CUDA error %d %s", e, cudaGetErrorName(e));             \
-        }                                                                      \
-    } while (0)
-
 typedef struct ucc_tl_cuda_iface {
     ucc_tl_iface_t super;
 } ucc_tl_cuda_iface_t;
@@ -100,6 +85,8 @@ typedef struct ucc_tl_cuda_context {
     ucc_tl_context_t              super;
     ucc_tl_cuda_context_config_t  cfg;
     int                           device;
+    ucc_tl_cuda_device_id_t       device_id;
+    ucc_tl_cuda_topo_t           *topo;
     ucc_mpool_t                   req_mp;
     tl_cuda_ep_hash_t            *ipc_cache;
 } ucc_tl_cuda_context_t;
@@ -117,8 +104,9 @@ typedef struct ucc_tl_cuda_shm_barrier {
 } ucc_tl_cuda_shm_barrier_t;
 
 typedef struct ucc_tl_cuda_rank_id {
-    int device;
-    int shm;
+    int                     device;
+    ucc_tl_cuda_device_id_t pci_id;
+    int                     shm;
 } ucc_tl_cuda_rank_id_t;
 
 typedef struct ucc_tl_cuda_sync_data {
@@ -141,22 +129,10 @@ typedef struct ucc_tl_cuda_sync {
     ucc_tl_cuda_sync_data_t  data[1];
 } ucc_tl_cuda_sync_t;
 
-typedef struct ucc_tl_cuda_proxy {
-    ucc_rank_t proxy;
-    ucc_rank_t src;
-    ucc_rank_t dst;
-} ucc_tl_cuda_proxy_t;
-
-typedef struct ucc_tl_cuda_topo {
-    ucc_rank_t           num_proxies;
-    ucc_tl_cuda_proxy_t *proxies;
-    int                 *matrix;
-} ucc_tl_cuda_topo_t;
-
 typedef struct ucc_tl_cuda_team {
     ucc_tl_team_t              super;
     uint32_t                   seq_num;
-    ucc_tl_cuda_topo_t        *topo;
+    ucc_tl_cuda_team_topo_t   *topo;
     ucc_tl_cuda_sync_t        *sync;
     ucc_tl_cuda_sync_state_t  *sync_state;
     ucc_tl_cuda_shm_barrier_t *bar;

--- a/src/components/tl/cuda/tl_cuda_common.h
+++ b/src/components/tl/cuda/tl_cuda_common.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_COMMON_H_
+#define UCC_TL_CUDA_COMMON_H_
+
+#include <cuda_runtime.h>
+
+#define CUDACHECK_GOTO(_cmd, _label, _status, _lib)                            \
+    do {                                                                       \
+        cudaError_t e = _cmd;                                                  \
+        if (ucc_unlikely(cudaSuccess != e)) {                                  \
+            tl_error(_lib, "CUDA error %d %s", e, cudaGetErrorName(e));        \
+            _status = UCC_ERR_NO_MESSAGE;                                      \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
+
+#define CUDACHECK_NORET(_cmd)                                                  \
+    do {                                                                       \
+        cudaError_t e = _cmd;                                                  \
+        if (ucc_unlikely(cudaSuccess != e)) {                                  \
+            ucc_error("CUDA error %d %s", e, cudaGetErrorName(e));             \
+        }                                                                      \
+    } while (0)
+
+#define NVMLCHECK_GOTO(_cmd, _label, _status, _lib)                            \
+    do {                                                                       \
+        nvmlReturn_t e = _cmd;                                                 \
+        if (ucc_unlikely(NVML_SUCCESS != e)) {                                 \
+            tl_error(_lib, "NVML error %d %s", e, nvmlErrorString(e));         \
+            _status = UCC_ERR_NO_MESSAGE;                                      \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
+
+#endif

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -33,13 +33,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
                               params->context);
     memcpy(&self->cfg, tl_cuda_config, sizeof(*tl_cuda_config));
 
-    cu_st = cuCtxGetCurrent(&cu_ctx);
-    if (cu_ctx == NULL || cu_st != CUDA_SUCCESS) {
-        tl_info(self->super.super.lib,
-                "cannot create CUDA TL context without active CUDA context");
-        return UCC_ERR_NO_RESOURCE;
-    }
-
     cuda_st = cudaGetDeviceCount(&num_devices);
     if (cuda_st != cudaSuccess) {
         tl_info(self->super.super.lib, "failed to get number of GPU devices"
@@ -47,6 +40,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
         return UCC_ERR_NO_MESSAGE;
     } else if (num_devices == 0) {
         tl_info(self->super.super.lib, "no GPU devices found");
+        return UCC_ERR_NO_RESOURCE;
+    }
+
+    cu_st = cuCtxGetCurrent(&cu_ctx);
+    if (cu_ctx == NULL || cu_st != CUDA_SUCCESS) {
+        tl_info(self->super.super.lib,
+                "cannot create CUDA TL context without active CUDA context");
         return UCC_ERR_NO_RESOURCE;
     }
 

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -24,7 +24,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
     ucc_status_t status;
     int shm_id, i, j;
     size_t ctrl_size, alloc_size;
-
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
 
     self->oob    = params->params.oob;

--- a/src/components/tl/cuda/tl_cuda_team_topo.c
+++ b/src/components/tl/cuda/tl_cuda_team_topo.c
@@ -1,0 +1,172 @@
+#include "tl_cuda_team_topo.h"
+#include "tl_cuda.h"
+
+static ucc_status_t
+ucc_tl_cuda_team_topo_init_proxy(const ucc_tl_cuda_team_t *team,
+                                 ucc_tl_cuda_team_topo_t *topo)
+{
+    ucc_rank_t size        = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t num_proxies = 0;
+    ucc_rank_t i, j, p, k;
+    ucc_status_t status;
+
+    for (i = 0; i < size * size; i++) {
+        if (topo->matrix[i] == 0) {
+            num_proxies ++;
+        }
+    }
+
+    topo->num_proxies = num_proxies;
+    if (num_proxies == 0) {
+        return UCC_OK;
+    }
+    topo->proxies = (ucc_tl_cuda_proxy_t*)ucc_malloc(
+            num_proxies * sizeof(ucc_tl_cuda_proxy_t), "cuda_topo_proxies");
+    if (!topo->proxies) {
+        tl_error(UCC_TL_TEAM_LIB(team), "failed to alloc cuda topo proxy");
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    p = 0;
+    for (i = 0; i < size; i++) {
+        for (j = 0; j < size; j++) {
+            if (ucc_tl_cuda_team_topo_is_direct(&team->super, topo, i, j)) {
+                continue;
+            }
+            for (k = 0; k < size; k++) {
+                if (ucc_tl_cuda_team_topo_is_direct(&team->super, topo, i, k) &&
+                    ucc_tl_cuda_team_topo_is_direct(&team->super, topo, k, j)) {
+                    topo->proxies[p].src   = i;
+                    topo->proxies[p].dst   = j;
+                    topo->proxies[p].proxy = k;
+                    break;
+                }
+            }
+            if (k == size) {
+                tl_info(UCC_TL_TEAM_LIB(team), "no proxy found between "
+                        "dev %d rank %d and dev %d rank %d, "
+                        "cuda topology is not supported",
+                        i, team->ids[i].device, j, team->ids[j].device);
+                status = UCC_ERR_NOT_SUPPORTED;
+                goto free_proxy;
+            }
+            p++;
+        }
+    }
+    return UCC_OK;
+
+free_proxy:
+   ucc_free(topo->proxies);
+    return status;
+}
+
+static ucc_status_t
+ucc_tl_cuda_team_topo_init_matrix(const ucc_tl_cuda_team_t *team,
+                                  int *matrix)
+{
+    ucc_tl_cuda_topo_t *topo = UCC_TL_CUDA_TEAM_CTX(team)->topo;
+    int                 size = UCC_TL_TEAM_SIZE(team);
+    ucc_status_t status;
+    int i, j;
+
+    for (i = 0; i < size; i++) {
+        matrix[i + i*size] = 1;
+        for (j = i + 1; j < size; j++) {
+            status = ucc_tl_cuda_topo_num_links(topo,
+                                                &team->ids[i].pci_id,
+                                                &team->ids[j].pci_id,
+                                                &matrix[i + j*size]);
+            if (status != UCC_OK) {
+                return status;
+            }
+            matrix[j + i*size] = matrix[i +j*size];
+        }
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_cuda_team_topo_create(const ucc_tl_team_t *cuda_team,
+                                          ucc_tl_cuda_team_topo_t **team_topo)
+{
+    ucc_tl_cuda_team_t *team = ucc_derived_of(cuda_team, ucc_tl_cuda_team_t);
+    ucc_rank_t          size = UCC_TL_TEAM_SIZE(team);
+    ucc_tl_cuda_team_topo_t *topo;
+    ucc_status_t status;
+
+    topo = (ucc_tl_cuda_team_topo_t*)ucc_malloc(sizeof(*topo), "cuda_team_topo");
+    if (!topo) {
+        tl_error(UCC_TL_TEAM_LIB(team), "failed to alloc cuda team topo");
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    topo->matrix = (int*)ucc_malloc(size * size * sizeof(int),
+                                     "cuda_topo_matrix");
+    if (!topo->matrix) {
+        tl_error(UCC_TL_TEAM_LIB(team), "failed to alloc cuda team topo matrix");
+        status = UCC_ERR_NO_MEMORY;
+        goto free_topo;
+    }
+    status = ucc_tl_cuda_team_topo_init_matrix(team, topo->matrix);
+    if (status != UCC_OK) {
+        goto free_matrix;
+    }
+
+    status = ucc_tl_cuda_team_topo_init_proxy(team, topo);
+    if (status != UCC_OK) {
+        if (status != UCC_ERR_NOT_SUPPORTED) {
+            tl_error(UCC_TL_TEAM_LIB(team), "failed to init cuda topo proxy");
+        }
+        goto free_matrix;
+    }
+
+    *team_topo = topo;
+    return UCC_OK;
+free_matrix:
+    ucc_free(topo->matrix);
+free_topo:
+    ucc_free(team_topo);
+    return status;
+}
+
+void ucc_tl_cuda_team_topo_print(const ucc_tl_team_t *tl_team,
+                                 const ucc_tl_cuda_team_topo_t *topo)
+{
+    ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
+    ucc_rank_t size          = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t rank          = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t i, j;
+
+    for (i = 0; i < size; i++) {
+        if (ucc_tl_cuda_team_topo_is_direct(tl_team, topo, rank, i)) {
+            tl_debug(UCC_TL_TEAM_LIB(team),
+                     "dev %d rank %d to dev %d rank %d: %d direct links",
+                     team->ids[rank].device, rank, team->ids[i].device, i,
+                     topo->matrix[rank * size + i]);
+        } else {
+            for (j = 0 ; j < topo->num_proxies; j++) {
+                if ((topo->proxies[j].src == rank) &&
+                    (topo->proxies[j].dst == i)) {
+                    tl_debug(UCC_TL_TEAM_LIB(team),
+                             "dev %d rank %d to dev %d rank %d: "
+                             "proxy dev %d rank %d",
+                             team->ids[rank].device, rank,
+                             team->ids[i].device, i,
+                             team->ids[topo->proxies[j].proxy].device,
+                             topo->proxies[j].proxy);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+ucc_status_t ucc_tl_cuda_team_topo_destroy(ucc_tl_cuda_team_topo_t *team_topo)
+{
+    if (team_topo->num_proxies) {
+        ucc_free(team_topo->proxies);
+    }
+    ucc_free(team_topo->matrix);
+    ucc_free(team_topo);
+    return UCC_OK;
+}

--- a/src/components/tl/cuda/tl_cuda_team_topo.h
+++ b/src/components/tl/cuda/tl_cuda_team_topo.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_TEAM_TOPO_H_
+#define UCC_TL_CUDA_TEAM_TOPO_H_
+
+#include "components/tl/ucc_tl.h"
+#include "tl_cuda_topo.h"
+
+typedef struct ucc_tl_cuda_proxy {
+    ucc_rank_t src;
+    ucc_rank_t dst;
+    ucc_rank_t proxy;
+} ucc_tl_cuda_proxy_t;
+
+typedef struct ucc_tl_cuda_team_topo {
+    int                     *matrix;
+    int                      num_proxies;
+    ucc_tl_cuda_proxy_t     *proxies;
+} ucc_tl_cuda_team_topo_t;
+
+ucc_status_t ucc_tl_cuda_team_topo_create(const ucc_tl_team_t *team,
+                                          ucc_tl_cuda_team_topo_t **team_topo);
+
+ucc_status_t ucc_tl_cuda_team_topo_destroy(ucc_tl_cuda_team_topo_t *team_topo);
+
+void ucc_tl_cuda_team_topo_print(const ucc_tl_team_t *team,
+                                 const ucc_tl_cuda_team_topo_t *cuda_topo);
+
+static inline int
+ucc_tl_cuda_team_topo_is_direct(const ucc_tl_team_t *team,
+                                const ucc_tl_cuda_team_topo_t *topo,
+                                ucc_rank_t r1, ucc_rank_t r2)
+{
+    return topo->matrix[r1 * team->super.params.size + r2] != 0;
+}
+
+#endif

--- a/src/components/tl/cuda/tl_cuda_topo.c
+++ b/src/components/tl/cuda/tl_cuda_topo.c
@@ -5,172 +5,295 @@
  */
 
 #include "tl_cuda_topo.h"
+#include "tl_cuda_common.h"
+#include <nvml.h>
+#include "unistd.h"
 
-static ucc_status_t ucc_tl_cuda_topo_init_matrix(ucc_tl_cuda_team_t *team,
-                                                 ucc_tl_cuda_topo_t *cuda_topo)
+#define MAX_PCI_BUS_ID_STR 16
+#define MAX_PCI_DEVICES    32
+
+static ucc_status_t ucc_tl_cuda_topo_pci_id_from_str(const char * bus_id_str,
+                                                     ucc_tl_cuda_device_id_t *pci_id)
 {
-    ucc_rank_t size = UCC_TL_TEAM_SIZE(team);
-    ucc_rank_t i, j;
-    int dev, peer_dev, peer_access;
-    ucc_status_t status;
+    int n;
 
-    for (i = 0; i < size; i++) {
-       dev = team->ids[i].device;
-       cuda_topo->matrix[i*size + i] = 1;
-        for (j = i + 1; j < size; j++) {
-            peer_dev = team->ids[j].device;
-            CUDACHECK_GOTO(cudaDeviceCanAccessPeer(&peer_access, dev, peer_dev),
-                           exit_err, status, UCC_TL_TEAM_LIB(team));
-            cuda_topo->matrix[i*size + j] = peer_access;
-            cuda_topo->matrix[j*size + i] = peer_access;
-        }
+    n = sscanf(bus_id_str, "%hx:%hhx:%hhx.%hhx", &pci_id->domain, &pci_id->bus,
+               &pci_id->device, &pci_id->function);
+    if (n != 4) {
+        return UCC_ERR_INVALID_PARAM;
     }
     return UCC_OK;
-exit_err:
-    return status;
 }
 
-static ucc_status_t ucc_tl_cuda_topo_init_proxy(ucc_tl_cuda_team_t *team,
-                                                ucc_tl_cuda_topo_t *topo)
-{
-    ucc_rank_t size        = UCC_TL_TEAM_SIZE(team);
-    ucc_rank_t num_proxies = 0;
-    ucc_rank_t i, j, k, p;
-    ucc_status_t status;
+// TODO: add to topo print
+// static void ucc_tl_cuda_topo_pci_id_to_str(const ucc_tl_cuda_device_id_t *pci_id,
+//                                            char *str, size_t max)
+// {
+//     ucc_snprintf_safe(str, max, "%04x:%02x:%02x.%d", pci_id->domain,
+//                       pci_id->bus, pci_id->device, pci_id->function);
+// }
 
-    for (i = 0; i < size * size; i++) {
-        if (topo->matrix[i] == 0) {
-            num_proxies ++;
+ucc_status_t ucc_tl_cuda_topo_get_pci_id(const ucc_base_lib_t *lib,
+                                         int device,
+                                         ucc_tl_cuda_device_id_t *pci_id)
+{
+    char pci_bus_id[MAX_PCI_BUS_ID_STR];
+    ucc_status_t st;
+
+    CUDACHECK_GOTO(cudaDeviceGetPCIBusId(pci_bus_id, MAX_PCI_BUS_ID_STR,
+                                         device), exit, st, lib);
+    st = ucc_tl_cuda_topo_pci_id_from_str(pci_bus_id, pci_id);
+exit:
+    return st;
+}
+
+int ucc_tl_cuda_topo_device_id_equal(const ucc_tl_cuda_device_id_t *id1,
+                                     const ucc_tl_cuda_device_id_t *id2)
+{
+    return ((id1->domain   == id2->domain) &&
+            (id1->bus      == id2->bus)    &&
+            (id1->device   == id2->device) &&
+            (id1->function == id2->function));
+}
+
+static uint64_t
+ucc_tl_cuda_device_id_to_uint64(const ucc_tl_cuda_device_id_t *id)
+{
+    return (((uint64_t)id->domain << 24) |
+            ((uint64_t)id->bus << 16)    |
+            ((uint64_t)id->device << 8)  |
+            ((uint64_t)id->function));
+}
+
+
+static ucc_status_t
+ucc_tl_cuda_topo_graph_find_by_id(const ucc_tl_cuda_topo_t *topo,
+                                  const ucc_tl_cuda_device_id_t *dev_id,
+                                  ucc_tl_cuda_topo_node_t **node)
+{
+    uint64_t id;
+    khiter_t iter;
+
+    id = ucc_tl_cuda_device_id_to_uint64(dev_id);
+    iter = kh_get(bus_to_node, &topo->bus_to_node_hash, id);
+    if (iter == kh_end(&topo->bus_to_node_hash)) {
+        return UCC_ERR_NOT_FOUND;
+    }
+    *node = &topo->graph[kh_value(&topo->bus_to_node_hash, iter)];
+    return UCC_OK;
+}
+
+static ucc_status_t
+ucc_tl_cuda_topo_graph_add_device(const ucc_tl_cuda_device_id_t *dev_id,
+                                  ucc_tl_cuda_topo_t *topo,
+                                  ucc_tl_cuda_topo_node_t **node)
+{
+    uint64_t key;
+    khiter_t iter;
+    int ret;
+    int n;
+
+    key = ucc_tl_cuda_device_id_to_uint64(dev_id);
+    iter = kh_put(bus_to_node, &topo->bus_to_node_hash, key, &ret);
+    if (ret < 0) {
+        tl_error(topo->lib, "failed to add device id to hash");
+        return UCC_ERR_NO_MESSAGE;
+    } else if (ret == 0) {
+        /* device already exists */
+        *node = &topo->graph[kh_value(&topo->bus_to_node_hash, iter)];
+        return UCC_OK;
+    } else {
+        n = topo->num_nodes;
+        topo->num_nodes++;
+        kh_value(&topo->bus_to_node_hash, iter) = n;
+        topo->graph[n].pci_id = *dev_id;
+        ucc_list_head_init(&topo->graph[n].link.list_link);
+        *node = &topo->graph[n];
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t
+ucc_tl_cuda_topo_graph_add_link(ucc_tl_cuda_topo_t *topo,
+                                ucc_tl_cuda_topo_node_t *src,
+                                ucc_tl_cuda_topo_node_t *dst)
+{
+    ucc_tl_cuda_topo_link_t *link;
+    ucc_list_for_each(link, &src->link.list_link, list_link) {
+        if (ucc_tl_cuda_topo_device_id_equal(&link->pci_id, &dst->pci_id)) {
+            link->width += 1;
+            return UCC_OK;
         }
     }
-
-    topo->num_proxies = num_proxies;
-    if (num_proxies == 0) {
-        return UCC_OK;
-    }
-    topo->proxies = (ucc_tl_cuda_proxy_t*)ucc_malloc(
-            num_proxies * sizeof(ucc_tl_cuda_proxy_t), "cuda_topo_proxies");
-    if (!topo->proxies) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to alloc cuda topo proxy");
+    link = (ucc_tl_cuda_topo_link_t*)ucc_malloc(sizeof(*link));
+    if (!link) {
+        tl_error(topo->lib, "failed to allocate topo link");
         return UCC_ERR_NO_MEMORY;
     }
+    link->pci_id = dst->pci_id;
+    link->width  = 1;
+    ucc_list_add_tail(&src->link.list_link, &link->list_link);
 
-    p = 0;
-    for (i = 0; i < size; i++) {
-        for (j = 0; j < size; j++) {
-            if (ucc_tl_cuda_topo_is_direct(team, topo, i, j)) {
+    return UCC_OK;
+}
+
+static void ucc_tl_cuda_topo_free_link(ucc_tl_cuda_topo_link_t *link) {
+    return;
+}
+
+static void ucc_tl_cuda_topo_graph_destroy(ucc_tl_cuda_topo_t *topo)
+{
+    int i;
+
+    for (i = 0; i < topo->num_nodes; i++) {
+        ucc_list_destruct(&topo->graph[i].link.list_link,
+                          ucc_tl_cuda_topo_link_t, ucc_tl_cuda_topo_free_link,
+                          list_link);
+    }
+    kh_destroy_inplace(bus_to_node, &topo->bus_to_node_hash);
+    free(topo->graph);
+}
+
+static ucc_status_t ucc_tl_cuda_topo_graph_create(ucc_tl_cuda_topo_t *topo)
+{
+    ucc_status_t status = UCC_OK;
+    cudaError_t cuda_st;
+    char pci_bus_str[MAX_PCI_BUS_ID_STR];
+    nvmlDevice_t nvml_dev;
+    nvmlFieldValue_t nvml_value;
+    nvmlPciInfo_t nvml_pci;
+    nvmlIntNvLinkDeviceType_t nvml_dev_type;
+    ucc_tl_cuda_device_id_t pci_id;
+    ucc_tl_cuda_topo_node_t *node, *peer_node;
+    int num_gpus;
+    int i, num_nvlinks, link;
+
+    cuda_st = cudaGetDeviceCount(&num_gpus);
+    if ((cuda_st != cudaSuccess) || (num_gpus == 0)){
+        tl_info(topo->lib, "cudaGetDeviceCount failed or no GPU devices found");
+        return UCC_ERR_NO_RESOURCE;
+    }
+    topo->num_nodes = 0;
+    topo->graph = (ucc_tl_cuda_topo_node_t*)ucc_malloc(MAX_PCI_DEVICES *
+                                                       sizeof(*topo->graph),
+                                                       "tl cuda topo graph");
+    if (!topo->graph) {
+        tl_error(topo->lib, "failed to allocate tl cuda topo graph");
+        return UCC_ERR_NO_MEMORY;
+    }
+    kh_init_inplace(bus_to_node, &topo->bus_to_node_hash);
+    NVMLCHECK_GOTO(nvmlInit_v2(), exit_free_graph, status, topo->lib);
+    nvml_value.fieldId = NVML_FI_DEV_NVLINK_LINK_COUNT;
+    for (i = 0; i < num_gpus; i++) {
+        CUDACHECK_GOTO(cudaDeviceGetPCIBusId(pci_bus_str, MAX_PCI_BUS_ID_STR, i),
+                       exit_nvml_shutdown, status, topo->lib);
+        status = ucc_tl_cuda_topo_get_pci_id(topo->lib, i, &pci_id);
+        if (status != UCC_OK) {
+            goto exit_nvml_shutdown;
+        }
+        status = ucc_tl_cuda_topo_graph_add_device(&pci_id, topo, &node);
+        if (status != UCC_OK) {
+            goto exit_nvml_shutdown;
+        }
+        NVMLCHECK_GOTO(nvmlDeviceGetHandleByPciBusId_v2(pci_bus_str, &nvml_dev),
+                       exit_nvml_shutdown, status, topo->lib);
+        NVMLCHECK_GOTO(nvmlDeviceGetFieldValues(nvml_dev, 1, &nvml_value),
+                       exit_nvml_shutdown, status, topo->lib);
+        num_nvlinks = ((nvml_value.nvmlReturn == NVML_SUCCESS) &&
+                       (nvml_value.valueType == NVML_VALUE_TYPE_UNSIGNED_INT)) ?
+                      nvml_value.value.uiVal : 0;
+        for (link = 0; link < num_nvlinks; link++) {
+            NVMLCHECK_GOTO(nvmlDeviceGetNvLinkRemoteDeviceType(nvml_dev, link,
+                                                               &nvml_dev_type),
+                           exit_nvml_shutdown, status, topo->lib);
+            if ((nvml_dev_type != NVML_NVLINK_DEVICE_TYPE_GPU) &&
+                (nvml_dev_type != NVML_NVLINK_DEVICE_TYPE_SWITCH))
+            {
+                /* nvlink connected device is not supported by cuda tl */
                 continue;
             }
-            for (k = 0; k < size; k++) {
-                if (ucc_tl_cuda_topo_is_direct(team, topo, i, k) &&
-                    ucc_tl_cuda_topo_is_direct(team, topo, k, j)) {
-                    topo->proxies[p].src   = i;
-                    topo->proxies[p].dst   = j;
-                    topo->proxies[p].proxy = k;
-                    break;
-                }
+            NVMLCHECK_GOTO(nvmlDeviceGetNvLinkRemotePciInfo_v2(nvml_dev, link,
+                                                               &nvml_pci),
+                           exit_nvml_shutdown, status, topo->lib);
+            pci_id.domain   = nvml_pci.domain;
+            pci_id.bus      = nvml_pci.bus;
+            pci_id.device   = nvml_pci.device;
+            pci_id.function = 0;
+            status = ucc_tl_cuda_topo_graph_add_device(&pci_id, topo,
+                                                       &peer_node);
+            if (status != UCC_OK) {
+                goto exit_nvml_shutdown;
             }
-            if (k == size) {
-                tl_info(UCC_TL_TEAM_LIB(team), "no proxy found between"
-                        "dev %d rank %d and dev %d rank %d, "
-                        "cuda topology is not supported",
-                        i, team->ids[i].device, j, team->ids[j].device);
-                status = UCC_ERR_NOT_SUPPORTED;
-                goto free_proxy;
+            status = ucc_tl_cuda_topo_graph_add_link(topo, node, peer_node);
+            if (status != UCC_OK) {
+                goto exit_nvml_shutdown;
             }
-            p++;
         }
     }
+    nvmlShutdown();
     return UCC_OK;
 
-free_proxy:
-    ucc_free(topo->proxies);
+exit_nvml_shutdown:
+    nvmlShutdown();
+exit_free_graph:
+    ucc_tl_cuda_topo_graph_destroy(topo);
     return status;
 }
 
-ucc_status_t ucc_tl_cuda_topo_create(ucc_tl_cuda_team_t *team,
+ucc_status_t ucc_tl_cuda_topo_create(const ucc_base_lib_t *lib,
                                      ucc_tl_cuda_topo_t **cuda_topo)
 {
-    ucc_rank_t size = UCC_TL_TEAM_SIZE(team);
     ucc_tl_cuda_topo_t *topo;
     ucc_status_t status;
 
     topo = (ucc_tl_cuda_topo_t*)ucc_malloc(sizeof(*topo), "cuda_topo");
     if (!topo) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to alloc cuda topo");
+        tl_error(lib, "failed to alloc cuda topo");
         status = UCC_ERR_NO_MEMORY;
         goto exit_err;
     }
 
-    topo->proxies = NULL;
-    topo->matrix  = (int*)ucc_malloc(size * size * sizeof(int),
-                                     "cuda_topo_matrix");
-    if (!topo->matrix) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to alloc cuda topo matrix");
-        status = UCC_ERR_NO_MEMORY;
+    status = ucc_tl_cuda_topo_graph_create(topo);
+    if (status != UCC_OK) {
         goto free_topo;
-    }
-
-    status = ucc_tl_cuda_topo_init_matrix(team, topo);
-    if (status != UCC_OK) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to init cuda topo matrix");
-        goto free_topo_matrix;
-    }
-
-    status = ucc_tl_cuda_topo_init_proxy(team, topo);
-    if (status != UCC_OK) {
-        if (status != UCC_ERR_NOT_SUPPORTED) {
-            tl_error(UCC_TL_TEAM_LIB(team), "failed to init cuda topo proxy");
-        }
-        goto free_topo_matrix;
     }
 
     *cuda_topo = topo;
     return UCC_OK;
-free_topo_matrix:
-    ucc_free(topo->matrix);
 free_topo:
     ucc_free(topo);
 exit_err:
     return status;
 }
 
-void ucc_tl_cuda_topo_print(ucc_tl_cuda_team_t *team,
-                            ucc_tl_cuda_topo_t *cuda_topo)
+ucc_status_t ucc_tl_cuda_topo_num_links(const ucc_tl_cuda_topo_t *topo,
+                                        const ucc_tl_cuda_device_id_t *dev1,
+                                        const ucc_tl_cuda_device_id_t *dev2,
+                                        int *num_links)
 {
-    ucc_rank_t size = UCC_TL_TEAM_SIZE(team);
-    ucc_rank_t rank = UCC_TL_TEAM_RANK(team);
-    ucc_rank_t i, j;
+    ucc_status_t status;
+    ucc_tl_cuda_topo_node_t *dev1_node;
+    ucc_tl_cuda_topo_link_t *link;
 
-    for (i = 0; i < size; i++) {
-        if (ucc_tl_cuda_topo_is_direct(team, cuda_topo, rank, i)) {
-            tl_debug(UCC_TL_TEAM_LIB(team),
-                     "dev %d rank %d to dev %d rank %d: direct",
-                     team->ids[rank].device, rank, team->ids[i].device, i);
-        } else {
-            for (j = 0 ; j < cuda_topo->num_proxies; j++) {
-                if ((cuda_topo->proxies[j].src == rank) &&
-                    (cuda_topo->proxies[j].dst == i)) {
-                    tl_debug(UCC_TL_TEAM_LIB(team),
-                             "dev %d rank %d to dev %d rank %d: "
-                             "proxy dev %d rank %d",
-                             team->ids[rank].device, rank,
-                             team->ids[i].device, i,
-                             team->ids[cuda_topo->proxies[j].proxy].device,
-                             cuda_topo->proxies[j].proxy);
-                    break;
-                }
-            }
+    *num_links = 0;
+    status = ucc_tl_cuda_topo_graph_find_by_id(topo, dev1, &dev1_node);
+    if (status != UCC_OK) {
+        return status;
+    }
+
+    ucc_list_for_each(link, &dev1_node->link.list_link, list_link) {
+        if (ucc_tl_cuda_topo_device_id_equal(&link->pci_id, dev2)) {
+            *num_links += link->width;
+            return UCC_OK;
         }
     }
+
+    return UCC_OK;
 }
 
 ucc_status_t ucc_tl_cuda_topo_destroy(ucc_tl_cuda_topo_t *cuda_topo)
 {
-    ucc_free(cuda_topo->matrix);
-    if (cuda_topo->proxies) {
-        ucc_free(cuda_topo->proxies);
-    }
+    ucc_tl_cuda_topo_graph_destroy(cuda_topo);
     ucc_free(cuda_topo);
     return UCC_OK;
 }

--- a/src/components/tl/cuda/tl_cuda_topo.h
+++ b/src/components/tl/cuda/tl_cuda_topo.h
@@ -7,21 +7,48 @@
 #ifndef UCC_TL_CUDA_TOPO_H_
 #define UCC_TL_CUDA_TOPO_H_
 
-#include "tl_cuda.h"
+#include "components/tl/ucc_tl_log.h"
+#include "utils/khash.h"
 
-ucc_status_t ucc_tl_cuda_topo_create(ucc_tl_cuda_team_t *team,
+typedef struct ucc_tl_cuda_device_id {
+    uint16_t domain;   /* range: 0 to ffff */
+    uint8_t  bus;      /* range: 0 to ff */
+    uint8_t  device;   /* range: 0 to 1f */
+    uint8_t  function; /* range: 0 to 7 */
+} ucc_tl_cuda_device_id_t;
+
+typedef struct ucc_tl_cuda_topo_link {
+    ucc_list_link_t         list_link;
+    ucc_tl_cuda_device_id_t pci_id;
+    int                     width;
+} ucc_tl_cuda_topo_link_t;
+
+typedef struct ucc_tl_cuda_topo_node {
+    ucc_tl_cuda_device_id_t pci_id;
+    ucc_tl_cuda_topo_link_t link;
+} ucc_tl_cuda_topo_node_t;
+
+KHASH_MAP_INIT_INT64(bus_to_node, int);
+
+typedef struct ucc_tl_cuda_topo {
+    const ucc_base_lib_t    *lib;
+    khash_t(bus_to_node)     bus_to_node_hash;
+    int                      num_nodes;
+    ucc_tl_cuda_topo_node_t *graph;
+} ucc_tl_cuda_topo_t;
+
+ucc_status_t ucc_tl_cuda_topo_get_pci_id(const ucc_base_lib_t *lib,
+                                         int device,
+                                         ucc_tl_cuda_device_id_t *pci_id);
+
+ucc_status_t ucc_tl_cuda_topo_create(const ucc_base_lib_t *lib,
                                      ucc_tl_cuda_topo_t **cuda_topo);
 
 ucc_status_t ucc_tl_cuda_topo_destroy(ucc_tl_cuda_topo_t *cuda_topo);
 
-static inline int ucc_tl_cuda_topo_is_direct(ucc_tl_cuda_team_t *team,
-                                             ucc_tl_cuda_topo_t *cuda_topo,
-                                             ucc_rank_t r1, ucc_rank_t r2)
-{
-    return cuda_topo->matrix[r1 * UCC_TL_TEAM_SIZE(team) + r2] == 1;
-}
-
-void ucc_tl_cuda_topo_print(ucc_tl_cuda_team_t *team,
-                            ucc_tl_cuda_topo_t *cuda_topo);
+ucc_status_t ucc_tl_cuda_topo_num_links(const ucc_tl_cuda_topo_t *topo,
+                                        const ucc_tl_cuda_device_id_t *dev1,
+                                        const ucc_tl_cuda_device_id_t *dev2,
+                                        int *num_links);
 
 #endif

--- a/src/components/tl/cuda/tl_cuda_topo.h
+++ b/src/components/tl/cuda/tl_cuda_topo.h
@@ -15,11 +15,11 @@ typedef struct ucc_tl_cuda_device_id {
     uint8_t  bus;      /* range: 0 to ff */
     uint8_t  device;   /* range: 0 to 1f */
     uint8_t  function; /* range: 0 to 7 */
-} ucc_tl_cuda_device_id_t;
+} ucc_tl_cuda_device_pci_id_t;
 
 static inline int
-ucc_tl_cuda_topo_device_id_equal(const ucc_tl_cuda_device_id_t *id1,
-                                 const ucc_tl_cuda_device_id_t *id2)
+ucc_tl_cuda_topo_device_id_equal(const ucc_tl_cuda_device_pci_id_t *id1,
+                                 const ucc_tl_cuda_device_pci_id_t *id2)
 {
     return ((id1->domain   == id2->domain) &&
             (id1->bus      == id2->bus)    &&
@@ -29,12 +29,12 @@ ucc_tl_cuda_topo_device_id_equal(const ucc_tl_cuda_device_id_t *id1,
 
 typedef struct ucc_tl_cuda_topo_link {
     ucc_list_link_t         list_link;
-    ucc_tl_cuda_device_id_t pci_id;
+    ucc_tl_cuda_device_pci_id_t pci_id;
     int                     width;
 } ucc_tl_cuda_topo_link_t;
 
 typedef struct ucc_tl_cuda_topo_node {
-    ucc_tl_cuda_device_id_t pci_id;
+    ucc_tl_cuda_device_pci_id_t pci_id;
     ucc_tl_cuda_topo_link_t link;
 } ucc_tl_cuda_topo_node_t;
 
@@ -49,7 +49,7 @@ typedef struct ucc_tl_cuda_topo {
 
 ucc_status_t ucc_tl_cuda_topo_get_pci_id(const ucc_base_lib_t *lib,
                                          int device,
-                                         ucc_tl_cuda_device_id_t *pci_id);
+                                         ucc_tl_cuda_device_pci_id_t *pci_id);
 
 ucc_status_t ucc_tl_cuda_topo_create(const ucc_base_lib_t *lib,
                                      ucc_tl_cuda_topo_t **cuda_topo);
@@ -57,8 +57,8 @@ ucc_status_t ucc_tl_cuda_topo_create(const ucc_base_lib_t *lib,
 ucc_status_t ucc_tl_cuda_topo_destroy(ucc_tl_cuda_topo_t *cuda_topo);
 
 ucc_status_t ucc_tl_cuda_topo_num_links(const ucc_tl_cuda_topo_t *topo,
-                                        const ucc_tl_cuda_device_id_t *dev1,
-                                        const ucc_tl_cuda_device_id_t *dev2,
+                                        const ucc_tl_cuda_device_pci_id_t *dev1,
+                                        const ucc_tl_cuda_device_pci_id_t *dev2,
                                         int *num_links);
 
 #endif

--- a/src/components/tl/cuda/tl_cuda_topo.h
+++ b/src/components/tl/cuda/tl_cuda_topo.h
@@ -17,6 +17,16 @@ typedef struct ucc_tl_cuda_device_id {
     uint8_t  function; /* range: 0 to 7 */
 } ucc_tl_cuda_device_id_t;
 
+static inline int
+ucc_tl_cuda_topo_device_id_equal(const ucc_tl_cuda_device_id_t *id1,
+                                 const ucc_tl_cuda_device_id_t *id2)
+{
+    return ((id1->domain   == id2->domain) &&
+            (id1->bus      == id2->bus)    &&
+            (id1->device   == id2->device) &&
+            (id1->function == id2->function));
+}
+
 typedef struct ucc_tl_cuda_topo_link {
     ucc_list_link_t         list_link;
     ucc_tl_cuda_device_id_t pci_id;

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -280,6 +280,8 @@ UccJob::UccJob(int _n_procs, ucc_job_ctx_mode_t _ctx_mode, ucc_job_env_t vars) :
     /* NCCL TL is disabled since it currently can not support non-blocking
        team creation. */
     vars.push_back({"UCC_TL_NCCL_TUNE", "0"});
+    /* CUDA TL is disabled since cuda context is not initialized in threads. */
+    vars.push_back({"UCC_TL_CUDA_TUNE", "0"});
     /* GDR is temporarily disabled due to known issue that may result
        in a hang in the destruction flow */
     vars.push_back({"UCX_IB_GPU_DIRECT_RDMA", "no"});


### PR DESCRIPTION
## What
Use NVIDIA Management Library (NVML) to detect GPU topology

## Why ?
NVML allows to understand the underlying GPU topology more precisely compared to current solution.

## How ?
Check each NVLink connection to know what devices are connected. Additionally store number of links for each pair.