### PR TITLE
TEST: mpi test fixes

### DIFF
--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -12,11 +12,12 @@
 TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                              ucc_memory_type_t _mt, ucc_test_team_t &_team,
                              size_t _max_size) :
-    TestCase(_team, _mt, _msgsize, _inplace, _max_size)
+    TestCase(_team, UCC_COLL_TYPE_ALLGATHER, _mt, _msgsize, _inplace, _max_size)
 {
-    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t dt_size           = ucc_dt_size(TEST_DT);
     size_t single_rank_count = _msgsize / dt_size;
-    int rank, size;
+    int    rank, size;
+
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
 
@@ -26,21 +27,17 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
     }
 
     UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, _msgsize * size, _mt));
-    rbuf       = rbuf_mc_header->addr;
-    check_rbuf = ucc_malloc(_msgsize*size, "check rbuf");
-    UCC_MALLOC_CHECK(check_rbuf);
+    rbuf      = rbuf_mc_header->addr;
+    check_buf = ucc_malloc(_msgsize*size, "check buf");
+    UCC_MALLOC_CHECK(check_buf);
     if (TEST_NO_INPLACE == inplace) {
         UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
-        UCC_CHECK(ucc_mc_alloc(&check_sbuf_mc_header, _msgsize,
-                               UCC_MEMORY_TYPE_HOST));
         sbuf = sbuf_mc_header->addr;
-        check_sbuf = check_sbuf_mc_header->addr;
     } else {
         args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
 
-    args.coll_type         = UCC_COLL_TYPE_ALLGATHER;
     if (TEST_NO_INPLACE == inplace) {
         args.src.info.buffer   = sbuf;
         args.src.info.count    = single_rank_count;
@@ -57,22 +54,22 @@ TestAllgather::TestAllgather(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 
 ucc_status_t TestAllgather::set_input()
 {
-    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t dt_size           = ucc_dt_size(TEST_DT);
     size_t single_rank_count = msgsize / dt_size;
-    size_t single_rank_size = single_rank_count * dt_size;
-    int rank;
-    void *buf, *check_buf;
+    size_t single_rank_size  = single_rank_count * dt_size;
+    int    rank;
+    void  *buf, *check;
 
     MPI_Comm_rank(team.comm, &rank);
     if (inplace == TEST_NO_INPLACE) {
-        buf       = sbuf;
-        check_buf = check_sbuf;
+        buf   = sbuf;
     } else {
-        buf       = PTR_OFFSET(rbuf, rank * single_rank_size);
-        check_buf = PTR_OFFSET(check_rbuf, rank * single_rank_size);
+        buf   = PTR_OFFSET(rbuf, rank * single_rank_size);
     }
+    check = PTR_OFFSET(check_buf, rank * single_rank_size);
+
     init_buffer(buf, single_rank_count, TEST_DT, mem_type, rank);
-    UCC_CHECK(ucc_mc_memcpy(check_buf, buf, single_rank_size,
+    UCC_CHECK(ucc_mc_memcpy(check, buf, single_rank_size,
                             UCC_MEMORY_TYPE_HOST, mem_type));
     return UCC_OK;
 }
@@ -90,13 +87,13 @@ ucc_status_t TestAllgather::check()
     MPI_Datatype dt    = ucc_dt_to_mpi(TEST_DT);
     MPI_Request  req;
 
-    MPI_Iallgather(inplace ? MPI_IN_PLACE : check_sbuf, single_rank_count, dt,
-                   check_rbuf, single_rank_count, dt, team.comm, &req);
+    MPI_Iallgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                   check_buf, single_rank_count, dt, team.comm, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
     } while(!completed);
 
-    return compare_buffers(rbuf, check_rbuf, single_rank_count * size, TEST_DT,
+    return compare_buffers(rbuf, check_buf, single_rank_count * size, TEST_DT,
                            mem_type);
 }

--- a/test/mpi/test_barrier.cc
+++ b/test/mpi/test_barrier.cc
@@ -6,10 +6,10 @@
 
 #include "test_mpi.h"
 
-TestBarrier::TestBarrier(ucc_test_team_t &team) : TestCase(team)
+TestBarrier::TestBarrier(ucc_test_team_t &team) :
+    TestCase(team, UCC_COLL_TYPE_BARRIER)
 {
     status = UCC_OK;
-    args.coll_type = UCC_COLL_TYPE_BARRIER;
     UCC_CHECK(ucc_collective_init(&args, &req, team.team));
 }
 

--- a/test/mpi/test_bcast.cc
+++ b/test/mpi/test_bcast.cc
@@ -12,11 +12,12 @@
 TestBcast::TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                      ucc_memory_type_t _mt, int _root, ucc_test_team_t &_team,
                      size_t _max_size) :
-    TestCase(_team, _mt, _msgsize, _inplace, _max_size)
+    TestCase(_team, UCC_COLL_TYPE_BCAST, _mt, _msgsize, _inplace, _max_size)
 {
     size_t dt_size = ucc_dt_size(TEST_DT);
-    size_t count = _msgsize / dt_size;
+    size_t count   = _msgsize / dt_size;
     int rank, size;
+
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
     root = _root;
@@ -26,15 +27,11 @@ TestBcast::TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
-    check_rbuf = ucc_malloc(_msgsize * size, "check rbuf");
-    UCC_MALLOC_CHECK(check_rbuf);
+    check_buf = ucc_malloc(_msgsize, "check buf");
+    UCC_MALLOC_CHECK(check_buf);
     UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
     sbuf = sbuf_mc_header->addr;
-    UCC_CHECK(
-        ucc_mc_alloc(&check_sbuf_mc_header, _msgsize, UCC_MEMORY_TYPE_HOST));
-    check_sbuf = check_sbuf_mc_header->addr;
 
-    args.coll_type         = UCC_COLL_TYPE_BCAST;
     args.src.info.buffer   = sbuf;
     args.src.info.count    = count;
     args.src.info.datatype = TEST_DT;
@@ -47,13 +44,13 @@ TestBcast::TestBcast(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
 ucc_status_t TestBcast::set_input()
 {
     size_t dt_size = ucc_dt_size(TEST_DT);
-    size_t count = msgsize / dt_size;
-    int rank;
+    size_t count   = msgsize / dt_size;
+    int    rank;
 
     MPI_Comm_rank(team.comm, &rank);
     if (rank == root) {
         init_buffer(sbuf, count, TEST_DT, mem_type, rank);
-        UCC_CHECK(ucc_mc_memcpy(check_sbuf, sbuf, count * dt_size,
+        UCC_CHECK(ucc_mc_memcpy(check_buf, sbuf, count * dt_size,
                   UCC_MEMORY_TYPE_HOST, mem_type));
     }
     return UCC_OK;
@@ -72,12 +69,12 @@ ucc_status_t TestBcast::check()
     MPI_Request  req;
 
     MPI_Comm_rank(team.comm, &rank);
-    MPI_Ibcast((rank == root) ? check_sbuf : check_rbuf, count, dt, root, team.comm, &req);
+    MPI_Ibcast(check_buf, count, dt, root, team.comm, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
     } while(!completed);
 
     return (rank == root) ? UCC_OK :
-        compare_buffers(sbuf, check_rbuf, count, TEST_DT, mem_type);
+        compare_buffers(sbuf, check_buf, count, TEST_DT, mem_type);
 }

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -159,20 +159,22 @@ test_skip_cause_t TestCase::skip_reduce(test_skip_cause_t cause, MPI_Comm comm)
     return skip_reduce(1, cause, comm);
 }
 
-TestCase::TestCase(ucc_test_team_t &_team, ucc_memory_type_t _mem_type,
+TestCase::TestCase(ucc_test_team_t &_team, ucc_coll_type_t ct,
+                   ucc_memory_type_t _mem_type,
                    size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
                    size_t _max_size) :
     team(_team), mem_type(_mem_type),  msgsize(_msgsize), inplace(_inplace),
     test_max_size(_max_size)
 {
     int rank;
-    sbuf      = NULL;
-    rbuf      = NULL;
-    check_sbuf = NULL;
-    check_rbuf = NULL;
-    test_skip = TEST_SKIP_NONE;
-    args.flags = 0;
-    args.mask = 0;
+
+    sbuf           = NULL;
+    rbuf           = NULL;
+    check_buf      = NULL;
+    test_skip      = TEST_SKIP_NONE;
+    args.flags     = 0;
+    args.mask      = 0;
+    args.coll_type = ct;
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Irecv((void*)progress_buf, 1, MPI_CHAR, rank, 0, MPI_COMM_WORLD,
@@ -194,10 +196,7 @@ TestCase::~TestCase()
     if (rbuf) {
         UCC_CHECK(ucc_mc_free(rbuf_mc_header));
     }
-    if (check_sbuf) {
-        UCC_CHECK(ucc_mc_free(check_sbuf_mc_header));
-    }
-    if (check_rbuf) {
-        ucc_free(check_rbuf);
+    if (check_buf) {
+        ucc_free(check_buf);
     }
 }

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -170,12 +170,10 @@ protected:
     ucc_test_mpi_inplace_t inplace;
     ucc_coll_args_t args;
     ucc_coll_req_h req;
-    ucc_mc_buffer_header_t *sbuf_mc_header, *rbuf_mc_header,
-        *check_sbuf_mc_header;
+    ucc_mc_buffer_header_t *sbuf_mc_header, *rbuf_mc_header;
     void *sbuf;
     void *rbuf;
-    void *check_sbuf;
-    void *check_rbuf;
+    void *check_buf;
     MPI_Request progress_request;
     uint8_t     progress_buf[1];
     size_t test_max_size;
@@ -207,7 +205,8 @@ public:
             ucc_reduction_op_t op = UCC_OP_SUM,
             ucc_test_vsize_flag_t count_vsize = TEST_FLAG_VSIZE_64BIT,
             ucc_test_vsize_flag_t displ_vsize = TEST_FLAG_VSIZE_64BIT);
-    TestCase(ucc_test_team_t &_team, ucc_memory_type_t _mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+    TestCase(ucc_test_team_t &_team, ucc_coll_type_t ct,
+             ucc_memory_type_t _mem_type = UCC_MEMORY_TYPE_UNKNOWN,
              size_t _msgsize = 0, ucc_test_mpi_inplace_t _inplace = TEST_NO_INPLACE,
              size_t _max_size = TEST_UCC_RANK_BUF_SIZE_MAX);
     virtual ~TestCase();


### PR DESCRIPTION
## What
- Always init args.coll_type of a test_case (force that by moving to constructor). Otherwise segv may happen during TestCase::str  (ucc_coll_type_str(args.coll_type)) if test_case was skipped w/o setting coll_type.
- Make MPI_Reduce_scatter_block in TestReduceScatter non-blocking to avoid potential dead-lock
- Remove check_sbuf (3 reasons: 1st it is unnecessary, 2nd it always takes 1 entry from mc mpool away, 3rd it complicates test_cases init/set/check logic).

