### PR TITLE
CL/BASIC score fix

### DIFF
--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -1078,3 +1078,18 @@ ucc_status_t ucc_coll_score_dup(const ucc_coll_score_t *in,
     *out = score;
     return status;
 }
+
+void ucc_coll_score_set(ucc_coll_score_t *score,
+                        ucc_score_t       value)
+{
+    int               i, j;
+    ucc_msg_range_t  *range;
+
+    for (i = 0; i < UCC_COLL_TYPE_NUM; i++) {
+        for (j = 0; j < UCC_MEMORY_TYPE_LAST; j++) {
+            ucc_list_for_each(range, &score->scores[i][j], super.list_elem) {
+                range->super.score = value;
+            }
+        }
+    }
+}

--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -5,6 +5,7 @@
  */
 #include "ucc_coll_score.h"
 #include "utils/ucc_string.h"
+#include "utils/ucc_log.h"
 #include "utils/ucc_coll_utils.h"
 
 ucc_status_t ucc_coll_score_alloc(ucc_coll_score_t **score)

--- a/src/coll_score/ucc_coll_score.h
+++ b/src/coll_score/ucc_coll_score.h
@@ -153,4 +153,6 @@ ucc_status_t ucc_coll_score_dup(const ucc_coll_score_t *in,
 
 void ucc_coll_score_set(ucc_coll_score_t *score,
                         ucc_score_t       value);
+
+void ucc_coll_score_map_print_info(const ucc_score_map_t *score);
 #endif

--- a/src/coll_score/ucc_coll_score.h
+++ b/src/coll_score/ucc_coll_score.h
@@ -150,4 +150,7 @@ ucc_status_t ucc_coll_init(ucc_score_map_t      *map,
 
 ucc_status_t ucc_coll_score_dup(const ucc_coll_score_t *in,
                                 ucc_coll_score_t      **out);
+
+void ucc_coll_score_set(ucc_coll_score_t *score,
+                        ucc_score_t       value);
 #endif

--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -157,6 +157,7 @@ ucc_status_t ucc_cl_basic_team_create_test(ucc_base_team_t *cl_team)
             cl_error(ctx->super.super.lib, "failed to build score map");
         }
         team->score = score;
+        ucc_coll_score_set(team->score, UCC_CL_BASIC_DEFAULT_SCORE);
     }
     return status;
 }
@@ -172,6 +173,7 @@ ucc_status_t ucc_cl_basic_team_get_scores(ucc_base_team_t   *cl_team,
     if (UCC_OK != status) {
         return status;
     }
+
     if (strlen(lib->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
             lib->score_str, *score, UCC_CL_TEAM_SIZE(team), NULL, cl_team,

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -192,9 +192,8 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
     task->seq_num = team->seq_num++;
     if (ucc_global_config.log_component.log_level >= UCC_LOG_LEVEL_DEBUG) {
         char coll_debug_str[256];
-        ucc_coll_str(&op_args, coll_debug_str, sizeof(coll_debug_str));
-        ucc_debug("coll_init: %s, req %p, seq_num %u", coll_debug_str, task,
-                  task->seq_num);
+        ucc_coll_str(task, coll_debug_str, sizeof(coll_debug_str));
+        ucc_debug("coll_init: %s", coll_debug_str);
     }
     *request = &task->super;
     return UCC_OK;

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -432,6 +432,15 @@ out:
     if (UCC_OK == status) {
         status = ucc_team_build_score_map(team);
     }
+
+    if (UCC_OK == status &&
+        ucc_global_config.log_component.log_level >= UCC_LOG_LEVEL_INFO &&
+        team->rank == 0) {
+        ucc_info("===== COLL_SCORE_MAP (team_id %d) =====",
+                 team->id);
+        ucc_coll_score_map_print_info(team->score_map);
+        ucc_info("=======================================");
+    }
     /* TODO: add team/coll selection and check if some teams are never
              used after selection and clean them up */
     return status;

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -126,9 +126,9 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
         /* error in task status */
         if (UCC_ERR_TIMED_OUT == status) {
             char coll_str[256];
-            ucc_coll_str(&task->bargs, coll_str, sizeof(coll_str));
-            ucc_warn("timeout %g sec has expired on task %p, seq_num %u, %s",
-                     task->bargs.args.timeout, task, task->seq_num, coll_str);
+            ucc_coll_str(task, coll_str, sizeof(coll_str));
+            ucc_warn("timeout %g sec has expired on %s",
+                     task->bargs.args.timeout, coll_str);
         } else {
             ucc_error("failure in task %p, %s", task,
                       ucc_status_string(task->super.status));

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -242,29 +242,6 @@ ucc_coll_args_is_rooted(const ucc_base_coll_args_t *bargs)
     return 0;
 }
 
-static inline const char* ucc_mem_type_str(ucc_memory_type_t ct)
-{
-    switch((int)ct) {
-    case UCC_MEMORY_TYPE_HOST:
-        return "Host";
-    case UCC_MEMORY_TYPE_CUDA:
-        return "Cuda";
-    case UCC_MEMORY_TYPE_CUDA_MANAGED:
-        return "CudaManaged";
-    case UCC_MEMORY_TYPE_ROCM:
-        return "Rocm";
-    case UCC_MEMORY_TYPE_ROCM_MANAGED:
-        return "RocmManaged";
-    case UCC_MEMORY_TYPE_ASSYMETRIC:
-        return "assymetric";
-    case UCC_MEMORY_TYPE_NOT_APPLY:
-        return "n/a";
-    default:
-        break;
-    }
-    return "invalid";
-}
-
 void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len)
 {
     const ucc_base_coll_args_t *args  = &task->bargs;

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -265,14 +265,18 @@ static inline const char* ucc_mem_type_str(ucc_memory_type_t ct)
     return "invalid";
 }
 
-void ucc_coll_str(const ucc_base_coll_args_t *args, char *str, size_t len)
+void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len)
 {
-    ucc_team_t     *team  = args->team;
-    ucc_coll_type_t ct    = args->args.coll_type;
-    size_t          left  = len;
-    char            tmp[64];
+    const ucc_base_coll_args_t *args  = &task->bargs;
+    ucc_team_t                *team  = args->team;
+    ucc_coll_type_t            ct    = args->args.coll_type;
+    size_t                     left  = len;
+    char                       tmp[64];
 
-    ucc_snprintf_safe(str, left, "team id %u size %u rank %u ctx_rank %u: %s %s inplace=%u",
+    ucc_snprintf_safe(str, left, "req %p, seq_num %u, %s, team_id %u, size %u, "
+                      "rank %u, ctx_rank %u: %s %s inplace=%u",
+                      task, task->seq_num,
+                      task->team->context->lib->log_component.name,
                       team->id, team->size, team->rank,
                       ucc_ep_map_eval(team->ctx_map, team->rank),
                       ucc_coll_type_str(ct),

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -52,6 +52,29 @@ ucc_coll_args_get_count(const ucc_coll_args_t *args, const ucc_count_t *counts,
     return ((uint32_t *)counts)[idx];
 }
 
+static inline const char* ucc_mem_type_str(ucc_memory_type_t ct)
+{
+    switch((int)ct) {
+    case UCC_MEMORY_TYPE_HOST:
+        return "Host";
+    case UCC_MEMORY_TYPE_CUDA:
+        return "Cuda";
+    case UCC_MEMORY_TYPE_CUDA_MANAGED:
+        return "CudaManaged";
+    case UCC_MEMORY_TYPE_ROCM:
+        return "Rocm";
+    case UCC_MEMORY_TYPE_ROCM_MANAGED:
+        return "RocmManaged";
+    case UCC_MEMORY_TYPE_ASSYMETRIC:
+        return "assymetric";
+    case UCC_MEMORY_TYPE_NOT_APPLY:
+        return "n/a";
+    default:
+        break;
+    }
+    return "invalid";
+}
+
 static inline size_t
 ucc_coll_args_get_displacement(const ucc_coll_args_t *args,
                                const ucc_aint_t *displacements, ucc_rank_t idx)

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -128,5 +128,6 @@ static inline ucc_rank_t ucc_ep_map_eval(ucc_ep_map_t map, ucc_rank_t rank)
 ucc_ep_map_t ucc_ep_map_from_array(ucc_rank_t **array, ucc_rank_t size,
                                    ucc_rank_t full_size, int need_free);
 
-void ucc_coll_str(const ucc_base_coll_args_t *args, char *str, size_t len);
+typedef struct ucc_coll_task ucc_coll_task_t;
+void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len);
 #endif

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -71,14 +71,20 @@ static inline const char* ucc_coll_type_str(ucc_coll_type_t ct)
         return "Allgatherv";
     case UCC_COLL_TYPE_GATHER:
         return "Gather";
+    case UCC_COLL_TYPE_GATHERV:
+        return "Gatherv";
     case UCC_COLL_TYPE_SCATTER:
         return "Scatter";
+    case UCC_COLL_TYPE_SCATTERV:
+        return "Scatterv";
     case UCC_COLL_TYPE_FANIN:
         return "Fanin";
     case UCC_COLL_TYPE_FANOUT:
         return "Fanout";
     case UCC_COLL_TYPE_REDUCE_SCATTER:
-        return "Reduce scatter";
+        return "Reduce_scatter";
+    case UCC_COLL_TYPE_REDUCE_SCATTERV:
+        return "Reduce_scatterv";
     default:
         break;
     }
@@ -154,4 +160,5 @@ static inline const char* ucc_reduction_op_str(ucc_reduction_op_t op)
         return NULL;
     }
 }
+
 #endif

--- a/src/utils/ucc_string.c
+++ b/src/utils/ucc_string.c
@@ -8,6 +8,7 @@
 #include "ucc_log.h"
 #include <ctype.h>
 #include <ucs/sys/string.h>
+
 char **ucc_str_split(const char *str, const char *delim)
 {
     unsigned alloc_size = 8;

--- a/src/utils/ucc_string.h
+++ b/src/utils/ucc_string.h
@@ -17,4 +17,7 @@ void         ucc_str_split_free(char **split);
 ucc_status_t ucc_str_is_number(const char *str);
 
 ucc_status_t ucc_str_to_memunits(const char *buf, void *dest);
+
+#define      ucc_memunits_range_str ucs_memunits_range_str
+
 #endif


### PR DESCRIPTION
## What
CL/BASIC constructs score_map by merging the scores of underlying TLs. This way the final "score" value for a given collective would be equal to the score value of best TL and not the value of CL_BASIC score.

Additional score info improvements:
1. Print selected component during coll_init, e.g. (CL_HIER is selected):
`ucc_coll.c:196  UCC  DEBUG coll_init: req 0x4147b80, seq_num 0, CL_HIER, team_id 1, size 4, rank 0, ctx_rank 0: Allreduce Host inplace=0 bytes=8 int32 sum`

2. Print the whole team score map at INFO level. Example:
```
[1642508430.469634] [vulcan03:26915:0]        ucc_team.c:439  UCC  INFO  ===== COLL_SCORE_MAP (team_id 1) =====
[1642508430.469648] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO  Allgather:
[1642508430.469648] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Host: {0..inf}:TL_UCP:10
[1642508430.469648] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Cuda: {0..inf}:TL_NCCL:10
[1642508430.469648] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      CudaManaged: {0..inf}:TL_UCP:10
[1642508430.469667] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO  Allgatherv:
[1642508430.469667] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Host: {0..inf}:TL_UCP:10
[1642508430.469667] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Cuda: {0..16K}:TL_NCCL:10 {16K..1M}:TL_NCCL:10 {1M..inf}:TL_NCCL:10
[1642508430.469667] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      CudaManaged: {0..inf}:TL_UCP:10
[1642508430.469688] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO  Allreduce:
[1642508430.469688] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Host: {0..2K}:CL_HIER:50 {2K..4K}:TL_UCP:10 {4K..inf}:TL_UCP:10
[1642508430.469688] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Cuda: {0..2K}:CL_HIER:50 {2K..4K}:TL_NCCL:10 {4K..inf}:TL_NCCL:10
[1642508430.469688] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      CudaManaged: {0..4K}:TL_UCP:10 {4K..inf}:TL_UCP:10
[1642508430.469707] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO  Alltoall:
[1642508430.469707] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Host: {0..inf}:TL_UCP:10
[1642508430.469707] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Cuda: {0..inf}:TL_NCCL:10
[1642508430.469707] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      CudaManaged: {0..inf}:TL_UCP:10
[1642508430.469723] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO  Alltoallv:
[1642508430.469723] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Host: {0..inf}:TL_UCP:10
[1642508430.469723] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Cuda: {0..inf}:TL_NCCL:10
[1642508430.469723] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      CudaManaged: {0..inf}:TL_UCP:10
[1642508430.469739] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO  Barrier:
[1642508430.469739] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Host: {0..inf}:TL_UCP:10
[1642508430.469739] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Cuda: {0..inf}:TL_NCCL:10
[1642508430.469739] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      CudaManaged: {0..inf}:TL_UCP:10
[1642508430.469758] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO  Bcast:
[1642508430.469758] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Host: {0..32K}:TL_UCP:10 {32K..inf}:TL_UCP:10
[1642508430.469758] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Cuda: {0..32K}:TL_NCCL:10 {32K..inf}:TL_NCCL:10
[1642508430.469758] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      CudaManaged: {0..32K}:TL_UCP:10 {32K..inf}:TL_UCP:10
[1642508430.469775] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO  Reduce:
[1642508430.469775] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Host: {0..inf}:TL_UCP:10
[1642508430.469775] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Cuda: {0..inf}:TL_NCCL:10
[1642508430.469775] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      CudaManaged: {0..inf}:TL_UCP:10
[1642508430.469790] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO  Reduce_scatter:
[1642508430.469790] [vulcan03:26915:0] ucc_coll_score_map.c:155  UCC  INFO      Cuda: {0..inf}:TL_NCCL:10
[1642508430.469797] [vulcan03:26915:0]        ucc_team.c:442  UCC  INFO  =======================================

```

later we can also add actual algorithm name for each range (need to extend tl/cl iface to map init fn to alg name str)

## Why ?
Fixes selection between CL/HIER and CL/BASIC. For example, w/o the fix, setting UCC_TL_UCP_TUNE=inf would make CL/BASIC having the score of "inf".


