### PR TITLE
CORE: ctx.create_epilog iface

### DIFF
--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -90,6 +90,7 @@ typedef struct ucc_base_context_iface {
     ucc_status_t (*create)(const ucc_base_context_params_t *params,
                            const ucc_base_config_t *config,
                            ucc_base_context_t **ctx);
+    ucc_status_t (*create_epilog)(ucc_base_context_t *ctx);
     void         (*destroy)(ucc_base_context_t *ctx);
     ucc_status_t (*get_attr)(const ucc_base_context_t *context,
                              ucc_base_ctx_attr_t      *attr);
@@ -184,6 +185,7 @@ typedef struct ucc_base_coll_alg_info {
         .super.lib.get_attr = ucc_##_f##_name##_get_lib_attr,                  \
         .super.context.create =                                                \
             UCC_CLASS_NEW_FUNC_NAME(ucc_##_f##_name##_context_t),              \
+        .super.context.create_epilog = NULL,                                   \
         .super.context.destroy =                                               \
             UCC_CLASS_DELETE_FUNC_NAME(ucc_##_f##_name##_context_t),           \
         .super.context.get_attr = ucc_##_f##_name##_get_context_attr,          \


### PR DESCRIPTION
## What
Adds a base interface callback which is called by CORE at the end of context creation. By default it is set for NULL for any component. If required a component can define it to its own specific implementation.

## Why ?
Some TL components may want to do smth "topo"-aware during context creation. For example, TL/MLX5 which implements NDR Alltoall offload performs ib ctx/pd sharing within the group of ranks on the same now. It is done during ucc_tl_mlx5_context create. However, TLs contexts are created before the address exchange in core_context_create, hence before the topo information is available. This late "epilog" callback allows TL to access topo info (as well as service ucp team) during context creation (example usage in tl/mlx5: https://github.com/vspetrov/ucc/blob/b53b7c5f1f5e40d73429bf367f2fac98b8d5f9e6/src/components/tl/mlx5/tl_mlx5_context.c#L112)

