### PR TITLE
Cl/HIER: 2lvl barrier

### DIFF
--- a/.ci/scripts/run_tests_ucc_mpi.sh
+++ b/.ci/scripts/run_tests_ucc_mpi.sh
@@ -72,3 +72,19 @@ mpirun \
     -x UCC_TL_NCCL_TUNE=0 \
     /opt/nvidia/src/ucc/build/test/mpi/ucc_test_mpi --mtypes cuda --inplace 2 --set_device 1 --root random:2 --count_bits 32,64 --displ_bits 32,64
 echo "INFO: UCC MPI unit tests (GPU without NCCL) ... DONE"
+
+echo "INFO: UCC MPI unit tests (CPU/GPU with CL/HIER) ..."
+# shellcheck disable=SC2086
+mpirun \
+    -np $NP \
+    --hostfile ${HOSTFILE} \
+    --map-by node \
+    --allow-run-as-root \
+    --mca plm_rsh_args '-p 12345' \
+    -x PATH \
+    -x LD_LIBRARY_PATH \
+    -x UCC_TL_NCCL_TUNE=0 \
+    -x UCC_CLS=hier,basic \
+    -x UCC_CL_HIER_TUNE=inf \
+    /opt/nvidia/src/ucc/build/test/mpi/ucc_test_mpi --mtypes host,cuda --inplace 2 --set_device 1 --root random:2 --count_bits 32,64 --displ_bits 32,64
+echo "INFO: UCC MPI unit tests (GPU without NCCL) ... DONE"

--- a/src/components/cl/hier/Makefile.am
+++ b/src/components/cl/hier/Makefile.am
@@ -14,6 +14,10 @@ alltoall =                  \
 	alltoall/alltoall.h     \
 	alltoall/alltoall.c
 
+barrier =                 \
+	barrier/barrier.h     \
+	barrier/barrier.c
+
 sources =             \
 	cl_hier.h         \
 	cl_hier.c         \
@@ -24,7 +28,8 @@ sources =             \
 	cl_hier_coll.h    \
 	$(allreduce)      \
 	$(alltoallv)      \
-	$(alltoall)
+	$(alltoall)       \
+	$(barrier)
 
 module_LTLIBRARIES         = libucc_cl_hier.la
 libucc_cl_hier_la_SOURCES  = $(sources)

--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -56,7 +56,6 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
 
     if (SBGP_ENABLED(cl_team, NODE)) {
         ucc_assert(n_tasks == 0);
-        /* can have only NODE sbgp, both above have been skipped */
         if (cl_team->top_sbgp == UCC_HIER_SBGP_NODE) {
             args.args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
         } else {

--- a/src/components/cl/hier/barrier/barrier.c
+++ b/src/components/cl/hier/barrier/barrier.c
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "barrier.h"
+#include "../cl_hier_coll.h"
+
+#define MAX_BARRIER_TASKS 3
+
+static ucc_status_t ucc_cl_hier_barrier_start(ucc_coll_task_t *task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
+
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_barrier_start", 0);
+    return ucc_schedule_start(schedule);
+}
+
+static ucc_status_t ucc_cl_hier_barrier_finalize(ucc_coll_task_t *task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
+    ucc_status_t    status;
+
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_barrier_finalize",
+                                      0);
+    status = ucc_schedule_finalize(task);
+    ucc_cl_hier_put_schedule(schedule);
+    return status;
+}
+
+UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_barrier_init,
+                         (coll_args, team, task),
+                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+                         ucc_coll_task_t **task)
+{
+    ucc_cl_hier_team_t  *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_coll_task_t     *tasks[MAX_BARRIER_TASKS] = {NULL};
+    ucc_schedule_t      *schedule;
+    ucc_status_t         status;
+    ucc_base_coll_args_t args;
+    int                  n_tasks, i;
+
+    schedule = &ucc_cl_hier_get_schedule(cl_team)->super.super;
+    if (ucc_unlikely(!schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    memcpy(&args, coll_args, sizeof(args));
+    args.args.root = 0; /* TODO: we can select the rank closest to HCA */
+    n_tasks        = 0;
+    status         = ucc_schedule_init(schedule, &args, team);
+    if (ucc_unlikely(UCC_OK != status)) {
+        goto out;
+    }
+
+    if (SBGP_ENABLED(cl_team, NODE)) {
+        ucc_assert(n_tasks == 0);
+        /* can have only NODE sbgp, both above have been skipped */
+        if (cl_team->top_sbgp == UCC_HIER_SBGP_NODE) {
+            args.args.coll_type = UCC_COLL_TYPE_BARRIER;
+        } else {
+            args.args.coll_type = UCC_COLL_TYPE_FANIN;
+        }
+        status =
+            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+    }
+
+    if (SBGP_ENABLED(cl_team, NODE_LEADERS)) {
+        ucc_assert(cl_team->top_sbgp == UCC_HIER_SBGP_NODE_LEADERS);
+        args.args.coll_type = UCC_COLL_TYPE_BARRIER;
+        status = ucc_coll_init(SCORE_MAP(cl_team, NODE_LEADERS), &args,
+                               &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+    }
+
+
+    if (SBGP_ENABLED(cl_team, NODE) &&
+        cl_team->top_sbgp != UCC_HIER_SBGP_NODE) {
+        args.args.coll_type = UCC_COLL_TYPE_FANOUT;
+        status =
+            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+    }
+
+    ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
+                                tasks[0], ucc_task_start_handler);
+    ucc_schedule_add_task(schedule, tasks[0]);
+    for (i = 1; i < n_tasks; i++) {
+        ucc_event_manager_subscribe(&tasks[i - 1]->em, UCC_EVENT_COMPLETED,
+                                    tasks[i], ucc_task_start_handler);
+        ucc_schedule_add_task(schedule, tasks[i]);
+    }
+
+    schedule->super.post     = ucc_cl_hier_barrier_start;
+    schedule->super.finalize = ucc_cl_hier_barrier_finalize;
+    *task                    = &schedule->super;
+    return UCC_OK;
+
+out:
+    for (i = 0; i < n_tasks; i++) {
+        tasks[i]->finalize(tasks[i]);
+    }
+    ucc_cl_hier_put_schedule(schedule);
+    return status;
+}

--- a/src/components/cl/hier/barrier/barrier.c
+++ b/src/components/cl/hier/barrier/barrier.c
@@ -56,7 +56,6 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_barrier_init,
 
     if (SBGP_ENABLED(cl_team, NODE)) {
         ucc_assert(n_tasks == 0);
-        /* can have only NODE sbgp, both above have been skipped */
         if (cl_team->top_sbgp == UCC_HIER_SBGP_NODE) {
             args.args.coll_type = UCC_COLL_TYPE_BARRIER;
         } else {

--- a/src/components/cl/hier/barrier/barrier.h
+++ b/src/components/cl/hier/barrier/barrier.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef BARRIER_H_
+#define BARRIER_H_
+#include "../cl_hier.h"
+
+ucc_status_t ucc_cl_hier_barrier_init(ucc_base_coll_args_t *coll_args,
+                                      ucc_base_team_t      *team,
+                                      ucc_coll_task_t     **task);
+
+#endif

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -11,6 +11,7 @@
 #include "allreduce/allreduce.h"
 #include "alltoallv/alltoallv.h"
 #include "alltoall/alltoall.h"
+#include "barrier/barrier.h"
 
 #define SBGP_SET(_team, _sbgp, _enable)                                        \
     _team->sbgps[UCC_HIER_SBGP_##_sbgp].sbgp_type = UCC_SBGP_##_sbgp;          \
@@ -391,6 +392,16 @@ ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
             cl_error(lib, "failed to add range to score_t");
             return status;
         }
+    }
+
+    status = ucc_coll_score_add_range(
+        score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
+        0, UCC_MSG_MAX, UCC_CL_HIER_DEFAULT_SCORE,
+        ucc_cl_hier_barrier_init, cl_team);
+    if (UCC_OK != status) {
+        cl_error(lib, "faild to add range to score_t");
+        return status;
+
     }
 
     if (strlen(ctx->score_str) > 0) {

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -60,6 +60,14 @@ scatter =	                   \
 	scatter/scatter.h          \
 	scatter/scatter_knomial.c
 
+fanin =	                  \
+	fanin/fanin.h         \
+	fanin/fanin.c
+
+fanout =	                \
+	fanout/fanout.h         \
+	fanout/fanout.c
+
 sources =                 \
 	tl_ucp.h              \
 	tl_ucp.c              \
@@ -80,7 +88,9 @@ sources =                 \
 	$(bcast)              \
 	$(reduce)             \
 	$(reduce_scatter)     \
-	$(scatter)
+	$(scatter)            \
+	$(fanin)              \
+	$(fanout)
 
 module_LTLIBRARIES = libucc_tl_ucp.la
 libucc_tl_ucp_la_SOURCES  = $(sources)

--- a/src/components/tl/ucp/bcast/bcast.c
+++ b/src/components/tl/ucp/bcast/bcast.c
@@ -22,11 +22,14 @@ ucc_base_coll_alg_info_t
         [UCC_TL_UCP_BCAST_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 
-ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *task);
-
 ucc_status_t ucc_tl_ucp_bcast_init(ucc_tl_ucp_task_t *task)
 {
+    ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
+    ucc_rank_t         team_size = UCC_TL_TEAM_SIZE(team);
+
+    task->bcast_kn.radix =
+        ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.bcast_kn_radix, team_size);
+
     task->super.post     = ucc_tl_ucp_bcast_knomial_start;
     task->super.progress = ucc_tl_ucp_bcast_knomial_progress;
     return UCC_OK;

--- a/src/components/tl/ucp/bcast/bcast.h
+++ b/src/components/tl/ucp/bcast/bcast.h
@@ -24,6 +24,10 @@ ucc_status_t
 ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
                               ucc_base_team_t *team, ucc_coll_task_t **task_h);
 
+ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *task);
+ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *task);
+
+
 #define UCC_TL_UCP_BCAST_DEFAULT_ALG_SELECT_STR              \
     "bcast:0-32k:@0#bcast:32k-inf:@1"
 

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -77,8 +77,6 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *coll_task)
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_bcast_kn_start", 0);
     ucc_tl_ucp_task_reset(task);
 
-    task->bcast_kn.radix =
-        ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.bcast_kn_radix, size);
     CALC_KN_TREE_DIST(size, task->bcast_kn.radix, task->bcast_kn.dist);
 
     status = ucc_tl_ucp_bcast_knomial_progress(&task->super);

--- a/src/components/tl/ucp/fanin/fanin.c
+++ b/src/components/tl/ucp/fanin/fanin.c
@@ -13,13 +13,13 @@ ucc_status_t ucc_tl_ucp_fanin_init(ucc_tl_ucp_task_t *task)
     ucc_rank_t         team_size = UCC_TL_TEAM_SIZE(team);
     ucc_status_t       status    = UCC_OK;
 
-    TASK_ARGS(task).src.info.buffer = NULL;
-    TASK_ARGS(task).src.info.count = 0;
+    TASK_ARGS(task).src.info.buffer   = NULL;
+    TASK_ARGS(task).src.info.count    = 0;
     TASK_ARGS(task).src.info.mem_type = UCC_MEMORY_TYPE_UNKNOWN;
     TASK_ARGS(task).src.info.datatype = UCC_DT_INT8;
 
-    TASK_ARGS(task).dst.info.buffer = NULL;
-    TASK_ARGS(task).dst.info.count = 0;
+    TASK_ARGS(task).dst.info.buffer   = NULL;
+    TASK_ARGS(task).dst.info.count    = 0;
     TASK_ARGS(task).dst.info.mem_type = UCC_MEMORY_TYPE_UNKNOWN;
     TASK_ARGS(task).dst.info.datatype = UCC_DT_INT8;
 

--- a/src/components/tl/ucp/fanin/fanin.c
+++ b/src/components/tl/ucp/fanin/fanin.c
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#include "config.h"
+#include "fanin.h"
+#include "../reduce/reduce.h"
+
+ucc_status_t ucc_tl_ucp_fanin_init(ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
+    ucc_rank_t         team_size = UCC_TL_TEAM_SIZE(team);
+    ucc_status_t       status    = UCC_OK;
+
+    TASK_ARGS(task).src.info.buffer = NULL;
+    TASK_ARGS(task).src.info.count = 0;
+    TASK_ARGS(task).src.info.mem_type = UCC_MEMORY_TYPE_UNKNOWN;
+    TASK_ARGS(task).src.info.datatype = UCC_DT_INT8;
+
+    TASK_ARGS(task).dst.info.buffer = NULL;
+    TASK_ARGS(task).dst.info.count = 0;
+    TASK_ARGS(task).dst.info.mem_type = UCC_MEMORY_TYPE_UNKNOWN;
+    TASK_ARGS(task).dst.info.datatype = UCC_DT_INT8;
+
+    task->super.post      = ucc_tl_ucp_reduce_knomial_start;
+    task->super.progress  = ucc_tl_ucp_reduce_knomial_progress;
+    task->reduce_kn.radix =
+        ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.fanin_kn_radix, team_size);
+
+    CALC_KN_TREE_DIST(team_size, task->reduce_kn.radix,
+                      task->reduce_kn.max_dist);
+    return status;
+}

--- a/src/components/tl/ucp/fanin/fanin.h
+++ b/src/components/tl/ucp/fanin/fanin.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#ifndef FANIN_H_
+#define FANIN_H_
+#include "../tl_ucp.h"
+#include "../tl_ucp_coll.h"
+
+ucc_status_t ucc_tl_ucp_fanin_init(ucc_tl_ucp_task_t *task);
+
+#endif

--- a/src/components/tl/ucp/fanout/fanout.c
+++ b/src/components/tl/ucp/fanout/fanout.c
@@ -13,8 +13,8 @@ ucc_status_t ucc_tl_ucp_fanout_init(ucc_tl_ucp_task_t *task)
     ucc_rank_t         team_size = UCC_TL_TEAM_SIZE(team);
     ucc_status_t       status    = UCC_OK;
 
-    TASK_ARGS(task).src.info.buffer = NULL;
-    TASK_ARGS(task).src.info.count = 0;
+    TASK_ARGS(task).src.info.buffer   = NULL;
+    TASK_ARGS(task).src.info.count    = 0;
     TASK_ARGS(task).src.info.mem_type = UCC_MEMORY_TYPE_UNKNOWN;
     TASK_ARGS(task).src.info.datatype = UCC_DT_INT8;
     task->bcast_kn.radix =

--- a/src/components/tl/ucp/fanout/fanout.c
+++ b/src/components/tl/ucp/fanout/fanout.c
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#include "config.h"
+#include "fanout.h"
+#include "../bcast/bcast.h"
+
+ucc_status_t ucc_tl_ucp_fanout_init(ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
+    ucc_rank_t         team_size = UCC_TL_TEAM_SIZE(team);
+    ucc_status_t       status    = UCC_OK;
+
+    TASK_ARGS(task).src.info.buffer = NULL;
+    TASK_ARGS(task).src.info.count = 0;
+    TASK_ARGS(task).src.info.mem_type = UCC_MEMORY_TYPE_UNKNOWN;
+    TASK_ARGS(task).src.info.datatype = UCC_DT_INT8;
+    task->bcast_kn.radix =
+        ucc_min(UCC_TL_UCP_TEAM_LIB(team)->cfg.fanout_kn_radix, team_size);
+
+    task->super.post      = ucc_tl_ucp_bcast_knomial_start;
+    task->super.progress  = ucc_tl_ucp_bcast_knomial_progress;
+    return status;
+}

--- a/src/components/tl/ucp/fanout/fanout.h
+++ b/src/components/tl/ucp/fanout/fanout.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#ifndef FANOUT_H_
+#define FANOUT_H_
+#include "../tl_ucp.h"
+#include "../tl_ucp_coll.h"
+
+ucc_status_t ucc_tl_ucp_fanout_init(ucc_tl_ucp_task_t *task);
+
+#endif

--- a/src/components/tl/ucp/reduce/reduce.c
+++ b/src/components/tl/ucp/reduce/reduce.c
@@ -6,10 +6,6 @@
 #include "config.h"
 #include "reduce.h"
 
-ucc_status_t ucc_tl_ucp_reduce_knomial_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_reduce_knomial_progress(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_reduce_knomial_finalize(ucc_coll_task_t *task);
-
 ucc_status_t ucc_tl_ucp_reduce_init(ucc_tl_ucp_task_t *task)
 {
     ucc_coll_args_t   *args      = &TASK_ARGS(task);

--- a/src/components/tl/ucp/reduce/reduce.h
+++ b/src/components/tl/ucp/reduce/reduce.h
@@ -30,4 +30,8 @@ enum {
 
 ucc_status_t ucc_tl_ucp_reduce_init(ucc_tl_ucp_task_t *task);
 
+ucc_status_t ucc_tl_ucp_reduce_knomial_start(ucc_coll_task_t *task);
+ucc_status_t ucc_tl_ucp_reduce_knomial_progress(ucc_coll_task_t *task);
+ucc_status_t ucc_tl_ucp_reduce_knomial_finalize(ucc_coll_task_t *task);
+
 #endif

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -44,6 +44,16 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, barrier_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
+    {"FANIN_KN_RADIX", "4",
+     "Radix of the knomial tree fanin algorithm",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, fanin_kn_radix),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"FANOUT_KN_RADIX", "4",
+     "Radix of the knomial tree fanout algorithm",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, fanout_kn_radix),
+     UCC_CONFIG_TYPE_UINT},
+
     {"ALLREDUCE_KN_RADIX", "4",
      "Radix of the recursive-knomial allreduce algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_kn_radix),

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -43,6 +43,8 @@ extern ucc_tl_ucp_iface_t ucc_tl_ucp;
 typedef struct ucc_tl_ucp_lib_config {
     ucc_tl_lib_config_t super;
     uint32_t            kn_radix;
+    uint32_t            fanin_kn_radix;
+    uint32_t            fanout_kn_radix;
     uint32_t            barrier_kn_radix;
     uint32_t            allreduce_kn_radix;
     uint32_t            allreduce_sra_kn_radix;
@@ -119,7 +121,7 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
     (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                        \
      UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                      \
      UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST | UCC_COLL_TYPE_BARRIER |   \
-     UCC_COLL_TYPE_REDUCE)
+     UCC_COLL_TYPE_REDUCE |   UCC_COLL_TYPE_FANIN | UCC_COLL_TYPE_FANOUT)
 
 #define UCC_TL_UCP_TEAM_LIB(_team)                                             \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_ucp_lib_t))

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -16,6 +16,9 @@
 #include "allgatherv/allgatherv.h"
 #include "bcast/bcast.h"
 #include "reduce/reduce.h"
+#include "fanin/fanin.h"
+#include "fanout/fanout.h"
+
 const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR] = {
         UCC_TL_UCP_ALLREDUCE_DEFAULT_ALG_SELECT_STR,
@@ -89,6 +92,12 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_args_t *coll_args,
         break;
     case UCC_COLL_TYPE_REDUCE:
         status = ucc_tl_ucp_reduce_init(task);
+        break;
+    case UCC_COLL_TYPE_FANIN:
+        status = ucc_tl_ucp_fanin_init(task);
+        break;
+    case UCC_COLL_TYPE_FANOUT:
+        status = ucc_tl_ucp_fanout_init(task);
         break;
     default:
         status = UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/ucp/tl_ucp_reduce.h
+++ b/src/components/tl/ucp/tl_ucp_reduce.h
@@ -15,6 +15,9 @@ ucc_tl_ucp_reduce_multi(void *src1, void *src2, void *dst, size_t n_vectors,
                         ucc_memory_type_t mem_type, ucc_tl_ucp_task_t *task,
                         int is_avg)
 {
+    if (count == 0) {
+        return UCC_OK;
+    }
     if (is_avg) {
         return ucc_dt_reduce_multi_alpha(
             src1, src2, dst, n_vectors, count, stride, dt, UCC_OP_PROD,


### PR DESCRIPTION
## What
 - Adds 2lvl fanin-barrier-fanout Barrier algorithm in CL/HIER
 - Adds implementations of knomial fanin and fanout in TL/UCP
 - Adds CL/HIER to .CI

## Why ?
Enabling hierarchical barrier

## How ?
TL/UCP Fanin and Fanout are implemented as calls to the knomial reduce and bcast respectively with count = 0, buffer = NULL
