### PR TITLE
TL/UCP: reduce_scatter_ring

### DIFF
--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -54,7 +54,9 @@ reduce =	                 \
 
 reduce_scatter =	                        \
 	reduce_scatter/reduce_scatter.h         \
-	reduce_scatter/reduce_scatter_knomial.c
+	reduce_scatter/reduce_scatter_knomial.c \
+	reduce_scatter/reduce_scatter_ring.c    \
+	reduce_scatter/reduce_scatter.c
 
 scatter =	                   \
 	scatter/scatter.h          \

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -62,9 +62,10 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
                                       ucc_coll_task_t     **task_h)
 {
     ucc_tl_ucp_team_t   *tl_team  = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_schedule_t      *schedule = ucc_tl_ucp_get_schedule(tl_team, coll_args);
     size_t               count    = coll_args->args.src.info.count;
     ucc_base_coll_args_t args     = *coll_args;
+    ucc_schedule_t      *schedule =
+        &ucc_tl_ucp_get_schedule(tl_team, coll_args)->super.super;
     ucc_coll_task_t     *task, *rs_task;
     ucc_status_t         status;
     ucc_kn_radix_t       radix, cfg_radix;

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter.c
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+#include "tl_ucp.h"
+#include "reduce_scatter.h"
+#include "utils/ucc_coll_utils.h"
+
+ucc_base_coll_alg_info_t
+    ucc_tl_ucp_reduce_scatter_algs[UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST + 1] = {
+        [UCC_TL_UCP_REDUCE_SCATTER_ALG_RING] =
+            {.id   = UCC_TL_UCP_REDUCE_SCATTER_ALG_RING,
+             .name = "ring",
+             .desc = "O(N) ring"},
+        [UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter.h
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter.h
@@ -1,11 +1,34 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
 #ifndef REDUCE_SCATTER_H_
 #define REDUCE_SCATTER_H_
 #include "../tl_ucp_reduce.h"
+
+enum
+{
+    UCC_TL_UCP_REDUCE_SCATTER_ALG_RING,
+    UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST
+};
+
+extern ucc_base_coll_alg_info_t
+    ucc_tl_ucp_reduce_scatter_algs[UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST + 1];
+
+#define UCC_TL_UCP_REDUCE_SCATTER_DEFAULT_ALG_SELECT_STR                       \
+    "reduce_scatter:@ring"
+
+static inline int ucc_tl_ucp_reduce_scatter_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_tl_ucp_reduce_scatter_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
 
 /* Base interface signature: uses reduce_scatter_kn_radix from config. */
 
@@ -18,4 +41,9 @@ ucc_tl_ucp_reduce_scatter_knomial_init(ucc_base_coll_args_t *coll_args,
 ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
     ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
     ucc_coll_task_t **task_h, ucc_kn_radix_t radix);
+
+ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_args,
+                                    ucc_base_team_t *     team,
+                                    ucc_coll_task_t **    task_h);
 #endif

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -1,0 +1,364 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "reduce_scatter.h"
+#include "tl_ucp_coll.h"
+#include "tl_ucp_sendrecv.h"
+#include "core/ucc_progress_queue.h"
+#include "components/mc/ucc_mc.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
+
+static inline void ucc_ring_frag_count(ucc_tl_ucp_task_t *task, size_t count,
+                                       ucc_rank_t block, size_t *frag_count)
+{
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+    size_t             size = UCC_TL_TEAM_SIZE(team);
+    int                n_frags, frag;
+    size_t             block_count;
+
+    n_frags = task->reduce_scatter_ring.n_frags;
+    frag    = task->reduce_scatter_ring.frag;
+
+    block_count = ucc_buffer_block_count(count, size, block);
+    *frag_count = ucc_buffer_block_count(block_count, n_frags, frag);
+}
+
+static inline void ucc_ring_frag_block_offset(ucc_tl_ucp_task_t *task,
+                                              size_t count, ucc_rank_t block,
+                                              size_t *block_offset,
+                                              size_t *frag_offset)
+{
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+    size_t             size = UCC_TL_TEAM_SIZE(team);
+    int                n_frags, frag;
+    size_t             block_count;
+
+    n_frags = task->reduce_scatter_ring.n_frags;
+    frag    = task->reduce_scatter_ring.frag;
+
+    block_count   = ucc_buffer_block_count(count, size, block);
+    *frag_offset  = ucc_buffer_block_offset(block_count, n_frags, frag);
+    *block_offset = ucc_buffer_block_offset(count, size, block);
+}
+
+static inline ucc_status_t ucc_tl_ucp_test_ring(ucc_tl_ucp_task_t *task)
+{
+    int polls = 0;
+    while (polls++ < task->n_polls) {
+        if (task->send_posted - task->send_completed <= 1 &&
+            task->recv_posted == task->recv_completed) {
+            return UCC_OK;
+        }
+        ucp_worker_progress(TASK_CTX(task)->ucp_worker);
+    }
+    return UCC_INPROGRESS;
+}
+
+static ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task     = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_coll_args_t *  args     = &TASK_ARGS(task);
+    ucc_tl_ucp_team_t *team     = TASK_TEAM(task);
+    ucc_rank_t         size     = task->subset.map.ep_num;
+    ucc_rank_t         rank     = task->subset.myrank;
+    void *             sbuf     = args->src.info.buffer;
+    ucc_memory_type_t  mem_type = args->dst.info.mem_type;
+    size_t             count    = args->dst.info.count * size;
+    ucc_datatype_t     dt       = args->dst.info.datatype;
+    size_t             dt_size  = ucc_dt_size(dt);
+    ucc_rank_t         sendto   = (rank + 1) % size;
+    ucc_rank_t         recvfrom = (rank - 1 + size) % size;
+    ucc_rank_t         prevblock, recv_data_from;
+    ucc_status_t       status;
+    size_t max_block_size, block_offset, frag_count, frag_offset, final_offset;
+    int    step, is_avg;
+    void  *r_scratch, *s_scratch[2];
+
+    final_offset = 0;
+    if (UCC_IS_INPLACE(*args)) {
+        sbuf = args->dst.info.buffer;
+        count /= size;
+        final_offset =
+            ucc_buffer_block_offset(count, size, UCC_TL_TEAM_RANK(team));
+    }
+
+    sendto   = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, sendto);
+    recvfrom = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recvfrom);
+
+    max_block_size = task->reduce_scatter_ring.max_block_count * dt_size;
+    r_scratch      = task->reduce_scatter_ring.scratch;
+    s_scratch[0]   = PTR_OFFSET(r_scratch, max_block_size);
+    s_scratch[1]   = PTR_OFFSET(s_scratch[0], max_block_size);
+
+    if (UCC_INPROGRESS == ucc_tl_ucp_test_ring(task)) {
+        return task->super.super.status;
+    }
+    while (task->recv_posted > 0) {
+        void *reduce_target = s_scratch[(task->recv_completed - 1) % 2];
+        step                = task->send_posted;
+        prevblock           = (rank - 1 - step + size) % size;
+        prevblock =
+            ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, prevblock);
+        /* reduction */
+        ucc_assert(task->recv_posted == task->recv_completed);
+        ucc_assert(task->recv_posted < size);
+
+        ucc_ring_frag_count(task, count, prevblock, &frag_count);
+        ucc_ring_frag_block_offset(task, count, prevblock, &block_offset,
+                                   &frag_offset);
+        if (task->recv_completed == size - 1) {
+            reduce_target = PTR_OFFSET(args->dst.info.buffer,
+                                       (frag_offset + final_offset) * dt_size);
+        }
+        is_avg =
+            (args->op == UCC_OP_AVG) && (task->recv_completed == (size - 1));
+        if (UCC_OK !=
+            (status = ucc_tl_ucp_reduce_multi(
+                 r_scratch,
+                 PTR_OFFSET(sbuf, (block_offset + frag_offset) * dt_size),
+                 reduce_target, 1, frag_count, 0, dt, mem_type, task,
+                 is_avg))) {
+            tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
+            task->super.super.status = status;
+            return status;
+        }
+        if (task->recv_completed == size - 1) {
+            task->recv_posted = task->recv_completed = 0;
+            break;
+        }
+        ucc_assert(task->send_posted - task->send_completed <= 1);
+        ucc_assert(task->send_posted < size);
+
+        UCPCHECK_GOTO(ucc_tl_ucp_send_nb(s_scratch[(task->send_posted - 1) % 2],
+                                         frag_count * dt_size, mem_type, sendto,
+                                         team, task),
+                      task, out);
+
+        recv_data_from = (rank - 2 - step + size) % size;
+        recv_data_from =
+            ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recv_data_from);
+
+        ucc_ring_frag_count(task, count, recv_data_from, &frag_count);
+
+        UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(r_scratch, frag_count * dt_size, mem_type,
+                                         recvfrom, team, task),
+                      task, out);
+
+        if (UCC_INPROGRESS == ucc_tl_ucp_test_ring(task)) {
+            return task->super.super.status;
+        }
+    }
+    if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+        return task->super.super.status;
+    }
+    task->super.super.status = UCC_OK;
+out:
+    return task->super.super.status;
+}
+
+static ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task     = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_coll_args_t *  args     = &TASK_ARGS(task);
+    ucc_tl_ucp_team_t *team     = TASK_TEAM(task);
+    ucc_rank_t         size     = task->subset.map.ep_num;
+    ucc_rank_t         rank     = task->subset.myrank;
+    ucc_rank_t         sendto   = (rank + 1) % size;
+    ucc_rank_t         recvfrom = (rank - 1 + size) % size;
+    size_t             count    = args->dst.info.count * size;
+    ucc_datatype_t     dt       = args->dst.info.datatype;
+    size_t             dt_size  = ucc_dt_size(dt);
+    ucc_memory_type_t  mem_type = args->dst.info.mem_type;
+    void *             sbuf     = args->src.info.buffer;
+    int                step     = 0;
+    ucc_status_t       status;
+    size_t             block_offset, frag_count, frag_offset;
+    void              *r_scratch;
+    ucc_rank_t         send_block, recv_block;
+
+    if (UCC_IS_INPLACE(*args)) {
+        sbuf = args->dst.info.buffer;
+        count /= size;
+    }
+    task->super.super.status = UCC_INPROGRESS;
+    ucc_tl_ucp_task_reset(task);
+
+    sendto     = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, sendto);
+    recvfrom   = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recvfrom);
+    r_scratch  = task->reduce_scatter_ring.scratch;
+    recv_block = (rank - 2 - step + size) % size;
+    send_block = (rank - 1 - step + size) % size;
+    recv_block = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recv_block);
+    send_block = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, send_block);
+
+    ucc_ring_frag_count(task, count, recv_block, &frag_count);
+    UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(r_scratch, frag_count * dt_size, mem_type,
+                                     recvfrom, team, task),
+                  task, out);
+
+    ucc_ring_frag_count(task, count, send_block, &frag_count);
+    ucc_ring_frag_block_offset(task, count, send_block, &block_offset,
+                               &frag_offset);
+    UCPCHECK_GOTO(ucc_tl_ucp_send_nb(
+                      PTR_OFFSET(sbuf, (block_offset + frag_offset) * dt_size),
+                      frag_count * dt_size, mem_type, sendto, team, task),
+                  task, out);
+
+    status = ucc_tl_ucp_reduce_scatter_ring_progress(&task->super);
+    if (UCC_INPROGRESS == status) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+        return UCC_OK;
+    }
+    return ucc_task_complete(coll_task);
+out:
+    return task->super.super.status;
+}
+
+static ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+
+    if (task->reduce_scatter_ring.inv_map.type != UCC_EP_MAP_FULL) {
+        ucc_ep_map_destroy(&task->reduce_scatter_ring.inv_map);
+    }
+    return ucc_tl_ucp_coll_finalize(coll_task);
+}
+
+static ucc_status_t ucc_tl_ucp_reduce_scatter_ring_init_subset(
+    ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+    ucc_coll_task_t **task_h, ucc_subset_t subset, int n_frags, int frag,
+    void *scratch, size_t max_block_count)
+{
+    ucc_tl_ucp_task_t *task;
+    ucc_status_t       status;
+
+    task                 = ucc_tl_ucp_init_task(coll_args, team);
+    task->super.post     = ucc_tl_ucp_reduce_scatter_ring_start;
+    task->super.progress = ucc_tl_ucp_reduce_scatter_ring_progress;
+    task->super.finalize = ucc_tl_ucp_reduce_scatter_ring_finalize;
+    task->subset         = subset;
+
+    if (task->subset.map.type != UCC_EP_MAP_FULL) {
+        status = ucc_ep_map_create_inverse(task->subset.map,
+                                           &task->reduce_scatter_ring.inv_map);
+        if (UCC_OK != status) {
+            return status;
+        }
+    } else {
+        task->reduce_scatter_ring.inv_map.type   = UCC_EP_MAP_FULL;
+        task->reduce_scatter_ring.inv_map.ep_num = task->subset.map.ep_num;
+    }
+    task->reduce_scatter_ring.n_frags         = n_frags;
+    task->reduce_scatter_ring.frag            = frag;
+    task->reduce_scatter_ring.scratch         = scratch;
+    task->reduce_scatter_ring.max_block_count = max_block_count;
+
+    *task_h = &task->super;
+    return UCC_OK;
+}
+
+static ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_sched_post(ucc_coll_task_t *coll_task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
+
+    return ucc_schedule_start(schedule);
+}
+
+static ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_sched_finalize(ucc_coll_task_t *task)
+{
+    ucc_tl_ucp_schedule_t *schedule = ucc_derived_of(task,
+                                                     ucc_tl_ucp_schedule_t);
+    ucc_status_t    status;
+
+    ucc_mc_free(schedule->scratch_mc_header);
+    status = ucc_schedule_finalize(task);
+    ucc_tl_ucp_put_schedule(&schedule->super.super);
+    return status;
+}
+
+ucc_status_t
+ucc_tl_ucp_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_args,
+                                    ucc_base_team_t *     team,
+                                    ucc_coll_task_t **    task_h)
+{
+
+    ucc_tl_ucp_team_t *tl_team  = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_rank_t         size     = UCC_TL_TEAM_SIZE(tl_team);
+    size_t             count    = coll_args->args.dst.info.count * size;
+    ucc_datatype_t     dt       = coll_args->args.dst.info.datatype;
+    size_t             dt_size  = ucc_dt_size(dt);
+    ucc_memory_type_t  mem_type = coll_args->args.dst.info.mem_type;
+    int                bidir =
+        UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.reduce_scatter_ring_bidirectional;
+    size_t                 to_alloc_per_set, max_segcount, count_per_set;
+    ucc_tl_ucp_schedule_t *tl_schedule;
+    ucc_schedule_t        *schedule;
+    ucc_coll_task_t       *ctask;
+    ucc_status_t           status;
+    ucc_subset_t           s[2];
+    int                    i, n_subsets;
+
+    if (UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.reduce_avg_pre_op &&
+        coll_args->args.op == UCC_OP_AVG) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    tl_schedule  = ucc_tl_ucp_get_schedule(tl_team, coll_args);
+    schedule     = &tl_schedule->super.super;
+    /* if count == size then we have 1 elem per rank, not enough
+       to split into 2 sets */
+    n_subsets    = (bidir && (count > size)) ? 2 : 1;
+
+    s[0].myrank     = UCC_TL_TEAM_RANK(tl_team);
+    s[0].map.type   = UCC_EP_MAP_FULL;
+    s[0].map.ep_num = UCC_TL_TEAM_SIZE(tl_team);
+
+    s[1].map    = ucc_ep_map_create_reverse(UCC_TL_TEAM_SIZE(tl_team));
+    s[1].myrank = ucc_ep_map_eval(s[1].map, UCC_TL_TEAM_RANK(tl_team));
+
+    if (UCC_IS_INPLACE(coll_args->args)) {
+        count /= size;
+    }
+
+    count_per_set    = (count + n_subsets - 1) / n_subsets;
+    max_segcount     = ucc_buffer_block_count(count_per_set, size, 0);
+    /* in flight we can have 2 sends from 2 differnt blocks and 1 recv:
+       need 3 * max_segcount of scratch per set */
+    to_alloc_per_set = max_segcount * 3;
+    status = ucc_mc_alloc(&tl_schedule->scratch_mc_header,
+                          to_alloc_per_set * dt_size * n_subsets, mem_type);
+
+    if (status != UCC_OK) {
+        ucc_tl_ucp_put_schedule(schedule);
+        return status;
+    }
+
+    for (i = 0; i < n_subsets; i++) {
+        status = ucc_tl_ucp_reduce_scatter_ring_init_subset(
+            coll_args, team, &ctask, s[i], n_subsets, i,
+            PTR_OFFSET(tl_schedule->scratch_mc_header->addr,
+                       to_alloc_per_set * i * dt_size), max_segcount);
+        if (UCC_OK != status) {
+            tl_error(UCC_TL_TEAM_LIB(tl_team), "failed to allocate ring task");
+            return status;
+        }
+        ctask->n_deps = 1;
+        ucc_schedule_add_task(schedule, ctask);
+        ucc_event_manager_subscribe(&schedule->super.em,
+                                    UCC_EVENT_SCHEDULE_STARTED, ctask,
+                                    ucc_task_start_handler);
+    }
+    schedule->super.post     = ucc_tl_ucp_reduce_scatter_ring_sched_post;
+    schedule->super.finalize = ucc_tl_ucp_reduce_scatter_ring_sched_finalize;
+    *task_h                  = &schedule->super;
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -125,6 +125,11 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_avg_pre_op),
      UCC_CONFIG_TYPE_BOOL},
 
+    {"REDUCE_SCATTER_RING_BIDIRECTIONAL", "y",
+     "Launch 2 inverted rings concurrently",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_scatter_ring_bidirectional),
+     UCC_CONFIG_TYPE_BOOL},
+
     {NULL}};
 
 static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -62,6 +62,7 @@ typedef struct ucc_tl_ucp_lib_config {
     size_t              allreduce_sra_kn_frag_thresh;
     size_t              allreduce_sra_kn_frag_size;
     int                 reduce_avg_pre_op;
+    int                 reduce_scatter_ring_bidirectional;
 } ucc_tl_ucp_lib_config_t;
 
 typedef struct ucc_tl_ucp_context_config {
@@ -121,7 +122,8 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
     (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                        \
      UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                      \
      UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST | UCC_COLL_TYPE_BARRIER |   \
-     UCC_COLL_TYPE_REDUCE |   UCC_COLL_TYPE_FANIN | UCC_COLL_TYPE_FANOUT)
+     UCC_COLL_TYPE_REDUCE |   UCC_COLL_TYPE_FANIN | UCC_COLL_TYPE_FANOUT   |   \
+     UCC_COLL_TYPE_REDUCE_SCATTER)
 
 #define UCC_TL_UCP_TEAM_LIB(_team)                                             \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_ucp_lib_t))

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -14,6 +14,7 @@
 #include "allreduce/allreduce.h"
 #include "allgather/allgather.h"
 #include "allgatherv/allgatherv.h"
+#include "reduce_scatter/reduce_scatter.h"
 #include "bcast/bcast.h"
 #include "reduce/reduce.h"
 #include "fanin/fanin.h"
@@ -23,7 +24,8 @@ const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR] = {
         UCC_TL_UCP_ALLREDUCE_DEFAULT_ALG_SELECT_STR,
         UCC_TL_UCP_BCAST_DEFAULT_ALG_SELECT_STR,
-        UCC_TL_UCP_ALLTOALL_DEFAULT_ALG_SELECT_STR};
+        UCC_TL_UCP_ALLTOALL_DEFAULT_ALG_SELECT_STR,
+        UCC_TL_UCP_REDUCE_SCATTER_DEFAULT_ALG_SELECT_STR};
 
 void ucc_tl_ucp_send_completion_cb(void *request, ucs_status_t status,
                                    void *user_data)
@@ -120,6 +122,8 @@ static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
         return ucc_tl_ucp_bcast_alg_from_str(str);
     case UCC_COLL_TYPE_ALLTOALL:
         return ucc_tl_ucp_alltoall_alg_from_str(str);
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        return ucc_tl_ucp_reduce_scatter_alg_from_str(str);
     default:
         break;
     }
@@ -176,6 +180,17 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
             break;
         };
         break;
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        switch (alg_id) {
+        case UCC_TL_UCP_REDUCE_SCATTER_ALG_RING:
+            *init = ucc_tl_ucp_reduce_scatter_ring_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+
     default:
         status = UCC_ERR_NOT_SUPPORTED;
         break;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -84,6 +84,11 @@ typedef struct ucc_tl_ucp_task {
     };
 } ucc_tl_ucp_task_t;
 
+typedef struct ucc_tl_ucp_schedule {
+    ucc_schedule_pipelined_t super;
+    ucc_mc_buffer_header_t  *scratch_mc_header;
+} ucc_tl_ucp_schedule_t;
+
 #define TASK_TEAM(_task)                                                       \
     (ucc_derived_of((_task)->super.team, ucc_tl_ucp_team_t))
 #define TASK_CTX(_task)                                                        \
@@ -124,24 +129,15 @@ static inline void ucc_tl_ucp_put_task(ucc_tl_ucp_task_t *task)
     ucc_mpool_put(task);
 }
 
-static inline ucc_schedule_t *ucc_tl_ucp_get_schedule(ucc_tl_ucp_team_t *team,
-                                                      ucc_base_coll_args_t *args)
+static inline
+ucc_tl_ucp_schedule_t *ucc_tl_ucp_get_schedule(ucc_tl_ucp_team_t *team,
+                                               ucc_base_coll_args_t *args)
 {
-    ucc_tl_ucp_context_t *ctx      = UCC_TL_UCP_TEAM_CTX(team);
-    ucc_schedule_t       *schedule = ucc_mpool_get(&ctx->req_mp);
+    ucc_tl_ucp_context_t  *ctx      = UCC_TL_UCP_TEAM_CTX(team);
+    ucc_tl_ucp_schedule_t *schedule = ucc_mpool_get(&ctx->req_mp);
 
     UCC_TL_UCP_PROFILE_REQUEST_NEW(schedule, "tl_ucp_sched", 0);
-    ucc_schedule_init(schedule, args, &team->super.super);
-    return schedule;
-}
-
-static inline ucc_schedule_pipelined_t *
-ucc_tl_ucp_get_schedule_pipelined(ucc_tl_ucp_team_t *team)
-{
-    ucc_tl_ucp_context_t     *ctx      = UCC_TL_UCP_TEAM_CTX(team);
-    ucc_schedule_pipelined_t *schedule = ucc_mpool_get(&ctx->req_mp);
-
-    UCC_TL_UCP_PROFILE_REQUEST_NEW(schedule, "tl_ucp_sched_p", 0);
+    ucc_schedule_init(&schedule->super.super, args, &team->super.super);
     return schedule;
 }
 
@@ -151,12 +147,6 @@ static inline void ucc_tl_ucp_put_schedule(ucc_schedule_t *schedule)
     ucc_mpool_put(schedule);
 }
 
-static inline void
-ucc_tl_ucp_put_schedule_pipelined(ucc_schedule_pipelined_t *schedule)
-{
-    UCC_TL_UCP_PROFILE_REQUEST_FREE(schedule);
-    ucc_mpool_put(schedule);
-}
 
 ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_args_t *coll_args,
                                   ucc_base_team_t *     team,

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -63,6 +63,7 @@ typedef struct ucc_tl_ucp_task {
             ucc_ep_map_t            inv_map;
             int                     n_frags;
             int                     frag;
+            char                    s_scratch_busy[2];
         } reduce_scatter_ring;
         struct {
             int                     phase;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -13,7 +13,7 @@
 #include "components/mc/base/ucc_mc_base.h"
 #include "tl_ucp_tag.h"
 
-#define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 3
+#define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 4
 extern const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR];
 
@@ -57,6 +57,13 @@ typedef struct ucc_tl_ucp_task {
             void                   *scratch;
             ucc_mc_buffer_header_t *scratch_mc_header;
         } reduce_scatter_kn;
+        struct {
+            void                   *scratch;
+            size_t                  max_block_count;
+            ucc_ep_map_t            inv_map;
+            int                     n_frags;
+            int                     frag;
+        } reduce_scatter_ring;
         struct {
             int                     phase;
             ucc_knomial_pattern_t   p;

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -116,7 +116,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
 
     ucc_status = ucc_mpool_init(
         &self->req_mp, 0,
-        ucc_max(sizeof(ucc_tl_ucp_task_t), sizeof(ucc_schedule_pipelined_t)), 0,
+        ucc_max(sizeof(ucc_tl_ucp_task_t), sizeof(ucc_tl_ucp_schedule_t)), 0,
         UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL, params->thread_mode,
         "tl_ucp_req_mp");
     if (UCC_OK != ucc_status) {

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -291,3 +291,62 @@ void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len)
         strncat(str, tmp, left);
     }
 }
+
+ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size)
+{
+    ucc_ep_map_t map = {.type           = UCC_EP_MAP_STRIDED,
+                        .ep_num         = size,
+                        .strided.start  = size - 1,
+                        .strided.stride = -1};
+    return map;
+}
+
+static inline int ucc_ep_map_is_reverse(ucc_ep_map_t *map)
+{
+    return (map->type == UCC_EP_MAP_STRIDED) &&
+           (map->strided.start == map->ep_num - 1) &&
+           (map->strided.stride == -1);
+}
+
+ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map)
+{
+    ucc_ep_map_t inv;
+    ucc_rank_t   i, r;
+    ucc_rank_t   max_rank;
+
+    if (ucc_ep_map_is_reverse(&map)) {
+        inv = map;
+    } else {
+        inv.type            = UCC_EP_MAP_ARRAY;
+        inv.ep_num          = map.ep_num;
+        inv.array.elem_size = sizeof(ucc_rank_t);
+        max_rank            = 0;
+        for (i = 0; i < map.ep_num; i++) {
+            r = (ucc_rank_t)ucc_ep_map_eval(map, i);
+            if (r > max_rank) {
+                max_rank = r;
+            }
+        }
+        inv.array.map =
+            ucc_malloc(sizeof(ucc_rank_t) * (max_rank + 1), "inv_map");
+        if (!inv.array.map) {
+            ucc_error("failed to allocate %zd bytes for inv map\n",
+                      sizeof(ucc_rank_t) * map.ep_num);
+            return UCC_ERR_NO_MEMORY;
+        }
+        for (i = 0; i < map.ep_num; i++) {
+            r = (ucc_rank_t)ucc_ep_map_eval(map, i);
+            *((ucc_rank_t *)PTR_OFFSET(inv.array.map, sizeof(ucc_rank_t) * r)) =
+                i;
+        }
+    }
+    *inv_map = inv;
+    return UCC_OK;
+}
+
+void ucc_ep_map_destroy(ucc_ep_map_t *map)
+{
+    if (map->type == UCC_EP_MAP_ARRAY) {
+        ucc_free(map->array.map);
+    }
+}

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -159,4 +159,14 @@ ucc_ep_map_t ucc_ep_map_from_array(ucc_rank_t **array, ucc_rank_t size,
 
 typedef struct ucc_coll_task ucc_coll_task_t;
 void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len);
+
+/* Creates a rank map that reverses rank order, ie
+   rank r -> size - 1 - r */
+ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size);
+
+/* Creates an inverse mapping for a given map */
+ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map);
+
+void ucc_ep_map_destroy(ucc_ep_map_t *map);
+
 #endif

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -169,4 +169,31 @@ ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map);
 
 void ucc_ep_map_destroy(ucc_ep_map_t *map);
 
+/* The two helper routines below are used to partition a buffer
+   consisiting of total_count elements into blocks.
+   This is used, e.g., in ReduceScatter or during fragmentation
+   process.
+   First total_count is devided into n_blocks. If the devision
+   has remainder then it is evenly distributed among first blocks.
+*/
+static inline size_t ucc_buffer_block_count(size_t     total_count,
+                                            ucc_rank_t n_blocks,
+                                            ucc_rank_t block)
+{
+    size_t block_count = total_count / n_blocks;
+    size_t left        = total_count % n_blocks;
+
+    return (block < left) ? block_count + 1 : block_count;
+}
+
+static inline size_t ucc_buffer_block_offset(size_t     total_count,
+                                             ucc_rank_t n_blocks,
+                                             ucc_rank_t block)
+{
+    size_t block_count = total_count / n_blocks;
+    size_t left        = total_count % n_blocks;
+    size_t offset      = block * block_count + left;
+
+    return (block < left) ? offset - (left - block) : offset;
+}
 #endif

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -83,6 +83,7 @@ gtest_SOURCES =                     \
 	core/test_bcast.cc              \
 	core/test_reduce.cc             \
 	core/test_allreduce.cc          \
+	core/test_reduce_scatter.cc     \
 	core/test_schedule.cc           \
 	core/test_topo.cc               \
 	core/test_service_coll.cc       \

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -565,16 +565,25 @@ UccReq::UccReq(UccTeam_h _team, UccCollCtxVec ctxs) :
 {
     EXPECT_EQ(team->procs.size(), ctxs.size());
     ucc_coll_req_h req;
+    ucc_status_t   status, err_status;
+
+    err_status = UCC_OK;
     for (auto i = 0; i < team->procs.size(); i++) {
-        if (UCC_OK != ucc_collective_init(ctxs[i]->args, &req,
-                                          team->procs[i].team)) {
-            goto err;
+        if (UCC_OK !=(status = ucc_collective_init(ctxs[i]->args, &req,
+                                                   team->procs[i].team))) {
+            err_status = status;
         }
         reqs.push_back(req);
+    }
+    if (UCC_OK != err_status) {
+        goto err;
     }
     return;
 err:
     reqs.clear();
+    if (err_status == UCC_ERR_NOT_SUPPORTED) {
+        UCC_TEST_SKIP;
+    }
 }
 
 UccReq::~UccReq()

--- a/test/gtest/core/test_reduce_scatter.cc
+++ b/test/gtest/core/test_reduce_scatter.cc
@@ -1,11 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
- *
- * See file LICENSE for terms.
- */
-
-/**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -58,6 +52,7 @@ class test_reduce_scatter : public UccCollArgs, public testing::Test {
             UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_mc_header,
                                    ucc_dt_size(dt) * rcount, mem_type));
             coll->dst.info.buffer = ctxs[r]->dst_mc_header->addr;
+            coll->src.info.buffer = NULL;
             if (TEST_INPLACE == inplace) {
                 coll->mask |= UCC_COLL_ARGS_FIELD_FLAGS;
                 coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;

--- a/test/gtest/core/test_reduce_scatter.cc
+++ b/test/gtest/core/test_reduce_scatter.cc
@@ -1,0 +1,337 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#include "test_mc_reduce.h"
+#include "common/test_ucc.h"
+#include "utils/ucc_math.h"
+
+#include <array>
+
+template <typename T>
+class test_reduce_scatter : public UccCollArgs, public testing::Test {
+  public:
+    void data_init(int nprocs, ucc_datatype_t dt, size_t count,
+                   UccCollCtxVec &ctxs)
+    {
+        size_t rcount;
+        ctxs.resize(nprocs);
+        if (count < nprocs) {
+            count = nprocs;
+        }
+        count  = count - (count % nprocs);
+        rcount = count / nprocs;
+        if (TEST_INPLACE == inplace) {
+            rcount = count;
+        }
+
+        for (int r = 0; r < nprocs; r++) {
+            ucc_coll_args_t *coll =
+                (ucc_coll_args_t *)calloc(1, sizeof(ucc_coll_args_t));
+
+            ctxs[r] =
+                (gtest_ucc_coll_ctx_t *)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
+            ctxs[r]->args = coll;
+
+            coll->mask      = 0;
+            coll->coll_type = UCC_COLL_TYPE_REDUCE_SCATTER;
+            coll->op        = T::redop;
+
+            ctxs[r]->init_buf = ucc_malloc(ucc_dt_size(dt) * count, "init buf");
+            EXPECT_NE(ctxs[r]->init_buf, nullptr);
+            for (int i = 0; i < count; i++) {
+                typename T::type *ptr;
+                ptr = (typename T::type *)ctxs[r]->init_buf;
+                /* need to limit the init value so that "prod" operation
+                   would not grow too large. We have teams up to 16 procs
+                   in gtest, this would result in prod ~2**48 */
+                ptr[i] = (typename T::type)((i + r + 1) % 8);
+            }
+
+            UCC_CHECK(ucc_mc_alloc(&ctxs[r]->dst_mc_header,
+                                   ucc_dt_size(dt) * rcount, mem_type));
+            coll->dst.info.buffer = ctxs[r]->dst_mc_header->addr;
+            if (TEST_INPLACE == inplace) {
+                coll->mask |= UCC_COLL_ARGS_FIELD_FLAGS;
+                coll->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+                UCC_CHECK(ucc_mc_memcpy(
+                    coll->dst.info.buffer, ctxs[r]->init_buf,
+                    ucc_dt_size(dt) * rcount, mem_type, UCC_MEMORY_TYPE_HOST));
+                coll->src.info.mem_type = UCC_MEMORY_TYPE_UNKNOWN;
+                coll->src.info.count    = SIZE_MAX;
+                coll->src.info.datatype = (ucc_datatype_t)-1;
+            } else {
+                UCC_CHECK(ucc_mc_alloc(&ctxs[r]->src_mc_header,
+                                       ucc_dt_size(dt) * count, mem_type));
+                coll->src.info.buffer = ctxs[r]->src_mc_header->addr;
+                UCC_CHECK(ucc_mc_memcpy(
+                    coll->src.info.buffer, ctxs[r]->init_buf,
+                    ucc_dt_size(dt) * count, mem_type, UCC_MEMORY_TYPE_HOST));
+                coll->src.info.mem_type = mem_type;
+                coll->src.info.count    = (ucc_count_t)count;
+                coll->src.info.datatype = dt;
+            }
+            coll->dst.info.mem_type = mem_type;
+            coll->dst.info.count    = (ucc_count_t)rcount;
+            coll->dst.info.datatype = dt;
+        }
+    }
+    void data_fini(UccCollCtxVec ctxs)
+    {
+        for (gtest_ucc_coll_ctx_t *ctx : ctxs) {
+            ucc_coll_args_t *coll = ctx->args;
+            if (coll->src.info.buffer) { /* no inplace */
+                UCC_CHECK(ucc_mc_free(ctx->src_mc_header));
+            }
+            UCC_CHECK(ucc_mc_free(ctx->dst_mc_header));
+            ucc_free(ctx->init_buf);
+            free(coll);
+            free(ctx);
+        }
+        ctxs.clear();
+    }
+    void reset(UccCollCtxVec ctxs)
+    {
+        for (auto r = 0; r < ctxs.size(); r++) {
+            ucc_coll_args_t *coll  = ctxs[r]->args;
+            size_t           count = coll->dst.info.count;
+            ucc_datatype_t   dtype = coll->dst.info.datatype;
+            clear_buffer(coll->dst.info.buffer, count * ucc_dt_size(dtype),
+                         mem_type, 0);
+
+            if (TEST_INPLACE == inplace) {
+                UCC_CHECK(ucc_mc_memcpy(coll->dst.info.buffer,
+                                        ctxs[r]->init_buf,
+                                        ucc_dt_size(dtype) * count, mem_type,
+                                        UCC_MEMORY_TYPE_HOST));
+            }
+        }
+    }
+    bool data_validate(UccCollCtxVec ctxs)
+    {
+        size_t                          total_count, rcount, offset;
+        std::vector<typename T::type *> dsts(ctxs.size());
+
+        if (TEST_INPLACE != inplace) {
+            offset      = 0;
+            total_count = (ctxs[0])->args->src.info.count;
+            rcount      = (ctxs[0])->args->dst.info.count;
+        } else {
+            total_count = (ctxs[0])->args->dst.info.count;
+            rcount      = total_count / ctxs.size();
+            offset      = rcount * sizeof(typename T::type);
+        }
+
+        ucc_assert(rcount * ctxs.size() == total_count);
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                dsts[r] = (typename T::type *)ucc_malloc(
+                    rcount * sizeof(typename T::type), "dsts buf");
+                EXPECT_NE(dsts[r], nullptr);
+                UCC_CHECK(ucc_mc_memcpy(
+                    dsts[r],
+                    PTR_OFFSET(ctxs[r]->args->dst.info.buffer, offset * r),
+                    rcount * sizeof(typename T::type), UCC_MEMORY_TYPE_HOST,
+                    mem_type));
+            }
+        } else {
+            for (int r = 0; r < ctxs.size(); r++) {
+                dsts[r] = (typename T::type *)(PTR_OFFSET(
+                    ctxs[r]->args->dst.info.buffer, offset * r));
+            }
+        }
+
+        for (int i = 0; i < total_count; i++) {
+            typename T::type res =
+                ((typename T::type *)((ctxs[0])->init_buf))[i];
+            for (int r = 1; r < ctxs.size(); r++) {
+                res = T::do_op(res,
+                               ((typename T::type *)((ctxs[r])->init_buf))[i]);
+            }
+            if (T::redop == UCC_OP_AVG) {
+                res = res / (typename T::type)ctxs.size();
+            }
+            T::assert_equal(res, dsts[i / rcount][i % rcount]);
+        }
+        if (UCC_MEMORY_TYPE_HOST != mem_type) {
+            for (int r = 0; r < ctxs.size(); r++) {
+                ucc_free(dsts[r]);
+            }
+        }
+        return true;
+    }
+};
+
+TYPED_TEST_CASE(test_reduce_scatter, ReductionTypesOps);
+
+#define TEST_DECLARE(_mem_type, _inplace, _repeat)                             \
+    {                                                                          \
+        std::array<int, 1> counts{123};                                        \
+        for (int tid = 0; tid < UccJob::nStaticTeams; tid++) {                 \
+            for (int count : counts) {                                         \
+                UccTeam_h     team = UccJob::getStaticTeams()[tid];            \
+                int           size = team->procs.size();                       \
+                UccCollCtxVec ctxs;                                            \
+                this->set_mem_type(_mem_type);                                 \
+                this->set_inplace(_inplace);                                   \
+                this->data_init(size, TypeParam::dt, count, ctxs);             \
+                try {                                                          \
+                    UccReq req(team, ctxs);                                    \
+                    for (auto i = 0; i < _repeat; i++) {                       \
+                        req.start();                                           \
+                        req.wait();                                            \
+                        EXPECT_EQ(true, this->data_validate(ctxs));            \
+                        this->reset(ctxs);                                     \
+                    }                                                          \
+                } catch (const std::exception &e) {                            \
+                    /* NOT_SUPPORTED return by coll_init */                    \
+                }                                                              \
+                this->data_fini(ctxs);                                         \
+            }                                                                  \
+        }                                                                      \
+    }
+
+TYPED_TEST(test_reduce_scatter, single_host)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_NO_INPLACE, 1);
+}
+
+TYPED_TEST(test_reduce_scatter, single_host_persistent)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_NO_INPLACE, 3);
+}
+
+TYPED_TEST(test_reduce_scatter, single_host_inplace)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_INPLACE, 1);
+}
+
+TYPED_TEST(test_reduce_scatter, single_host_persistent_inplace)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_HOST, TEST_INPLACE, 3);
+}
+
+#ifdef HAVE_CUDA
+TYPED_TEST(test_reduce_scatter, single_cuda)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_NO_INPLACE, 1);
+}
+
+TYPED_TEST(test_reduce_scatter, single_cuda_persistent)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_NO_INPLACE, 3);
+}
+
+TYPED_TEST(test_reduce_scatter, single_cuda_inplace)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE, 1);
+}
+
+TYPED_TEST(test_reduce_scatter, single_cuda_persistent_inplace)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE, 3);
+}
+#endif
+
+#define TEST_DECLARE_MULTIPLE(_mem_type, _inplace)                             \
+    {                                                                          \
+        std::array<int, 3> counts{4, 256, 65536};                              \
+        for (int count : counts) {                                             \
+            std::vector<UccReq>        reqs;                                   \
+            std::vector<UccCollCtxVec> ctxs;                                   \
+            try {                                                              \
+                for (int tid = 0; tid < UccJob::nStaticTeams; tid++) {         \
+                    UccTeam_h     team = UccJob::getStaticTeams()[tid];        \
+                    int           size = team->procs.size();                   \
+                    UccCollCtxVec ctx;                                         \
+                    this->set_inplace(_inplace);                               \
+                    this->set_mem_type(_mem_type);                             \
+                    this->data_init(size, TypeParam::dt, count, ctx);          \
+                    ctxs.push_back(ctx);                                       \
+                    reqs.push_back(UccReq(team, ctx));                         \
+                }                                                              \
+                UccReq::startall(reqs);                                        \
+                UccReq::waitall(reqs);                                         \
+                for (auto ctx : ctxs) {                                        \
+                    EXPECT_EQ(true, this->data_validate(ctx));                 \
+                }                                                              \
+            } catch (const std::exception &e) {                                \
+                    /* NOT_SUPPORTED return by coll_init */                    \
+            }                                                                  \
+            for (auto ctx : ctxs) {                                            \
+                this->data_fini(ctx);                                          \
+            }                                                                  \
+        }                                                                      \
+    }
+
+TYPED_TEST(test_reduce_scatter, multiple)
+{
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_HOST, TEST_NO_INPLACE);
+}
+
+TYPED_TEST(test_reduce_scatter, multiple_inplace)
+{
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_HOST, TEST_INPLACE);
+}
+
+#ifdef HAVE_CUDA
+TYPED_TEST(test_reduce_scatter, multiple_cuda)
+{
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_NO_INPLACE);
+}
+
+TYPED_TEST(test_reduce_scatter, multiple_cuda_inplace)
+{
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE);
+}
+#endif
+
+template <typename T>
+class test_reduce_scatter_alg : public test_reduce_scatter<T> {
+};
+
+using test_reduce_scatter_alg_type =
+    ::testing::Types<ReductionTest<UCC_DT_INT32, sum>>;
+TYPED_TEST_CASE(test_reduce_scatter_alg, test_reduce_scatter_alg_type);
+
+TYPED_TEST(test_reduce_scatter_alg, ring)
+{
+    int           n_procs = 15;
+    ucc_job_env_t env     = {{"UCC_CL_BASIC_TUNE", "inf"},
+                         {"UCC_TL_UCP_TUNE", "reduce_scatter:@ring:inf"}};
+    UccJob        job(n_procs, UccJob::UCC_JOB_CTX_GLOBAL, env);
+    UccTeam_h     team   = job.create_team(n_procs);
+    int           repeat = 3;
+    UccCollCtxVec ctxs;
+    std::vector<ucc_memory_type_t> mt = {UCC_MEMORY_TYPE_HOST};
+
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
+        mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+
+    for (auto count : {65536, 123567}) {
+        for (auto inplace : {TEST_NO_INPLACE, TEST_INPLACE}) {
+            for (auto m : mt) {
+                this->set_mem_type(m);
+                this->set_inplace(inplace);
+                this->data_init(n_procs, TypeParam::dt, count, ctxs);
+                UccReq req(team, ctxs);
+
+                for (auto i = 0; i < repeat; i++) {
+                    req.start();
+                    req.wait();
+                    EXPECT_EQ(true, this->data_validate(ctxs));
+                    this->reset(ctxs);
+                }
+                this->data_fini(ctxs);
+            }
+        }
+    }
+}

--- a/test/mpi/test_reduce_scatter.cc
+++ b/test/mpi/test_reduce_scatter.cc
@@ -24,14 +24,15 @@ TestReduceScatter::TestReduceScatter(size_t _msgsize,
     op = _op;
     dt = _dt;
 
-    if (skip_reduce(test_max_size < _msgsize, TEST_SKIP_MEM_LIMIT,
-                    team.comm) ||
-        skip_reduce((count % comm_size != 0), TEST_SKIP_NOT_SUPPORTED,
-                    team.comm)) {
+    if (skip_reduce(test_max_size < _msgsize, TEST_SKIP_MEM_LIMIT, team.comm) ||
+        skip_reduce((count < comm_size), TEST_SKIP_NOT_SUPPORTED, team.comm)) {
         return;
     }
     check_buf = ucc_malloc( _msgsize, "check buf");
     UCC_MALLOC_CHECK(check_buf);
+
+    count   = count - (count % comm_size);
+    msgsize = _msgsize = count * dt_size;
 
     if (TEST_NO_INPLACE == inplace) {
         args.dst.info.count = count / comm_size;
@@ -39,7 +40,7 @@ TestReduceScatter::TestReduceScatter(size_t _msgsize,
         UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, _msgsize, _mt));
         rbuf = rbuf_mc_header->addr;
         sbuf = sbuf_mc_header->addr;
-  } else {
+    } else {
         args.mask           = UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags          = UCC_COLL_ARGS_FLAG_IN_PLACE;
         args.dst.info.count = count;


### PR DESCRIPTION
## What
Adds implementation of bi- uni- directional ring reduce_scatterin TL/UCP

## Why ?
Core API. Also used as part of 3-stage allreduce.

