### PR TITLE
TEST: fixes clang tidy and asan

### DIFF
--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -468,6 +468,9 @@ ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t * ctx,
         tl_error(ctx->super.super.lib, "failed to pack remote data");
         goto fail_pack;
     }
+    for (i = 0; i < nsegs; i++) {
+        ucp_rkey_buffer_release(my_pack[i]);
+    }
 
     global_pack_data = ucc_malloc(total * size, "ucp_global_packed_data");
     if (NULL == global_pack_data) {

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -54,9 +54,14 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
                 status = UCC_ERR_NO_MEMORY;
                 goto err_cfg;
             }
-            status = ucc_config_parser_fill_opts(self->tlcp_configs[i], tlcp->config.table,
+            status = ucc_config_parser_fill_opts(self->tlcp_configs[i],
+                                                 tlcp->config.table,
                                                  params->full_prefix,
                                                  ucc_tl_ucp.super.tl_lib_config.prefix, 0);
+            if (status != UCC_OK) {
+                tl_error(&self->super, "failed to read tlcp config");
+                goto err_cfg;
+            }
         }
     }
     tl_info(&self->super, "initialized lib object: %p", self);

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -452,8 +452,9 @@ ucc_status_t ucc_lib_get_attr(ucc_lib_h lib_p, ucc_lib_attr_t *lib_attr)
 ucc_status_t ucc_finalize(ucc_lib_info_t *lib)
 {
     int          i;
-    ucc_status_t status;
+    ucc_status_t status, gl_status;
 
+    gl_status = UCC_OK;
     ucc_assert(lib->n_cl_libs_opened > 0);
     ucc_assert(lib->cl_libs);
     for (i = 0; i < lib->n_tl_libs_opened; i++) {
@@ -463,11 +464,20 @@ ucc_status_t ucc_finalize(ucc_lib_info_t *lib)
         lib->cl_libs[i]->iface->lib.finalize(&lib->cl_libs[i]->super);
     }
     status = ucc_mc_finalize();
+    if (status != UCC_OK) {
+        gl_status = status;
+    }
+
     status = ucc_ec_finalize();
+    if (status != UCC_OK) {
+        gl_status = status;
+    }
+
     ucc_free(lib->tl_libs);
     ucc_free(lib->cl_libs);
     ucc_free(lib->full_prefix);
     ucc_free(lib->cl_attrs);
     ucc_free(lib);
-    return status;
+
+    return gl_status;
 }

--- a/test/gtest/core/test_alltoall.cc
+++ b/test/gtest/core/test_alltoall.cc
@@ -86,11 +86,13 @@ public:
             }
         }
     }
+
     void data_init(int nprocs, ucc_datatype_t dtype, size_t single_rank_count,
                    UccCollCtxVec &ctxs)
     {
         data_init(nprocs, dtype, single_rank_count, ctxs, NULL);
     }
+
     void reset(UccCollCtxVec ctxs)
     {
         for (auto r = 0; r < ctxs.size(); r++) {
@@ -107,6 +109,7 @@ public:
             }
         }
     }
+
     void data_fini(UccCollCtxVec ctxs)
     {
         for (gtest_ucc_coll_ctx_t* ctx : ctxs) {
@@ -121,6 +124,7 @@ public:
         }
         ctxs.clear();
     }
+
     void data_fini_onesided(UccCollCtxVec ctxs)
     {
         for (gtest_ucc_coll_ctx_t *ctx : ctxs) {
@@ -131,6 +135,7 @@ public:
         }
         ctxs.clear();
     }
+
     bool data_validate(UccCollCtxVec ctxs)
     {
         bool                   ret = true;


### PR DESCRIPTION
## What
Fixes following warnings and leak
```
tl_ucp_lib.c:57:13: warning: Value stored to 'status' is never read [clang-analyzer-deadcode.DeadStores]
            status = ucc_config_parser_fill_opts(self->tlcp_configs[i], tlcp->config.table,
```

```
core/ucc_lib.c:465:5: warning: Value stored to 'status' is never read [clang-analyzer-deadcode.DeadStores]
    status = ucc_mc_finalize();
```

```
Direct leak of 4320 byte(s) in 48 object(s) allocated from:
    #0 0x7f3045247c6f in __interceptor_malloc ../../../../source/gcc-10.1.0/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f3045e66a9e in ucs_malloc debug/memtrack.c:313
    #2 0x7f304035e794 in ucp_rkey_pack core/ucp_rkey.c:211
    #3 0x7f303f955978 in ucc_tl_ucp_ctx_remote_populate ../../../../../src/components/tl/ucp/tl_ucp_context.c:430
    #4 0x7f303f952f05 in ucc_tl_ucp_context_t_init ../../../../../src/components/tl/ucp/tl_ucp_context.c:140
    #5 0x7f303f95005e in ucc_tl_ucp_context_t_new ../../../../../src/components/tl/ucp/tl_ucp.c:152
    #6 0x7f3044f43aa8 in ucc_create_tl_contexts ../../src/core/ucc_context.c:376
    #7 0x7f3044f45cac in ucc_context_create ../../src/core/ucc_context.c:572
```