### PR TITLE
TEST: adding op and dt to mpi_reduce_test output str

### DIFF
--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -369,6 +369,7 @@ public:
     ucc_status_t set_input() override;
     ucc_status_t reset_sbuf() override;
     ucc_status_t check();
+    std::string  str();
 };
 
 class TestAlltoall : public TestCase {

--- a/test/mpi/test_reduce.cc
+++ b/test/mpi/test_reduce.cc
@@ -107,3 +107,12 @@ ucc_status_t TestReduce::check()
     return (rank != root) ? UCC_OK :
         compare_buffers(rbuf, check_buf, count, dt, mem_type);
 }
+
+std::string TestReduce::str() {
+    return std::string("tc=")+ucc_coll_type_str(args.coll_type) +
+        " team=" + team_str(team.type) + " msgsize=" +
+        std::to_string(msgsize) + " inplace=" +
+        (inplace == TEST_INPLACE ? "1" : "0") + " dt=" +
+        ucc_datatype_str(dt) + " op=" + ucc_reduction_op_str(op) +
+        " root=" + std::to_string(root);
+}


### PR DESCRIPTION
## What
Adding op and dt to output string of mpi reduce test

## Why ?
To be able to differentiate between tests in case of failure/skipping.
