### PR TITLE
TL/UCP: enable UCX active messages

### DIFF
--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -42,7 +42,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
 
     ucp_params.field_mask =
         UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_TAG_SENDER_MASK;
-    ucp_params.features = UCP_FEATURE_TAG;
+    ucp_params.features = UCP_FEATURE_TAG | UCP_FEATURE_AM;
     if (params->params.mask & UCC_CONTEXT_PARAM_FIELD_MEM_PARAMS) {
         ucp_params.features |= UCP_FEATURE_RMA | UCP_FEATURE_AMO64;
     }


### PR DESCRIPTION
## What
Enable UCX active messages.

## Why ?
A plugin is using UCX active messages which can only be enabled if the feature is activated when calling `ucp_init()`.

## How ?
N/A