### PR TITLE
CL/HIER: 2lvl alltoallv

### DIFF
--- a/src/components/cl/hier/Makefile.am
+++ b/src/components/cl/hier/Makefile.am
@@ -1,10 +1,14 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
 #
 
 allreduce =                   \
 	allreduce/allreduce.h     \
 	allreduce/allreduce_rab.c
+
+alltoallv =                   \
+	alltoallv/alltoallv.h     \
+	alltoallv/alltoallv.c
 
 sources =             \
 	cl_hier.h         \
@@ -14,7 +18,8 @@ sources =             \
 	cl_hier_team.c    \
 	cl_hier_coll.c    \
 	cl_hier_coll.h    \
-	$(allreduce)
+	$(allreduce)      \
+	$(alltoallv)
 
 module_LTLIBRARIES         = libucc_cl_hier.la
 libucc_cl_hier_la_SOURCES  = $(sources)

--- a/src/components/cl/hier/Makefile.am
+++ b/src/components/cl/hier/Makefile.am
@@ -10,6 +10,10 @@ alltoallv =                   \
 	alltoallv/alltoallv.h     \
 	alltoallv/alltoallv.c
 
+alltoall =                  \
+	alltoall/alltoall.h     \
+	alltoall/alltoall.c
+
 sources =             \
 	cl_hier.h         \
 	cl_hier.c         \
@@ -19,7 +23,8 @@ sources =             \
 	cl_hier_coll.c    \
 	cl_hier_coll.h    \
 	$(allreduce)      \
-	$(alltoallv)
+	$(alltoallv)      \
+	$(alltoall)
 
 module_LTLIBRARIES         = libucc_cl_hier.la
 libucc_cl_hier_la_SOURCES  = $(sources)

--- a/src/components/cl/hier/alltoall/alltoall.c
+++ b/src/components/cl/hier/alltoall/alltoall.c
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "alltoall.h"
+#include "../alltoallv/alltoallv.h"
+
+ucc_base_coll_alg_info_t
+    ucc_cl_hier_alltoall_algs[UCC_CL_HIER_ALLTOALL_ALG_LAST + 1] = {
+        [UCC_CL_HIER_ALLTOALL_ALG_NODE_SPLIT] =
+            {.id   = UCC_CL_HIER_ALLTOALL_ALG_NODE_SPLIT,
+             .name = "node_split",
+             .desc = "splitting alltoall into two concurrent a2av calls"
+                     " withing the node and outside of it"},
+        [UCC_CL_HIER_ALLTOALL_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};
+
+UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoall_init,
+                         (coll_args, team, task),
+                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+                         ucc_coll_task_t **task)
+{
+    ucc_cl_hier_team_t     *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_status_t            status;
+    ucc_base_coll_args_t    args;
+    int                     i, count;
+    ucc_rank_t              team_size;
+    ucc_mc_buffer_header_t *h;
+
+    if (!SBGP_ENABLED(cl_team, NODE) || !SBGP_ENABLED(cl_team, FULL)) {
+        cl_debug(team->context->lib, "alltoall requires NODE and FULL sbgps");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    memcpy(&args, coll_args, sizeof(args));
+    args.args.coll_type = UCC_COLL_TYPE_ALLTOALLV;
+    team_size           = UCC_CL_TEAM_SIZE(cl_team);
+
+    status =
+        ucc_mc_alloc(&h, sizeof(int) * team_size * 2, UCC_MEMORY_TYPE_HOST);
+    if (ucc_unlikely(UCC_OK != status)) {
+        cl_error(team->context->lib,
+                 "failed to allocate %zd bytes for full counts",
+                 sizeof(int) * team_size * 2);
+        return status;
+    }
+
+    args.args.src.info_v.buffer   = coll_args->args.src.info.buffer;
+    args.args.dst.info_v.buffer   = coll_args->args.dst.info.buffer;
+    args.args.src.info_v.datatype = coll_args->args.src.info.datatype;
+    args.args.dst.info_v.datatype = coll_args->args.dst.info.datatype;
+    args.args.src.info_v.mem_type = coll_args->args.src.info.mem_type;
+    args.args.dst.info_v.mem_type = coll_args->args.dst.info.mem_type;
+
+    args.args.src.info_v.counts = h->addr;
+    args.args.src.info_v.displacements =
+        PTR_OFFSET(h->addr, sizeof(int) * team_size);
+
+    args.args.dst.info_v.counts        = args.args.src.info_v.counts;
+    args.args.dst.info_v.displacements = args.args.src.info_v.displacements;
+
+    count = (int)coll_args->args.src.info.count / team_size;
+    ((int *)args.args.src.info_v.counts)[0]        = count;
+    ((int *)args.args.src.info_v.displacements)[0] = 0;
+
+    for (i = 1; i < team_size; i++) {
+        ((int *)args.args.src.info_v.counts)[i] = count;
+        ((int *)args.args.src.info_v.displacements)[i] =
+            ((int *)args.args.src.info_v.displacements)[i - 1] + count;
+    }
+    status = ucc_cl_hier_alltoallv_init(&args, team, task);
+    if (UCC_OK != status) {
+        cl_error(team->context->lib, "failed to init split node a2av task");
+    }
+
+    ucc_mc_free(h);
+    return status;
+}

--- a/src/components/cl/hier/alltoall/alltoall.h
+++ b/src/components/cl/hier/alltoall/alltoall.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef ALLTOALL_H_
+#define ALLTOALL_H_
+#include "../cl_hier_coll.h"
+
+enum
+{
+    UCC_CL_HIER_ALLTOALL_ALG_NODE_SPLIT,
+    UCC_CL_HIER_ALLTOALL_ALG_LAST,
+};
+
+extern ucc_base_coll_alg_info_t
+    ucc_cl_hier_alltoall_algs[UCC_CL_HIER_ALLTOALL_ALG_LAST + 1];
+
+ucc_status_t ucc_cl_hier_alltoall_init(ucc_base_coll_args_t *coll_args,
+                                       ucc_base_team_t *     team,
+                                       ucc_coll_task_t **    task);
+
+static inline int ucc_cl_hier_alltoall_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_CL_HIER_ALLTOALL_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_cl_hier_alltoall_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
+
+#endif

--- a/src/components/cl/hier/alltoallv/alltoallv.c
+++ b/src/components/cl/hier/alltoallv/alltoallv.c
@@ -1,0 +1,240 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "alltoallv.h"
+#include "../cl_hier_coll.h"
+#include "core/ucc_team.h"
+
+ucc_base_coll_alg_info_t
+    ucc_cl_hier_alltoallv_algs[UCC_CL_HIER_ALLTOALLV_ALG_LAST + 1] = {
+        [UCC_CL_HIER_ALLTOALLV_ALG_NODE_SPLIT] =
+            {.id   = UCC_CL_HIER_ALLTOALLV_ALG_NODE_SPLIT,
+             .name = "node_split",
+             .desc = "splitting alltoallv into two concurrent a2av calls"
+                     " withing the node and outside of it"},
+        [UCC_CL_HIER_ALLTOALLV_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};
+
+static ucc_status_t ucc_cl_hier_alltoallv_start(ucc_coll_task_t *task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
+
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_alltoallv_start", 0);
+    return ucc_schedule_start(schedule);
+}
+
+static ucc_status_t ucc_cl_hier_alltoallv_finalize(ucc_coll_task_t *task)
+{
+    ucc_cl_hier_schedule_t *schedule = ucc_derived_of(task,
+                                                      ucc_cl_hier_schedule_t);
+    ucc_status_t status;
+
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_alltoallv_finalize", 0);
+    ucc_assert(schedule->super.super.n_tasks == 2);
+    ucc_mc_free(schedule->scratch);
+    status = ucc_schedule_finalize(task);
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}
+
+#define SET_FULL_COUNTS(_type, _sbgp, _coll_args, _team, _node_thresh,         \
+                        _sdt_size, _rdt_size, _sc_full, _sd_full, _rc_full,    \
+                        _rd_full)                                              \
+    do {                                                                       \
+        int   _i, _is_local;                                                   \
+        _type _scount, _rcount;                                                \
+                                                                               \
+        for (_i = 0; _i < (_sbgp)->group_size; _i++) {                         \
+            _scount = ((_type *)(_coll_args)->args.src.info_v.counts)[_i];     \
+            _rcount = ((_type *)(_coll_args)->args.dst.info_v.counts)[_i];     \
+            _is_local =                                                        \
+                ucc_rank_on_local_node(_i, (_team)->params.team->topo);        \
+            if ((_scount * _sdt_size > (_node_thresh)) && _is_local) {         \
+                ((_type *)_sc_full)[_i] = 0;                                   \
+            } else {                                                           \
+                ((_type *)_sc_full)[_i] = _scount;                             \
+                ((_type *)_sd_full)[_i] =                                      \
+                    ((_type *)(_coll_args)                                     \
+                         ->args.src.info_v.displacements)[_i];                 \
+            }                                                                  \
+            if ((_rcount * _rdt_size > (_node_thresh)) && _is_local) {         \
+                ((_type *)_rc_full)[_i] = 0;                                   \
+            } else {                                                           \
+                ((_type *)_rc_full)[_i] = _rcount;                             \
+                ((_type *)_rd_full)[_i] =                                      \
+                    ((_type *)(_coll_args)                                     \
+                         ->args.dst.info_v.displacements)[_i];                 \
+            }                                                                  \
+        }                                                                      \
+    } while (0)
+
+#define SET_NODE_COUNTS(_type, _sbgp, _coll_args, _node_thresh, _sdt_size,     \
+                        _rdt_size, _sc_node, _sd_node, _rc_node, _rd_node)     \
+    do {                                                                       \
+        int   _i;                                                              \
+        _type _scount, _rcount;                                                \
+                                                                               \
+        for (_i = 0; _i < (_sbgp)->group_size; _i++) {                         \
+            ucc_rank_t r = ucc_ep_map_eval((_sbgp)->map, _i);                  \
+            _scount      = ((_type *)(_coll_args)->args.src.info_v.counts)[r]; \
+            _rcount      = ((_type *)(_coll_args)->args.dst.info_v.counts)[r]; \
+            if (_scount * _sdt_size <= (_node_thresh)) {                       \
+                ((_type *)_sc_node)[_i] = 0;                                   \
+            } else {                                                           \
+                ((_type *)_sc_node)[_i] = _scount;                             \
+                ((_type *)_sd_node)[_i] =                                      \
+                    ((_type *)(_coll_args)->args.src.info_v.displacements)[r]; \
+            }                                                                  \
+            if (_rcount * _rdt_size <= (_node_thresh)) {                       \
+                ((_type *)_rc_node)[_i] = 0;                                   \
+            } else {                                                           \
+                ((_type *)_rc_node)[_i] = _rcount;                             \
+                ((_type *)_rd_node)[_i] =                                      \
+                    ((_type *)(_coll_args)->args.dst.info_v.displacements)[r]; \
+            }                                                                  \
+        }                                                                      \
+    } while (0)
+
+UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoallv_init,
+                         (coll_args, team, task),
+                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+                         ucc_coll_task_t **task)
+{
+    ucc_cl_hier_team_t     *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_cl_hier_lib_t      *cl_lib  = UCC_CL_HIER_TEAM_LIB(cl_team);
+    ucc_cl_hier_schedule_t *cl_schedule;
+    ucc_schedule_t         *schedule;
+    ucc_status_t            status;
+    ucc_base_coll_args_t    args;
+    ucc_coll_task_t        *task_node, *task_full;
+    int                     c64, d64;
+    void                   *sc_full, *sd_full, *rc_full, *rd_full;
+    void                   *sc_node, *sd_node, *rc_node, *rd_node;
+    ucc_rank_t              full_size, node_size;
+    size_t                  sdt_size, rdt_size;
+    ucc_sbgp_t             *sbgp;
+    size_t                  elem_size;
+
+    if (!SBGP_ENABLED(cl_team, NODE) || !SBGP_ENABLED(cl_team, FULL)) {
+        cl_debug(team->context->lib, "alltoallv requires NODE and FULL sbgps");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    c64 = UCC_COLL_ARGS_COUNT64(&coll_args->args);
+    d64 = UCC_COLL_ARGS_DISPL64(&coll_args->args);
+
+    if (c64 ^ d64) {
+        cl_debug(team->context->lib,
+                 "mixed 64 bit count/displ mode is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    cl_schedule = ucc_cl_hier_get_schedule(cl_team);
+    if (ucc_unlikely(!cl_schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+    schedule = &cl_schedule->super.super;
+    memcpy(&args, coll_args, sizeof(args));
+    status = ucc_schedule_init(schedule, &args, team);
+    if (ucc_unlikely(UCC_OK != status)) {
+        goto error;
+    }
+
+    full_size = cl_team->sbgps[UCC_HIER_SBGP_FULL].sbgp->group_size;
+    node_size = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp->group_size;
+
+    elem_size = c64 ? 8 : 4;
+    status = ucc_mc_alloc(&cl_schedule->scratch,
+                          elem_size * (full_size + node_size) * 4,
+                          UCC_MEMORY_TYPE_HOST);
+    if (ucc_unlikely(UCC_OK != status)) {
+        cl_error(team->context->lib,
+                 "failed to allocate %zd bytes for full counts",
+                 elem_size * (full_size + node_size) * 4);
+        goto error;
+    }
+
+    sc_full = cl_schedule->scratch->addr;
+    sd_full = PTR_OFFSET(sc_full, full_size * elem_size);
+    rc_full = PTR_OFFSET(sc_full, full_size * elem_size * 2);
+    rd_full = PTR_OFFSET(sc_full, full_size * elem_size * 3);
+
+    sc_node = PTR_OFFSET(sc_full, full_size * elem_size * 4);
+    sd_node = PTR_OFFSET(sc_node, node_size * elem_size);
+    rc_node = PTR_OFFSET(sc_node, node_size * elem_size * 2);
+    rd_node = PTR_OFFSET(sc_node, node_size * elem_size * 3);
+
+    /* Duplicate FULL a2av info and alloc task */
+    sbgp = cl_team->sbgps[UCC_HIER_SBGP_FULL].sbgp;
+    ucc_assert(sbgp->group_size == team->params.size);
+    sdt_size = ucc_dt_size(coll_args->args.src.info_v.datatype);
+    rdt_size = ucc_dt_size(coll_args->args.dst.info_v.datatype);
+
+    if (c64) {
+        SET_FULL_COUNTS(uint64_t, sbgp, coll_args, team,
+                        cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
+                        sc_full, sd_full, rc_full, rd_full);
+    } else {
+        SET_FULL_COUNTS(uint32_t, sbgp, coll_args, team,
+                        cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
+                        sc_full, sd_full, rc_full, rd_full);
+    }
+    args.args.src.info_v.counts        = (ucc_aint_t *)sc_full;
+    args.args.dst.info_v.counts        = (ucc_aint_t *)rc_full;
+    args.args.src.info_v.displacements = (ucc_aint_t *)sd_full;
+    args.args.dst.info_v.displacements = (ucc_aint_t *)rd_full;
+
+    status = ucc_coll_init(cl_team->sbgps[UCC_HIER_SBGP_FULL].score_map, &args,
+                           &task_full);
+    if (UCC_OK != status) {
+        cl_error(team->context->lib, "failed to init full a2av task");
+        goto err_init_1;
+    }
+
+    /* Setup NODE a2av */
+    sbgp = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp;
+
+    if (c64) {
+        SET_NODE_COUNTS(uint64_t, sbgp, coll_args, cl_lib->cfg.a2av_node_thresh,
+                        sdt_size, rdt_size, sc_node, sd_node, rc_node, rd_node);
+
+    } else {
+        SET_NODE_COUNTS(uint32_t, sbgp, coll_args, cl_lib->cfg.a2av_node_thresh,
+                        sdt_size, rdt_size, sc_node, sd_node, rc_node, rd_node);
+    }
+
+    args.args.src.info_v.counts        = (ucc_aint_t *)sc_node;
+    args.args.dst.info_v.counts        = (ucc_aint_t *)rc_node;
+    args.args.src.info_v.displacements = (ucc_aint_t *)sd_node;
+    args.args.dst.info_v.displacements = (ucc_aint_t *)rd_node;
+    status = ucc_coll_init(cl_team->sbgps[UCC_HIER_SBGP_NODE].score_map, &args,
+                           &task_node);
+    if (UCC_OK != status) {
+        cl_error(team->context->lib, "failed to init full a2av task");
+        goto err_init_2;
+    }
+    ucc_schedule_add_task(schedule, task_node);
+    ucc_schedule_add_task(schedule, task_full);
+    ucc_task_subscribe_dep(&schedule->super, task_node,
+                           UCC_EVENT_SCHEDULE_STARTED);
+    ucc_task_subscribe_dep(&schedule->super, task_full,
+                           UCC_EVENT_SCHEDULE_STARTED);
+
+    schedule->super.post           = ucc_cl_hier_alltoallv_start;
+    schedule->super.progress       = NULL;
+    schedule->super.finalize       = ucc_cl_hier_alltoallv_finalize;
+    schedule->super.triggered_post = ucc_triggered_post;
+    *task                          = &schedule->super;
+    return UCC_OK;
+
+err_init_2:
+    ucc_collective_finalize(&task_full->super);
+err_init_1:
+    ucc_mc_free(cl_schedule->scratch);
+error:
+    ucc_cl_hier_put_schedule(schedule);
+    return status;
+}

--- a/src/components/cl/hier/alltoallv/alltoallv.h
+++ b/src/components/cl/hier/alltoallv/alltoallv.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef ALLTOALLV_H_
+#define ALLTOALLV_H_
+#include "../cl_hier.h"
+
+enum
+{
+    UCC_CL_HIER_ALLTOALLV_ALG_NODE_SPLIT,
+    UCC_CL_HIER_ALLTOALLV_ALG_LAST,
+};
+
+extern ucc_base_coll_alg_info_t
+    ucc_cl_hier_alltoallv_algs[UCC_CL_HIER_ALLTOALLV_ALG_LAST + 1];
+
+ucc_status_t ucc_cl_hier_alltoallv_init(ucc_base_coll_args_t *coll_args,
+                                        ucc_base_team_t      *team,
+                                        ucc_coll_task_t     **task);
+
+static inline int ucc_cl_hier_alltoallv_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_CL_HIER_ALLTOALLV_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_cl_hier_alltoallv_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
+
+#endif

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -38,6 +38,17 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NET]),
      UCC_CONFIG_TYPE_STRING_ARRAY},
 
+    {"FULL_SBGP_TLS", "ucp",
+     "TLS to be used for FULL subgroup.\n"
+     "FULL subgroup contains all processes of the team",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_FULL]),
+     UCC_CONFIG_TYPE_STRING_ARRAY},
+
+    {"ALLTOALLV_SPLIT_NODE_THRESH", "0",
+     "Messages larger than that threshold will be sent via node sbgp tl",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, a2av_node_thresh),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
     {NULL}};
 
 static ucs_config_field_t ucc_cl_hier_context_config_table[] = {

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -37,6 +37,7 @@ typedef enum {
     UCC_HIER_SBGP_NODE,
     UCC_HIER_SBGP_NODE_LEADERS,
     UCC_HIER_SBGP_NET,
+    UCC_HIER_SBGP_FULL,
     UCC_HIER_SBGP_LAST,
 } ucc_hier_sbgp_type_t;
 //DO we need it? Potential use case: different hier sbgps over same sbgp
@@ -46,6 +47,7 @@ typedef struct ucc_cl_hier_lib_config {
     /* List of TLs corresponding to the sbgp team,
        which are selected based on the TL scores */
     ucc_config_names_array_t sbgp_tls[UCC_HIER_SBGP_LAST];
+    size_t                   a2av_node_thresh;
 } ucc_cl_hier_lib_config_t;
 
 typedef struct ucc_cl_hier_context_config {

--- a/src/components/cl/hier/cl_hier_coll.h
+++ b/src/components/cl/hier/cl_hier_coll.h
@@ -8,9 +8,11 @@
 
 #include "cl_hier.h"
 #include "schedule/ucc_schedule_pipelined.h"
+#include "components/mc/ucc_mc.h"
 
 typedef struct ucc_cl_hier_schedule_t {
     ucc_schedule_pipelined_t super;
+    ucc_mc_buffer_header_t  *scratch;
 } ucc_cl_hier_schedule_t;
 
 static inline ucc_cl_hier_schedule_t *

--- a/src/components/topo/ucc_sbgp.h
+++ b/src/components/topo/ucc_sbgp.h
@@ -33,7 +33,7 @@ typedef enum ucc_sbgp_type_t
                                 local_socket_rank = 0. This group is DISABLED
                                 but EXISTS for procs with local_socket_rank != 0 */
     UCC_SBGP_NUMA_LEADERS,   /* Same as SOCKET_LEADERS but for NUMA grouping */
-    UCC_SBGP_FLAT,           /* Group contains ALL the ranks of the team */
+    UCC_SBGP_FULL,           /* Group contains ALL the ranks of the team */
     UCC_SBGP_LAST
 } ucc_sbgp_type_t;
 

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -76,4 +76,14 @@ int ucc_topo_is_single_node(ucc_topo_t *topo);
 /* Returns the array of ALL existing socket subgroups of given topo */
 ucc_status_t ucc_topo_get_all_sockets(ucc_topo_t *topo, ucc_sbgp_t **sbgps,
                                       int *n_sbgps);
+
+static inline int ucc_rank_on_local_node(ucc_rank_t team_rank, ucc_topo_t *topo)
+{
+    ucc_proc_info_t *procs    = topo->topo->procs;
+    ucc_rank_t       ctx_rank = ucc_ep_map_eval(topo->set.map, team_rank);
+    ucc_rank_t my_ctx_rank = ucc_ep_map_eval(topo->set.map, topo->set.myrank);
+
+    return procs[ctx_rank].host_hash == procs[my_ctx_rank].host_hash;
+}
+
 #endif

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -41,15 +41,32 @@
         (_task)->start_time   = ucc_get_time();                    \
     } while(0)
 
+#define UCC_COLL_ARGS_COUNT64(_args)                                           \
+    (((_args)->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&                            \
+     ((_args)->flags & UCC_COLL_ARGS_FLAG_COUNT_64BIT))
+
+#define UCC_COLL_ARGS_DISPL64(_args)                                           \
+    (((_args)->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&                            \
+     ((_args)->flags & UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT))
+
 static inline size_t
 ucc_coll_args_get_count(const ucc_coll_args_t *args, const ucc_count_t *counts,
                         ucc_rank_t idx)
 {
-    if ((args->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
-        (args->flags & UCC_COLL_ARGS_FLAG_COUNT_64BIT)) {
+    if (UCC_COLL_ARGS_COUNT64(args)) {
         return ((uint64_t *)counts)[idx];
     }
     return ((uint32_t *)counts)[idx];
+}
+
+static inline size_t
+ucc_coll_args_get_displacement(const ucc_coll_args_t *args,
+                               const ucc_aint_t *displacements, ucc_rank_t idx)
+{
+    if (UCC_COLL_ARGS_DISPL64(args)) {
+        return ((uint64_t *)displacements)[idx];
+    }
+    return ((uint32_t *)displacements)[idx];
 }
 
 static inline const char* ucc_mem_type_str(ucc_memory_type_t ct)
@@ -73,17 +90,6 @@ static inline const char* ucc_mem_type_str(ucc_memory_type_t ct)
         break;
     }
     return "invalid";
-}
-
-static inline size_t
-ucc_coll_args_get_displacement(const ucc_coll_args_t *args,
-                               const ucc_aint_t *displacements, ucc_rank_t idx)
-{
-    if ((args->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
-        (args->flags & UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT)) {
-        return ((uint64_t *)displacements)[idx];
-    }
-    return ((uint32_t *)displacements)[idx];
 }
 
 static inline size_t

--- a/test/mpi/test_alltoall.cc
+++ b/test/mpi/test_alltoall.cc
@@ -100,7 +100,7 @@ ucc_status_t TestAlltoall::reset_sbuf()
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &nprocs);
     if (TEST_NO_INPLACE == inplace) {
-        init_buffer(sbuf, single_rank_count * nprocs, TEST_DT, mem_type, 0);
+        init_buffer(sbuf, single_rank_count * nprocs, TEST_DT, mem_type, rank);
     }
     return UCC_OK;
 }


### PR DESCRIPTION
## What
Adds implementation of 2lvl alltoallv in the CL/HIER. 

## Why ?
Allows splitting a2av among TLs (e.g., TL/CUDA for intranode + TL/UCP for internode)

## How ?
CL/HIER allocates 2 sbgps: NODE and FULL, allocates a storage for counts/displs for 2 tasks and initializes it. Then the 2 tasks are launched concurrently.
