### PR TITLE
TL/CUDA: query nvml dev type in cuda11.0

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -66,16 +66,14 @@ AS_IF([test "x$cuda_checked" != "xyes"],
         # Check nvml library
         AS_IF([test "x$cuda_happy" = "xyes" -a "x$nvml_happy" = "xyes"],
               [AC_CHECK_LIB([nvidia-ml], [nvmlInit_v2],
-                            [nvml_happy="yes"],
+                            [NVML_LIBS="-lnvidia-ml"],
                             [AS_IF([test "x$with_cuda" != "xguess"],
                                    [AC_MSG_WARN([libnvidia-ml not found. Install appropriate nvidia-driver package])])
                              nvml_happy="no"])])
         AS_IF([test "x$cuda_happy" = "xyes" -a "x$nvml_happy" = "xyes"],
               [AC_CHECK_LIB([nvidia-ml], [nvmlDeviceGetNvLinkRemoteDeviceType],
-                            [NVML_LIBS="-lnvidia-ml"],
-                            [AS_IF([test "x$with_cuda" != "xguess"],
-                                   [AC_MSG_WARN([libnvidia-ml not found. Install appropriate nvidia-driver package])])
-                             nvml_happy="no"])])
+                            [AC_DEFINE([HAVE_NVML_REMOTE_DEVICE_TYPE], 1, ["Use nvmlDeviceGetNvLinkRemoteDeviceType"])],
+                            [])])
 
          # Check for NVCC
          AC_ARG_VAR(NVCC, [NVCC compiler command])

--- a/src/components/tl/cuda/tl_cuda_topo.h
+++ b/src/components/tl/cuda/tl_cuda_topo.h
@@ -19,7 +19,8 @@ typedef struct ucc_tl_cuda_device_id {
 
 typedef enum ucc_tl_cuda_topo_dev_type {
     UCC_TL_CUDA_TOPO_DEV_TYPE_GPU,
-    UCC_TL_CUDA_TOPO_DEV_TYPE_SWITCH
+    UCC_TL_CUDA_TOPO_DEV_TYPE_SWITCH,
+    UCC_TL_CUDA_TOPO_DEV_TYPE_LAST
 } ucc_tl_cuda_topo_dev_type_t;
 
 static inline int


### PR DESCRIPTION
## What
Support for device type detection in TL CUDA topo for older CUDA versions

## Why ?
Allows to use TL CUDA with CUDA 11.0 and above, currently it requires CUDA 11.4

## How ?
If nvmlDeviceGetNvLinkRemoteDeviceType function is not available do the following:
If remote device doesn't have PCI id it is not supported by CUDA TL return UCC_TL_CUDA_TOPO_DEV_TYPE_LAST, otherwise it's either NVSwitch or GPU
If can get remote device handle it's GPU otherwise it's NVSwtich
