### PR TITLE
CL/HIER: split rail allreduce

### DIFF
--- a/.ci/scripts/run_tests_ucc_mpi.sh
+++ b/.ci/scripts/run_tests_ucc_mpi.sh
@@ -86,5 +86,37 @@ mpirun \
     -x UCC_TL_NCCL_TUNE=0 \
     -x UCC_CLS=hier,basic \
     -x UCC_CL_HIER_TUNE=inf \
-    /opt/nvidia/src/ucc/build/test/mpi/ucc_test_mpi --mtypes host,cuda --inplace 2 --set_device 1 --root random:2 --count_bits 32,64 --displ_bits 32,64
-echo "INFO: UCC MPI unit tests (GPU without NCCL) ... DONE"
+    /opt/nvidia/src/ucc/build/test/mpi/ucc_test_mpi -c alltoall,alltoallv,allreduce,barrier --mtypes host,cuda --inplace 2 --set_device 1 --root random:2 --count_bits 32,64 --displ_bits 32,64
+echo "INFO: UCC MPI unit tests (CPU/GPU with CL/HIER) ... DONE"
+
+echo "INFO: UCC MPI unit tests (CPU/GPU Allreduce with CL/HIER RAB) ..."
+# shellcheck disable=SC2086
+mpirun \
+    -np $NP \
+    --hostfile ${HOSTFILE} \
+    --map-by node \
+    --allow-run-as-root \
+    --mca plm_rsh_args '-p 12345' \
+    -x PATH \
+    -x LD_LIBRARY_PATH \
+    -x UCC_TL_NCCL_TUNE=0 \
+    -x UCC_CLS=hier,basic \
+    -x UCC_CL_HIER_TUNE=allreduce:@rab:inf \
+    /opt/nvidia/src/ucc/build/test/mpi/ucc_test_mpi -c allreduce --mtypes host,cuda --inplace 2 --set_device 1
+echo "INFO: UCC MPI unit tests (CPU/GPU Allreduce with CL/HIER RAB) ... DONE"
+
+echo "INFO: UCC MPI unit tests (CPU/GPU Allreduce with CL/HIER SplitRail) ..."
+# shellcheck disable=SC2086
+mpirun \
+    -np $NP \
+    --hostfile ${HOSTFILE} \
+    --map-by node \
+    --allow-run-as-root \
+    --mca plm_rsh_args '-p 12345' \
+    -x PATH \
+    -x LD_LIBRARY_PATH \
+    -x UCC_TL_NCCL_TUNE=0 \
+    -x UCC_CLS=hier,basic \
+    -x UCC_CL_HIER_TUNE=allreduce:@split_rail:inf \
+    /opt/nvidia/src/ucc/build/test/mpi/ucc_test_mpi -c allreduce --mtypes host,cuda --inplace 2 --set_device 1
+echo "INFO: UCC MPI unit tests (CPU/GPU Allreduce with CL/HIER SplitRail) ... DONE"

--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -855,9 +855,10 @@ static ucc_status_t ucc_coll_score_update_one(ucc_list_link_t *dest,
     ucc_coll_entry_t *fb;
     ucc_status_t      status;
 
-    if (ucc_list_is_empty(src) || ucc_list_is_empty(dest)) {
+    if (ucc_list_is_empty(src) && ucc_list_is_empty(dest)) {
         return UCC_OK;
     }
+
     while (s != src && d != dest) {
         rs = ucc_container_of(s, ucc_msg_range_t, super.list_elem);
         rd = ucc_container_of(d, ucc_msg_range_t, super.list_elem);
@@ -944,6 +945,9 @@ static ucc_status_t ucc_coll_score_update_one(ucc_list_link_t *dest,
         rs = ucc_container_of(s, ucc_msg_range_t, super.list_elem);
         if (rs->super.init) {
             new = MSG_RANGE_DUP(rs);
+            if (new->super.score == UCC_SCORE_INVALID) {
+                new->super.score = default_score;
+            }
             ucc_list_add_tail(dest, &new->super.list_elem);
         }
         s = s->next;

--- a/src/components/cl/hier/Makefile.am
+++ b/src/components/cl/hier/Makefile.am
@@ -12,12 +12,12 @@ alltoallv =                   \
 	alltoallv/alltoallv.h     \
 	alltoallv/alltoallv.c
 
-alltoall =                  \
-	alltoall/alltoall.h     \
+alltoall =                    \
+	alltoall/alltoall.h       \
 	alltoall/alltoall.c
 
-barrier =                 \
-	barrier/barrier.h     \
+barrier =                     \
+	barrier/barrier.h         \
 	barrier/barrier.c
 
 sources =             \

--- a/src/components/cl/hier/Makefile.am
+++ b/src/components/cl/hier/Makefile.am
@@ -2,9 +2,11 @@
 # Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
 #
 
-allreduce =                   \
-	allreduce/allreduce.h     \
-	allreduce/allreduce_rab.c
+allreduce =                          \
+	allreduce/allreduce.h            \
+	allreduce/allreduce.c            \
+	allreduce/allreduce_rab.c        \
+	allreduce/allreduce_split_rail.c
 
 alltoallv =                   \
 	alltoallv/alltoallv.h     \

--- a/src/components/cl/hier/allreduce/allreduce.c
+++ b/src/components/cl/hier/allreduce/allreduce.c
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "allreduce.h"
+#include "../allreduce/allreduce.h"
+
+ucc_base_coll_alg_info_t
+    ucc_cl_hier_allreduce_algs[UCC_CL_HIER_ALLREDUCE_ALG_LAST + 1] = {
+        [UCC_CL_HIER_ALLREDUCE_ALG_RAB] =
+            {.id   = UCC_CL_HIER_ALLREDUCE_ALG_RAB,
+             .name = "rab",
+             .desc = "innode reduce, followed by inter node allreduce,"
+                     " followed by innode broadcast"},
+        [UCC_CL_HIER_ALLREDUCE_ALG_SPLIT_RAIL] =
+            {.id   = UCC_CL_HIER_ALLREDUCE_ALG_SPLIT_RAIL,
+             .name = "split_rail",
+             .desc = "innode reduce scatter, followed by PPN concurrent inter"
+                     " node allreduces, followed by innode allgather"},
+        [UCC_CL_HIER_ALLREDUCE_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};

--- a/src/components/cl/hier/allreduce/allreduce.h
+++ b/src/components/cl/hier/allreduce/allreduce.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -26,12 +26,13 @@ ucc_status_t ucc_cl_hier_allreduce_rab_init(ucc_base_coll_args_t *coll_args,
 
 ucc_status_t
 ucc_cl_hier_allreduce_split_rail_init(ucc_base_coll_args_t *coll_args,
-                                      ucc_base_team_t *     team,
-                                      ucc_coll_task_t **    task);
+                                      ucc_base_team_t      *team,
+                                      ucc_coll_task_t     **task);
 
 static inline int ucc_cl_hier_allreduce_alg_from_str(const char *str)
 {
     int i;
+
     for (i = 0; i < UCC_CL_HIER_ALLREDUCE_ALG_LAST; i++) {
         if (0 == strcasecmp(str, ucc_cl_hier_allreduce_algs[i].name)) {
             break;

--- a/src/components/cl/hier/allreduce/allreduce.h
+++ b/src/components/cl/hier/allreduce/allreduce.h
@@ -8,8 +8,36 @@
 #define ALLREDUCE_H_
 #include "../cl_hier.h"
 
+enum
+{
+    UCC_CL_HIER_ALLREDUCE_ALG_RAB,
+    UCC_CL_HIER_ALLREDUCE_ALG_SPLIT_RAIL,
+    UCC_CL_HIER_ALLREDUCE_ALG_LAST,
+};
+
+extern ucc_base_coll_alg_info_t
+    ucc_cl_hier_allreduce_algs[UCC_CL_HIER_ALLREDUCE_ALG_LAST + 1];
+
+#define UCC_CL_HIER_ALLREDUCE_DEFAULT_ALG_SELECT_STR "allreduce:0-4k:@rab"
+
 ucc_status_t ucc_cl_hier_allreduce_rab_init(ucc_base_coll_args_t *coll_args,
                                             ucc_base_team_t      *team,
                                             ucc_coll_task_t     **task);
+
+ucc_status_t
+ucc_cl_hier_allreduce_split_rail_init(ucc_base_coll_args_t *coll_args,
+                                      ucc_base_team_t *     team,
+                                      ucc_coll_task_t **    task);
+
+static inline int ucc_cl_hier_allreduce_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_CL_HIER_ALLREDUCE_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_cl_hier_allreduce_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
 
 #endif

--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -11,10 +11,8 @@
 
 static ucc_status_t ucc_cl_hier_allreduce_rab_start(ucc_coll_task_t *task)
 {
-    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
-
     UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_allreduce_rab_start", 0);
-    return ucc_schedule_start(schedule);
+    return ucc_schedule_start(task);
 }
 
 static ucc_status_t ucc_cl_hier_allreduce_rab_finalize(ucc_coll_task_t *task)

--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -1,0 +1,369 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "allreduce.h"
+#include "../cl_hier_coll.h"
+#include "core/ucc_team.h"
+
+static ucc_status_t
+ucc_cl_hier_allreduce_split_rail_frag_finalize(ucc_coll_task_t *task)
+{
+    ucc_status_t            status = UCC_OK;
+    ucc_cl_hier_schedule_t *schedule =
+        ucc_derived_of(task, ucc_cl_hier_schedule_t);
+
+    status = ucc_schedule_finalize(&schedule->super.super.super);
+    ucc_free(schedule->allreduce_split_rail.counts);
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}
+
+static ucc_status_t
+ucc_cl_hier_ar_split_rail_schedule_finalize(ucc_coll_task_t *task)
+{
+    ucc_cl_hier_schedule_t *schedule =
+        ucc_derived_of(task, ucc_cl_hier_schedule_t);
+    ucc_status_t status = UCC_OK;
+
+    if (schedule->scratch) {
+        ucc_mc_free(schedule->scratch);
+    }
+    status = ucc_schedule_pipelined_finalize(&schedule->super.super.super);
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}
+
+static ucc_status_t ucc_cl_hier_allreduce_split_rail_frag_setup(
+    ucc_schedule_pipelined_t *schedule_p, ucc_schedule_t *frag, int frag_num)
+{
+    ucc_cl_hier_team_t *cl_team =
+        ucc_derived_of(schedule_p->super.super.team, ucc_cl_hier_team_t);
+    ucc_cl_hier_schedule_t *sched =
+        ucc_derived_of(schedule_p, ucc_cl_hier_schedule_t);
+    ucc_coll_args_t *args    = &schedule_p->super.super.bargs.args;
+    size_t           dt_size = ucc_dt_size(args->dst.info.datatype);
+    int              n_frags = schedule_p->super.n_tasks;
+    int              inplace = UCC_IS_INPLACE(*args);
+    size_t           frag_count, frag_offset, ar_count, ar_offset;
+    ucc_rank_t       node_size, node_rank;
+    ucc_coll_task_t *task_rs, *task_ar, *task_ag;
+    int              i;
+    uint64_t *       counts, *displs;
+
+    node_size = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp->group_size;
+    node_rank = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp->group_rank;
+    frag_count =
+        ucc_buffer_block_count(args->dst.info.count, n_frags, frag_num);
+    frag_offset =
+        ucc_buffer_block_offset(args->dst.info.count, n_frags, frag_num);
+    counts = ucc_derived_of(frag, ucc_cl_hier_schedule_t)
+                 ->allreduce_split_rail.counts;
+    displs = counts + node_size;
+    for (i = 0; i < node_size; i++) {
+        counts[i] = ucc_buffer_block_count(frag_count, node_size, i);
+        displs[i] = ucc_buffer_block_offset(frag_count, node_size, i);
+    }
+
+    ar_count  = counts[node_rank];
+    ar_offset = displs[node_rank];
+
+    task_rs = frag->tasks[0];
+    task_ar = frag->tasks[1];
+    task_ag = frag->tasks[2];
+
+    ucc_assert(task_rs->bargs.args.dst.info_v.counts == counts);
+
+    if (inplace) {
+        task_rs->bargs.args.src.info.buffer =
+            PTR_OFFSET(args->dst.info.buffer, frag_offset * dt_size);
+        task_rs->bargs.args.dst.info_v.buffer = PTR_OFFSET(
+            sched->scratch->addr, (frag_offset + ar_offset) * dt_size);
+    } else {
+        task_rs->bargs.args.src.info.buffer =
+            PTR_OFFSET(args->src.info.buffer, frag_offset * dt_size);
+        task_rs->bargs.args.dst.info_v.buffer = PTR_OFFSET(
+            args->dst.info.buffer, (frag_offset + ar_offset) * dt_size);
+        task_rs->bargs.args.src.info.count = frag_count;
+    }
+
+    task_ar->bargs.args.src.info.count = ar_count;
+    task_ar->bargs.args.dst.info.count = ar_count;
+    if (!inplace) {
+        task_ar->bargs.args.dst.info.buffer =
+            task_rs->bargs.args.dst.info_v.buffer;
+    } else {
+        task_ar->bargs.args.src.info.buffer =
+            task_rs->bargs.args.dst.info_v.buffer;
+        task_ar->bargs.args.dst.info.buffer = PTR_OFFSET(
+            args->dst.info.buffer, (frag_offset + ar_offset) * dt_size);
+    }
+
+    ucc_assert(UCC_IS_INPLACE(task_ag->bargs.args));
+    task_ag->bargs.args.dst.info_v.buffer = PTR_OFFSET(
+        args->dst.info.buffer, frag_offset * dt_size); //only dst since inplace
+    task_ag->bargs.args.src.info.count = frag_count;
+    ucc_assert(task_ag->bargs.args.dst.info_v.counts == counts);
+    ucc_assert(task_ag->bargs.args.dst.info_v.displacements == displs);
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_cl_hier_allreduce_split_rail_frag_init(
+    ucc_base_coll_args_t *coll_args, ucc_schedule_pipelined_t *sp,
+    ucc_base_team_t *team, ucc_schedule_t **frag_p)
+{
+    ucc_cl_hier_team_t *    cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_cl_hier_schedule_t *sched = ucc_derived_of(sp, ucc_cl_hier_schedule_t);
+    size_t           dt_size = ucc_dt_size(coll_args->args.dst.info.datatype);
+    ucc_status_t     status  = UCC_OK;
+    int              inplace = UCC_IS_INPLACE(coll_args->args);
+    ucc_coll_task_t *task_rs, *task_ag, *task_ar;
+    ucc_base_coll_args_t    rs_args, ar_args, ag_args;
+    ucc_cl_hier_schedule_t *cl_schedule;
+    ucc_schedule_t *        schedule;
+    size_t                  total_count;
+    ucc_rank_t              node_size, node_rank;
+    int       i;
+    uint64_t *counts, *displs;
+
+    cl_schedule = ucc_cl_hier_get_schedule(cl_team);
+
+    if (ucc_unlikely(!cl_schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    schedule = &cl_schedule->super.super;
+    status   = ucc_schedule_init(schedule, coll_args, team);
+    if (UCC_OK != status) {
+        return status;
+    }
+
+    node_size   = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp->group_size;
+    node_rank   = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp->group_rank;
+    total_count = coll_args->args.dst.info.count;
+
+    cl_schedule->allreduce_split_rail.counts =
+        ucc_malloc(node_size * 2 * sizeof(uint64_t), "counts");
+    if (ucc_unlikely(!cl_schedule->allreduce_split_rail.counts)) {
+        cl_error(team->context->lib,
+                 "failed to allocate %zd bytes for counts array",
+                 node_size * 2 * sizeof(uint64_t));
+        goto err_rs;
+    }
+    counts = cl_schedule->allreduce_split_rail.counts;
+    displs = counts + node_size;
+    for (i = 0; i < node_size; i++) {
+        counts[i] = ucc_buffer_block_count(total_count, node_size, i);
+        displs[i] = ucc_buffer_block_offset(total_count, node_size, i);
+    }
+    memcpy(&rs_args, coll_args, sizeof(rs_args));
+    memcpy(&ar_args, coll_args, sizeof(ar_args));
+    memcpy(&ag_args, coll_args, sizeof(ag_args));
+
+    rs_args.args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
+    rs_args.args.flags &= (~UCC_COLL_ARGS_FLAG_IN_PLACE);
+    rs_args.args.flags |= (UCC_COLL_ARGS_FLAG_COUNT_64BIT |
+                           UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT);
+
+    /* REDUCE-SCATTER */
+    rs_args.args.coll_type           = UCC_COLL_TYPE_REDUCE_SCATTERV;
+    rs_args.args.dst.info_v.counts   = counts;
+    rs_args.args.dst.info_v.mem_type = coll_args->args.dst.info.mem_type;
+    rs_args.args.dst.info_v.datatype = coll_args->args.dst.info.datatype;
+    if (inplace) {
+        rs_args.args.src.info.buffer   = coll_args->args.dst.info.buffer;
+        rs_args.args.src.info.datatype = coll_args->args.dst.info.datatype;
+        rs_args.args.dst.info_v.buffer =
+            PTR_OFFSET(sched->scratch->addr, displs[node_rank] * dt_size);
+    } else {
+        rs_args.args.dst.info_v.buffer = PTR_OFFSET(
+            coll_args->args.dst.info.buffer, displs[node_rank] * dt_size);
+        rs_args.args.src.info.count = coll_args->args.dst.info.count;
+    }
+
+    status = ucc_coll_init(SCORE_MAP(cl_team, NODE), &rs_args, &task_rs);
+    if (ucc_unlikely(UCC_OK != status)) {
+        cl_error(team->context->lib, "failed to init rs task");
+        goto err_rs;
+    }
+
+    /* ALLREDUCE */
+    ar_args.args.coll_type      = UCC_COLL_TYPE_ALLREDUCE;
+    ar_args.args.src.info.count = counts[node_rank];
+    if (!inplace) {
+        ar_args.args.mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
+        ar_args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+        ar_args.args.dst.info.count = counts[node_rank];
+    } else {
+        ar_args.args.flags &= (~UCC_COLL_ARGS_FLAG_IN_PLACE);
+        ar_args.args.src.info.buffer = rs_args.args.dst.info.buffer;
+        ar_args.args.dst.info.buffer = PTR_OFFSET(
+            coll_args->args.dst.info.buffer, displs[node_rank] * dt_size);
+    }
+
+    status = ucc_coll_init(SCORE_MAP(cl_team, NET), &ar_args, &task_ar);
+    if (ucc_unlikely(UCC_OK != status)) {
+        cl_error(team->context->lib, "failed to init ar task");
+        goto err_ar;
+    }
+
+    /* ALLGATHER */
+    ag_args.args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
+    ag_args.args.flags |= (UCC_COLL_ARGS_FLAG_COUNT_64BIT |
+                           UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT);
+    ag_args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+    ag_args.args.coll_type                = UCC_COLL_TYPE_ALLGATHERV;
+    ag_args.args.dst.info_v.buffer        = coll_args->args.dst.info.buffer;
+    ag_args.args.dst.info_v.mem_type      = coll_args->args.dst.info.mem_type;
+    ag_args.args.dst.info_v.datatype      = coll_args->args.dst.info.datatype;
+    ag_args.args.dst.info_v.counts        = counts;
+    ag_args.args.dst.info_v.displacements = displs;
+
+    status = ucc_coll_init(SCORE_MAP(cl_team, NODE), &ag_args, &task_ag);
+    if (ucc_unlikely(UCC_OK != status)) {
+        cl_error(team->context->lib, "failed to init ag task");
+        goto err_ag;
+    }
+
+    task_rs->n_deps = 1;
+    ucc_schedule_add_task(schedule, task_rs);
+    ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
+                                task_rs, ucc_dependency_handler);
+
+    task_ar->n_deps = 1;
+    ucc_schedule_add_task(schedule, task_ar);
+    ucc_event_manager_subscribe(&task_rs->em, UCC_EVENT_COMPLETED, task_ar,
+                                ucc_dependency_handler);
+
+    task_ag->n_deps = 1;
+    ucc_schedule_add_task(schedule, task_ag);
+    ucc_event_manager_subscribe(&task_ar->em, UCC_EVENT_COMPLETED, task_ag,
+                                ucc_dependency_handler);
+
+    schedule->super.post     = ucc_schedule_start;
+    schedule->super.progress = NULL;
+    schedule->super.finalize = ucc_cl_hier_allreduce_split_rail_frag_finalize;
+
+    *frag_p = schedule;
+    return status;
+
+err_ag:
+    if (task_ar) {
+        ucc_collective_finalize(&task_ar->super);
+    }
+err_ar:
+    if (task_rs) {
+        ucc_collective_finalize(&task_rs->super);
+    }
+err_rs:
+    ucc_cl_hier_put_schedule(schedule);
+    return status;
+}
+
+static inline void get_n_frags(ucc_base_coll_args_t *coll_args,
+                               ucc_cl_hier_team_t *team, int *n_frags,
+                               int *pipeline_depth)
+{
+    ucc_cl_hier_lib_config_t *cfg     = &UCC_CL_HIER_TEAM_LIB(team)->cfg;
+    size_t                    msgsize = coll_args->args.dst.info.count *
+                     ucc_dt_size(coll_args->args.dst.info.datatype);
+    int min_num_frags;
+
+    *n_frags = 1;
+    if (msgsize > cfg->allreduce_split_rail_frag_thresh) {
+        min_num_frags = msgsize / cfg->allreduce_split_rail_frag_size;
+        *n_frags = ucc_max(min_num_frags, cfg->allreduce_split_rail_n_frags);
+    }
+    *pipeline_depth =
+        ucc_min(*n_frags, cfg->allreduce_split_rail_pipeline_depth);
+}
+
+static ucc_status_t
+ucc_cl_hier_split_rail_allreduce_start(ucc_coll_task_t *task)
+{
+    ucc_schedule_pipelined_t *schedule =
+        ucc_derived_of(task, ucc_schedule_pipelined_t);
+
+    cl_info(task->team->context->lib,
+            "posting split_rail ar, sbuf %p, rbuf %p, count %zd, dt %s, op %s, "
+            "inplace %d, pdepth %d, frags_total %d",
+            task->bargs.args.src.info.buffer, task->bargs.args.dst.info.buffer,
+            task->bargs.args.dst.info.count,
+            ucc_datatype_str(task->bargs.args.src.info.datatype),
+            ucc_reduction_op_str(task->bargs.args.op),
+            UCC_IS_INPLACE(task->bargs.args), schedule->n_frags,
+            schedule->super.n_tasks);
+
+    return ucc_schedule_pipelined_post(task);
+}
+
+UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_split_rail_init,
+                         (coll_args, team, task),
+                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+                         ucc_coll_task_t **task)
+{
+    ucc_cl_hier_team_t *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    int                 n_frags, pipeline_depth;
+    ucc_cl_hier_lib_config_t *cfg   = &UCC_CL_HIER_TEAM_LIB(cl_team)->cfg;
+    size_t                    count = coll_args->args.dst.info.count;
+    size_t data_size = count * ucc_dt_size(coll_args->args.dst.info.datatype);
+    ucc_cl_hier_schedule_t *schedule;
+
+    ucc_status_t status;
+
+    if (!SBGP_ENABLED(cl_team, NODE) || !SBGP_ENABLED(cl_team, NET)) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    if (!ucc_topo_isoppn(team->params.team->topo)) {
+        cl_debug(team->context->lib, "split_rail algorithm does not support "
+                                     "teams with non-uniform ppn across nodes");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    schedule = ucc_cl_hier_get_schedule(cl_team);
+    if (ucc_unlikely(!schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    if (UCC_IS_INPLACE(coll_args->args)) {
+        status = ucc_mc_alloc(&schedule->scratch, data_size,
+                              coll_args->args.dst.info.mem_type);
+        if (ucc_unlikely(UCC_OK != status)) {
+            cl_error(team->context->lib,
+                     "failed to allocate %zd bytes for inplace scratch",
+                     data_size);
+            goto err_scratch;
+        }
+    }
+
+    get_n_frags(coll_args, cl_team, &n_frags, &pipeline_depth);
+
+    status = ucc_schedule_pipelined_init(
+        coll_args, team, ucc_cl_hier_allreduce_split_rail_frag_init,
+        ucc_cl_hier_allreduce_split_rail_frag_setup, pipeline_depth, n_frags,
+        cfg->allreduce_split_rail_seq, &schedule->super);
+
+    if (ucc_unlikely(status != UCC_OK)) {
+        cl_error(team->context->lib,
+                 "failed to init pipelined split_rail ar schedule");
+        goto err_pipe_init;
+    }
+
+    schedule->super.super.super.post = ucc_cl_hier_split_rail_allreduce_start;
+    schedule->super.super.super.triggered_post = ucc_triggered_post;
+    schedule->super.super.super.finalize =
+        ucc_cl_hier_ar_split_rail_schedule_finalize;
+    *task = &schedule->super.super.super;
+    return UCC_OK;
+
+err_pipe_init:
+    if (schedule->scratch) {
+        ucc_mc_free(schedule->scratch);
+    }
+err_scratch:
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}

--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -305,13 +305,16 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_split_rail_init,
                          ucc_coll_task_t **task)
 {
     ucc_cl_hier_team_t *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
-    int                 n_frags, pipeline_depth;
     ucc_cl_hier_lib_config_t *cfg   = &UCC_CL_HIER_TEAM_LIB(cl_team)->cfg;
     size_t                    count = coll_args->args.dst.info.count;
     size_t data_size = count * ucc_dt_size(coll_args->args.dst.info.datatype);
     ucc_cl_hier_schedule_t *schedule;
-
+    int                 n_frags, pipeline_depth;
     ucc_status_t status;
+
+    if (coll_args->args.op == UCC_OP_AVG) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
 
     if (!SBGP_ENABLED(cl_team, NODE) || !SBGP_ENABLED(cl_team, NET)) {
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/cl/hier/alltoallv/alltoallv.c
+++ b/src/components/cl/hier/alltoallv/alltoallv.c
@@ -20,10 +20,8 @@ ucc_base_coll_alg_info_t
 
 static ucc_status_t ucc_cl_hier_alltoallv_start(ucc_coll_task_t *task)
 {
-    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
-
     UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_alltoallv_start", 0);
-    return ucc_schedule_start(schedule);
+    return ucc_schedule_start(task);
 }
 
 static ucc_status_t ucc_cl_hier_alltoallv_finalize(ucc_coll_task_t *task)

--- a/src/components/cl/hier/barrier/barrier.c
+++ b/src/components/cl/hier/barrier/barrier.c
@@ -11,10 +11,8 @@
 
 static ucc_status_t ucc_cl_hier_barrier_start(ucc_coll_task_t *task)
 {
-    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
-
     UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_barrier_start", 0);
-    return ucc_schedule_start(schedule);
+    return ucc_schedule_start(task);
 }
 
 static ucc_status_t ucc_cl_hier_barrier_finalize(ucc_coll_task_t *task)

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -49,6 +49,36 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      ucc_offsetof(ucc_cl_hier_lib_config_t, a2av_node_thresh),
      UCC_CONFIG_TYPE_MEMUNITS},
 
+    {"ALLREDUCE_SPLIT_RAIL_FRAG_THRESH", "inf",
+     "Threshold to enable fragmentation and pipelining of Split_Rail "
+     "allreduce alg",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_frag_thresh),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"ALLREDUCE_SPLIT_RAIL_FRAG_SIZE", "inf",
+     "Maximum allowed fragment size of Split_Rail alg",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_frag_size),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"ALLREDUCE_SPLIT_RAIL_N_FRAGS", "2",
+     "Number of fragments each allreduce is split into when Split_Rail alg is "
+     "used\n"
+     "The actual number of fragments can be larger if fragment size exceeds\n"
+     "ALLREDUCE_SPLIT_RAIL_FRAG_SIZE",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_n_frags),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLREDUCE_SPLIT_RAIL_PIPELINE_DEPTH", "2",
+     "Number of fragments simultaneously progressed by the Split_Rail alg",
+     ucc_offsetof(ucc_cl_hier_lib_config_t,
+                  allreduce_split_rail_pipeline_depth),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLREDUCE_SPLIT_RAIL_SEQUENTIAL", "n",
+     "Type of pipelined schedule for Split_Rail alg (sequential/parallel)",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_seq),
+     UCC_CONFIG_TYPE_BOOL},
+
     {NULL}};
 
 static ucs_config_field_t ucc_cl_hier_context_config_table[] = {

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -48,6 +48,12 @@ typedef struct ucc_cl_hier_lib_config {
        which are selected based on the TL scores */
     ucc_config_names_array_t sbgp_tls[UCC_HIER_SBGP_LAST];
     size_t                   a2av_node_thresh;
+    uint32_t                 allreduce_split_rail_n_frags;
+    uint32_t                 allreduce_split_rail_pipeline_depth;
+    int                      allreduce_split_rail_seq;
+    size_t                   allreduce_split_rail_frag_thresh;
+    size_t                   allreduce_split_rail_frag_size;
+
 } ucc_cl_hier_lib_config_t;
 
 typedef struct ucc_cl_hier_context_config {

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -13,7 +13,7 @@
 #include "utils/ucc_mpool.h"
 
 #ifdef HAVE_PROFILING_CL_HIER
-#include "utils/profile/ucc_profile.h"
+#include "utils/profile/ucc_profile_on.h"
 #else
 #include "utils/profile/ucc_profile_off.h"
 #endif

--- a/src/components/cl/hier/cl_hier_coll.c
+++ b/src/components/cl/hier/cl_hier_coll.c
@@ -8,7 +8,11 @@
 #include "components/mc/ucc_mc.h"
 #include "core/ucc_team.h"
 #include "utils/ucc_coll_utils.h"
-#include "allreduce/allreduce.h"
+#include "cl_hier_coll.h"
+
+const char *
+    ucc_cl_hier_default_alg_select_str[UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR] = {
+        UCC_CL_HIER_ALLREDUCE_DEFAULT_ALG_SELECT_STR};
 
 ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t      *team,
@@ -17,10 +21,82 @@ ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
     switch (coll_args->args.coll_type) {
     case UCC_COLL_TYPE_ALLREDUCE:
         return ucc_cl_hier_allreduce_rab_init(coll_args, team, task);
+    case UCC_COLL_TYPE_BARRIER:
+        return ucc_cl_hier_barrier_init(coll_args, team, task);
+    case UCC_COLL_TYPE_ALLTOALL:
+        return ucc_cl_hier_alltoall_init(coll_args, team, task);
+    case UCC_COLL_TYPE_ALLTOALLV:
+        return ucc_cl_hier_alltoallv_init(coll_args, team, task);
     default:
         cl_error(team->context->lib, "coll_type %s is not supported",
                  ucc_coll_type_str(coll_args->args.coll_type));
         break;
     }
     return UCC_ERR_NOT_SUPPORTED;
+}
+
+static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
+{
+    switch (coll_type) {
+    case UCC_COLL_TYPE_ALLTOALLV:
+        return ucc_cl_hier_alltoallv_alg_from_str(str);
+    case UCC_COLL_TYPE_ALLTOALL:
+        return ucc_cl_hier_alltoall_alg_from_str(str);
+    case UCC_COLL_TYPE_ALLREDUCE:
+        return ucc_cl_hier_allreduce_alg_from_str(str);
+    default:
+        break;
+    }
+    return -1;
+}
+
+ucc_status_t ucc_cl_hier_alg_id_to_init(int alg_id, const char *alg_id_str,
+                                        ucc_coll_type_t   coll_type,
+                                        ucc_memory_type_t mem_type, //NOLINT
+                                        ucc_base_coll_init_fn_t *init)
+{
+    ucc_status_t status = UCC_OK;
+    if (alg_id_str) {
+        alg_id = alg_id_from_str(coll_type, alg_id_str);
+    }
+
+    switch (coll_type) {
+    case UCC_COLL_TYPE_ALLTOALLV:
+        switch (alg_id) {
+        case UCC_CL_HIER_ALLTOALLV_ALG_NODE_SPLIT:
+            *init = ucc_cl_hier_alltoallv_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    case UCC_COLL_TYPE_ALLTOALL:
+        switch (alg_id) {
+        case UCC_CL_HIER_ALLTOALL_ALG_NODE_SPLIT:
+            *init = ucc_cl_hier_alltoall_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    case UCC_COLL_TYPE_ALLREDUCE:
+        switch (alg_id) {
+        case UCC_CL_HIER_ALLREDUCE_ALG_RAB:
+            *init = ucc_cl_hier_allreduce_rab_init;
+            break;
+        case UCC_CL_HIER_ALLREDUCE_ALG_SPLIT_RAIL:
+            *init = ucc_cl_hier_allreduce_split_rail_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    default:
+        status = UCC_ERR_NOT_SUPPORTED;
+        break;
+    }
+    return status;
 }

--- a/src/components/cl/hier/cl_hier_coll.c
+++ b/src/components/cl/hier/cl_hier_coll.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/cl/hier/cl_hier_coll.h
+++ b/src/components/cl/hier/cl_hier_coll.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/cl/hier/cl_hier_coll.h
+++ b/src/components/cl/hier/cl_hier_coll.h
@@ -9,10 +9,24 @@
 #include "cl_hier.h"
 #include "schedule/ucc_schedule_pipelined.h"
 #include "components/mc/ucc_mc.h"
+#include "allreduce/allreduce.h"
+#include "alltoallv/alltoallv.h"
+#include "alltoall/alltoall.h"
+#include "barrier/barrier.h"
+
+#define UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR 1
+
+extern const char
+    *ucc_cl_hier_default_alg_select_str[UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR];
 
 typedef struct ucc_cl_hier_schedule_t {
     ucc_schedule_pipelined_t super;
     ucc_mc_buffer_header_t  *scratch;
+    union {
+        struct {
+            uint64_t *counts;
+        } allreduce_split_rail;
+    };
 } ucc_cl_hier_schedule_t;
 
 static inline ucc_cl_hier_schedule_t *
@@ -21,6 +35,7 @@ ucc_cl_hier_get_schedule(ucc_cl_hier_team_t *team)
     ucc_cl_hier_context_t  *ctx      = UCC_CL_HIER_TEAM_CTX(team);
     ucc_cl_hier_schedule_t *schedule = ucc_mpool_get(&ctx->sched_mp);
 
+    schedule->scratch = NULL;
     UCC_CL_HIER_PROFILE_REQUEST_NEW(schedule, "cl_hier_sched_p", 0);
     return schedule;
 }
@@ -31,4 +46,8 @@ static inline void ucc_cl_hier_put_schedule(ucc_schedule_t *schedule)
     ucc_mpool_put(schedule);
 }
 
+ucc_status_t ucc_cl_hier_alg_id_to_init(int alg_id, const char *alg_id_str,
+                                        ucc_coll_type_t   coll_type,
+                                        ucc_memory_type_t mem_type, //NOLINT
+                                        ucc_base_coll_init_fn_t *init);
 #endif

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/nccl/allgatherv/allgatherv.h
+++ b/src/components/tl/nccl/allgatherv/allgatherv.h
@@ -16,8 +16,8 @@ enum {
     UCC_TL_NCCL_ALLGATHERV_ALG_LAST
 };
 
-#define UCC_TL_NCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR                          \
-    "allgatherv:0-16k:@0#allgatherv:16k-1M:@1#allgatherv:1M-inf:@2"
+#define UCC_TL_NCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR          \
+    "allgatherv:cuda:0-16k:@0#allgatherv:cuda:16k-1M:@1#allgatherv:cuda:1M-inf:@2"
 
 extern ucc_base_coll_alg_info_t
              ucc_tl_nccl_allgatherv_algs[UCC_TL_NCCL_ALLGATHERV_ALG_LAST + 1];

--- a/src/components/tl/nccl/allgatherv/allgatherv.h
+++ b/src/components/tl/nccl/allgatherv/allgatherv.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -39,9 +39,7 @@
 static ucc_status_t
 ucc_tl_ucp_allreduce_sra_knomial_frag_start(ucc_coll_task_t *task)
 {
-    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
-
-    return ucc_schedule_start(schedule);
+    return ucc_schedule_start(task);
 }
 
 static ucc_status_t

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -38,10 +38,8 @@
  */
 ucc_status_t ucc_tl_ucp_bcast_sag_knomial_start(ucc_coll_task_t *coll_task)
 {
-    ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
-
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(schedule, "ucp_bcast_sag_kn_start", 0);
-    return ucc_schedule_start(schedule);
+    return ucc_schedule_start(coll_task);
 }
 
 ucc_status_t

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -302,9 +302,7 @@ static ucc_status_t ucc_tl_ucp_reduce_scatter_ring_init_subset(
 static ucc_status_t
 ucc_tl_ucp_reduce_scatter_ring_sched_post(ucc_coll_task_t *coll_task)
 {
-    ucc_schedule_t *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
-
-    return ucc_schedule_start(schedule);
+    return ucc_schedule_start(coll_task);
 }
 
 static ucc_status_t

--- a/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
@@ -313,7 +313,7 @@ ucc_tl_ucp_reduce_scatterv_ring_sched_post(ucc_coll_task_t *task)
         schedule->tasks[i]->bargs.args.dst = task->bargs.args.dst;
     }
 
-    return ucc_schedule_start(schedule);
+    return ucc_schedule_start(task);
 }
 
 static ucc_status_t

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -238,8 +238,8 @@ skip:
     ucc_free(nl_array_2);
 
     if (n_node_leaders > 1) {
+        sbgp->group_size = n_node_leaders;
         if (i_am_node_leader) {
-            sbgp->group_size = n_node_leaders;
             sbgp->rank_map   = nl_array_1;
             sbgp->status     = UCC_SBGP_ENABLED;
         } else {

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -86,4 +86,34 @@ static inline int ucc_rank_on_local_node(ucc_rank_t team_rank, ucc_topo_t *topo)
     return procs[ctx_rank].host_hash == procs[my_ctx_rank].host_hash;
 }
 
+/* Returns min ppn value across the nodes */
+static inline ucc_rank_t ucc_topo_min_ppn(ucc_topo_t *topo)
+{
+    ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+
+    if (sbgp->status == UCC_SBGP_NOT_EXISTS) {
+        ucc_assert(ucc_topo_is_single_node(topo));
+        return ucc_subset_size(&topo->set);
+    }
+    return topo->min_ppn;
+}
+
+/* Returns max ppn value across the nodes */
+static inline ucc_rank_t ucc_topo_max_ppn(ucc_topo_t *topo)
+{
+    ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+
+    if (sbgp->status == UCC_SBGP_NOT_EXISTS) {
+        ucc_assert(ucc_topo_is_single_node(topo));
+        return ucc_subset_size(&topo->set);
+    }
+    return topo->max_ppn;
+}
+
+/* Returns true if PPN is the same across all the nodes */
+static inline int ucc_topo_isoppn(ucc_topo_t *topo)
+{
+    return ucc_topo_max_ppn(topo) == ucc_topo_min_ppn(topo);
+}
+
 #endif

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 #ifndef UCC_TOPO_H_

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -131,5 +131,4 @@ static inline int ucc_team_map_is_single_node(ucc_team_t *team,
     }
     return 1;
 }
-
 #endif

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 #include "ucc_schedule.h"

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -157,8 +157,10 @@ void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task)
     }
 }
 
-ucc_status_t ucc_schedule_start(ucc_schedule_t *schedule)
+ucc_status_t ucc_schedule_start(ucc_coll_task_t *task)
 {
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
+
     schedule->n_completed_tasks  = 0;
     schedule->super.status       = UCC_INPROGRESS;
     schedule->super.super.status = UCC_INPROGRESS;

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -138,7 +138,7 @@ ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule,
 
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
 
-ucc_status_t ucc_schedule_start(ucc_coll_task_t *schedule);
+ucc_status_t ucc_schedule_start(ucc_coll_task_t *task);
 
 ucc_status_t ucc_task_start_handler(ucc_coll_task_t *parent,
                                     ucc_coll_task_t *task);

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -138,7 +138,7 @@ ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule,
 
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
 
-ucc_status_t ucc_schedule_start(ucc_schedule_t *schedule);
+ucc_status_t ucc_schedule_start(ucc_coll_task_t *schedule);
 
 ucc_status_t ucc_task_start_handler(ucc_coll_task_t *parent,
                                     ucc_coll_task_t *task);

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -118,7 +118,7 @@ ucc_status_t ucc_schedule_pipelined_post(ucc_coll_task_t *task)
         }
     }
 
-    return ucc_schedule_start(&schedule_p->super);
+    return ucc_schedule_start(task);
 }
 
 ucc_status_t ucc_schedule_pipelined_init(

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 #include "ucc_schedule.h"


### PR DESCRIPTION
## What
Adds 2 lvl hierarchical "split_rail" allreduce. The algorithm is 3 stages: reduce_scatterV within the NODE_SBGP, followed by PPN concurrent allreduces within the NET_SBGP (ak "rail", hence the name), followed by allgatherV within the NODE_SBGP. The algorithm is only enabled for teams with uniform PPN across the nodes. 
If allreduce is INPLACE, then the first RSV is performed from user buffer -> into scratch (allocated by CL/HIER); AR is performed from scratch -> to user dest buffer; AGV is INPLACE.
If allreduce is NOT INPLACE, then the first RST is performed from user src buffer -> into user dst buffer; AR is performed inplace in user dst buffer; AGV is INPLACE in user dst buffer as well.
Algorithm supports pipelining/fragmentation with same set of controls as SRA allreduce in TL/UCP (frag_thresh, pipeline depth, type, n_frags, frag_size).

## Why ?
Required to implement GPU Allreduce over TL/CUDA as scale-in part.

