### PR TITLE
TL/UCP: add union for ptp/onesided posts/completion

### DIFF
--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -35,8 +35,8 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
     sendto   = ucc_ep_map_eval(task->subset.map, sendto);
     recvfrom = ucc_ep_map_eval(task->subset.map, recvfrom);
 
-    while (task->send_posted < group_size - 1) {
-        step = task->send_posted;
+    while (task->tagged.send_posted < group_size - 1) {
+        step = task->tagged.send_posted;
         buf  = (void *)((ptrdiff_t)rbuf +
                        ((group_rank - step + group_size) % group_size) *
                            data_size);

--- a/src/components/tl/ucp/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv_ring.c
@@ -30,8 +30,8 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
     if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
         return task->super.super.status;
     }
-    while (task->send_posted < gsize) {
-        send_idx = (grank - task->send_posted + 1 + gsize) % gsize;
+    while (task->tagged.send_posted < gsize) {
+        send_idx   = (grank - task->tagged.send_posted + 1 + gsize) % gsize;
         data_displ = ucc_coll_args_get_displacement(
                          args, args->dst.info_v.displacements, send_idx) *
                      rdt_size;
@@ -41,7 +41,7 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
         UCPCHECK_GOTO(ucc_tl_ucp_send_nb((void *)(rbuf + data_displ), data_size,
                                          rmem, sendto, team, task),
                       task, out);
-        recv_idx = (grank - task->recv_posted + gsize) % gsize;
+        recv_idx   = (grank - task->tagged.recv_posted + gsize) % gsize;
         data_displ = ucc_coll_args_get_displacement(
                          args, args->dst.info_v.displacements, recv_idx) *
                      rdt_size;
@@ -95,8 +95,8 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *coll_task)
     } else {
         /* to simplify progress fucnction and make it identical for
            in-place and non in-place */
-        task->send_posted = task->recv_posted = 1;
-        task->send_completed = task->recv_completed = 1;
+        task->tagged.send_posted = task->tagged.recv_posted = 1;
+        task->tagged.send_completed = task->tagged.recv_completed = 1;
     }
 
     status = ucc_tl_ucp_allgatherv_ring_progress(&task->super);

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -120,7 +120,7 @@ UCC_KN_PHASE_EXTRA:
             return task->super.super.status;
         }
 
-        if (task->send_posted > p->iteration * (radix - 1)) {
+        if (task->tagged.send_posted > p->iteration * (radix - 1)) {
             if ((ucc_knomial_pattern_loop_first_iteration(p)) &&
                 (KN_NODE_PROXY != node_type) && !UCC_IS_INPLACE(*args)) {
                 send_buf = sbuf;
@@ -132,7 +132,7 @@ UCC_KN_PHASE_EXTRA:
                                  : ucc_knomial_pattern_loop_last_iteration(p));
             status = ucc_tl_ucp_reduce_multi(
                 send_buf, scratch, rbuf,
-                task->send_posted - p->iteration * (radix - 1), count,
+                task->tagged.send_posted - p->iteration * (radix - 1), count,
                 data_size, dt, mem_type, task, is_avg);
             if (ucc_unlikely(UCC_OK != status)) {
                 tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");

--- a/src/components/tl/ucp/alltoall/alltoall_onesided.c
+++ b/src/components/tl/ucp/alltoall/alltoall_onesided.c
@@ -62,7 +62,8 @@ ucc_status_t ucc_tl_ucp_alltoall_onesided_progress(ucc_coll_task_t *ctask)
     ucc_rank_t         gsize = UCC_TL_TEAM_SIZE(team);
     long *             pSync = TASK_ARGS(task).global_work_buffer;
 
-    if (*pSync < gsize || task->send_completed < task->send_posted) {
+    if (*pSync < gsize ||
+        task->onesided.put_completed < task->onesided.put_posted) {
         ucp_worker_progress(UCC_TL_UCP_TEAM_CTX(team)->ucp_worker);
         return UCC_INPROGRESS;
     }

--- a/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
@@ -43,18 +43,20 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
     nreqs    = (posts > gsize || posts == 0) ? gsize : posts;
     rdt_size = ucc_dt_size(TASK_ARGS(task).dst.info_v.datatype);
     sdt_size = ucc_dt_size(TASK_ARGS(task).src.info_v.datatype);
-    while ((task->send_posted < gsize || task->recv_posted < gsize) &&
+    while ((task->tagged.send_posted < gsize ||
+            task->tagged.recv_posted < gsize) &&
            (polls++ < task->n_polls)) {
         ucp_worker_progress(UCC_TL_UCP_TEAM_CTX(team)->ucp_worker);
-        while ((task->recv_posted < gsize) &&
-               ((task->recv_posted - task->recv_completed) < nreqs)) {
-            peer       = get_recv_peer(grank, gsize, task->recv_posted);
+        while ((task->tagged.recv_posted < gsize) &&
+               ((task->tagged.recv_posted - task->tagged.recv_completed) <
+                nreqs)) {
+            peer = get_recv_peer(grank, gsize, task->tagged.recv_posted);
             data_size =
                 ucc_coll_args_get_count(
                     &TASK_ARGS(task), TASK_ARGS(task).dst.info_v.counts, peer) *
                 rdt_size;
             data_displ = ucc_coll_args_get_displacement(
-                            &TASK_ARGS(task),
+                             &TASK_ARGS(task),
                              TASK_ARGS(task).dst.info_v.displacements, peer) *
                          rdt_size;
             UCPCHECK_GOTO(ucc_tl_ucp_recv_nz((void *)(rbuf + data_displ),
@@ -62,15 +64,16 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
                           task, out);
             polls = 0;
         }
-        while ((task->send_posted < gsize) &&
-               ((task->send_posted - task->send_completed) < nreqs)) {
-            peer       = get_send_peer(grank, gsize, task->send_posted);
+        while ((task->tagged.send_posted < gsize) &&
+               ((task->tagged.send_posted - task->tagged.send_completed) <
+                nreqs)) {
+            peer = get_send_peer(grank, gsize, task->tagged.send_posted);
             data_size =
                 ucc_coll_args_get_count(
                     &TASK_ARGS(task), TASK_ARGS(task).src.info_v.counts, peer) *
                 sdt_size;
             data_displ = ucc_coll_args_get_displacement(
-                            &TASK_ARGS(task),
+                             &TASK_ARGS(task),
                              TASK_ARGS(task).src.info_v.displacements, peer) *
                          sdt_size;
             UCPCHECK_GOTO(ucc_tl_ucp_send_nz((void *)(sbuf + data_displ),
@@ -79,7 +82,8 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
             polls = 0;
         }
     }
-    if ((task->send_posted < gsize) || (task->recv_posted < gsize)) {
+    if ((task->tagged.send_posted < gsize) ||
+        (task->tagged.recv_posted < gsize)) {
         return task->super.super.status;
     }
     task->super.super.status = ucc_tl_ucp_test(task);

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -130,7 +130,7 @@ UCC_KN_PHASE_EXTRA:
             SAVE_STATE(UCC_KN_PHASE_LOOP);
             return task->super.super.status;
         }
-        if (task->send_posted > p->iteration * (radix - 1)) {
+        if (task->tagged.send_posted > p->iteration * (radix - 1)) {
             sbuf       = (ucc_knomial_pattern_loop_first_iteration(p))
                              ? ((KN_NODE_PROXY == node_type || UCC_IS_INPLACE(*args))
                                     ? args->dst.info.buffer
@@ -155,8 +155,9 @@ UCC_KN_PHASE_EXTRA:
 
             status = ucc_tl_ucp_reduce_multi(
                 local_data, rbuf, reduce_data,
-                task->send_posted - p->iteration * (radix - 1), local_seg_count,
-                local_seg_count * dt_size, dt, mem_type, task, is_avg);
+                task->tagged.send_posted - p->iteration * (radix - 1),
+                local_seg_count, local_seg_count * dt_size, dt, mem_type, task,
+                is_avg);
             if (ucc_unlikely(UCC_OK != status)) {
                 tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
                 task->super.super.status = status;

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -22,7 +22,7 @@ static inline void send_completion_common(void *request, ucs_status_t status,
                  ucs_status_string(status));
         task->super.super.status = ucs_status_to_ucc_status(status);
     }
-    task->send_completed++;
+    task->tagged.send_completed++;
     if (request) {
         ucp_request_free(request);
     }
@@ -84,8 +84,8 @@ static inline ucc_status_t ucc_tl_ucp_test_ring(ucc_tl_ucp_task_t *task)
 {
     int polls = 0;
     while (polls++ < task->n_polls) {
-        if (task->send_posted - task->send_completed <= 1 &&
-            task->recv_posted == task->recv_completed) {
+        if (task->tagged.send_posted - task->tagged.send_completed <= 1 &&
+            task->tagged.recv_posted == task->tagged.recv_completed) {
             return UCC_OK;
         }
         ucp_worker_progress(TASK_CTX(task)->ucp_worker);
@@ -137,28 +137,28 @@ ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
     if (UCC_INPROGRESS == ucc_tl_ucp_test_ring(task)) {
         return task->super.super.status;
     }
-    while (task->recv_posted > 0) {
+    while (task->tagged.recv_posted > 0) {
         /* always have at least 1 send completion, ie 1 free slot */
         ucc_assert(!busy[0] || !busy[1]);
         id            = busy[0] ? 1 : 0;
         reduce_target = s_scratch[id];
-        step          = task->send_posted;
+        step          = task->tagged.send_posted;
         prevblock     = (rank - 1 - step + size) % size;
         prevblock =
             ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, prevblock);
         /* reduction */
-        ucc_assert(task->recv_posted == task->recv_completed);
-        ucc_assert(task->recv_posted < size);
+        ucc_assert(task->tagged.recv_posted == task->tagged.recv_completed);
+        ucc_assert(task->tagged.recv_posted < size);
 
         ucc_ring_frag_count(task, count, prevblock, &frag_count);
         ucc_ring_frag_block_offset(task, count, prevblock, &block_offset,
                                    &frag_offset);
-        if (task->recv_completed == size - 1) {
+        if (task->tagged.recv_completed == size - 1) {
             reduce_target = PTR_OFFSET(args->dst.info.buffer,
                                        (frag_offset + final_offset) * dt_size);
         }
-        is_avg =
-            (args->op == UCC_OP_AVG) && (task->recv_completed == (size - 1));
+        is_avg = (args->op == UCC_OP_AVG) &&
+                 (task->tagged.recv_completed == (size - 1));
         if (UCC_OK !=
             (status = ucc_tl_ucp_reduce_multi(
                  r_scratch,
@@ -169,12 +169,12 @@ ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
             task->super.super.status = status;
             return status;
         }
-        if (task->recv_completed == size - 1) {
-            task->recv_posted = task->recv_completed = 0;
+        if (task->tagged.recv_completed == size - 1) {
+            task->tagged.recv_posted = task->tagged.recv_completed = 0;
             break;
         }
-        ucc_assert(task->send_posted - task->send_completed <= 1);
-        ucc_assert(task->send_posted < size);
+        ucc_assert(task->tagged.send_posted - task->tagged.send_completed <= 1);
+        ucc_assert(task->tagged.send_posted < size);
 
         busy[id] = 1;
         UCPCHECK_GOTO(ucc_tl_ucp_send_cb(reduce_target, frag_count * dt_size,

--- a/src/components/tl/ucp/scatter/scatter_knomial.c
+++ b/src/components/tl/ucp/scatter/scatter_knomial.c
@@ -103,7 +103,7 @@ ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
          it's parent's send.
         */
         if (rank != root && task->scatter_kn.recv_dist == p->radix_pow &&
-                                                      task->recv_posted == 0) {
+            task->tagged.recv_posted == 0) {
             for (loop_step = 1; loop_step < radix; loop_step++) {
                 peer = ucc_knomial_pattern_get_loop_peer(p, rank, size,
                                                              loop_step);
@@ -130,8 +130,9 @@ ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
          Each rank's send (besides leaf ranks) happens only after it's recieve
          from previous iteration has completed.
         */
-        if (root == rank || (task->recv_posted > 0 &&
-                             task->recv_posted == task->recv_completed)) {
+        if (root == rank ||
+            (task->tagged.recv_posted > 0 &&
+             task->tagged.recv_posted == task->tagged.recv_completed)) {
             for (loop_step = 1; loop_step < radix; loop_step++) {
                 peer = ucc_knomial_pattern_get_loop_peer(p, rank, size,
                                                              loop_step);

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -38,7 +38,33 @@ void ucc_tl_ucp_send_completion_cb(void *request, ucs_status_t status,
                  ucs_status_string(status));
         task->super.super.status = ucs_status_to_ucc_status(status);
     }
-    task->send_completed++;
+    task->tagged.send_completed++;
+    ucp_request_free(request);
+}
+
+void ucc_tl_ucp_put_completion_cb(void *request, ucs_status_t status,
+                                  void *user_data)
+{
+    ucc_tl_ucp_task_t *task = (ucc_tl_ucp_task_t *)user_data;
+    if (ucc_unlikely(UCS_OK != status)) {
+        tl_error(UCC_TASK_LIB(task), "failure in put completion %s",
+                 ucs_status_string(status));
+        task->super.super.status = ucs_status_to_ucc_status(status);
+    }
+    task->onesided.put_completed++;
+    ucp_request_free(request);
+}
+
+void ucc_tl_ucp_get_completion_cb(void *request, ucs_status_t status,
+                                  void *user_data)
+{
+    ucc_tl_ucp_task_t *task = (ucc_tl_ucp_task_t *)user_data;
+    if (ucc_unlikely(UCS_OK != status)) {
+        tl_error(UCC_TASK_LIB(task), "failure in get completion %s",
+                 ucs_status_string(status));
+        task->super.super.status = ucs_status_to_ucc_status(status);
+    }
+    task->onesided.get_completed++;
     ucp_request_free(request);
 }
 
@@ -52,7 +78,7 @@ void ucc_tl_ucp_recv_completion_cb(void *request, ucs_status_t status,
                  ucs_status_string(status));
         task->super.super.status = ucs_status_to_ucc_status(status);
     }
-    task->recv_completed++;
+    task->tagged.recv_completed++;
     ucp_request_free(request);
 }
 

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -43,7 +43,7 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
         goto free_task;
     }
     task->subset         = subset;
-    task->tag            = UCC_TL_UCP_SERVICE_TAG;
+    task->tagged.tag     = UCC_TL_UCP_SERVICE_TAG;
     task->n_polls        = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;
@@ -97,7 +97,7 @@ ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
         goto free_task;
     }
     task->subset         = subset;
-    task->tag            = UCC_TL_UCP_SERVICE_TAG;
+    task->tagged.tag     = UCC_TL_UCP_SERVICE_TAG;
     task->n_polls        = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
     task->super.progress = ucc_tl_ucp_allgather_ring_progress;
     task->super.finalize = ucc_tl_ucp_coll_finalize;

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -51,13 +51,13 @@ static ucc_status_t ucc_tl_ucp_team_preconnect(ucc_tl_ucp_team_t *team)
     size = UCC_TL_TEAM_SIZE(team);
     rank = UCC_TL_TEAM_RANK(team);
     if (!team->preconnect_task) {
-        team->preconnect_task = ucc_tl_ucp_get_task(team);
-        team->preconnect_task->tag = 0;
+        team->preconnect_task             = ucc_tl_ucp_get_task(team);
+        team->preconnect_task->tagged.tag = 0;
     }
     if (UCC_INPROGRESS == ucc_tl_ucp_test(team->preconnect_task)) {
         return UCC_INPROGRESS;
     }
-    for (i = team->preconnect_task->send_posted; i < size; i++) {
+    for (i = team->preconnect_task->tagged.send_posted; i < size; i++) {
         src = (rank - i + size) % size;
         dst = (rank + i) % size;
         status = ucc_tl_ucp_send_nb(NULL, 0, UCC_MEMORY_TYPE_UNKNOWN, src, team,


### PR DESCRIPTION
## What
Adds a set of posted/complete counters for a task using onesided collectives. 

## Why ?
This should make code cleaner with respect to send/recv and put/get operations. 


