### PR TITLE
BUILD: tl profiling fix

### DIFF
--- a/config/m4/configure.m4
+++ b/config/m4/configure.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -7,12 +7,8 @@ AC_DEFUN([ENABLE_MODULE_PROFILING],
 [
     AS_IF([test "x$with_profiling" = xall],
         [
-            prof_modules=":core:mc:tl_ucp:tl_nccl:tl_sharp:cl_hier:tl_cuda"
+            prof_modules=":core:mc:cl_hier"
             AC_DEFINE([HAVE_PROFILING_CORE], [1], [Enable profiling for CORE])
-            AC_DEFINE([HAVE_PROFILING_TL_UCP], [1], [Enable profiling for TL UCP])
-            AC_DEFINE([HAVE_PROFILING_TL_NCCL], [1], [Enable profiling for TL NCCL])
-            AC_DEFINE([HAVE_PROFILING_TL_SHARP], [1], [Enable profiling for TL SHARP])
-            AC_DEFINE([HAVE_PROFILING_TL_CUDA], [1], [Enable profiling for TL CUDA])
             AC_DEFINE([HAVE_PROFILING_CL_HIER], [1], [Enable profiling for CL HIER])
             AC_DEFINE([HAVE_PROFILING_MC], [1], [Enable profiling for MC])
         ],
@@ -30,36 +26,23 @@ AC_DEFUN([ENABLE_MODULE_PROFILING],
                 ;;
             esac
             case $1 in
-            *tl_ucp*)
-                prof_modules="${prof_modules}:tl_ucp"
-                AC_DEFINE([HAVE_PROFILING_TL_UCP], [1], [Enable profiling for TL UCP])
-                ;;
-            esac
-            case $1 in
-            *tl_nccl*)
-                prof_modules="${prof_modules}:tl_nccl"
-                AC_DEFINE([HAVE_PROFILING_TL_NCCL], [1], [Enable profiling for TL NCCL])
-                ;;
-            esac
-            case $1 in
-            *tl_sharp*)
-                prof_modules="${prof_modules}:tl_sharp"
-                AC_DEFINE([HAVE_PROFILING_TL_SHARP], [1], [Enable profiling for TL SHARP])
-                ;;
-            esac
-            case $1 in
             *cl_hier*)
                 prof_modules="${prof_modules}:cl_hier"
                 AC_DEFINE([HAVE_PROFILING_CL_HIER], [1], [Enable profiling for CL HIER])
                 ;;
             esac
-            case $1 in
-            *tl_cuda*)
-                prof_modules="${prof_modules}:tl_cuda"
-                AC_DEFINE([HAVE_PROFILING_TL_CUDA], [1], [Enable profiling for TL CUDA])
-                ;;
-            esac
         ])
+])
+
+AC_DEFUN([CHECK_NEED_TL_PROFILING], [
+    tl_name=$1
+    TL_PROFILING_REQUIRED=n
+    AS_IF([ test x"$with_profiling" = "xall" ], [TL_PROFILING_REQUIRED=y],
+    [
+       for t in $(echo ${with_profiling} | tr ":" " "); do
+           AS_IF([ test "$t" == "$tl_name" ], [TL_PROFILING_REQUIRED=y], [])
+       done
+    ])
 ])
 
 #

--- a/src/components/tl/cuda/configure.m4
+++ b/src/components/tl/cuda/configure.m4
@@ -9,6 +9,12 @@ AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
     if test $cuda_happy = "yes" -a $nvml_happy = "yes"; then
        tl_modules="${tl_modules}:cuda"
        tl_cuda_enabled=y
+        CHECK_NEED_TL_PROFILING(["tl_cuda"])
+        AS_IF([test "$TL_PROFILING_REQUIRED" = "y"],
+              [
+                AC_DEFINE([HAVE_PROFILING_TL_CUDA], [1], [Enable profiling for TL CUDA])
+                prof_modules="${prof_modules}:tl_cuda"
+              ], [])
     fi
 ], [])
 

--- a/src/components/tl/nccl/configure.m4
+++ b/src/components/tl/nccl/configure.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
 #
 
 tl_nccl_enabled=n
@@ -11,6 +11,12 @@ AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
     if test $nccl_happy = "yes"; then
         tl_modules="${tl_modules}:nccl"
         tl_nccl_enabled=y
+        CHECK_NEED_TL_PROFILING(["tl_nccl"])
+        AS_IF([test "$TL_PROFILING_REQUIRED" = "y"],
+              [
+                AC_DEFINE([HAVE_PROFILING_TL_NCCL], [1], [Enable profiling for TL NCCL])
+                prof_modules="${prof_modules}:tl_nccl"
+              ], [])
     fi
 ], [])
 

--- a/src/components/tl/sharp/configure.m4
+++ b/src/components/tl/sharp/configure.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
 #
 
 tl_sharp_enabled=n
@@ -11,6 +11,12 @@ AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
     if test $sharp_happy = "yes"; then
        tl_modules="${tl_modules}:sharp"
        tl_sharp_enabled=y
+       CHECK_NEED_TL_PROFILING(["tl_sharp"])
+       AS_IF([test "$TL_PROFILING_REQUIRED" = "y"],
+             [
+               AC_DEFINE([HAVE_PROFILING_TL_SHARP], [1], [Enable profiling for TL SHARP])
+               prof_modules="${prof_modules}:tl_sharp"
+             ], [])
     fi
 ], [])
 

--- a/src/components/tl/ucp/configure.m4
+++ b/src/components/tl/ucp/configure.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
 #
 
 tl_ucp_enabled=n
@@ -9,6 +9,12 @@ AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
     if test $ucx_happy = "yes"; then
         tl_modules="${tl_modules}:ucp"
         tl_ucp_enabled=y
+        CHECK_NEED_TL_PROFILING(["tl_ucp"])
+        AS_IF([test "$TL_PROFILING_REQUIRED" = "y"],
+              [
+                AC_DEFINE([HAVE_PROFILING_TL_UCP], [1], [Enable profiling for TL UCP])
+                prof_modules="${prof_modules}:tl_ucp"
+              ], [])
     fi
 ], [])
 


### PR DESCRIPTION
## What
    TLs are autodetected, so they should add their profiling macros
    automatically as well.


