### PR TITLE
Implement TL context config modify

### DIFF
--- a/src/components/base/ucc_base_iface.c
+++ b/src/components/base/ucc_base_iface.c
@@ -2,14 +2,17 @@
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_log.h"
 
-ucc_config_field_t ucc_base_config_table[] = {
+ucc_config_field_t ucc_base_lib_config_table[] = {
     {"LOG_LEVEL", "warn",
      "UCC logging level. Messages with a level higher or equal to the "
      "selected will be printed.\n"
      "Possible values are: fatal, error, warn, info, debug, trace, data, func, "
      "poll.",
-     ucc_offsetof(ucc_base_config_t, log_component), UCC_CONFIG_TYPE_LOG_COMP},
+     ucc_offsetof(ucc_base_lib_config_t, log_component), UCC_CONFIG_TYPE_LOG_COMP},
 
+    {NULL}};
+
+ucc_config_field_t ucc_base_ctx_config_table[] = {
     {"TUNE", "", "Collective tuning modifier for a CL/TL component\n"
      "format: token1#token2#...#tokenn - '#' separated list of tokens where\n"
      "    token=coll_type:msg_range:mem_type:team_size:score:alg - ':' separated\n"
@@ -30,7 +33,7 @@ ucc_config_field_t ucc_base_config_table[] = {
      "          inf - forces the CL/TL in the given range for a given coll\n"
      "    alg=@<value|str> - character @ followed by either int number or string\n"
      "        representing the collective algorithm.",
-     ucc_offsetof(ucc_base_config_t, score_str), UCC_CONFIG_TYPE_STRING},
+     ucc_offsetof(ucc_base_ctx_config_t, score_str), UCC_CONFIG_TYPE_STRING},
 
     {NULL}};
 

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -26,14 +26,21 @@ typedef struct ucc_coll_task ucc_coll_task_t;
 
 typedef struct ucc_base_lib {
     ucc_log_component_config_t log_component;
-    char                      *score_str;
 } ucc_base_lib_t;
 
 typedef struct ucc_base_config {
     ucc_config_global_list_entry_t *cfg_entry;
-    ucc_log_component_config_t      log_component;
-    char                           *score_str;
 } ucc_base_config_t;
+
+typedef struct ucc_base_lib_config {
+    ucc_base_config_t               super;
+    ucc_log_component_config_t      log_component;
+} ucc_base_lib_config_t;
+
+typedef struct ucc_base_ctx_config {
+    ucc_base_config_t               super;
+    char                           *score_str;
+} ucc_base_ctx_config_t;
 
 enum {
     UCC_BASE_LIB_FLAG_TEAM_ID_REQUIRED      = UCC_BIT(1),
@@ -49,11 +56,13 @@ typedef struct ucc_base_lib_params {
     ucc_lib_params_t params;
     char            *full_prefix;
 } ucc_base_lib_params_t;
-extern ucc_config_field_t ucc_base_config_table[];
+extern ucc_config_field_t ucc_base_lib_config_table[];
+extern ucc_config_field_t ucc_base_ctx_config_table[];
 
 typedef struct ucc_base_lib_iface {
     ucc_status_t (*init)(const ucc_base_lib_params_t *params,
-                         const ucc_base_config_t *config, ucc_base_lib_t **lib);
+                         const ucc_base_config_t *config,
+                         ucc_base_lib_t **lib);
     void         (*finalize)(ucc_base_lib_t *lib);
     ucc_status_t (*get_attr)(const ucc_base_lib_t *lib,
                              ucc_base_lib_attr_t  *attr);
@@ -71,6 +80,7 @@ typedef struct ucc_base_context_params {
 typedef struct ucc_base_context {
     ucc_context_t  *ucc_context;
     ucc_base_lib_t *lib;
+    char           *score_str;
 } ucc_base_context_t;
 
 typedef struct ucc_base_ctx_attr_t {

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -17,7 +17,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
     ucc_status_t status;
     int          i;
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_config->cl_lib,
+    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_config,
                               params->context);
     if (tls->count == 1 && !strcmp(tls->names[0], "all")) {
         tls = &params->context->all_tls;

--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -166,7 +166,7 @@ ucc_status_t ucc_cl_basic_team_get_scores(ucc_base_team_t   *cl_team,
                                           ucc_coll_score_t **score)
 {
     ucc_cl_basic_team_t *team = ucc_derived_of(cl_team, ucc_cl_basic_team_t);
-    ucc_base_lib_t      *lib  = UCC_CL_TEAM_LIB(team);
+    ucc_base_context_t  *ctx  = UCC_CL_TEAM_CTX(team);
     ucc_status_t         status;
 
     status = ucc_coll_score_dup(team->score, score);
@@ -174,9 +174,9 @@ ucc_status_t ucc_cl_basic_team_get_scores(ucc_base_team_t   *cl_team,
         return status;
     }
 
-    if (strlen(lib->score_str) > 0) {
+    if (strlen(ctx->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->score_str, *score, UCC_CL_TEAM_SIZE(team), NULL, cl_team,
+            ctx->score_str, *score, UCC_CL_TEAM_SIZE(team), NULL, cl_team,
             UCC_CL_BASIC_DEFAULT_SCORE, NULL);
 
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */

--- a/src/components/cl/hier/cl_hier_context.c
+++ b/src/components/cl/hier/cl_hier_context.c
@@ -21,7 +21,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_context_t,
     ucc_status_t              status;
     int                       i;
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_config->cl_lib,
+    UCC_CLASS_CALL_SUPER_INIT(ucc_cl_context_t, cl_config,
                               params->context);
     if (tls->count == 1 && !strcmp(tls->names[0], "all")) {
         tls = &params->context->all_tls;

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -298,6 +298,7 @@ ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
 {
     ucc_cl_hier_team_t *team  = ucc_derived_of(cl_team, ucc_cl_hier_team_t);
     ucc_base_lib_t     *lib   = UCC_CL_TEAM_LIB(team);
+    ucc_base_context_t *ctx   = UCC_CL_TEAM_CTX(team);
     ucc_memory_type_t   mt[2] = {UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA};
     ucc_coll_score_t   *score;
     ucc_status_t        status;
@@ -319,9 +320,9 @@ ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
         }
     }
 
-    if (strlen(lib->score_str) > 0) {
+    if (strlen(ctx->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->score_str, score, UCC_CL_TEAM_SIZE(team),
+            ctx->score_str, score, UCC_CL_TEAM_SIZE(team),
             ucc_cl_hier_coll_init,
             cl_team, UCC_CL_HIER_DEFAULT_SCORE, NULL);
 

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -120,7 +120,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_context_t, const ucc_cl_context_config_t *cl_config,
     self->super.ucc_context = ucc_context;
 
     if (0 == strcmp(cl_config->super.score_str, "0")) {
-        return UCC_ERR_NO_MESSAGE;
+        return UCC_ERR_LAST;
     }
     self->super.score_str = strdup(cl_config->super.score_str);
 

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -14,7 +14,7 @@ static char * ucc_cl_tls_doc_str = "List of TLs used by a given CL component.\n"
 #define TLS_CONFIG_ENTRY 1
 ucc_config_field_t ucc_cl_lib_config_table[] = {
     [0] = {"", "", NULL, ucc_offsetof(ucc_cl_lib_config_t, super),
-     UCC_CONFIG_TYPE_TABLE(ucc_base_config_table)},
+     UCC_CONFIG_TYPE_TABLE(ucc_base_lib_config_table)},
 
     [TLS_CONFIG_ENTRY] = {"TLS", "all", NULL,
                           ucc_offsetof(ucc_cl_lib_config_t, tls),
@@ -24,6 +24,9 @@ ucc_config_field_t ucc_cl_lib_config_table[] = {
 };
 
 ucc_config_field_t ucc_cl_context_config_table[] = {
+    [0] = {"", "", NULL, ucc_offsetof(ucc_cl_context_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_base_ctx_config_table)},
+
     {NULL}
 };
 
@@ -41,13 +44,10 @@ UCC_CLASS_INIT_FUNC(ucc_cl_lib_t, ucc_cl_iface_t *cl_iface,
     UCC_CLASS_CALL_BASE_INIT();
     self->iface         = cl_iface;
     self->super.log_component = cl_config->super.log_component;
-    if (0 == strcmp(cl_config->super.score_str, "0")) {
-        return UCC_ERR_NO_MESSAGE;
-    }
     ucc_strncpy_safe(self->super.log_component.name,
                      cl_iface->cl_lib_config.name,
                      sizeof(self->super.log_component.name));
-    self->super.score_str = strdup(cl_config->super.score_str);
+
     status = ucc_config_names_array_dup(&self->tls, &cl_config->tls);
     if (UCC_OK != status) {
         ucc_error("failed to dup TLS config_names_array for CL %s",
@@ -58,7 +58,6 @@ UCC_CLASS_INIT_FUNC(ucc_cl_lib_t, ucc_cl_iface_t *cl_iface,
 
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_lib_t)
 {
-    ucc_free(self->super.score_str);
     ucc_config_names_array_free(&self->tls);
 }
 
@@ -113,17 +112,24 @@ ucc_status_t ucc_parse_cls_string(const char *cls_str,
     return UCC_OK;
 }
 
-UCC_CLASS_INIT_FUNC(ucc_cl_context_t, ucc_cl_lib_t *cl_lib,
+UCC_CLASS_INIT_FUNC(ucc_cl_context_t, const ucc_cl_context_config_t *cl_config,
                     ucc_context_t *ucc_context)
 {
     UCC_CLASS_CALL_BASE_INIT();
-    self->super.lib         = &cl_lib->super;
+    self->super.lib         = &cl_config->cl_lib->super;
     self->super.ucc_context = ucc_context;
+
+    if (0 == strcmp(cl_config->super.score_str, "0")) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    self->super.score_str = strdup(cl_config->super.score_str);
+
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_context_t)
 {
+    ucc_free(self->super.score_str);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_context_t, void);

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -37,7 +37,7 @@ typedef struct ucc_cl_context ucc_cl_context_t;
 typedef struct ucc_cl_team    ucc_cl_team_t;
 
 typedef struct ucc_cl_lib_config {
-    ucc_base_config_t        super;
+    ucc_base_lib_config_t    super;
     ucc_cl_iface_t          *iface;
     ucc_config_names_array_t tls;
 } ucc_cl_lib_config_t;
@@ -45,8 +45,8 @@ extern ucc_config_field_t ucc_cl_lib_config_table[];
 
 
 typedef struct ucc_cl_context_config {
-    ucc_base_config_t super;
-    ucc_cl_lib_t   *cl_lib;
+    ucc_base_ctx_config_t super;
+    ucc_cl_lib_t         *cl_lib;
 } ucc_cl_context_config_t;
 extern ucc_config_field_t ucc_cl_context_config_table[];
 
@@ -80,7 +80,8 @@ UCC_CLASS_DECLARE(ucc_cl_lib_t, ucc_cl_iface_t *, const ucc_cl_lib_config_t *);
 typedef struct ucc_cl_context {
     ucc_base_context_t super;
 } ucc_cl_context_t;
-UCC_CLASS_DECLARE(ucc_cl_context_t, ucc_cl_lib_t *, ucc_context_t *);
+UCC_CLASS_DECLARE(ucc_cl_context_t, const ucc_cl_context_config_t *,
+                  ucc_context_t *);
 
 typedef struct ucc_cl_team {
     ucc_base_team_t super;
@@ -107,6 +108,8 @@ typedef struct ucc_cl_lib_attr {
     (ucc_derived_of((_cl_team)->super.context->lib, ucc_cl_lib_t))->iface
 
 #define UCC_CL_TEAM_LIB(_cl_team) (_cl_team)->super.super.context->lib
+
+#define UCC_CL_TEAM_CTX(_cl_team) (_cl_team)->super.super.context
 
 #define UCC_CL_TEAM_SIZE(_cl_team) (_cl_team)->super.super.params.size
 

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -29,7 +29,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
     CUcontext cu_ctx;
     CUresult cu_st;
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_cuda_config->super.tl_lib,
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_cuda_config->super,
                               params->context);
     memcpy(&self->cfg, tl_cuda_config, sizeof(*tl_cuda_config));
 

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -283,7 +283,7 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
                                          ucc_coll_score_t **score_p)
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
-    ucc_tl_cuda_lib_t  *lib  = UCC_TL_CUDA_TEAM_LIB(team);
+    ucc_base_context_t *ctx  = UCC_TL_TEAM_CTX(team);
     ucc_memory_type_t   mt   = UCC_MEMORY_TYPE_CUDA;
     ucc_coll_score_t   *score;
     ucc_status_t        status;
@@ -297,9 +297,9 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
         return status;
     }
 
-    if (strlen(lib->super.super.score_str) > 0) {
+    if (strlen(ctx->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->super.super.score_str, score, UCC_TL_TEAM_SIZE(team),
+            ctx->score_str, score, UCC_TL_TEAM_SIZE(team),
             ucc_tl_cuda_coll_init, &team->super.super,
             UCC_TL_CUDA_DEFAULT_SCORE, NULL);
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -105,7 +105,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
     CUresult cu_st;
     CUdevice cu_dev;
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_nccl_config->super.tl_lib,
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_nccl_config->super,
                               params->context);
     memcpy(&self->cfg, tl_nccl_config, sizeof(*tl_nccl_config));
     if (self->cfg.sync_type != UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT) {

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -183,7 +183,7 @@ ucc_status_t ucc_tl_nccl_team_get_scores(ucc_base_team_t   *tl_team,
                                          ucc_coll_score_t **score_p)
 {
     ucc_tl_nccl_team_t *team = ucc_derived_of(tl_team, ucc_tl_nccl_team_t);
-    ucc_tl_nccl_lib_t * lib  = UCC_TL_NCCL_TEAM_LIB(team);
+    ucc_base_context_t *ctx  = UCC_TL_TEAM_CTX(team);
     ucc_memory_type_t   mt   = UCC_MEMORY_TYPE_CUDA;
     ucc_coll_score_t   *score;
     ucc_status_t        status;
@@ -221,9 +221,9 @@ ucc_status_t ucc_tl_nccl_team_get_scores(ucc_base_team_t   *tl_team,
         return status;
     }
 
-    if (strlen(lib->super.super.score_str) > 0) {
+    if (strlen(ctx->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->super.super.score_str, score, UCC_TL_TEAM_SIZE(team),
+            ctx->score_str, score, UCC_TL_TEAM_SIZE(team),
             ucc_tl_nccl_coll_init, &team->super.super,
             UCC_TL_NCCL_DEFAULT_SCORE, ucc_tl_nccl_alg_id_to_init);
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */

--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -207,7 +207,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_context_t,
         goto err;
     }
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_sharp_config->super.tl_lib,
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_sharp_config->super,
                               params->context);
     memcpy(&self->cfg, tl_sharp_config, sizeof(*tl_sharp_config));
 

--- a/src/components/tl/sharp/tl_sharp_team.c
+++ b/src/components/tl/sharp/tl_sharp_team.c
@@ -131,7 +131,7 @@ ucc_status_t ucc_tl_sharp_team_get_scores(ucc_base_team_t   *tl_team,
                                           ucc_coll_score_t **score_p)
 {
     ucc_tl_sharp_team_t *team = ucc_derived_of(tl_team, ucc_tl_sharp_team_t);
-    ucc_tl_sharp_lib_t  *lib  = UCC_TL_SHARP_TEAM_LIB(team);
+    ucc_base_context_t  *ctx  = UCC_TL_TEAM_CTX(team);
     ucc_coll_score_t    *score;
     ucc_status_t         status;
 
@@ -146,9 +146,9 @@ ucc_status_t ucc_tl_sharp_team_get_scores(ucc_base_team_t   *tl_team,
         return status;
     }
 
-    if (strlen(lib->super.super.score_str) > 0) {
+    if (strlen(ctx->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->super.super.score_str, score, UCC_TL_TEAM_SIZE(team),
+            ctx->score_str, score, UCC_TL_TEAM_SIZE(team),
             ucc_tl_sharp_coll_init, &team->super.super,
             UCC_TL_SHARP_DEFAULT_SCORE, NULL);
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -9,12 +9,15 @@
 
 ucc_config_field_t ucc_tl_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_lib_config_t, super),
-     UCC_CONFIG_TYPE_TABLE(ucc_base_config_table)},
+     UCC_CONFIG_TYPE_TABLE(ucc_base_lib_config_table)},
 
     {NULL}
 };
 
 ucc_config_field_t ucc_tl_context_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_tl_context_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_base_ctx_config_table)},
+
     {NULL}
 };
 
@@ -24,35 +27,36 @@ UCC_CLASS_INIT_FUNC(ucc_tl_lib_t, ucc_tl_iface_t *tl_iface,
     UCC_CLASS_CALL_BASE_INIT();
     self->iface         = tl_iface;
     self->super.log_component = tl_config->super.log_component;
-    if (0 == strcmp(tl_config->super.score_str, "0")) {
-        return UCC_ERR_NO_MESSAGE;
-    }
     ucc_strncpy_safe(self->super.log_component.name,
                      tl_iface->tl_lib_config.name,
                      sizeof(self->super.log_component.name));
-    self->super.score_str = strdup(tl_config->super.score_str);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_lib_t)
 {
-    ucc_free(self->super.score_str);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_lib_t, void);
 
-UCC_CLASS_INIT_FUNC(ucc_tl_context_t, ucc_tl_lib_t *tl_lib,
+UCC_CLASS_INIT_FUNC(ucc_tl_context_t, const ucc_tl_context_config_t *tl_config,
                     ucc_context_t *ucc_context)
 {
     UCC_CLASS_CALL_BASE_INIT();
-    self->super.lib         = &tl_lib->super;
+    self->super.lib         = &tl_config->tl_lib->super;
     self->super.ucc_context = ucc_context;
     self->ref_count = 0;
+    if (0 == strcmp(tl_config->super.score_str, "0")) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    self->super.score_str = strdup(tl_config->super.score_str);
+
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_context_t)
 {
+    ucc_free(self->super.score_str);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_context_t, void);

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -47,7 +47,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_context_t, const ucc_tl_context_config_t *tl_config,
     self->super.ucc_context = ucc_context;
     self->ref_count = 0;
     if (0 == strcmp(tl_config->super.score_str, "0")) {
-        return UCC_ERR_NO_MESSAGE;
+        return UCC_ERR_LAST;
     }
     self->super.score_str = strdup(tl_config->super.score_str);
 

--- a/src/components/tl/ucc_tl.h
+++ b/src/components/tl/ucc_tl.h
@@ -27,14 +27,14 @@ typedef struct ucc_tl_context ucc_tl_context_t;
 typedef struct ucc_tl_team    ucc_tl_team_t;
 
 typedef struct ucc_tl_lib_config {
-    ucc_base_config_t  super;
-    ucc_tl_iface_t    *iface;
+    ucc_base_lib_config_t  super;
+    ucc_tl_iface_t        *iface;
 } ucc_tl_lib_config_t;
 extern ucc_config_field_t ucc_tl_lib_config_table[];
 
 typedef struct ucc_tl_context_config {
-    ucc_base_config_t super;
-    ucc_tl_lib_t     *tl_lib;
+    ucc_base_ctx_config_t super;
+    ucc_tl_lib_t         *tl_lib;
 } ucc_tl_context_config_t;
 extern ucc_config_field_t ucc_tl_context_config_table[];
 
@@ -87,7 +87,8 @@ typedef struct ucc_tl_context {
     ucc_base_context_t super;
     int                ref_count;
 } ucc_tl_context_t;
-UCC_CLASS_DECLARE(ucc_tl_context_t, ucc_tl_lib_t *, ucc_context_t *);
+UCC_CLASS_DECLARE(ucc_tl_context_t, const ucc_tl_context_config_t *,
+                  ucc_context_t *);
 
 typedef struct ucc_tl_team {
     ucc_base_team_t super;
@@ -134,6 +135,8 @@ typedef struct ucc_tl_lib_attr {
     (ucc_derived_of((_tl_team)->super.context->lib, ucc_tl_lib_t))->iface
 
 #define UCC_TL_TEAM_LIB(_tl_team) (_tl_team)->super.super.context->lib
+
+#define UCC_TL_TEAM_CTX(_tl_team) (_tl_team)->super.super.context
 
 #define UCC_TL_CORE_CTX(_tl_team) ((_tl_team)->super.super.context->ucc_context)
 

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -29,7 +29,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     ucp_worker_h        ucp_worker;
     ucs_status_t        status;
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, tl_ucp_config->super.tl_lib,
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_ucp_config->super,
                               params->context);
     memcpy(&self->cfg, tl_ucp_config, sizeof(*tl_ucp_config));
     status = ucp_config_read(params->prefix, NULL, &ucp_config);

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -122,8 +122,8 @@ ucc_status_t ucc_tl_ucp_team_get_scores(ucc_base_team_t   *tl_team,
     ucc_tl_ucp_team_t          *team    = ucc_derived_of(tl_team,
                                                       ucc_tl_ucp_team_t);
     ucc_component_framework_t  *plugins = &ucc_tl_ucp.super.coll_plugins;
-    ucc_tl_ucp_context_t       *ctx     = UCC_TL_UCP_TEAM_CTX(team);
-    ucc_tl_ucp_lib_t           *lib     = UCC_TL_UCP_TEAM_LIB(team);
+    ucc_tl_ucp_context_t       *tl_ctx  = UCC_TL_UCP_TEAM_CTX(team);
+    ucc_base_context_t         *ctx     = UCC_TL_TEAM_CTX(team);
     int                         mt_n    = 0;
     ucc_memory_type_t           mem_types[UCC_MEMORY_TYPE_LAST];
     ucc_coll_score_t           *score, *tlcp_score;
@@ -132,7 +132,7 @@ ucc_status_t ucc_tl_ucp_team_get_scores(ucc_base_team_t   *tl_team,
     unsigned                    i;
 
     for (i = 0; i < UCC_MEMORY_TYPE_LAST; i++) {
-        if (ctx->ucp_memory_types & UCC_BIT(ucc_memtype_to_ucs[i])) {
+        if (tl_ctx->ucp_memory_types & UCC_BIT(ucc_memtype_to_ucs[i])) {
             tl_debug(tl_team->context->lib,
                      "enable support for memory type %s",
                      ucc_memory_type_names[i]);
@@ -160,9 +160,9 @@ ucc_status_t ucc_tl_ucp_team_get_scores(ucc_base_team_t   *tl_team,
             goto err;
         }
     }
-    if (strlen(lib->super.super.score_str) > 0) {
+    if (strlen(ctx->score_str) > 0) {
         status = ucc_coll_score_update_from_str(
-            lib->super.super.score_str, score, UCC_TL_TEAM_SIZE(team), NULL,
+            ctx->score_str, score, UCC_TL_TEAM_SIZE(team), NULL,
             &team->super.super, UCC_TL_UCP_DEFAULT_SCORE,
             ucc_tl_ucp_alg_id_to_init);
 

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -10,6 +10,7 @@
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_log.h"
 #include "utils/ucc_list.h"
+#include "utils/ucc_string.h"
 #include "ucc_progress_queue.h"
 
 static uint32_t ucc_context_seq_num = 0;
@@ -51,6 +52,7 @@ ucc_status_t ucc_context_config_read(ucc_lib_info_t *lib, const char *filename,
                                      ucc_context_config_t **config_p)
 {
     ucc_cl_context_config_t *cl_config = NULL;
+    ucc_tl_context_config_t *tl_config = NULL;
     int                      i;
     ucc_status_t             status;
     ucc_context_config_t    *config;
@@ -64,24 +66,33 @@ ucc_status_t ucc_context_config_read(ucc_lib_info_t *lib, const char *filename,
     if (config == NULL) {
         ucc_error("failed to allocate %zd bytes for context config",
                   sizeof(ucc_context_config_t));
-        status = UCC_ERR_NO_MEMORY;
-        goto err_config;
+        return UCC_ERR_NO_MEMORY;
     }
 
     status = ucc_config_parser_fill_opts(config, ucc_context_config_table,
                                          lib->full_prefix, NULL, 0);
     if (status != UCC_OK) {
         ucc_error("failed to read UCC core context config");
-        goto err_configs;
+        goto err_config;
     }
 
     config->lib     = lib;
-    config->configs = (ucc_cl_context_config_t **)ucc_calloc(
+    config->cl_cfgs = (ucc_cl_context_config_t **)ucc_calloc(
         lib->n_cl_libs_opened, sizeof(ucc_cl_context_config_t *),
         "cl_configs_array");
-    if (config->configs == NULL) {
+    if (config->cl_cfgs == NULL) {
         ucc_error("failed to allocate %zd bytes for cl configs array",
                   sizeof(ucc_cl_context_config_t *));
+        status = UCC_ERR_NO_MEMORY;
+        goto err_config;
+    }
+
+    config->tl_cfgs = (ucc_tl_context_config_t **)ucc_calloc(
+        lib->n_tl_libs_opened, sizeof(ucc_tl_context_config_t *),
+        "tl_configs_array");
+    if (config->tl_cfgs == NULL) {
+        ucc_error("failed to allocate %zd bytes for tl configs array",
+                  sizeof(ucc_tl_context_config_t *));
         status = UCC_ERR_NO_MEMORY;
         goto err_configs;
     }
@@ -94,36 +105,71 @@ ucc_status_t ucc_context_config_read(ucc_lib_info_t *lib, const char *filename,
         if (UCC_OK != status) {
             ucc_error("failed to read CL \"%s\" context configuration",
                       lib->cl_libs[i]->iface->super.name);
-            goto err_config_i;
+            goto err_cl_config;
         }
-        config->configs[config->n_cl_cfg]         = cl_config;
+        config->cl_cfgs[config->n_cl_cfg] = cl_config;
         config->n_cl_cfg++;
     }
+
+    config->n_tl_cfg = 0;
+    for (i = 0; i < lib->n_tl_libs_opened; i++) {
+        ucc_assert(NULL != lib->tl_libs[i]->iface->tl_context_config.table);
+        status =
+            ucc_tl_context_config_read(lib->tl_libs[i], config, &tl_config);
+        if (UCC_OK != status) {
+            ucc_error("failed to read TL \"%s\" context configuration",
+                      lib->tl_libs[i]->iface->super.name);
+            goto err_tl_config;
+        }
+        config->tl_cfgs[config->n_tl_cfg] = tl_config;
+        config->n_tl_cfg++;
+    }
+
     *config_p   = config;
     return UCC_OK;
 
-err_config_i:
-    for (i = i - 1; i >= 0; i--) {
-        ucc_base_config_release(&config->configs[i]->super);
+err_tl_config:
+    for (i = 0; i < config->n_tl_cfg; i++) {
+        ucc_base_config_release(&config->tl_cfgs[i]->super);
     }
+
+err_cl_config:
+    for (i = 0; i < config->n_cl_cfg; i++) {
+        ucc_base_config_release(&config->cl_cfgs[i]->super);
+    }
+    ucc_free(config->tl_cfgs);
+
 err_configs:
-    ucc_free(config->configs);
+    ucc_free(config->cl_cfgs);
 
 err_config:
     ucc_free(config);
     return status;
 }
 
-/* Look up the cl_context_config in the array of configs based on the
-   cl_type. returns NULL if not found */
 static inline ucc_cl_context_config_t *
-find_cl_context_config(ucc_context_config_t *cfg, ucc_cl_type_t cl_type)
+find_cl_context_config(ucc_context_config_t *cfg, const char *name)
 {
     int i;
     for (i = 0; i < cfg->n_cl_cfg; i++) {
-        if (cfg->configs[i] &&
-            (cl_type == cfg->configs[i]->cl_lib->iface->type)) {
-            return cfg->configs[i];
+        if (cfg->cl_cfgs[i] &&
+            (0 == strcmp(cfg->cl_cfgs[i]->cl_lib->iface->super.name,
+                         name))) {
+            return cfg->cl_cfgs[i];
+        }
+    }
+    return NULL;
+}
+
+static inline ucc_tl_context_config_t *
+find_tl_context_config(ucc_context_config_t *cfg, const char *name)
+{
+    int i;
+    for (i = 0; i < cfg->n_tl_cfg; i++) {
+        if (cfg->tl_cfgs[i] &&
+            (0 == strcmp(cfg->tl_cfgs[i]->tl_lib->iface->super.name,
+                         name))) {
+            return cfg->tl_cfgs[i];
         }
     }
     return NULL;
@@ -137,13 +183,19 @@ find_cl_context_config(ucc_context_config_t *cfg, ucc_cl_type_t cl_type)
    If user passes a comma separated list of CLs, then we go over the list
    and apply modifications to the specified CLs only. */
 ucc_status_t ucc_context_config_modify(ucc_context_config_t *config,
-                                       const char *cls, const char *name,
+                                       const char *components,
+                                       const char *name,
                                        const char *value)
 {
     int                      i;
     ucc_status_t             status;
     ucc_cl_context_config_t *cl_cfg;
-    if (NULL == cls) {
+    ucc_tl_context_config_t *tl_cfg;
+    char                   **tokens;
+    const char              *component;
+    unsigned                 n_tokens;
+
+    if (NULL == components) {
         /* cls is NULL means modify core ucc context config */
         status = ucc_config_parser_set_value(config, ucc_context_config_table, name,
                                              value);
@@ -152,45 +204,69 @@ ucc_status_t ucc_context_config_modify(ucc_context_config_t *config,
                       name, value);;
             return status;
         }
-    } else if (0 != strcmp(cls, "all")) {
-        ucc_cl_type_t *required_cls;
-        int            n_required_cls;
-        status = ucc_parse_cls_string(cls, &required_cls, &n_required_cls);
-        if (UCC_OK != status) {
-            ucc_error("failed to parse cls string: %s", cls);
-            return status;
+    } else if (0 != strcmp(components, "all")) {
+        tokens = ucc_str_split(components, ",");
+        if (!tokens) {
+            return UCC_ERR_INVALID_PARAM;
         }
-        for (i = 0; i < n_required_cls; i++) {
-            cl_cfg = find_cl_context_config(config, required_cls[i]);
-            if (!cl_cfg) {
-                ucc_error("required CL %s is not part of the context",
-                          ucc_cl_names[required_cls[i]]);
-                ucc_free(required_cls);
-                return UCC_ERR_INVALID_PARAM;
+        n_tokens = ucc_str_split_count(tokens);
+
+        for (i = 0; i < n_tokens; i++) {
+            if (strlen(tokens[i]) < 4) {
+                status = UCC_ERR_INVALID_PARAM;
+                goto err_input;
             }
-            status = ucc_config_parser_set_value(
-                cl_cfg, cl_cfg->cl_lib->iface->cl_context_config.table, name,
-                value);
-            if (UCC_OK != status) {
-                ucc_error("failed to modify CL \"%s\" configuration, name %s, "
-                          "value %s",
-                          cl_cfg->cl_lib->iface->super.name, name, value);
-                ucc_free(required_cls);
-                return status;
+            component = tokens[i] + 3;
+            if (0 == strncmp(tokens[i], "cl/", 3)) {
+                cl_cfg = find_cl_context_config(config, component);
+                if (!cl_cfg) {
+                    ucc_error("required CL %s is not part of the context",
+                              component);
+                    status = UCC_ERR_NOT_FOUND;
+                    goto err;
+                }
+                status = ucc_config_parser_set_value(
+                    cl_cfg, cl_cfg->cl_lib->iface->cl_context_config.table, name,
+                    value);
+                if (UCC_OK != status) {
+                    ucc_error("failed to modify CL \"%s\" configuration, name %s, "
+                              "value %s", component, name, value);
+                    goto err;
+                }
+            } else if (0 == strncmp(tokens[i], "tl/", 3)) {
+                tl_cfg = find_tl_context_config(config, component);
+                if (!tl_cfg) {
+                    ucc_error("required TL %s is not part of the context",
+                              component);
+                    status = UCC_ERR_NOT_FOUND;
+                    goto err;
+                }
+                status = ucc_config_parser_set_value(
+                    tl_cfg, tl_cfg->tl_lib->iface->tl_context_config.table, name,
+                    value);
+                if (UCC_OK != status) {
+                    ucc_error("failed to modify TL \"%s\" configuration, name %s, "
+                              "value %s", component, name, value);
+                    goto err;
+                }
+            } else {
+                status = UCC_ERR_INVALID_PARAM;
+                ucc_error("invalid component name %s", tokens[i]);
+                goto err_input;
             }
         }
-        ucc_free(required_cls);
+        ucc_str_split_free(tokens);
     } else {
         for (i = 0; i < config->n_cl_cfg; i++) {
-            if (config->configs[i]) {
+            if (config->cl_cfgs[i]) {
                 status = ucc_config_parser_set_value(
-                    config->configs[i],
-                    config->lib->cl_libs[i]->iface->cl_context_config.table, name,
-                    value);
+                    config->cl_cfgs[i],
+                    config->cl_cfgs[i]->cl_lib->iface->cl_context_config.table,
+                    name, value);
                 if (UCC_OK != status) {
                     ucc_error("failed to modify CL \"%s\" configuration, name "
                               "%s, value %s",
-                              config->lib->cl_libs[i]->iface->super.name, name,
+                              config->cl_cfgs[i]->cl_lib->iface->super.name, name,
                               value);
                     return status;
                 }
@@ -198,18 +274,29 @@ ucc_status_t ucc_context_config_modify(ucc_context_config_t *config,
         }
     }
     return UCC_OK;
+
+err_input:
+    ucc_error("incorrect component name %s is provided. "
+              "expected cl/<cl_name> or tl/<tl_name>.",
+              tokens[i]);
+err:
+    ucc_str_split_free(tokens);
+    return status;
 }
 
 void ucc_context_config_release(ucc_context_config_t *config)
 {
     int i;
-    for (i = 0; i < config->n_cl_cfg; i++) {
-        if (!config->configs[i]) {
-            continue;
-        }
-        ucc_base_config_release(&config->configs[i]->super);
+
+    for (i = 0; i < config->n_tl_cfg; i++) {
+        ucc_base_config_release(&config->tl_cfgs[i]->super);
     }
-    ucc_free(config->configs);
+
+    for (i = 0; i < config->n_cl_cfg; i++) {
+        ucc_base_config_release(&config->cl_cfgs[i]->super);
+    }
+    ucc_free(config->tl_cfgs);
+    ucc_free(config->cl_cfgs);
     ucc_free(config);
 }
 
@@ -244,13 +331,9 @@ void ucc_context_config_print(const ucc_context_config_h config, FILE *stream,
         config->lib->full_prefix, (ucc_config_print_flags_t)flags);
 
     for (i = 0; i < config->n_cl_cfg; i++) {
-        if (!config->configs[i]) {
-            continue;
-        }
-
         ucc_config_parser_print_opts(
             stream, config->lib->cl_libs[i]->iface->cl_context_config.name,
-            config->configs[i],
+            config->cl_cfgs[i],
             config->lib->cl_libs[i]->iface->cl_context_config.table,
             config->lib->cl_libs[i]->iface->cl_context_config.prefix,
             config->lib->full_prefix, (ucc_config_print_flags_t)flags);
@@ -273,14 +356,13 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
                                            ucc_context_config_t *ctx_config,
                                            ucc_base_context_params_t b_params)
 {
-    ucc_lib_info_t *lib = ctx->lib;
-    ucc_tl_lib_t *tl_lib;
-    ucc_tl_context_config_t *tl_config;
-    ucc_base_context_t       *b_ctx;
-    int i, num_tls;
-    ucc_status_t status;
+    ucc_lib_info_t     *lib = ctx->lib;
+    ucc_tl_lib_t       *tl_lib;
+    ucc_base_context_t *b_ctx;
+    int                 i, num_tls;
+    ucc_status_t        status;
 
-    num_tls = lib->n_tl_libs_opened;
+    num_tls = ctx_config->n_tl_cfg;
     ctx->tl_ctx = (ucc_tl_context_t **)ucc_malloc(
         sizeof(ucc_tl_context_t *) * num_tls, "tl_ctx_array");
     if (!ctx->tl_ctx) {
@@ -289,19 +371,10 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
         return UCC_ERR_NO_MEMORY;
     }
     ctx->n_tl_ctx = 0;
-    for (i = 0; i < lib->n_tl_libs_opened; i++) {
-        tl_lib = lib->tl_libs[i];
-        ucc_assert(NULL != tl_lib->iface->tl_context_config.table);
-        status =
-            ucc_tl_context_config_read(tl_lib, ctx_config, &tl_config);
-        if (UCC_OK != status) {
-            ucc_warn("failed to read TL \"%s\" context configuration",
-                     tl_lib->iface->super.name);
-            continue;
-        }
+    for (i = 0; i < num_tls; i++) {
+        tl_lib = ctx_config->tl_cfgs[i]->tl_lib;
         status = tl_lib->iface->context.create(
-            &b_params, &tl_config->super, &b_ctx);
-        ucc_base_config_release(&tl_config->super);
+            &b_params, &ctx_config->tl_cfgs[i]->super, &b_ctx);
         if (UCC_OK != status) {
             ucc_warn("failed to create tl context for %s",
                       tl_lib->iface->super.name);
@@ -510,9 +583,9 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
     ctx->n_cl_ctx = 0;
     ctx->cl_flags = 0;
     for (i = 0; i < num_cls; i++) {
-        cl_lib = config->configs[i]->cl_lib;
+        cl_lib = config->cl_cfgs[i]->cl_lib;
         status = cl_lib->iface->context.create(
-            &b_params, &config->configs[i]->super, &b_ctx);
+            &b_params, &config->cl_cfgs[i]->super, &b_ctx);
         if (UCC_OK != status) {
             if (lib->specific_cls_requested) {
                 ucc_error("failed to create cl context for %s",
@@ -652,7 +725,7 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
 
 error_ctx_create:
     for (i = 0; i < ctx->n_cl_ctx; i++) {
-        config->configs[i]->cl_lib->iface->context.destroy(
+        config->cl_cfgs[i]->cl_lib->iface->context.destroy(
             &ctx->cl_ctx[i]->super);
     }
     ucc_free(ctx->cl_ctx);

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -130,12 +130,12 @@ ucc_status_t ucc_context_config_read(ucc_lib_info_t *lib, const char *filename,
 
 err_tl_config:
     for (i = 0; i < config->n_tl_cfg; i++) {
-        ucc_base_config_release(&config->tl_cfgs[i]->super);
+        ucc_base_config_release(&config->tl_cfgs[i]->super.super);
     }
 
 err_cl_config:
     for (i = 0; i < config->n_cl_cfg; i++) {
-        ucc_base_config_release(&config->cl_cfgs[i]->super);
+        ucc_base_config_release(&config->cl_cfgs[i]->super.super);
     }
     ucc_free(config->tl_cfgs);
 
@@ -289,11 +289,11 @@ void ucc_context_config_release(ucc_context_config_t *config)
     int i;
 
     for (i = 0; i < config->n_tl_cfg; i++) {
-        ucc_base_config_release(&config->tl_cfgs[i]->super);
+        ucc_base_config_release(&config->tl_cfgs[i]->super.super);
     }
 
     for (i = 0; i < config->n_cl_cfg; i++) {
-        ucc_base_config_release(&config->cl_cfgs[i]->super);
+        ucc_base_config_release(&config->cl_cfgs[i]->super.super);
     }
     ucc_free(config->tl_cfgs);
     ucc_free(config->cl_cfgs);
@@ -374,7 +374,7 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
     for (i = 0; i < num_tls; i++) {
         tl_lib = ctx_config->tl_cfgs[i]->tl_lib;
         status = tl_lib->iface->context.create(
-            &b_params, &ctx_config->tl_cfgs[i]->super, &b_ctx);
+            &b_params, &ctx_config->tl_cfgs[i]->super.super, &b_ctx);
         if (UCC_OK != status) {
             ucc_warn("failed to create tl context for %s",
                       tl_lib->iface->super.name);
@@ -585,7 +585,7 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
     for (i = 0; i < num_cls; i++) {
         cl_lib = config->cl_cfgs[i]->cl_lib;
         status = cl_lib->iface->context.create(
-            &b_params, &config->cl_cfgs[i]->super, &b_ctx);
+            &b_params, &config->cl_cfgs[i]->super.super, &b_ctx);
         if (UCC_OK != status) {
             if (lib->specific_cls_requested) {
                 ucc_error("failed to create cl context for %s",

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -376,8 +376,12 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
         status = tl_lib->iface->context.create(
             &b_params, &ctx_config->tl_cfgs[i]->super.super, &b_ctx);
         if (UCC_OK != status) {
-            ucc_warn("failed to create tl context for %s",
-                      tl_lib->iface->super.name);
+            /* UCC_ERR_LAST means component was disabled via TUNE param:
+               don't print warning. */
+            if (UCC_ERR_LAST != status) {
+                ucc_warn("failed to create tl context for %s",
+                         tl_lib->iface->super.name);
+            }
             continue;
         }
         ctx->tl_ctx[ctx->n_tl_ctx] = ucc_derived_of(b_ctx, ucc_tl_context_t);
@@ -592,8 +596,13 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
                           cl_lib->iface->super.name);
                 goto error_ctx_create;
             } else {
-                ucc_warn("failed to create cl context for %s, skipping",
-                         cl_lib->iface->super.name);
+                /* UCC_ERR_LAST means component was disabled via TUNE param:
+                   don't print warning. */
+                if (UCC_ERR_LAST != status) {
+
+                    ucc_warn("failed to create cl context for %s, skipping",
+                             cl_lib->iface->super.name);
+                }
                 continue;
             }
         }

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -16,6 +16,7 @@ typedef struct ucc_lib_info          ucc_lib_info_t;
 typedef struct ucc_cl_context        ucc_cl_context_t;
 typedef struct ucc_tl_context        ucc_tl_context_t;
 typedef struct ucc_cl_context_config ucc_cl_context_config_t;
+typedef struct ucc_tl_context_config ucc_tl_context_config_t;
 typedef struct ucc_tl_team           ucc_tl_team_t;
 
 typedef unsigned (*ucc_context_progress_fn_t)(void *progress_arg);
@@ -71,8 +72,10 @@ typedef struct ucc_context {
 
 typedef struct ucc_context_config {
     ucc_lib_info_t           *lib;
-    ucc_cl_context_config_t **configs;
+    ucc_cl_context_config_t **cl_cfgs;
+    ucc_tl_context_config_t **tl_cfgs;
     int                       n_cl_cfg;
+    int                       n_tl_cfg;
     uint32_t                  team_ids_pool_size;
     uint32_t                  estimated_num_eps;
     uint32_t                  estimated_num_ppn;

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -119,7 +119,7 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
                       cl_iface->super.name);
             goto error_cfg_read;
         }
-        status = cl_iface->lib.init(&b_params, &cl_config->super, &b_lib);
+        status = cl_iface->lib.init(&b_params, &cl_config->super.super, &b_lib);
         if (UCC_OK != status) {
             if (lib->specific_cls_requested) {
                 ucc_error("lib_init failed for component: %s",
@@ -128,11 +128,11 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
             } else {
                 ucc_info("lib_init failed for component: %s, skipping",
                          cl_iface->super.name);
-                ucc_base_config_release(&cl_config->super);
+                ucc_base_config_release(&cl_config->super.super);
                 continue;
             }
         }
-        ucc_base_config_release(&cl_config->super);
+        ucc_base_config_release(&cl_config->super.super);
         cl_lib                          = ucc_derived_of(b_lib, ucc_cl_lib_t);
         lib->cl_libs[lib->n_cl_libs_opened] = cl_lib;
         status = cl_iface->lib.get_attr(&cl_lib->super,
@@ -201,7 +201,7 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
     return UCC_OK;
 
 error_cl_init:
-    ucc_base_config_release(&cl_config->super);
+    ucc_base_config_release(&cl_config->super.super);
 error_cfg_read:
     for (i = 0; i < lib->n_cl_libs_opened; i++) {
         lib->cl_libs[i]->iface->lib.finalize(&lib->cl_libs[i]->super);
@@ -263,8 +263,9 @@ static ucc_status_t ucc_tl_lib_init(const ucc_lib_params_t *user_params,
                          tl_iface->super.name);
                 continue;
             }
-            status = tl_iface->lib.init(&b_params, &tl_config->super, &b_lib);
-            ucc_base_config_release(&tl_config->super);
+            status = tl_iface->lib.init(&b_params, &tl_config->super.super,
+                                        &b_lib);
+            ucc_base_config_release(&tl_config->super.super);
             if (UCC_OK != status) {
                 ucc_info("lib_init failed for component: %s, skipping",
                          tl_iface->super.name);

--- a/test/gtest/core/test_context_config.cc
+++ b/test/gtest/core/test_context_config.cc
@@ -51,7 +51,7 @@ UCC_TEST_F(test_context_config, modify)
     /* modify uknown field */
     testing::internal::CaptureStdout();
     EXPECT_NE(UCC_OK,
-              ucc_context_config_modify(ctx_config, "basic", "_UNKNOWN_FIELD", "_unknown_value"));
+              ucc_context_config_modify(ctx_config, "cl/basic", "_UNKNOWN_FIELD", "_unknown_value"));
     output = testing::internal::GetCapturedStdout();
     EXPECT_NE(std::string::npos, output.find("failed to modify"));
 
@@ -60,7 +60,14 @@ UCC_TEST_F(test_context_config, modify)
     EXPECT_NE(UCC_OK,
               ucc_context_config_modify(ctx_config, "_unknown_cl", "_UNKNOWN_FIELD", "_unknown_value"));
     output = testing::internal::GetCapturedStdout();
-    EXPECT_NE(std::string::npos, output.find("incorrect value"));
+    EXPECT_NE(std::string::npos, output.find("invalid component name"));
+
+    /* modify "tl/ucp" */
+    EXPECT_EQ(UCC_OK,
+              ucc_context_config_modify(ctx_config, "tl/ucp", "NPOLLS", "123"));
+
+    EXPECT_EQ(UCC_OK,
+              ucc_context_config_modify(ctx_config, "tl/ucp", "TUNE", "123"));
 
     ucc_context_config_release(ctx_config);
 }


### PR DESCRIPTION
## What
Our previous implementation of ucc_context_config_modify only supported modification of CL context which is very limited.
- API/ABI is kept ucc_context_config_modify is kept the same only the name of the variable is changed: used to be "const char *cls", not it is "const char *component".
- The content of it changed though: before user should have passed cl names (e.g. "basic") now it is a CL/<name> or TL/<name>, e.g. ucc_context_config_modify(cfg, "tl/ucp", "TUNE", "alltoall:@onesided"); Passing NULL to modify CORE context is still supported of course (this is used in pytorch/OMPI).
- Moves "TUNE" family of parameters from lib to context. This way it will be available for modification via ctx cfg modify.

## Why ?
We already have seen use case when user wants to modify UCC context programmatically (in Ferrol's PR).

For discussion: is this an API change ? Alternative would be to add new fn ucc_context_config_modify_2 - which l think we want to avoid (deprecating APIs when we barely released v1). 
