### PR TITLE
EE/CUDA: executor kernel

### DIFF
--- a/src/components/ec/base/ucc_ec_base.h
+++ b/src/components/ec/base/ucc_ec_base.h
@@ -25,7 +25,8 @@ typedef struct ucc_ec_params {
  * UCC execution component attributes field mask
  */
 typedef enum ucc_ec_attr_field {
-    UCC_EC_ATTR_FIELD_THREAD_MODE = UCC_BIT(0)
+    UCC_EC_ATTR_FIELD_THREAD_MODE        = UCC_BIT(0),
+    UCC_EC_ATTR_FILED_MAX_EXECUTORS_BUFS = UCC_BIT(1)
 }  ucc_ec_attr_field_t;
 
 typedef struct ucc_ec_attr {
@@ -35,6 +36,11 @@ typedef struct ucc_ec_attr {
      */
     uint64_t          field_mask;
     ucc_thread_mode_t thread_mode;
+    /**
+     *  Maximum number of buffers in ucc_ee_executor_task_args,
+     *  includes src buffer
+     */
+    int               max_ee_bufs;
 } ucc_ec_attr_t;
 
 typedef struct ucc_ec_ops {
@@ -70,7 +76,7 @@ typedef struct ucc_ee_executor_params {
  *  buffers[0] - destination
  *  buffers[1] .. buffers[UCC_EE_EXECUTOR_NUM_BUFS - 1] - source
  *  count - number of elements in destination
- *  size - number of operands or step between source buffers
+ *  size - number of operands or step between source buffers in bytes
  *  dt - datatype
  *  op - reduction operation
  */
@@ -97,7 +103,7 @@ typedef struct ucc_ee_executor_ops {
                           void *ee_context);
     ucc_status_t (*stop)(ucc_ee_executor_t *executor);
     ucc_status_t (*finalize)(ucc_ee_executor_t *executor);
-    ucc_status_t (*task_post)(const ucc_ee_executor_t *executor,
+    ucc_status_t (*task_post)(ucc_ee_executor_t *executor,
                               const ucc_ee_executor_task_args_t *task_args,
                               ucc_ee_executor_task_t **task);
     ucc_status_t (*task_test)(const ucc_ee_executor_task_t *task);

--- a/src/components/ec/base/ucc_ec_base.h
+++ b/src/components/ec/base/ucc_ec_base.h
@@ -47,6 +47,62 @@ typedef struct ucc_ec_ops {
     ucc_status_t (*event_test)(void *event);
 } ucc_ec_ops_t;
 
+typedef struct ucc_ee_executor {
+    ucc_ee_type_t  ee_type;
+    void          *ee_context;
+} ucc_ee_executor_t;
+
+typedef enum ucc_ee_executor_task_type {
+    UCC_EE_EXECUTOR_TASK_TYPE_WAIT         = UCC_BIT(0),
+    UCC_EE_EXECUTOR_TASK_TYPE_REDUCE       = UCC_BIT(1),
+    UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI = UCC_BIT(2),
+    UCC_EE_EXECUTOR_TASK_TYPE_COPY         = UCC_BIT(3),
+} ucc_ee_executor_task_type_t;
+
+typedef struct ucc_ee_executor_params {
+    uint64_t        mask;
+    ucc_ee_type_t   ee_type;
+    uint64_t        task_types;
+} ucc_ee_executor_params_t;
+
+#define UCC_EE_EXECUTOR_NUM_BUFS 9
+/*
+ *  buffers[0] - destination
+ *  buffers[1] .. buffers[UCC_EE_EXECUTOR_NUM_BUFS - 1] - source
+ *  count - number of elements in destination
+ *  size - number of operands or step between source buffers
+ *  dt - datatype
+ *  op - reduction operation
+ */
+typedef struct ucc_ee_executor_task_args {
+    ucc_ee_executor_task_type_t  task_type;
+    void                        *bufs[UCC_EE_EXECUTOR_NUM_BUFS];
+    ucc_count_t                  count;
+    uint32_t                     size;
+    ucc_datatype_t               dt;
+    ucc_reduction_op_t           op;
+} ucc_ee_executor_task_args_t;
+
+typedef struct ucc_ee_executor_task {
+    ucc_ee_executor_t           *eee;
+    ucc_ee_executor_task_args_t  args;
+    ucc_status_t                 status;
+} ucc_ee_executor_task_t;
+
+typedef struct ucc_ee_executor_ops {
+    ucc_status_t (*init)(const ucc_ee_executor_params_t *params,
+                         ucc_ee_executor_t **executor);
+    ucc_status_t (*status)(const ucc_ee_executor_t *executor);
+    ucc_status_t (*start)(ucc_ee_executor_t *executor,
+                          void *ee_context);
+    ucc_status_t (*stop)(ucc_ee_executor_t *executor);
+    ucc_status_t (*finalize)(ucc_ee_executor_t *executor);
+    ucc_status_t (*task_post)(const ucc_ee_executor_t *executor,
+                              const ucc_ee_executor_task_args_t *task_args,
+                              ucc_ee_executor_task_t **task);
+    ucc_status_t (*task_test)(const ucc_ee_executor_task_t *task);
+} ucc_ee_executor_ops_t;
+
 typedef struct ucc_ec_base {
     ucc_component_iface_t           super;
     uint32_t                        ref_cnt;
@@ -57,6 +113,7 @@ typedef struct ucc_ec_base {
     ucc_status_t                   (*get_attr)(ucc_ec_attr_t *ec_attr);
     ucc_status_t                   (*finalize)();
     ucc_ec_ops_t                    ops;
+    ucc_ee_executor_ops_t           executor_ops;
 } ucc_ec_base_t;
 
 #endif

--- a/src/components/ec/base/ucc_ec_base.h
+++ b/src/components/ec/base/ucc_ec_base.h
@@ -59,10 +59,7 @@ typedef struct ucc_ee_executor {
 } ucc_ee_executor_t;
 
 typedef enum ucc_ee_executor_task_type {
-    UCC_EE_EXECUTOR_TASK_TYPE_WAIT         = UCC_BIT(0),
-    UCC_EE_EXECUTOR_TASK_TYPE_REDUCE       = UCC_BIT(1),
-    UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI = UCC_BIT(2),
-    UCC_EE_EXECUTOR_TASK_TYPE_COPY         = UCC_BIT(3),
+    UCC_EE_EXECUTOR_TASK_TYPE_COPY = UCC_BIT(0),
 } ucc_ee_executor_task_type_t;
 
 typedef struct ucc_ee_executor_params {

--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -77,7 +77,7 @@ static ucc_status_t ucc_ec_cuda_ee_executor_mpool_chunk_malloc(ucc_mpool_t *mp,
 static void ucc_ec_cuda_ee_executor_mpool_chunk_free(ucc_mpool_t *mp,
                                                      void *chunk)
 {
-    cudaFreeHost(chunk);
+    CUDA_FUNC(cudaFreeHost(chunk));
 }
 
 static void ucc_ec_cuda_executor_chunk_init(ucc_mpool_t *mp, void *obj,
@@ -159,7 +159,7 @@ static void ucc_ec_cuda_event_init(ucc_mpool_t *mp, void *obj, void *chunk)
     if (ucc_unlikely(
             cudaSuccess !=
             cudaEventCreateWithFlags(&base->event, cudaEventDisableTiming))) {
-        ec_error(&ucc_ec_cuda.super, "cudaEventCreateWithFlags Failed");
+        ec_error(&ucc_ec_cuda.super, "cudaEventCreateWithFlags failed");
     }
 }
 
@@ -167,7 +167,7 @@ static void ucc_ec_cuda_event_cleanup(ucc_mpool_t *mp, void *obj)
 {
     ucc_ec_cuda_event_t *base = (ucc_ec_cuda_event_t *) obj;
     if (ucc_unlikely(cudaSuccess != cudaEventDestroy(base->event))) {
-        ec_error(&ucc_ec_cuda.super, "cudaEventDestroy Failed");
+        ec_error(&ucc_ec_cuda.super, "cudaEventDestroy failed");
     }
 }
 
@@ -227,7 +227,7 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
                             &ucc_ec_cuda_event_mpool_ops, UCC_THREAD_MULTIPLE,
                             "CUDA Event Objects");
     if (status != UCC_OK) {
-        ec_error(&ucc_ec_cuda.super, "Failed to create event pool");
+        ec_error(&ucc_ec_cuda.super, "failed to create event pool");
         return status;
     }
 
@@ -237,7 +237,7 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
         UCC_CACHE_LINE_SIZE, 16, UINT_MAX, &ucc_ec_cuda_stream_req_mpool_ops,
         UCC_THREAD_MULTIPLE, "CUDA Event Objects");
     if (status != UCC_OK) {
-        ec_error(&ucc_ec_cuda.super, "Failed to create event pool");
+        ec_error(&ucc_ec_cuda.super, "failed to create event pool");
         return status;
     }
 
@@ -246,7 +246,7 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
         UCC_CACHE_LINE_SIZE, 16, UINT_MAX, &ucc_ec_cuda_ee_executor_mpool_ops,
         UCC_THREAD_MULTIPLE, "EE executor Objects");
     if (status != UCC_OK) {
-        ec_error(&ucc_ec_cuda.super, "Failed to create executors pool");
+        ec_error(&ucc_ec_cuda.super, "failed to create executors pool");
         return status;
     }
 
@@ -423,11 +423,11 @@ ucc_status_t ucc_cuda_executor_init(const ucc_ee_executor_params_t *params,
 {
     ucc_ec_cuda_executor_t *eee = ucc_mpool_get(&ucc_ec_cuda.executors);
 
-    UCC_EC_CUDA_INIT_STREAM();
     if (ucc_unlikely(!eee)) {
         ec_error(&ucc_ec_cuda.super, "failed to allocate executor");
         return UCC_ERR_NO_MEMORY;
     }
+    UCC_EC_CUDA_INIT_STREAM();
     ec_debug(&ucc_ec_cuda.super, "executor init, eee: %p", eee);
     eee->super.ee_type = params->ee_type;
     eee->state         = UCC_EC_CUDA_EXECUTOR_INITIALIZED;

--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -70,11 +70,8 @@ static ucc_status_t ucc_ec_cuda_ee_executor_mpool_chunk_malloc(ucc_mpool_t *mp,
                                                                size_t *size_p,
                                                                void ** chunk_p)
 {
-    ucc_status_t status;
-
-    status = CUDA_FUNC(cudaHostAlloc((void**)chunk_p, *size_p,
-                       cudaHostAllocMapped));
-    return status;
+    return CUDA_FUNC(cudaHostAlloc((void**)chunk_p, *size_p,
+                                   cudaHostAllocMapped));
 }
 
 static void ucc_ec_cuda_ee_executor_mpool_chunk_free(ucc_mpool_t *mp,
@@ -83,7 +80,8 @@ static void ucc_ec_cuda_ee_executor_mpool_chunk_free(ucc_mpool_t *mp,
     cudaFreeHost(chunk);
 }
 
-static void ucc_ec_cuda_ee_executor_init(ucc_mpool_t *mp, void *obj, void *chunk)
+static void ucc_ec_cuda_executor_chunk_init(ucc_mpool_t *mp, void *obj,
+                                            void *chunk)
 {
     ucc_ec_cuda_executor_t *eee       = (ucc_ec_cuda_executor_t*) obj;
     int                     max_tasks = EC_CUDA_CONFIG->exec_max_tasks;
@@ -98,6 +96,9 @@ static void ucc_ec_cuda_ee_executor_init(ucc_mpool_t *mp, void *obj, void *chunk
                             cudaHostAllocMapped));
     CUDA_FUNC(cudaHostGetDevicePointer(
                   (void**)(&eee->dev_tasks), (void *)eee->tasks, 0));
+    if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spinlock_init(&eee->tasks_lock, 0);
+    }
 }
 
 static void ucc_ec_cuda_executor_chunk_cleanup(ucc_mpool_t *mp, void *obj)
@@ -106,13 +107,16 @@ static void ucc_ec_cuda_executor_chunk_cleanup(ucc_mpool_t *mp, void *obj)
 
     CUDA_FUNC(cudaFree((void*)eee->dev_cidx));
     CUDA_FUNC(cudaFreeHost((void*)eee->tasks));
+    if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spinlock_destroy(&eee->tasks_lock);
+    }
 }
 
 
 static ucc_mpool_ops_t ucc_ec_cuda_ee_executor_mpool_ops = {
     .chunk_alloc   = ucc_ec_cuda_ee_executor_mpool_chunk_malloc,
     .chunk_release = ucc_ec_cuda_ee_executor_mpool_chunk_free,
-    .obj_init      = ucc_ec_cuda_ee_executor_init,
+    .obj_init      = ucc_ec_cuda_executor_chunk_init,
     .obj_cleanup   = ucc_ec_cuda_executor_chunk_cleanup,
 };
 
@@ -213,7 +217,7 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
     ucc_ec_cuda.thread_mode = ec_params->thread_mode;
     cuda_st = cudaGetDeviceCount(&num_devices);
     if ((cuda_st != cudaSuccess) || (num_devices == 0)) {
-        ec_info(&ucc_ec_cuda.super, "cuda devices are not found");
+        ec_info(&ucc_ec_cuda.super, "CUDA devices are not found");
         return UCC_ERR_NO_RESOURCE;
     }
     CUDA_CHECK(cudaGetDevice(&device));
@@ -223,7 +227,7 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
                             &ucc_ec_cuda_event_mpool_ops, UCC_THREAD_MULTIPLE,
                             "CUDA Event Objects");
     if (status != UCC_OK) {
-        ec_error(&ucc_ec_cuda.super, "Error to create event pool");
+        ec_error(&ucc_ec_cuda.super, "Failed to create event pool");
         return status;
     }
 
@@ -233,7 +237,7 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
         UCC_CACHE_LINE_SIZE, 16, UINT_MAX, &ucc_ec_cuda_stream_req_mpool_ops,
         UCC_THREAD_MULTIPLE, "CUDA Event Objects");
     if (status != UCC_OK) {
-        ec_error(&ucc_ec_cuda.super, "Error to create event pool");
+        ec_error(&ucc_ec_cuda.super, "Failed to create event pool");
         return status;
     }
 
@@ -242,7 +246,7 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
         UCC_CACHE_LINE_SIZE, 16, UINT_MAX, &ucc_ec_cuda_ee_executor_mpool_ops,
         UCC_THREAD_MULTIPLE, "EE executor Objects");
     if (status != UCC_OK) {
-        ec_error(&ucc_ec_cuda.super, "Error to create executors pool");
+        ec_error(&ucc_ec_cuda.super, "Failed to create executors pool");
         return status;
     }
 
@@ -329,7 +333,7 @@ ucc_status_t ucc_ec_cuda_task_post(void *ee_stream, void **ee_req)
 
     *ee_req = (void *) req;
 
-    ec_info(&ucc_ec_cuda.super, "CUDA stream task posted on \"%s\" stream. req:%p",
+    ec_info(&ucc_ec_cuda.super, "stream task posted on \"%s\" stream. req:%p",
             task_stream_types[ucc_ec_cuda.task_strm_type], req);
 
     return UCC_OK;
@@ -352,7 +356,7 @@ ucc_status_t ucc_ec_cuda_task_query(void *ee_req)
     if (req->status == UCC_EC_CUDA_TASK_POSTED) {
         return UCC_INPROGRESS;
     }
-    ec_info(&ucc_ec_cuda.super, "CUDA stream task started. req:%p", req);
+    ec_info(&ucc_ec_cuda.super, "stream task started. req:%p", req);
     return UCC_OK;
 }
 
@@ -369,7 +373,7 @@ ucc_status_t ucc_ec_cuda_task_end(void *ee_req)
         while(*st != UCC_EC_CUDA_TASK_COMPLETED_ACK) { }
     }
     ucc_mpool_put(req);
-    ec_info(&ucc_ec_cuda.super, "CUDA stream task done. req:%p", req);
+    ec_info(&ucc_ec_cuda.super, "stream task done. req:%p", req);
     return UCC_OK;
 }
 
@@ -419,13 +423,12 @@ ucc_status_t ucc_cuda_executor_init(const ucc_ee_executor_params_t *params,
 {
     ucc_ec_cuda_executor_t *eee = ucc_mpool_get(&ucc_ec_cuda.executors);
 
-    ec_debug(&ucc_ec_cuda.super, "CUDA executor init, eee: %p", eee);
     UCC_EC_CUDA_INIT_STREAM();
-    if (!eee) {
-        ec_error(&ucc_ec_cuda.super, "failed to allocate cuda executor");
+    if (ucc_unlikely(!eee)) {
+        ec_error(&ucc_ec_cuda.super, "failed to allocate executor");
         return UCC_ERR_NO_MEMORY;
     }
-    ucc_assert(eee);
+    ec_debug(&ucc_ec_cuda.super, "executor init, eee: %p", eee);
     eee->super.ee_type = params->ee_type;
     eee->state         = UCC_EC_CUDA_EXECUTOR_INITIALIZED;
 
@@ -439,15 +442,15 @@ ucc_status_t ucc_cuda_executor_status(const ucc_ee_executor_t *executor)
                                                  ucc_ec_cuda_executor_t);
 
     switch (eee->state) {
-        case UCC_EC_CUDA_EXECUTOR_INITIALIZED:
-            return UCC_OPERATION_INITIALIZED;
-        case UCC_EC_CUDA_EXECUTOR_POSTED:
-            return UCC_INPROGRESS;
-        case UCC_EC_CUDA_EXECUTOR_STARTED:
-            return UCC_OK;
-        default:
+    case UCC_EC_CUDA_EXECUTOR_INITIALIZED:
+        return UCC_OPERATION_INITIALIZED;
+    case UCC_EC_CUDA_EXECUTOR_POSTED:
+        return UCC_INPROGRESS;
+    case UCC_EC_CUDA_EXECUTOR_STARTED:
+        return UCC_OK;
+    default:
 /* executor has been destroyed */
-            return UCC_ERR_NO_RESOURCE;
+        return UCC_ERR_NO_RESOURCE;
     }
 }
 
@@ -460,19 +463,15 @@ ucc_status_t ucc_cuda_executor_start(ucc_ee_executor_t *executor,
                                                  ucc_ec_cuda_executor_t);
     ucc_status_t status;
 
-    ec_debug(&ucc_ec_cuda.super, "CUDA executor start, eee: %p", eee);
-    if (eee->state != UCC_EC_CUDA_EXECUTOR_INITIALIZED) {
-        ec_error(&ucc_ec_cuda.super, "failed to start CUDA executor, state %d",
-                                      eee->state);
-        return UCC_ERR_INVALID_PARAM;
-    }
+    ucc_assert(eee->state == UCC_EC_CUDA_EXECUTOR_INITIALIZED);
+    ec_debug(&ucc_ec_cuda.super, "executor start, eee: %p", eee);
     eee->super.ee_context = (NULL == ee_context) ? ucc_ec_cuda.stream : ee_context;
     eee->state            = UCC_EC_CUDA_EXECUTOR_POSTED;
     eee->pidx             = 0;
 
     status = ucc_ec_cuda_start_executor(eee);
     if (status != UCC_OK) {
-        ec_error(&ucc_ec_cuda.super, "failed to launch CUDA executor kernel");
+        ec_error(&ucc_ec_cuda.super, "failed to launch executor kernel");
         return status;
     }
 
@@ -485,7 +484,7 @@ ucc_status_t ucc_cuda_executor_stop(ucc_ee_executor_t *executor)
                                                  ucc_ec_cuda_executor_t);
     volatile ucc_ec_cuda_executor_state_t *st = &eee->state;
 
-    ec_debug(&ucc_ec_cuda.super, "CUDA executor stop, eee: %p", eee);
+    ec_debug(&ucc_ec_cuda.super, "executor stop, eee: %p", eee);
     /* can be safely ended only if it's in STARTED or COMPLETED_ACK state */
     ucc_assert((*st != UCC_EC_CUDA_EXECUTOR_POSTED) &&
                (*st != UCC_EC_CUDA_EXECUTOR_SHUTDOWN));
@@ -503,33 +502,41 @@ ucc_status_t ucc_cuda_executor_free(ucc_ee_executor_t *executor)
     ucc_ec_cuda_executor_t *eee = ucc_derived_of(executor,
                                                  ucc_ec_cuda_executor_t);
 
-    ec_debug(&ucc_ec_cuda.super, "CUDA executor free, eee: %p", eee);
+    ec_debug(&ucc_ec_cuda.super, "executor free, eee: %p", eee);
     ucc_assert(eee->state == UCC_EC_CUDA_EXECUTOR_INITIALIZED);
     ucc_mpool_put(eee);
 
     return UCC_OK;
 }
 
-ucc_status_t ucc_cuda_executor_task_test(ucc_ee_executor_task_t *task)
+ucc_status_t ucc_cuda_executor_task_test(const ucc_ee_executor_task_t *task)
 {
     CUDA_CHECK(cudaGetLastError());
     return task->status;
 }
 
-ucc_status_t ucc_cuda_executor_task_post(ucc_ee_executor_task_args_t *task_args,
-                                         ucc_ee_executor_task_t **task,
-                                         ucc_ee_executor_t *executor)
+ucc_status_t
+ucc_cuda_executor_task_post(ucc_ee_executor_t *executor,
+                            const ucc_ee_executor_task_args_t *task_args,
+                            ucc_ee_executor_task_t **task)
 {
     ucc_ec_cuda_executor_t *eee       = ucc_derived_of(executor,
                                                        ucc_ec_cuda_executor_t);
     int                     max_tasks = EC_CUDA_CONFIG->exec_max_tasks;
     ucc_ee_executor_task_t *ee_task;
 
-    ee_task = &(eee->tasks[eee->pidx % max_tasks]);
-    ee_task->eee = executor;
+    if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spin_lock(&eee->tasks_lock);
+    }
+    ee_task         = &(eee->tasks[eee->pidx % max_tasks]);
+    ee_task->eee    = executor;
     ee_task->status = UCC_OPERATION_INITIALIZED;
     memcpy(&ee_task->args, task_args, sizeof(ucc_ee_executor_task_args_t));
+    ucc_memory_bus_fence();
     eee->pidx += 1;
+    if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spin_unlock(&eee->tasks_lock);
+    }
 
     *task = ee_task;
     return UCC_OK;
@@ -561,13 +568,19 @@ ucc_ec_cuda_t ucc_ec_cuda = {
             .table  = ucc_ec_cuda_config_table,
             .size   = sizeof(ucc_ec_cuda_config_t),
         },
-    .super.ops.task_post     = ucc_ec_cuda_task_post,
-    .super.ops.task_query    = ucc_ec_cuda_task_query,
-    .super.ops.task_end      = ucc_ec_cuda_task_end,
-    .super.ops.create_event  = ucc_ec_cuda_create_event,
-    .super.ops.destroy_event = ucc_ec_cuda_destroy_event,
-    .super.ops.event_post    = ucc_ec_cuda_event_post,
-    .super.ops.event_test    = ucc_ec_cuda_event_test,
+    .super.ops.task_post          = ucc_ec_cuda_task_post,
+    .super.ops.task_query         = ucc_ec_cuda_task_query,
+    .super.ops.task_end           = ucc_ec_cuda_task_end,
+    .super.ops.create_event       = ucc_ec_cuda_create_event,
+    .super.ops.destroy_event      = ucc_ec_cuda_destroy_event,
+    .super.ops.event_post         = ucc_ec_cuda_event_post,
+    .super.ops.event_test         = ucc_ec_cuda_event_test,
+    .super.executor_ops.init      = ucc_cuda_executor_init,
+    .super.executor_ops.start     = ucc_cuda_executor_start,
+    .super.executor_ops.status    = ucc_cuda_executor_status,
+    .super.executor_ops.stop      = ucc_cuda_executor_stop,
+    .super.executor_ops.task_post = ucc_cuda_executor_task_post,
+    .super.executor_ops.task_test = ucc_cuda_executor_task_test,
 };
 
 UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_ec_cuda.super.config_table,

--- a/src/components/ec/cuda/ec_cuda.h
+++ b/src/components/ec/cuda/ec_cuda.h
@@ -93,6 +93,7 @@ typedef struct ucc_ec_cuda_stream_request {
 
 typedef struct ucc_ec_cuda_executor {
     ucc_ee_executor_t             super;
+    ucc_spinlock_t                tasks_lock;
     ucc_ec_cuda_executor_state_t  state;
     int                           pidx;
     ucc_ee_executor_task_t       *tasks;

--- a/src/components/ec/cuda/ec_cuda.h
+++ b/src/components/ec/cuda/ec_cuda.h
@@ -33,6 +33,14 @@ typedef enum ucc_ec_task_status {
     UCC_EC_CUDA_TASK_COMPLETED_ACK
 } ucc_ec_task_status_t;
 
+typedef enum ucc_ec_cuda_executor_state {
+    UCC_EC_CUDA_EXECUTOR_INITIALIZED,
+    UCC_EC_CUDA_EXECUTOR_POSTED,
+    UCC_EC_CUDA_EXECUTOR_STARTED,
+    UCC_EC_CUDA_EXECUTOR_SHUTDOWN,
+    UCC_EC_CUDA_EXECUTOR_SHUTDOWN_ACK
+} ucc_ec_cuda_executor_state_t;
+
 static inline ucc_status_t cuda_error_to_ucc_status(cudaError_t cu_err)
 {
     switch(cu_err) {
@@ -55,6 +63,9 @@ typedef struct ucc_ec_cuda_config {
     ucc_ec_cuda_strm_task_mode_t   strm_task_mode;
     ucc_ec_cuda_task_stream_type_t task_strm_type;
     int                            stream_blocking_wait;
+    unsigned long                  exec_num_workers;
+    unsigned long                  exec_num_threads;
+    unsigned long                  exec_max_tasks;
 } ucc_ec_cuda_config_t;
 
 typedef struct ucc_ec_cuda {
@@ -62,6 +73,7 @@ typedef struct ucc_ec_cuda {
     cudaStream_t                   stream;
     ucc_mpool_t                    events;
     ucc_mpool_t                    strm_reqs;
+    ucc_mpool_t                    executors;
     ucc_thread_mode_t              thread_mode;
     ucc_ec_cuda_strm_task_mode_t   strm_task_mode;
     ucc_ec_cuda_task_stream_type_t task_strm_type;
@@ -78,6 +90,17 @@ typedef struct ucc_ec_cuda_stream_request {
     uint32_t           *dev_status;
     cudaStream_t        stream;
 } ucc_ec_cuda_stream_request_t;
+
+typedef struct ucc_ec_cuda_executor {
+    ucc_ee_executor_t             super;
+    ucc_ec_cuda_executor_state_t  state;
+    int                           pidx;
+    ucc_ee_executor_task_t       *tasks;
+    ucc_ec_cuda_executor_state_t *dev_state;
+    ucc_ee_executor_task_t       *dev_tasks;
+    int                          *dev_pidx;
+    int                          *dev_cidx;
+} ucc_ec_cuda_executor_t;
 
 extern ucc_ec_cuda_t ucc_ec_cuda;
 

--- a/src/components/ec/cuda/kernel/Makefile.am
+++ b/src/components/ec/cuda/kernel/Makefile.am
@@ -21,7 +21,8 @@ LINK = $(LIBTOOL) --mode=link $(CC) -o $@
 
 comp_noinst = libucc_ec_cuda_kernels.la
 
-libucc_ec_cuda_kernels_la_SOURCES  = ec_cuda_wait_kernel.cu
+libucc_ec_cuda_kernels_la_SOURCES  = ec_cuda_wait_kernel.cu  \
+                                     ec_cuda_executor.cu
 libucc_ec_cuda_kernels_la_CPPFLAGS =
 
 noinst_LTLIBRARIES = $(comp_noinst)

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "../ec_cuda.h"
+#include "utils/ucc_math.h"
+#include <inttypes.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#define align_pow2(_n, _p) ((_n) & ((_p) - 1))
+
+__global__ void executor_start(ucc_ec_cuda_executor_state_t *state,
+                               int *cidx)
+{
+    *cidx  = 0;
+    *state = UCC_EC_CUDA_EXECUTOR_STARTED;
+}
+
+__global__ void executor_shutdown_ack(ucc_ec_cuda_executor_state_t *state)
+{
+    *state = UCC_EC_CUDA_EXECUTOR_SHUTDOWN_ACK;
+}
+
+template <typename T>
+__device__ void executor_copy(T* __restrict__ d, T* __restrict__ s,
+                              size_t count)
+{
+    size_t start = threadIdx.x;
+    const size_t step  = blockDim.x;
+
+    for (size_t i = start; i < count; i+=step) {
+        d[i] = s[i];
+    }
+}
+
+template <typename T>
+__device__ void executor_copy_aligned(T* __restrict__ d, T* __restrict__ s,
+                                      size_t count)
+{
+    size_t idx = threadIdx.x;
+    const size_t step  = blockDim.x;
+    const int n = count / sizeof(T);
+    const int num_iter = n / step + ((idx < n % step) ? 1 : 0);
+    char1 *s1 = (char1*)s;
+    char1 *d1 = (char1*)d;
+
+#pragma unroll 4
+    for(int i = 0; i < num_iter; i++) {
+        d[i * step + idx] = s[i * step + idx];
+    }
+
+    if (idx < count % sizeof(T)) {
+        d1[count - idx - 1] = s1[count - idx - 1];
+    }
+}
+
+__global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
+                                int q_size)
+{
+    const uint32_t  worker_id   = blockIdx.x;
+    const uint32_t  num_workers = gridDim.x;
+    bool            is_master   = (threadIdx.x == 0) ? true: false;
+    int             cidx_local, pidx_local;
+    volatile int *pidx, *cidx;
+    ucc_ee_executor_task_t *tasks;
+    __shared__ ucc_ee_executor_task_args_t args;
+    __shared__ bool worker_done;
+
+    if (is_master) {
+        cidx_local = worker_id;
+        pidx       = eee->dev_pidx;
+        cidx       = eee->dev_cidx;
+        tasks      = eee->dev_tasks;
+    }
+
+    worker_done = false;
+    __syncthreads();
+    while (1) {
+        if (is_master) {
+            while ((*cidx % num_workers) != worker_id);
+            do {
+                pidx_local = *pidx;
+            } while (*cidx == pidx_local);
+            (*cidx)++;
+            worker_done = (pidx_local == -1);
+            if (!worker_done) {
+                args = tasks[cidx_local].args;
+            }
+        }
+        __syncthreads();
+        if (worker_done) {
+            return;
+        }
+        switch (args.task_type) {
+            bool aligned;
+            case UCC_EE_EXECUTOR_TASK_TYPE_COPY:
+                aligned = !(align_pow2((intptr_t)args.bufs[0], 16) ||
+                            align_pow2((intptr_t)args.bufs[1], 16));
+                if (aligned) {
+                    executor_copy_aligned<uint4>((uint4*)args.bufs[0],
+                                                 (uint4*)args.bufs[1],
+                                                 args.count);
+
+                } else {
+                    executor_copy((char*)args.bufs[0],
+                                  (char*)args.bufs[1],
+                                   args.count);
+                }
+                break;
+            default: break;
+        }
+        __syncthreads();
+        __threadfence_system();
+        if (is_master) {
+            tasks[cidx_local].status = UCC_OK;
+            cidx_local = (cidx_local + num_workers) %q_size;
+        }
+    }
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ucc_status_t ucc_ec_cuda_start_executor(ucc_ec_cuda_executor_t *eee)
+{
+    cudaStream_t stream = (cudaStream_t)eee->super.ee_context;
+    int          nb     = EC_CUDA_CONFIG->exec_num_workers;
+    int          nt     = EC_CUDA_CONFIG->exec_num_threads;
+    int          q_size = EC_CUDA_CONFIG->exec_max_tasks;
+
+    executor_start<<<1, 1, 0, stream>>>(eee->dev_state, eee->dev_cidx);
+    executor_kernel<<<nb, nt, 0, stream>>>(eee, q_size);
+    executor_shutdown_ack<<<1, 1, 0, stream>>>(eee->dev_state);
+    CUDA_CHECK(cudaGetLastError());
+
+    return UCC_OK;
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/components/ec/ucc_ec.c
+++ b/src/components/ec/ucc_ec.c
@@ -88,6 +88,15 @@ ucc_status_t ucc_ec_available(ucc_ee_type_t ee_type)
     return UCC_OK;
 }
 
+ucc_status_t ucc_ec_get_attr(ucc_ec_attr_t *attr)
+{
+    if (attr->field_mask & UCC_EC_ATTR_FILED_MAX_EXECUTORS_BUFS) {
+        attr->max_ee_bufs = UCC_EE_EXECUTOR_NUM_BUFS;
+    }
+
+    return UCC_OK;
+}
+
 ucc_status_t ucc_ec_finalize()
 {
     ucc_ee_type_t  et;
@@ -186,7 +195,7 @@ ucc_status_t ucc_ee_executor_finalize(ucc_ee_executor_t *executor)
     return executor_ops[executor->ee_type]->finalize(executor);
 }
 
-ucc_status_t ucc_ee_executor_task_post(const ucc_ee_executor_t *executor,
+ucc_status_t ucc_ee_executor_task_post(ucc_ee_executor_t *executor,
                                        const ucc_ee_executor_task_args_t *task_args,
                                        ucc_ee_executor_task_t **task)
 {

--- a/src/components/ec/ucc_ec.c
+++ b/src/components/ec/ucc_ec.c
@@ -10,7 +10,8 @@
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_log.h"
 
-static const ucc_ec_ops_t *ec_ops[UCC_EE_LAST];
+static const ucc_ec_ops_t          *ec_ops[UCC_EE_LAST];
+static const ucc_ee_executor_ops_t *executor_ops[UCC_EE_LAST];
 
 #define UCC_CHECK_EC_AVAILABLE(ee)                                             \
     do {                                                                       \
@@ -72,6 +73,7 @@ ucc_status_t ucc_ec_init(const ucc_ec_params_t *ec_params)
         }
         ec->ref_cnt++;
         ec_ops[ec->type] = &ec->ops;
+        executor_ops[ec->type] = &ec->executor_ops;
     }
 
     return UCC_OK;
@@ -150,4 +152,50 @@ ucc_status_t ucc_ec_event_test(void *event, ucc_ee_type_t ee_type)
 {
     UCC_CHECK_EC_AVAILABLE(ee_type);
     return ec_ops[ee_type]->event_test(event);
+}
+
+ucc_status_t ucc_ee_executor_init(const ucc_ee_executor_params_t *params,
+                                  ucc_ee_executor_t **executor)
+{
+    UCC_CHECK_EC_AVAILABLE(params->ee_type);
+    return executor_ops[params->ee_type]->init(params, executor);
+}
+
+ucc_status_t ucc_ee_executor_status(const ucc_ee_executor_t *executor)
+{
+    UCC_CHECK_EC_AVAILABLE(executor->ee_type);
+    return executor_ops[executor->ee_type]->status(executor);
+}
+
+ucc_status_t ucc_ee_executor_start(ucc_ee_executor_t *executor,
+                                   void *ee_context)
+{
+    UCC_CHECK_EC_AVAILABLE(executor->ee_type);
+    return executor_ops[executor->ee_type]->start(executor, ee_context);
+}
+
+ucc_status_t ucc_ee_executor_stop(ucc_ee_executor_t *executor)
+{
+    UCC_CHECK_EC_AVAILABLE(executor->ee_type);
+    return executor_ops[executor->ee_type]->stop(executor);
+}
+
+ucc_status_t ucc_ee_executor_finalize(ucc_ee_executor_t *executor)
+{
+    UCC_CHECK_EC_AVAILABLE(executor->ee_type);
+    return executor_ops[executor->ee_type]->finalize(executor);
+}
+
+ucc_status_t ucc_ee_executor_task_post(const ucc_ee_executor_t *executor,
+                                       const ucc_ee_executor_task_args_t *task_args,
+                                       ucc_ee_executor_task_t **task)
+{
+    UCC_CHECK_EC_AVAILABLE(executor->ee_type);
+    return executor_ops[executor->ee_type]->task_post(executor, task_args, task);
+}
+
+ucc_status_t ucc_ee_executor_task_test(const ucc_ee_executor_task_t *task)
+{
+    UCC_CHECK_EC_AVAILABLE(task->eee->ee_type);
+    return executor_ops[task->eee->ee_type]->task_test(task);
 }

--- a/src/components/ec/ucc_ec.h
+++ b/src/components/ec/ucc_ec.h
@@ -31,4 +31,22 @@ ucc_status_t ucc_ec_event_post(void *ee_context, void *event,
 
 ucc_status_t ucc_ec_event_test(void *event, ucc_ee_type_t ee_type);
 
+ucc_status_t ucc_ee_executor_init(const ucc_ee_executor_params_t *params,
+                                  ucc_ee_executor_t **executor);
+
+ucc_status_t ucc_ee_executor_status(const ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_ee_executor_start(ucc_ee_executor_t *executor,
+                                   void *ee_context);
+
+ucc_status_t ucc_ee_executor_stop(ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_ee_executor_finalize(ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_ee_executor_task_post(const ucc_ee_executor_t *executor,
+                                       const ucc_ee_executor_task_args_t *task_args,
+                                       ucc_ee_executor_task_t **task);
+
+ucc_status_t ucc_ee_executor_task_test(const ucc_ee_executor_task_t *task);
+
 #endif

--- a/src/components/ec/ucc_ec.h
+++ b/src/components/ec/ucc_ec.h
@@ -13,6 +13,8 @@ ucc_status_t ucc_ec_init(const ucc_ec_params_t *ec_params);
 
 ucc_status_t ucc_ec_available(ucc_ee_type_t ee_type);
 
+ucc_status_t ucc_ec_get_attr(ucc_ec_attr_t *attr);
+
 ucc_status_t ucc_ec_finalize();
 
 ucc_status_t ucc_ec_task_post(void *ee_context, ucc_ee_type_t ee_type,
@@ -43,7 +45,7 @@ ucc_status_t ucc_ee_executor_stop(ucc_ee_executor_t *executor);
 
 ucc_status_t ucc_ee_executor_finalize(ucc_ee_executor_t *executor);
 
-ucc_status_t ucc_ee_executor_task_post(const ucc_ee_executor_t *executor,
+ucc_status_t ucc_ee_executor_task_post(ucc_ee_executor_t *executor,
                                        const ucc_ee_executor_task_args_t *task_args,
                                        ucc_ee_executor_task_t **task);
 


### PR DESCRIPTION
## What
Add executor interface and implement executor for CUDA EE.
Executor allows to run/offload different operations on/to execution engine 

## Why ?
CUDA executor is needed to correctly handle triggered operations with CUDA execution context

## How ?
Add new interface to EE (required #397 ) with executor operation.