### PR TITLE
TL/UCP: piggy-back data exchange for one-sided

### DIFF
--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -100,7 +100,7 @@ typedef struct ucc_tl_ucp_context {
     tl_ucp_ep_hash_t *          ep_hash;
     ucp_ep_h *                  eps;
     ucc_tl_ucp_remote_info_t *  remote_info;
-    ucp_rkey_h **               rkeys;
+    ucp_rkey_h *                rkeys;
     uint64_t                    n_rinfo_segs;
     uint64_t                    ucp_memory_types;
 } ucc_tl_ucp_context_t;
@@ -140,6 +140,9 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
 #define UCC_TL_CTX_OOB(_ctx) ((_ctx)->super.super.ucc_context->params.oob)
 
 #define IS_SERVICE_TEAM(_team) ((_team)->super.super.params.scope == UCC_CL_LAST + 1)
+
+#define UCC_TL_UCP_REMOTE_RKEY(_ctx, _rank, _seg)                              \
+    ((_ctx)->rkeys[_rank * _ctx->n_rinfo_segs + _seg])
 
 extern ucs_memory_type_t ucc_memtype_to_ucs[UCC_MEMORY_TYPE_LAST+1];
 

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -86,7 +86,7 @@ typedef struct ucc_tl_ucp_remote_info {
     size_t len;
     void * mem_h;
     void * packed_key;
-    void * rkey;
+    size_t packed_key_len;
 } ucc_tl_ucp_remote_info_t;
 
 typedef struct ucc_tl_ucp_context {
@@ -99,7 +99,8 @@ typedef struct ucc_tl_ucp_context {
     ucc_mpool_t                 req_mp;
     tl_ucp_ep_hash_t *          ep_hash;
     ucp_ep_h *                  eps;
-    ucc_tl_ucp_remote_info_t ** remote_info;
+    ucc_tl_ucp_remote_info_t *  remote_info;
+    ucp_rkey_h **               rkeys;
     uint64_t                    n_rinfo_segs;
     uint64_t                    ucp_memory_types;
 } ucc_tl_ucp_context_t;

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -473,7 +473,9 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
                 tl_error(ctx->super.super.lib, "failed to pack onesided information");
                 return ucc_status;
             }
-            memcpy(PTR_OFFSET(attr->attr.ctx_addr, ctx->ucp_addrlen), packed_data, packed_length);
+            if (ucc_likely(NULL != packed_data)) {
+                memcpy(PTR_OFFSET(attr->attr.ctx_addr, ctx->ucp_addrlen), packed_data, packed_length);
+            }
         }
     }
     if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_WORK_BUFFER_SIZE) {

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -212,8 +212,8 @@ ucc_status_t ucc_tl_ucp_rinfo_destroy(ucc_tl_ucp_context_t *ctx)
 
     for (i = 0; i < size; i++) {
         for (j = 0; j < ctx->n_rinfo_segs; j++) {
-            if (ctx->rkeys[i * ctx->n_rinfo_segs + j]) {
-                ucp_rkey_destroy(ctx->rkeys[i * ctx->n_rinfo_segs + j]);
+            if (UCC_TL_UCP_REMOTE_RKEY(ctx, i, j)) {
+                ucp_rkey_destroy(UCC_TL_UCP_REMOTE_RKEY(ctx, i, j));
             }
         }
     }

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -245,12 +245,11 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
         key_offset += key_sizes[i];
     }
     if (0 > *segment) {
-        tl_error(
-            UCC_TL_TEAM_LIB(team),
+        tl_error(UCC_TL_TEAM_LIB(team),
             "attempt to perform one-sided operation on non-registered memory");
         return UCC_ERR_NOT_FOUND;
     }
-    if (NULL == UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment)) {
+    if (ucc_unlikely(NULL == UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment))) {
         ucs_status_t ucs_status =
             ucp_ep_rkey_unpack(*ep, PTR_OFFSET(keys, key_offset),
                                &UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment));

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -230,7 +230,7 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
     peer = ucc_get_ctx_rank(UCC_TL_CORE_TEAM(team), core_rank);
 
     offset = ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), UCC_TL_CORE_TEAM(team),
-                                  peer, ucc_tl_ucp.super.super.id);
+                                  core_rank, ucc_tl_ucp.super.super.id);
     base_offset = (ptrdiff_t)PTR_OFFSET(offset, ctx->ucp_addrlen);
     rvas        = (uint64_t *)base_offset;
     key_sizes   = PTR_OFFSET(base_offset, (section_offset * 2));

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -100,11 +100,9 @@ ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team)
     }
 
     if (ctx->remote_info) {
-        ucc_rank_t rank = ctx->super.super.ucc_context->rank;
-
         for (int i = 0; i < ctx->n_rinfo_segs; i++) {
-            team->va_base[i]     = ctx->remote_info[rank][i].va_base;
-            team->base_length[i] = ctx->remote_info[rank][i].len;
+            team->va_base[i]     = ctx->remote_info[i].va_base;
+            team->base_length[i] = ctx->remote_info[i].len;
         }
     }
 


### PR DESCRIPTION
## What
Removes the two extra data exchanges performed during one-sided context creation.  

## Why ?
There can be a performance improvement for context create when reducing the number of data exchanges. 

Performance difference using up to 32 nodes with 40 PPN between current master version and this PR. Times are in milliseconds:
| Number of Nodes | Master | This PR|
|-------------------------|-----------|------------|
|2|335.443|328.389|
|4|355.145|324.561|
|8|384.267|350.165|
|16|441.401|416.414|
|32|548.325|465.787|

_NOTE: one-sided memory buffers were allocated to 128 MB in order to highlight communication time._
