### PR TITLE
TL/CUDA: Alltoallv implementation

### DIFF
--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
+# Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
 #
 
 if TL_CUDA_ENABLED
@@ -7,6 +8,11 @@ alltoall =                       \
 	alltoall/alltoall.h          \
 	alltoall/alltoall.c          \
 	alltoall/alltoall_ce.c
+
+alltoallv =                       \
+	alltoall/alltoallv.h      \
+	alltoall/alltoallv.c      \
+	alltoall/alltoallv_ce.c
 
 allgather =                      \
 	allgather/allgather.h        \
@@ -28,6 +34,7 @@ reduce_scatterv =                          \
 	reduce_scatterv/reduce_scatterv.c      \
 	reduce_scatterv/reduce_scatterv_ring.c
 
+
 sources =               \
 	tl_cuda.h           \
 	tl_cuda.c           \
@@ -39,6 +46,7 @@ sources =               \
 	tl_cuda_topo.c      \
 	tl_cuda_team_topo.c \
 	$(alltoall)         \
+	$(alltoallv)        \
 	$(allgather)        \
 	$(allgatherv)       \
 	$(reduce_scatter)   \

--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -9,10 +9,10 @@ alltoall =                       \
 	alltoall/alltoall.c          \
 	alltoall/alltoall_ce.c
 
-alltoallv =                       \
-	alltoall/alltoallv.h      \
-	alltoall/alltoallv.c      \
-	alltoall/alltoallv_ce.c
+alltoallv =                      \
+	alltoallv/alltoallv.h      	 \
+	alltoallv/alltoallv.c        \
+	alltoallv/alltoallv_ce.c
 
 allgather =                      \
 	allgather/allgather.h        \

--- a/src/components/tl/cuda/alltoall/alltoall.c
+++ b/src/components/tl/cuda/alltoall/alltoall.c
@@ -16,12 +16,12 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_progress(ucc_coll_task_t *task);
 ucc_status_t ucc_tl_cuda_alltoall_ce_finalize(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_cuda_alltoall_init(ucc_base_coll_args_t *coll_args,
-                                       ucc_base_team_t *tl_team,
-                                       ucc_coll_task_t **task_p)
+                                       ucc_base_team_t      *tl_team,
+                                       ucc_coll_task_t     **task_p)
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_task_t *task;
-    ucc_status_t status;
+    ucc_status_t        status;
 
     if (UCC_IS_INPLACE(coll_args->args)) {
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/cuda/alltoall/alltoall.h
+++ b/src/components/tl/cuda/alltoall/alltoall.h
@@ -11,7 +11,7 @@
 #include "tl_cuda_coll.h"
 
 ucc_status_t ucc_tl_cuda_alltoall_init(ucc_base_coll_args_t *coll_args,
-                                       ucc_base_team_t *tl_team,
-                                       ucc_coll_task_t **task_p);
+                                       ucc_base_team_t      *tl_team,
+                                       ucc_coll_task_t     **task_p);
 
 #endif

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -36,11 +36,6 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
     size_t           data_len;
 
     task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
-    status =
-        ucc_ec_create_event(&task->alltoallv_ce.copy_done, UCC_EE_CUDA_STREAM);
-    if (ucc_unlikely(status != UCC_OK)) {
-        return status;
-    }
 
     task->alltoallv_ce.get_size   = ucc_tl_cuda_alltoall_get_size;
     task->alltoallv_ce.get_offset = ucc_tl_cuda_alltoall_get_offset;
@@ -77,6 +72,5 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
     return UCC_OK;
 
 exit_err:
-    ucc_ec_destroy_event(task->alltoallv_ce.copy_done, UCC_EE_CUDA_STREAM);
     return status;
 }

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -1,331 +1,80 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
 
+#include "../alltoallv/alltoallv.h"
 #include "alltoall.h"
 #include "components/ec/ucc_ec.h"
 #include "tl_cuda_cache.h"
 #include "utils/arch/cpu.h"
 #include "utils/arch/cuda_def.h"
 
-enum {
-    ALLTOALL_CE_STAGE_SYNC,  /*< Wait for free SYNC segment */
-    ALLTOALL_CE_STAGE_SETUP, /*< Wait for memhandle setup to finish */
-    ALLTOALL_CE_STAGE_POST_COPIES,
-    ALLTOALL_CE_STAGE_COPY,  /*< Wait for all copies to finish */
-    ALLTOALL_CE_STAGE_BAR,   /*< Wait for other ranks to finish */
-};
-
-ucc_status_t ucc_tl_cuda_alltoall_ce_finalize(ucc_coll_task_t *coll_task)
+//NOLINTNEXTLINE
+size_t ucc_tl_cuda_alltoall_get_count(const ucc_tl_cuda_task_t *task,
+                                      ucc_count_t *cnts, ucc_rank_t block)
 {
-    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
-
-    tl_trace(UCC_TASK_LIB(task), "finalizing task %p", task);
-    ucc_ec_destroy_event((void*)task->alltoall_ce.copy_done,
-                         UCC_EE_CUDA_STREAM);
-    ucc_tl_cuda_task_put(task);
-    return UCC_OK;
+    return TASK_ARGS(task).dst.info.count / UCC_TL_TEAM_SIZE(TASK_TEAM(task));
 }
 
-ucc_status_t ucc_tl_cuda_alltoall_setup_start(ucc_tl_cuda_task_t *task)
+size_t ucc_tl_cuda_alltoall_get_offset(const ucc_tl_cuda_task_t *task,
+                                       size_t *displ, ucc_rank_t block)
 {
-    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, UCC_TL_TEAM_RANK(team));
-    ucc_status_t        status;
-
-    memcpy(&sync->mem_info_src, &task->alltoall_ce.mem_info_src,
-           sizeof(ucc_tl_cuda_mem_info_t));
-    memcpy(&sync->mem_info_dst, &task->alltoall_ce.mem_info_dst,
-           sizeof(ucc_tl_cuda_mem_info_t));
-    CUDA_CHECK_GOTO(cudaEventRecord(sync->ipc_event_local, team->stream),
-                    exit_err, status);
-    ucc_memory_cpu_store_fence();
-    status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
-    if (ucc_unlikely(status != UCC_OK)) {
-        goto exit_err;
-    }
-
-    return UCC_OK;
-
-exit_err:
-    return status;
-}
-
-ucc_status_t ucc_tl_cuda_alltoall_setup_test(ucc_tl_cuda_task_t *task)
-{
-    ucc_tl_cuda_team_t          *team = TASK_TEAM(task);
-    volatile ucc_tl_cuda_sync_t *peer_sync;
-    ucc_tl_cuda_cache_t         *cache;
-    ucc_status_t                 status;
-    ucc_rank_t                   i;
-
-    status = ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team), task->bar);
-    if (status != UCC_OK) {
-        return status;
-    }
-
-    for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
-        if (i == UCC_TL_TEAM_RANK(team) ||
-            !ucc_tl_cuda_team_topo_is_direct(&team->super, team->topo,
-                                             UCC_TL_TEAM_RANK(team), i)) {
-            continue;
-        }
-        peer_sync = TASK_SYNC(task, i);
-        cache = ucc_tl_cuda_get_cache(team, i);
-        if (ucc_unlikely(!cache)) {
-            status = UCC_ERR_NO_MESSAGE;
-            goto exit_err;
-        }
-        status = ucc_tl_cuda_map_memhandle(peer_sync->mem_info_src.ptr,
-                                           peer_sync->mem_info_src.length,
-                                           peer_sync->mem_info_src.handle,
-                                           &task->alltoall_ce.peer_map_addr_src[i],
-                                           cache);
-        if (UCC_OK != status) {
-            ucc_error("ucc_cuda_ipc_map_memhandle failed");
-            return UCC_ERR_INVALID_PARAM;
-        }
-        status = ucc_tl_cuda_map_memhandle(peer_sync->mem_info_dst.ptr,
-                                           peer_sync->mem_info_dst.length,
-                                           peer_sync->mem_info_dst.handle,
-                                           &task->alltoall_ce.peer_map_addr_dst[i],
-                                           cache);
-        if (UCC_OK != status) {
-            ucc_error("ucc_cuda_ipc_map_memhandle failed");
-            return UCC_ERR_INVALID_PARAM;
-        }
-    }
-    return UCC_OK;
-
-exit_err:
-    return status;
-}
-
-static ucc_status_t ucc_tl_cuda_alltoall_ce_post_copies(ucc_tl_cuda_task_t *task)
-{
-    ucc_tl_cuda_team_t          *team = TASK_TEAM(task);
-    ucc_coll_args_t             *args = &TASK_ARGS(task);
-    ucc_rank_t                   rank = UCC_TL_TEAM_RANK(team);
-    ucc_tl_cuda_sync_t          *sync = TASK_SYNC(task, rank);
-    ucc_tl_cuda_sync_t          *peer_sync;
-    ucc_ee_executor_t           *exec;
-    void                        *src, *dst;
-    ucc_ee_executor_task_t      **exec_task;
-    size_t                       send_len;
-    ucc_rank_t                   i, peer, psrc, pdst;
-    ucc_status_t                 status;
-    ucc_ee_executor_task_args_t  exec_args;
-
-    task->alltoall_ce.num_posted = 0;
-    status = ucc_coll_task_get_executor(&task->super, &exec);
-    if (ucc_unlikely(status != UCC_OK)) {
-        goto exit;
-    }
-
-    send_len = (args->src.info.count / UCC_TL_TEAM_SIZE(team)) *
-               ucc_dt_size(args->src.info.datatype);
-    for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
-        peer = (rank + i) % UCC_TL_TEAM_SIZE(team);
-        if (!ucc_tl_cuda_team_topo_is_direct(&team->super, team->topo,
-                                             rank, peer)) {
-            continue;
-        }
-        peer_sync = TASK_SYNC(task, peer);
-        if (peer == rank) {
-            src = args->src.info.buffer;
-        } else {
-            src = PTR_OFFSET(task->alltoall_ce.peer_map_addr_src[peer],
-                             peer_sync->mem_info_src.offset);
-            CUDA_CHECK_GOTO(cudaStreamWaitEvent(team->stream,
-                                                sync->data[peer].ipc_event_remote,
-                                                0),
-                           exit, status);
-        }
-        src = PTR_OFFSET(src, rank * send_len);
-        dst = PTR_OFFSET(args->dst.info.buffer, peer * send_len);
-        exec_args.task_type = UCC_EE_EXECUTOR_TASK_TYPE_COPY;
-        exec_args.bufs[0]   = dst;
-        exec_args.bufs[1]   = src;
-        exec_args.count     = send_len;
-        exec_task = &task->alltoall_ce.exec_task[task->alltoall_ce.num_posted];
-        status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
-        if (ucc_unlikely(status != UCC_OK)) {
-            goto exit;
-        }
-        task->alltoall_ce.num_posted++;
-    }
-
-    for (i = 0; i < team->topo->num_proxies; i++) {
-        if (team->topo->proxies[i].proxy == rank) {
-            psrc = team->topo->proxies[i].src;
-            pdst = team->topo->proxies[i].dst;
-            peer_sync = TASK_SYNC(task, psrc);
-            src = PTR_OFFSET(task->alltoall_ce.peer_map_addr_src[psrc],
-                             peer_sync->mem_info_src.offset);
-            src = PTR_OFFSET(src, pdst * send_len);
-            peer_sync = TASK_SYNC(task, pdst);
-            dst = PTR_OFFSET(task->alltoall_ce.peer_map_addr_dst[pdst],
-                             peer_sync->mem_info_dst.offset);
-            dst = PTR_OFFSET(dst, psrc * send_len);
-            exec_args.task_type = UCC_EE_EXECUTOR_TASK_TYPE_COPY;
-            exec_args.bufs[0]   = dst;
-            exec_args.bufs[1]   = src;
-            exec_args.count     = send_len;
-            exec_task = &task->alltoall_ce.exec_task[task->alltoall_ce.num_posted];
-            status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
-            if (ucc_unlikely(status != UCC_OK)) {
-                goto exit;
-            }
-            task->alltoall_ce.num_posted++;
-        }
-    }
-    status = ucc_ec_event_post(team->stream, task->alltoall_ce.copy_done,
-                               UCC_EE_CUDA_STREAM);
-exit:
-    return status;
-
-}
-
-void ucc_tl_cuda_alltoall_ce_progress(ucc_coll_task_t *coll_task)
-{
-    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
-    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    ucc_status_t        status;
-    int                 i;
-
-    switch (task->alltoall_ce.stage)
-    {
-    case ALLTOALL_CE_STAGE_SYNC:
-        if (ucc_tl_cuda_get_sync(task) != UCC_OK) {
-            task->super.status = UCC_INPROGRESS;
-            return;
-        }
-        status = ucc_tl_cuda_alltoall_setup_start(task);
-        if (status != UCC_OK) {
-            task->super.status = status;
-            return;
-        }
-        task->alltoall_ce.stage = ALLTOALL_CE_STAGE_SETUP;
-    case ALLTOALL_CE_STAGE_SETUP:
-        status =  ucc_tl_cuda_alltoall_setup_test(task);
-        if (status != UCC_OK) {
-            task->super.status = status;
-            return;
-        }
-    case ALLTOALL_CE_STAGE_POST_COPIES:
-        status = ucc_tl_cuda_alltoall_ce_post_copies(task);
-        if (ucc_unlikely(status != UCC_OK)) {
-            task->super.status = status;
-            return;
-        }
-        task->alltoall_ce.stage = ALLTOALL_CE_STAGE_COPY;
-    case ALLTOALL_CE_STAGE_COPY:
-        for (i = 0; i < task->alltoall_ce.num_posted; i++) {
-            status = ucc_ee_executor_task_test(task->alltoall_ce.exec_task[i]);
-            if (status != UCC_OK) {
-                if (status == UCC_OPERATION_INITIALIZED) {
-                    status = UCC_INPROGRESS;
-                }
-                task->super.status = status;
-                return;
-            }
-        }
-        status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team),
-                                               task->bar);
-        if (ucc_unlikely(status != UCC_OK)) {
-            task->super.status = status;
-            return;
-        }
-        task->alltoall_ce.stage = ALLTOALL_CE_STAGE_BAR;
-    default:
-        ucc_assert(task->alltoall_ce.stage == ALLTOALL_CE_STAGE_BAR);
-        break;
-    }
-    task->super.status = ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team),
-                                                      task->bar);
-    if (task->super.status == UCC_OK) {
-        ucc_tl_cuda_put_sync(task);
-    }
-}
-
-ucc_status_t ucc_tl_cuda_alltoall_ce_start(ucc_coll_task_t *coll_task)
-{
-    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
-    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-
-    if (task->alltoall_ce.stage != ALLTOALL_CE_STAGE_POST_COPIES) {
-        task->alltoall_ce.stage = ALLTOALL_CE_STAGE_SYNC;
-    }
-    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-}
-
-ucc_status_t ucc_tl_cuda_alltoall_ce_triggered_post_setup(ucc_coll_task_t *coll_task)
-{
-    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
-    ucc_status_t status;
-
-    do {
-        status = ucc_tl_cuda_get_sync(task);
-    } while (status == UCC_INPROGRESS);
-    if (ucc_unlikely(status != UCC_OK)) {
-        return status;
-    }
-
-    status = ucc_tl_cuda_alltoall_setup_start(task);
-    if (ucc_unlikely(status != UCC_OK)) {
-        ucc_tl_cuda_put_sync(task);
-        return status;
-    }
-
-    do {
-        status = ucc_tl_cuda_alltoall_setup_test(task);
-    } while(status == UCC_INPROGRESS);
-    if (ucc_unlikely(status != UCC_OK)) {
-        ucc_tl_cuda_put_sync(task);
-        return status;
-    }
-    task->alltoall_ce.stage = ALLTOALL_CE_STAGE_POST_COPIES;
-
-    return UCC_OK;
+    return (TASK_ARGS(task).dst.info.count /
+            UCC_TL_TEAM_SIZE(TASK_TEAM(task))) *
+           block;
 }
 
 ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
 {
-    ucc_coll_args_t    *args = &TASK_ARGS(task);
-    ucc_status_t status;
-    size_t data_len;
+    ucc_coll_args_t *args = &TASK_ARGS(task);
+    ucc_status_t     status;
+    size_t           data_len;
 
     task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
-    status = ucc_ec_create_event(&task->alltoall_ce.copy_done,
-                                 UCC_EE_CUDA_STREAM);
+    status =
+        ucc_ec_create_event(&task->alltoallv_ce.copy_done, UCC_EE_CUDA_STREAM);
     if (ucc_unlikely(status != UCC_OK)) {
         return status;
     }
 
+    task->alltoallv_ce.get_count  = ucc_tl_cuda_alltoall_get_count;
+    task->alltoallv_ce.get_offset = ucc_tl_cuda_alltoall_get_offset;
+    task->alltoallv_ce.sdt        = args->src.info.datatype;
+    task->alltoallv_ce.rdt        = args->dst.info.datatype;
+    task->alltoallv_ce.sbuf       = args->src.info.buffer;
+    task->alltoallv_ce.rbuf       = args->dst.info.buffer;
+    /* NOT used for alltoall */
+    task->alltoallv_ce.scnts  = 0;
+    task->alltoallv_ce.rcnts  = 0;
+    task->alltoallv_ce.sdispl = 0;
+    task->alltoallv_ce.rdispl = 0;
+
     data_len = ucc_dt_size(args->src.info.datatype) * args->src.info.count;
-    status = ucc_tl_cuda_mem_info_get(args->src.info.buffer, data_len,
-                                      &task->alltoall_ce.mem_info_src);
+    status   = ucc_tl_cuda_mem_info_get(args->src.info.buffer, data_len,
+                                        &task->alltoallv_ce.mem_info_src);
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;
     }
     status = ucc_tl_cuda_mem_info_get(args->dst.info.buffer, data_len,
-                                      &task->alltoall_ce.mem_info_dst);
+                                      &task->alltoallv_ce.mem_info_dst);
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;
     }
 
-    task->super.post                 = ucc_tl_cuda_alltoall_ce_start;
-    task->super.triggered_post       = ucc_triggered_post;
-    task->super.triggered_post_setup = ucc_tl_cuda_alltoall_ce_triggered_post_setup;
-    task->super.progress             = ucc_tl_cuda_alltoall_ce_progress;
-    task->super.finalize             = ucc_tl_cuda_alltoall_ce_finalize;
-    task->bar                        = TASK_BAR(task);
+    task->super.post           = ucc_tl_cuda_alltoallv_ce_start;
+    task->super.triggered_post = ucc_triggered_post;
+    task->super.triggered_post_setup =
+        ucc_tl_cuda_alltoallv_ce_triggered_post_setup;
+    task->super.progress = ucc_tl_cuda_alltoallv_ce_progress;
+    task->super.finalize = ucc_tl_cuda_alltoallv_ce_finalize;
+    task->bar            = TASK_BAR(task);
 
     return UCC_OK;
 
 exit_err:
-    ucc_ec_destroy_event(task->alltoall_ce.copy_done, UCC_EE_CUDA_STREAM);
+    ucc_ec_destroy_event(task->alltoallv_ce.copy_done, UCC_EE_CUDA_STREAM);
     return status;
 }

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -13,16 +13,18 @@
 #include "utils/arch/cuda_def.h"
 
 //NOLINTNEXTLINE
-size_t ucc_tl_cuda_alltoall_get_count(const ucc_tl_cuda_task_t *task,
-                                      ucc_count_t *cnts, ucc_rank_t block)
+size_t ucc_tl_cuda_alltoall_get_size(const ucc_tl_cuda_task_t *task,
+                                     size_t *cnts, ucc_rank_t block)
 {
-    return TASK_ARGS(task).dst.info.count / UCC_TL_TEAM_SIZE(TASK_TEAM(task));
+    return ucc_dt_size(TASK_ARGS(task).dst.info.datatype) *
+           (TASK_ARGS(task).dst.info.count / UCC_TL_TEAM_SIZE(TASK_TEAM(task)));
 }
 
 size_t ucc_tl_cuda_alltoall_get_offset(const ucc_tl_cuda_task_t *task,
                                        size_t *displ, ucc_rank_t block)
 {
-    return (TASK_ARGS(task).dst.info.count /
+    return ucc_dt_size(TASK_ARGS(task).dst.info.datatype) *
+           (TASK_ARGS(task).dst.info.count /
             UCC_TL_TEAM_SIZE(TASK_TEAM(task))) *
            block;
 }
@@ -40,7 +42,7 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
         return status;
     }
 
-    task->alltoallv_ce.get_count  = ucc_tl_cuda_alltoall_get_count;
+    task->alltoallv_ce.get_size   = ucc_tl_cuda_alltoall_get_size;
     task->alltoallv_ce.get_offset = ucc_tl_cuda_alltoall_get_offset;
     task->alltoallv_ce.sdt        = args->src.info.datatype;
     task->alltoallv_ce.rdt        = args->dst.info.datatype;

--- a/src/components/tl/cuda/alltoallv/alltoallv.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv.c
@@ -12,7 +12,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task);
 
 ucc_status_t ucc_tl_cuda_alltoallv_ce_start(ucc_coll_task_t *task);
 
-ucc_status_t ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *task);
+void ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *task);
 

--- a/src/components/tl/cuda/alltoallv/alltoallv.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv.c
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "alltoallv.h"
+#include "components/mc/ucc_mc.h"
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task);
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_start(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_cuda_alltoallv_init(ucc_base_coll_args_t *coll_args,
+                                        ucc_base_team_t *     tl_team,
+                                        ucc_coll_task_t **    task_p)
+{
+    ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
+    ucc_tl_cuda_task_t *task;
+    ucc_status_t        status;
+
+    if (UCC_IS_INPLACE(coll_args->args)) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    task = ucc_tl_cuda_task_init(coll_args, team);
+    if (ucc_unlikely(!task)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    status = ucc_tl_cuda_alltoallv_ce_init(task);
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto free_task;
+    }
+
+    *task_p = &task->super;
+    return UCC_OK;
+
+free_task:
+    ucc_tl_cuda_task_put(task);
+    return status;
+}

--- a/src/components/tl/cuda/alltoallv/alltoallv.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv.c
@@ -17,8 +17,8 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *task);
 ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_cuda_alltoallv_init(ucc_base_coll_args_t *coll_args,
-                                        ucc_base_team_t *     tl_team,
-                                        ucc_coll_task_t **    task_p)
+                                        ucc_base_team_t      *tl_team,
+                                        ucc_coll_task_t     **task_p)
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_task_t *task;

--- a/src/components/tl/cuda/alltoallv/alltoallv.h
+++ b/src/components/tl/cuda/alltoallv/alltoallv.h
@@ -15,7 +15,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *coll_task);
 
 ucc_status_t ucc_tl_cuda_alltoallv_ce_start(ucc_coll_task_t *coll_task);
 
-ucc_status_t ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task);
+void ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task);
 
 ucc_status_t
 ucc_tl_cuda_alltoallv_ce_triggered_post_setup(ucc_coll_task_t *coll_task);

--- a/src/components/tl/cuda/alltoallv/alltoallv.h
+++ b/src/components/tl/cuda/alltoallv/alltoallv.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef ALLTOALL_H_
+#define ALLTOALL_H_
+
+#include "../tl_cuda.h"
+#include "../tl_cuda_coll.h"
+
+ucc_status_t ucc_tl_cuda_alltoallv_init(ucc_base_coll_args_t *coll_args,
+                                        ucc_base_team_t *     tl_team,
+                                        ucc_coll_task_t **    task_p);
+
+#endif

--- a/src/components/tl/cuda/alltoallv/alltoallv.h
+++ b/src/components/tl/cuda/alltoallv/alltoallv.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -10,6 +10,15 @@
 
 #include "../tl_cuda.h"
 #include "../tl_cuda_coll.h"
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_start(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task);
+
+ucc_status_t
+ucc_tl_cuda_alltoallv_ce_triggered_post_setup(ucc_coll_task_t *coll_task);
 
 ucc_status_t ucc_tl_cuda_alltoallv_init(ucc_base_coll_args_t *coll_args,
                                         ucc_base_team_t      *tl_team,

--- a/src/components/tl/cuda/alltoallv/alltoallv.h
+++ b/src/components/tl/cuda/alltoallv/alltoallv.h
@@ -12,7 +12,7 @@
 #include "../tl_cuda_coll.h"
 
 ucc_status_t ucc_tl_cuda_alltoallv_init(ucc_base_coll_args_t *coll_args,
-                                        ucc_base_team_t *     tl_team,
-                                        ucc_coll_task_t **    task_p);
+                                        ucc_base_team_t      *tl_team,
+                                        ucc_coll_task_t     **task_p);
 
 #endif

--- a/src/components/tl/cuda/alltoallv/alltoallv.h
+++ b/src/components/tl/cuda/alltoallv/alltoallv.h
@@ -5,8 +5,8 @@
  * See file LICENSE for terms.
  */
 
-#ifndef ALLTOALL_H_
-#define ALLTOALL_H_
+#ifndef ALLTOALLV_H_
+#define ALLTOALLV_H_
 
 #include "../tl_cuda.h"
 #include "../tl_cuda_coll.h"

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -174,14 +174,14 @@ ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
                              args, peer_sync->src_displ, pdst) *
                          sdt_size;
             src       = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_src[psrc],
-                             peer_sync->mem_info_src.offset);
+                                   peer_sync->mem_info_src.offset);
             src       = PTR_OFFSET(src, data_displ);
             peer_sync = TASK_SYNC(task, pdst);
             ucc_assert(
                 (rdt_size * ucc_coll_args_get_count(args, peer_sync->dst_cnts,
                                                     psrc)) == data_size);
             dst        = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_dst[pdst],
-                             peer_sync->mem_info_dst.offset);
+                                    peer_sync->mem_info_dst.offset);
             data_displ = ucc_coll_args_get_displacement(
                              args, peer_sync->dst_displ, psrc) *
                          rdt_size;

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -11,8 +11,7 @@
 #include "utils/arch/cpu.h"
 #include "utils/arch/cuda_def.h"
 
-enum
-{
+enum {
     ALLTOALL_CE_STAGE_SYNC,  /*< Wait for free SYNC segment */
     ALLTOALL_CE_STAGE_SETUP, /*< Wait for memhandle setup to finish */
     ALLTOALL_CE_STAGE_COPY,  /*< Wait for all copies to finish */
@@ -71,9 +70,9 @@ exit_err:
 // TODO: reuse ucc_tl_cuda_alltoall_setup_test ?
 ucc_status_t ucc_tl_cuda_alltoallv_setup_test(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t *         team = TASK_TEAM(task);
+    ucc_tl_cuda_team_t          *team = TASK_TEAM(task);
     volatile ucc_tl_cuda_sync_t *peer_sync;
-    ucc_tl_cuda_cache_t *        cache;
+    ucc_tl_cuda_cache_t         *cache;
     ucc_status_t                 status;
     ucc_rank_t                   i;
 
@@ -121,13 +120,13 @@ static ucc_status_t
 ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    ucc_coll_args_t *   args = &TASK_ARGS(task);
+    ucc_coll_args_t    *args = &TASK_ARGS(task);
     ucc_rank_t          rank = UCC_TL_TEAM_RANK(team);
     ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
     ucc_tl_cuda_sync_t *peer_sync;
     size_t              data_size;
     ucc_rank_t          i, peer, psrc, pdst;
-    void *              src, *dst;
+    void               *src, *dst;
     ucc_status_t        status;
     size_t              rdt_size = ucc_dt_size(args->dst.info_v.datatype);
     size_t              sdt_size = ucc_dt_size(args->src.info_v.datatype);
@@ -177,7 +176,7 @@ ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
                              args, peer_sync->src_displ, pdst) *
                          sdt_size;
             src       = PTR_OFFSET(task->alltoall_ce.peer_map_addr_src[psrc],
-                             peer_sync->mem_info_src.offset);
+                                   peer_sync->mem_info_src.offset);
             src       = PTR_OFFSET(src, data_displ);
             peer_sync = TASK_SYNC(task, pdst);
             size_t dst_data_size =
@@ -185,7 +184,7 @@ ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
                 ucc_coll_args_get_count(args, peer_sync->dst_cnts, psrc);
             ucc_assert(dst_data_size == data_size);
             dst        = PTR_OFFSET(task->alltoall_ce.peer_map_addr_dst[pdst],
-                             peer_sync->mem_info_dst.offset);
+                                    peer_sync->mem_info_dst.offset);
             data_displ = ucc_coll_args_get_displacement(
                              args, peer_sync->dst_displ, psrc) *
                          rdt_size;
@@ -275,7 +274,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_start(ucc_coll_task_t *coll_task)
 ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    ucc_coll_args_t *   args = &TASK_ARGS(task);
+    ucc_coll_args_t    *args = &TASK_ARGS(task);
     ucc_status_t        status;
     size_t              data_len;
 

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -119,7 +119,6 @@ exit_err:
 ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t         *team = TASK_TEAM(task);
-    ucc_coll_args_t            *args = &TASK_ARGS(task);
     ucc_rank_t                  rank = UCC_TL_TEAM_RANK(team);
     ucc_tl_cuda_sync_t         *sync = TASK_SYNC(task, rank);
     ucc_tl_cuda_sync_t         *peer_sync;

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -24,8 +24,6 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *coll_task)
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
 
     tl_trace(UCC_TASK_LIB(task), "finalizing task %p", task);
-    ucc_ec_destroy_event((void *)task->alltoallv_ce.copy_done,
-                         UCC_EE_CUDA_STREAM);
     ucc_tl_cuda_task_put(task);
     return UCC_OK;
 }
@@ -214,8 +212,6 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
             task->alltoallv_ce.num_posted++;
         }
     }
-    status = ucc_ec_event_post(team->stream, task->alltoallv_ce.copy_done,
-                               UCC_EE_CUDA_STREAM);
 exit:
     return status;
 }
@@ -349,12 +345,6 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    status =
-        ucc_ec_create_event(&task->alltoallv_ce.copy_done, UCC_EE_CUDA_STREAM);
-    if (ucc_unlikely(status != UCC_OK)) {
-        return status;
-    }
-
     task->alltoallv_ce.get_size   = ucc_tl_cuda_alltoallv_get_size;
     task->alltoallv_ce.get_offset = ucc_tl_cuda_alltoallv_get_offset;
     task->alltoallv_ce.sdt        = args->src.info_v.datatype;
@@ -395,6 +385,5 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
     return UCC_OK;
 
 exit_err:
-    ucc_ec_destroy_event(task->alltoallv_ce.copy_done, UCC_EE_CUDA_STREAM);
     return status;
 }

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -341,7 +341,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
     size_t              data_len;
 
     if (!UCC_COLL_ARGS_CONTIG_BUFFER(args)) {
-        tl_error(UCC_TL_TEAM_LIB(team), "Do not support non-contiguous buffer");
+        tl_debug(UCC_TL_TEAM_LIB(team), "Do not support non-contiguous buffer");
         return UCC_ERR_NOT_SUPPORTED;
     }
 

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -1,0 +1,320 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "alltoallv.h"
+#include "components/ec/ucc_ec.h"
+#include "tl_cuda_cache.h"
+#include "utils/arch/cpu.h"
+#include "utils/arch/cuda_def.h"
+
+enum
+{
+    ALLTOALL_CE_STAGE_SYNC,  /*< Wait for free SYNC segment */
+    ALLTOALL_CE_STAGE_SETUP, /*< Wait for memhandle setup to finish */
+    ALLTOALL_CE_STAGE_COPY,  /*< Wait for all copies to finish */
+    ALLTOALL_CE_STAGE_BAR,   /*< Wait for other ranks to finish */
+};
+
+// TODO: reuse ucc_tl_cuda_alltoall_ce_finalize ?
+ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+
+    tl_trace(UCC_TASK_LIB(task), "finalizing task %p", task);
+    ucc_ec_destroy_event((void *)task->alltoall_ce.copy_done,
+                         UCC_EE_CUDA_STREAM);
+    ucc_tl_cuda_task_put(task);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_cuda_alltoallv_setup_start(ucc_tl_cuda_task_t *task)
+{
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, UCC_TL_TEAM_RANK(team));
+    ucc_status_t        status;
+
+    // copy a2av counts and displ. for proxies (if any) to access
+    if (team->topo->num_proxies > 0) {
+        ucc_coll_args_t *args = &TASK_ARGS(task);
+        int              i;
+        // TODO: would team size match the size in args when using HIER CL?
+        for (i = 0; i < UCC_TL_TEAM_SIZE(team); ++i) {
+            sync->src_cnts[i] =
+                ucc_coll_args_get_count(args, args->src.info_v.counts, i);
+            sync->dst_cnts[i] =
+                ucc_coll_args_get_count(args, args->dst.info_v.counts, i);
+            sync->src_displ[i] = ucc_coll_args_get_displacement(
+                args, args->src.info_v.displacements, i);
+            sync->dst_displ[i] = ucc_coll_args_get_displacement(
+                args, args->dst.info_v.displacements, i);
+        }
+    }
+    memcpy(&sync->mem_info_src, &task->alltoall_ce.mem_info_src,
+           sizeof(ucc_tl_cuda_mem_info_t));
+    memcpy(&sync->mem_info_dst, &task->alltoall_ce.mem_info_dst,
+           sizeof(ucc_tl_cuda_mem_info_t));
+    CUDA_CHECK_GOTO(cudaEventRecord(sync->ipc_event_local, team->stream),
+                    exit_err, status);
+    ucc_memory_bus_fence();
+    status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto exit_err;
+    }
+
+    return UCC_OK;
+
+exit_err:
+    return status;
+}
+
+// TODO: reuse ucc_tl_cuda_alltoall_setup_test ?
+ucc_status_t ucc_tl_cuda_alltoallv_setup_test(ucc_tl_cuda_task_t *task)
+{
+    ucc_tl_cuda_team_t *         team = TASK_TEAM(task);
+    volatile ucc_tl_cuda_sync_t *peer_sync;
+    ucc_tl_cuda_cache_t *        cache;
+    ucc_status_t                 status;
+    ucc_rank_t                   i;
+
+    status = ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team), task->bar);
+    if (status != UCC_OK) {
+        return status;
+    }
+
+    for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
+        if (i == UCC_TL_TEAM_RANK(team) ||
+            !ucc_tl_cuda_team_topo_is_direct(&team->super, team->topo,
+                                             UCC_TL_TEAM_RANK(team), i)) {
+            continue;
+        }
+        peer_sync = TASK_SYNC(task, i);
+        cache     = ucc_tl_cuda_get_cache(team, i);
+        if (ucc_unlikely(!cache)) {
+            status = UCC_ERR_NO_MESSAGE;
+            goto exit_err;
+        }
+        status = ucc_tl_cuda_map_memhandle(
+            peer_sync->mem_info_src.ptr, peer_sync->mem_info_src.length,
+            peer_sync->mem_info_src.handle,
+            &task->alltoall_ce.peer_map_addr_src[i], cache);
+        if (UCC_OK != status) {
+            ucc_error("ucc_cuda_ipc_map_memhandle failed");
+            return UCC_ERR_INVALID_PARAM;
+        }
+        status = ucc_tl_cuda_map_memhandle(
+            peer_sync->mem_info_dst.ptr, peer_sync->mem_info_dst.length,
+            peer_sync->mem_info_dst.handle,
+            &task->alltoall_ce.peer_map_addr_dst[i], cache);
+        if (UCC_OK != status) {
+            ucc_error("ucc_cuda_ipc_map_memhandle failed");
+            return UCC_ERR_INVALID_PARAM;
+        }
+    }
+    return UCC_OK;
+
+exit_err:
+    return status;
+}
+
+static ucc_status_t
+ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
+{
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_coll_args_t *   args = &TASK_ARGS(task);
+    ucc_rank_t          rank = UCC_TL_TEAM_RANK(team);
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
+    ucc_tl_cuda_sync_t *peer_sync;
+    size_t              data_size;
+    ucc_rank_t          i, peer, psrc, pdst;
+    void *              src, *dst;
+    ucc_status_t        status;
+    size_t              rdt_size = ucc_dt_size(args->dst.info_v.datatype);
+    size_t              sdt_size = ucc_dt_size(args->src.info_v.datatype);
+    size_t              data_displ;
+
+    for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
+        peer = (rank + i) % UCC_TL_TEAM_SIZE(team);
+        if (!ucc_tl_cuda_team_topo_is_direct(&team->super, team->topo, rank,
+                                             peer)) {
+            continue;
+        }
+        peer_sync = TASK_SYNC(task, peer);
+        if (peer == rank) {
+            src = args->src.info_v.buffer;
+        } else {
+            src = PTR_OFFSET(task->alltoall_ce.peer_map_addr_src[peer],
+                             peer_sync->mem_info_src.offset);
+            CUDA_CHECK_GOTO(
+                cudaStreamWaitEvent(team->stream,
+                                    sync->data[peer].ipc_event_remote, 0),
+                exit, status);
+        }
+        data_size = sdt_size * ucc_coll_args_get_count(
+                                   args, args->src.info_v.counts, peer);
+        data_displ = ucc_coll_args_get_displacement(
+                         args, args->src.info_v.displacements, peer) *
+                     sdt_size;
+        src        = PTR_OFFSET(src, data_displ);
+        data_displ = ucc_coll_args_get_displacement(
+                         args, args->dst.info_v.displacements, rank) *
+                     rdt_size;
+        dst = PTR_OFFSET(args->dst.info_v.buffer, data_displ);
+        CUDA_CHECK_GOTO(cudaMemcpyAsync(dst, src, data_size,
+                                        cudaMemcpyDeviceToDevice, team->stream),
+                        exit, status);
+    }
+
+    for (i = 0; i < team->topo->num_proxies; i++) {
+        if (team->topo->proxies[i].proxy == rank) {
+            psrc      = team->topo->proxies[i].src;
+            pdst      = team->topo->proxies[i].dst;
+            peer_sync = TASK_SYNC(task, psrc);
+            // FIXME: assume the same datatype
+            data_size = sdt_size * ucc_coll_args_get_count(
+                                       args, peer_sync->src_cnts, pdst);
+            data_displ = ucc_coll_args_get_displacement(
+                             args, peer_sync->src_displ, pdst) *
+                         sdt_size;
+            src       = PTR_OFFSET(task->alltoall_ce.peer_map_addr_src[psrc],
+                             peer_sync->mem_info_src.offset);
+            src       = PTR_OFFSET(src, data_displ);
+            peer_sync = TASK_SYNC(task, pdst);
+            size_t dst_data_size =
+                rdt_size *
+                ucc_coll_args_get_count(args, peer_sync->dst_cnts, psrc);
+            ucc_assert(dst_data_size == data_size);
+            dst        = PTR_OFFSET(task->alltoall_ce.peer_map_addr_dst[pdst],
+                             peer_sync->mem_info_dst.offset);
+            data_displ = ucc_coll_args_get_displacement(
+                             args, peer_sync->dst_displ, psrc) *
+                         rdt_size;
+            dst = PTR_OFFSET(dst, data_displ);
+            CUDA_CHECK_GOTO(cudaMemcpyAsync(dst, src, data_size,
+                                            cudaMemcpyDeviceToDevice,
+                                            team->stream),
+                            exit, status);
+        }
+    }
+    status = ucc_ec_event_post(team->stream, task->alltoall_ce.copy_done,
+                               UCC_EE_CUDA_STREAM);
+exit:
+    return status;
+}
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_status_t        status;
+
+    switch (task->alltoall_ce.stage) {
+    case ALLTOALL_CE_STAGE_SYNC:
+        if (ucc_tl_cuda_get_sync(task) != UCC_OK) {
+            task->super.super.status = UCC_INPROGRESS;
+            return task->super.super.status;
+        }
+        status = ucc_tl_cuda_alltoallv_setup_start(task);
+        if (status != UCC_OK) {
+            task->super.super.status = status;
+            return task->super.super.status;
+        }
+        task->alltoall_ce.stage = ALLTOALL_CE_STAGE_SETUP;
+    case ALLTOALL_CE_STAGE_SETUP:
+        status = ucc_tl_cuda_alltoallv_setup_test(task);
+        if (status != UCC_OK) {
+            task->super.super.status = status;
+            return task->super.super.status;
+        }
+        status = ucc_tl_cuda_alltoallv_ce_post_copies(task);
+        if (ucc_unlikely(status != UCC_OK)) {
+            task->super.super.status = status;
+            return task->super.super.status;
+        }
+        task->alltoall_ce.stage = ALLTOALL_CE_STAGE_COPY;
+    case ALLTOALL_CE_STAGE_COPY:
+        status =
+            ucc_ec_event_test(task->alltoall_ce.copy_done, UCC_EE_CUDA_STREAM);
+        if (status != UCC_OK) {
+            task->super.super.status = status;
+            return task->super.super.status;
+        }
+        status =
+            ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
+        if (ucc_unlikely(status != UCC_OK)) {
+            task->super.super.status = status;
+            return task->super.super.status;
+        }
+        task->alltoall_ce.stage = ALLTOALL_CE_STAGE_BAR;
+    default:
+        ucc_assert(task->alltoall_ce.stage == ALLTOALL_CE_STAGE_BAR);
+        break;
+    }
+    task->super.super.status =
+        ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team), task->bar);
+    if (task->super.super.status == UCC_OK) {
+        ucc_tl_cuda_put_sync(task);
+    }
+    return task->super.super.status;
+}
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+
+    task->alltoall_ce.stage = ALLTOALL_CE_STAGE_SYNC;
+    ucc_tl_cuda_alltoallv_ce_progress(coll_task);
+    if (task->super.super.status == UCC_INPROGRESS) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+        return UCC_OK;
+    }
+    return ucc_task_complete(coll_task);
+}
+
+ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
+{
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_coll_args_t *   args = &TASK_ARGS(task);
+    ucc_status_t        status;
+    size_t              data_len;
+
+    status =
+        ucc_ec_create_event(&task->alltoall_ce.copy_done, UCC_EE_CUDA_STREAM);
+    if (ucc_unlikely(status != UCC_OK)) {
+        return status;
+    }
+
+    data_len = ucc_dt_size(args->src.info_v.datatype) *
+               ucc_coll_args_get_total_count(args, args->src.info_v.counts,
+                                             UCC_TL_TEAM_SIZE(team));
+    status = ucc_tl_cuda_mem_info_get(args->src.info_v.buffer, data_len, team,
+                                      &task->alltoall_ce.mem_info_src);
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto exit_err;
+    }
+    data_len = ucc_dt_size(args->dst.info_v.datatype) *
+               ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
+                                             UCC_TL_TEAM_SIZE(team));
+    status = ucc_tl_cuda_mem_info_get(args->dst.info_v.buffer, data_len, team,
+                                      &task->alltoall_ce.mem_info_dst);
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto exit_err;
+    }
+
+    task->super.post = ucc_tl_cuda_alltoallv_ce_start;
+    task->super.triggered_post =
+        ucc_triggered_post; // FIXME: this may cause hang issue
+    task->super.progress = ucc_tl_cuda_alltoallv_ce_progress;
+    task->super.finalize = ucc_tl_cuda_alltoallv_ce_finalize;
+    task->bar            = TASK_BAR(task);
+
+    return UCC_OK;
+
+exit_err:
+    ucc_ec_destroy_event(task->alltoall_ce.copy_done, UCC_EE_CUDA_STREAM);
+    return status;
+}

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -275,6 +275,12 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
     ucc_status_t        status;
     size_t              data_len;
 
+    if (!(args->flags & (UCC_COLL_ARGS_FLAG_CONTIG_SRC_BUFFER |
+                         UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER))) {
+        tl_error(UCC_TL_TEAM_LIB(team), "Do not support non-contiguous buffer");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
     status =
         ucc_ec_create_event(&task->alltoallv_ce.copy_done, UCC_EE_CUDA_STREAM);
     if (ucc_unlikely(status != UCC_OK)) {

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -14,8 +14,9 @@
 enum {
     ALLTOALL_CE_STAGE_SYNC,  /*< Wait for free SYNC segment */
     ALLTOALL_CE_STAGE_SETUP, /*< Wait for memhandle setup to finish */
-    ALLTOALL_CE_STAGE_COPY,  /*< Wait for all copies to finish */
-    ALLTOALL_CE_STAGE_BAR,   /*< Wait for other ranks to finish */
+    ALLTOALL_CE_STAGE_POST_COPIES,
+    ALLTOALL_CE_STAGE_COPY, /*< Wait for all copies to finish */
+    ALLTOALL_CE_STAGE_BAR,  /*< Wait for other ranks to finish */
 };
 
 ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *coll_task)
@@ -34,19 +35,20 @@ ucc_status_t ucc_tl_cuda_alltoallv_setup_start(ucc_tl_cuda_task_t *task)
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
     ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, UCC_TL_TEAM_RANK(team));
     ucc_status_t        status;
+    ucc_coll_args_t    *args = &TASK_ARGS(task);
 
-    // copy a2av counts and displ. for proxies (if any) to access
-    if (team->topo->num_proxies > 0) {
-        ucc_coll_args_t *args = &TASK_ARGS(task);
-        // TODO: would team size match the size in args when using HIER CL?
+    // for A2av: copy counts and displ. for proxies (if any) to access
+    if (team->topo->num_proxies > 0 &&
+        UCC_COLL_TYPE_ALLTOALLV == args->coll_type) {
+        size_t elem_size = UCC_COLL_ARGS_COUNT64(args) ? 8 : 4;
         memcpy(sync->src_cnts, args->src.info_v.counts,
-               sizeof(ucc_count_t) * UCC_TL_TEAM_SIZE(team));
+               elem_size * UCC_TL_TEAM_SIZE(team));
         memcpy(sync->dst_cnts, args->dst.info_v.counts,
-               sizeof(ucc_count_t) * UCC_TL_TEAM_SIZE(team));
+               elem_size * UCC_TL_TEAM_SIZE(team));
         memcpy(sync->src_displ, args->src.info_v.displacements,
-               sizeof(ucc_aint_t) * UCC_TL_TEAM_SIZE(team));
+               elem_size * UCC_TL_TEAM_SIZE(team));
         memcpy(sync->dst_displ, args->src.info_v.displacements,
-               sizeof(ucc_aint_t) * UCC_TL_TEAM_SIZE(team));
+               elem_size * UCC_TL_TEAM_SIZE(team));
     }
     memcpy(&sync->mem_info_src, &task->alltoallv_ce.mem_info_src,
            sizeof(ucc_tl_cuda_mem_info_t));
@@ -114,21 +116,28 @@ exit_err:
     return status;
 }
 
-static ucc_status_t
-ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
+ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    ucc_coll_args_t    *args = &TASK_ARGS(task);
-    ucc_rank_t          rank = UCC_TL_TEAM_RANK(team);
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
-    ucc_tl_cuda_sync_t *peer_sync;
-    size_t              data_size;
-    ucc_rank_t          i, peer, psrc, pdst;
-    void               *src, *dst;
-    ucc_status_t        status;
-    size_t              rdt_size = ucc_dt_size(args->dst.info_v.datatype);
-    size_t              sdt_size = ucc_dt_size(args->src.info_v.datatype);
-    size_t              data_displ;
+    ucc_tl_cuda_team_t         *team = TASK_TEAM(task);
+    ucc_coll_args_t            *args = &TASK_ARGS(task);
+    ucc_rank_t                  rank = UCC_TL_TEAM_RANK(team);
+    ucc_tl_cuda_sync_t         *sync = TASK_SYNC(task, rank);
+    ucc_tl_cuda_sync_t         *peer_sync;
+    ucc_ee_executor_t          *exec;
+    void                       *src, *dst;
+    ucc_ee_executor_task_t    **exec_task;
+    size_t                      data_size, data_displ;
+    size_t                      rdt_size = ucc_dt_size(task->alltoallv_ce.rdt);
+    size_t                      sdt_size = ucc_dt_size(task->alltoallv_ce.sdt);
+    ucc_rank_t                  i, peer, psrc, pdst;
+    ucc_status_t                status;
+    ucc_ee_executor_task_args_t exec_args;
+
+    task->alltoallv_ce.num_posted = 0;
+    status = ucc_coll_task_get_executor(&task->super, &exec);
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto exit;
+    }
 
     for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
         peer = (rank + i) % UCC_TL_TEAM_SIZE(team);
@@ -138,7 +147,7 @@ ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
         }
         peer_sync = TASK_SYNC(task, peer);
         if (peer == rank) {
-            src = args->src.info_v.buffer;
+            src = task->alltoallv_ce.sbuf;
         } else {
             src = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_src[peer],
                              peer_sync->mem_info_src.offset);
@@ -147,19 +156,26 @@ ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
                                     sync->data[peer].ipc_event_remote, 0),
                 exit, status);
         }
-        data_size = sdt_size * ucc_coll_args_get_count(
-                                   args, args->src.info_v.counts, peer);
-        data_displ = ucc_coll_args_get_displacement(
-                         args, args->src.info_v.displacements, peer) *
-                     sdt_size;
+        data_size = sdt_size * task->alltoallv_ce.get_count(
+                                   task, task->alltoallv_ce.scnts, peer);
+        data_displ = sdt_size * task->alltoallv_ce.get_offset(
+                                    task, task->alltoallv_ce.sdispl, peer);
         src        = PTR_OFFSET(src, data_displ);
-        data_displ = ucc_coll_args_get_displacement(
-                         args, args->dst.info_v.displacements, peer) *
-                     rdt_size;
-        dst = PTR_OFFSET(args->dst.info_v.buffer, data_displ);
-        CUDA_CHECK_GOTO(cudaMemcpyAsync(dst, src, data_size,
-                                        cudaMemcpyDeviceToDevice, team->stream),
-                        exit, status);
+        data_displ = rdt_size * task->alltoallv_ce.get_offset(
+                                    task, task->alltoallv_ce.rdispl, peer);
+        dst = PTR_OFFSET(task->alltoallv_ce.rbuf, data_displ);
+
+        exec_args.task_type = UCC_EE_EXECUTOR_TASK_TYPE_COPY;
+        exec_args.bufs[0]   = dst;
+        exec_args.bufs[1]   = src;
+        exec_args.count     = data_size;
+        exec_task =
+            &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
+        status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
+        if (ucc_unlikely(status != UCC_OK)) {
+            goto exit;
+        }
+        task->alltoallv_ce.num_posted++;
     }
 
     for (i = 0; i < team->topo->num_proxies; i++) {
@@ -168,28 +184,30 @@ ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
             pdst      = team->topo->proxies[i].dst;
             peer_sync = TASK_SYNC(task, psrc);
             // FIXME: assume the same datatype
-            data_size = sdt_size * ucc_coll_args_get_count(
-                                       args, peer_sync->src_cnts, pdst);
-            data_displ = ucc_coll_args_get_displacement(
-                             args, peer_sync->src_displ, pdst) *
-                         sdt_size;
-            src       = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_src[psrc],
-                                   peer_sync->mem_info_src.offset);
-            src       = PTR_OFFSET(src, data_displ);
-            peer_sync = TASK_SYNC(task, pdst);
-            ucc_assert(
-                (rdt_size * ucc_coll_args_get_count(args, peer_sync->dst_cnts,
-                                                    psrc)) == data_size);
+            data_size = sdt_size * task->alltoallv_ce.get_count(
+                                       task, peer_sync->src_cnts, pdst);
+            data_displ = sdt_size * task->alltoallv_ce.get_offset(
+                                        task, peer_sync->src_displ, pdst);
+            src        = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_src[psrc],
+                                    peer_sync->mem_info_src.offset);
+            src        = PTR_OFFSET(src, data_displ);
+            peer_sync  = TASK_SYNC(task, pdst);
             dst        = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_dst[pdst],
                                     peer_sync->mem_info_dst.offset);
-            data_displ = ucc_coll_args_get_displacement(
-                             args, peer_sync->dst_displ, psrc) *
-                         rdt_size;
-            dst = PTR_OFFSET(dst, data_displ);
-            CUDA_CHECK_GOTO(cudaMemcpyAsync(dst, src, data_size,
-                                            cudaMemcpyDeviceToDevice,
-                                            team->stream),
-                            exit, status);
+            data_displ = rdt_size * task->alltoallv_ce.get_offset(
+                                        task, peer_sync->dst_displ, psrc);
+            dst                 = PTR_OFFSET(dst, data_displ);
+            exec_args.task_type = UCC_EE_EXECUTOR_TASK_TYPE_COPY;
+            exec_args.bufs[0]   = dst;
+            exec_args.bufs[1]   = src;
+            exec_args.count     = data_size;
+            exec_task =
+                &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
+            status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
+            if (ucc_unlikely(status != UCC_OK)) {
+                goto exit;
+            }
+            task->alltoallv_ce.num_posted++;
         }
     }
     status = ucc_ec_event_post(team->stream, task->alltoallv_ce.copy_done,
@@ -203,6 +221,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task)
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
     ucc_status_t        status;
+    int                 i;
 
     switch (task->alltoallv_ce.stage) {
     case ALLTOALL_CE_STAGE_SYNC:
@@ -222,6 +241,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task)
             task->super.super.status = status;
             return task->super.super.status;
         }
+    case ALLTOALL_CE_STAGE_POST_COPIES:
         status = ucc_tl_cuda_alltoallv_ce_post_copies(task);
         if (ucc_unlikely(status != UCC_OK)) {
             task->super.super.status = status;
@@ -229,11 +249,15 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task)
         }
         task->alltoallv_ce.stage = ALLTOALL_CE_STAGE_COPY;
     case ALLTOALL_CE_STAGE_COPY:
-        status =
-            ucc_ec_event_test(task->alltoallv_ce.copy_done, UCC_EE_CUDA_STREAM);
-        if (status != UCC_OK) {
-            task->super.super.status = status;
-            return task->super.super.status;
+        for (i = 0; i < task->alltoallv_ce.num_posted; i++) {
+            status = ucc_ee_executor_task_test(task->alltoallv_ce.exec_task[i]);
+            if (status != UCC_OK) {
+                if (status == UCC_OPERATION_INITIALIZED) {
+                    status = UCC_INPROGRESS;
+                }
+                task->super.super.status = status;
+                return task->super.super.status;
+            }
         }
         status =
             ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
@@ -259,13 +283,62 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_start(ucc_coll_task_t *coll_task)
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
 
-    task->alltoallv_ce.stage = ALLTOALL_CE_STAGE_SYNC;
+    if (task->alltoallv_ce.stage != ALLTOALL_CE_STAGE_POST_COPIES) {
+        task->alltoallv_ce.stage = ALLTOALL_CE_STAGE_SYNC;
+    }
+
     ucc_tl_cuda_alltoallv_ce_progress(coll_task);
     if (task->super.super.status == UCC_INPROGRESS) {
         ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
         return UCC_OK;
     }
     return ucc_task_complete(coll_task);
+}
+
+ucc_status_t
+ucc_tl_cuda_alltoallv_ce_triggered_post_setup(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+    ucc_status_t        status;
+
+    do {
+        status = ucc_tl_cuda_get_sync(task);
+    } while (status == UCC_INPROGRESS);
+    if (ucc_unlikely(status != UCC_OK)) {
+        return status;
+    }
+
+    status = ucc_tl_cuda_alltoallv_setup_start(task);
+    if (ucc_unlikely(status != UCC_OK)) {
+        ucc_tl_cuda_put_sync(task);
+        return status;
+    }
+
+    do {
+        status = ucc_tl_cuda_alltoallv_setup_test(task);
+    } while (status == UCC_INPROGRESS);
+    if (ucc_unlikely(status != UCC_OK)) {
+        ucc_tl_cuda_put_sync(task);
+        return status;
+    }
+    task->alltoallv_ce.stage = ALLTOALL_CE_STAGE_POST_COPIES;
+
+    return UCC_OK;
+}
+
+//NOLINTNEXTLINE
+size_t ucc_tl_cuda_alltoallv_get_count(const ucc_tl_cuda_task_t *task,
+                                       ucc_count_t *cnts, ucc_rank_t block)
+{
+    const ucc_coll_args_t *args = &TASK_ARGS(task);
+    return ucc_coll_args_get_count(args, cnts, block);
+}
+
+size_t ucc_tl_cuda_alltoallv_get_offset(const ucc_tl_cuda_task_t *task,
+                                        size_t *displ, ucc_rank_t block)
+{
+    const ucc_coll_args_t *args = &TASK_ARGS(task);
+    return ucc_coll_args_get_displacement(args, displ, block);
 }
 
 ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
@@ -275,8 +348,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
     ucc_status_t        status;
     size_t              data_len;
 
-    if (!(args->flags & (UCC_COLL_ARGS_FLAG_CONTIG_SRC_BUFFER |
-                         UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER))) {
+    if (!UCC_COLL_ARGS_CONTIG_BUFFER(args)) {
         tl_error(UCC_TL_TEAM_LIB(team), "Do not support non-contiguous buffer");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -287,10 +359,21 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
         return status;
     }
 
+    task->alltoallv_ce.get_count  = ucc_tl_cuda_alltoallv_get_count;
+    task->alltoallv_ce.get_offset = ucc_tl_cuda_alltoallv_get_offset;
+    task->alltoallv_ce.sdt        = args->src.info_v.datatype;
+    task->alltoallv_ce.rdt        = args->dst.info_v.datatype;
+    task->alltoallv_ce.sbuf       = args->src.info_v.buffer;
+    task->alltoallv_ce.rbuf       = args->dst.info_v.buffer;
+    task->alltoallv_ce.scnts      = args->src.info_v.counts;
+    task->alltoallv_ce.rcnts      = args->dst.info_v.counts;
+    task->alltoallv_ce.sdispl     = args->src.info_v.displacements;
+    task->alltoallv_ce.rdispl     = args->dst.info_v.displacements;
+
     data_len = ucc_dt_size(args->src.info_v.datatype) *
                ucc_coll_args_get_total_count(args, args->src.info_v.counts,
                                              UCC_TL_TEAM_SIZE(team));
-    status = ucc_tl_cuda_mem_info_get(args->src.info_v.buffer, data_len, team,
+    status = ucc_tl_cuda_mem_info_get(args->src.info_v.buffer, data_len,
                                       &task->alltoallv_ce.mem_info_src);
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;
@@ -298,15 +381,16 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
     data_len = ucc_dt_size(args->dst.info_v.datatype) *
                ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
                                              UCC_TL_TEAM_SIZE(team));
-    status = ucc_tl_cuda_mem_info_get(args->dst.info_v.buffer, data_len, team,
+    status = ucc_tl_cuda_mem_info_get(args->dst.info_v.buffer, data_len,
                                       &task->alltoallv_ce.mem_info_dst);
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;
     }
 
-    task->super.post = ucc_tl_cuda_alltoallv_ce_start;
-    task->super.triggered_post =
-        ucc_triggered_post; // FIXME: this may cause hang issue
+    task->super.post           = ucc_tl_cuda_alltoallv_ce_start;
+    task->super.triggered_post = ucc_triggered_post;
+    task->super.triggered_post_setup =
+        ucc_tl_cuda_alltoallv_ce_triggered_post_setup;
     task->super.progress = ucc_tl_cuda_alltoallv_ce_progress;
     task->super.finalize = ucc_tl_cuda_alltoallv_ce_finalize;
     task->bar            = TASK_BAR(task);

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -23,8 +23,8 @@
 
 #define UCC_TL_CUDA_MAX_PEERS 8
 #define UCC_TL_CUDA_SUPPORTED_COLLS                                            \
-    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                         \
-     UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                       \
+    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                        \
+     UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                      \
      UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE_SCATTERV)
 
 #define UCC_TL_CUDA_TEAM_LIB(_team)                                            \
@@ -131,10 +131,10 @@ typedef struct ucc_tl_cuda_sync {
     ucc_tl_cuda_mem_info_t   mem_info_dst;
     cudaEvent_t              ipc_event_local;
     cudaIpcEventHandle_t     ev_handle;
-    ucc_count_t              src_cnts[UCC_TL_CUDA_MAX_PEERS];
-    ucc_count_t              dst_cnts[UCC_TL_CUDA_MAX_PEERS];
-    size_t                   src_displ[UCC_TL_CUDA_MAX_PEERS];
-    size_t                   dst_displ[UCC_TL_CUDA_MAX_PEERS];
+    ucc_count_t             src_cnts[UCC_TL_CUDA_MAX_PEERS];
+    ucc_count_t             dst_cnts[UCC_TL_CUDA_MAX_PEERS];
+    size_t                  src_displ[UCC_TL_CUDA_MAX_PEERS];
+    size_t                  dst_displ[UCC_TL_CUDA_MAX_PEERS];
     ucc_tl_cuda_sync_data_t  data[1];
 } ucc_tl_cuda_sync_t;
 
@@ -175,9 +175,23 @@ struct ucc_tl_cuda_task {
             void                   *peer_map_addr_src[UCC_TL_CUDA_MAX_PEERS];
             void                   *peer_map_addr_dst[UCC_TL_CUDA_MAX_PEERS];
             int                     num_posted;
+            ucc_datatype_t          sdt;
+            ucc_datatype_t          rdt;
+            void                   *sbuf;
+            void                   *rbuf;
+            ucc_count_t            *scnts;
+            ucc_count_t            *rcnts;
+            size_t                 *sdispl;
+            size_t                 *rdispl;
             ucc_ee_executor_task_t *exec_task[UCC_TL_CUDA_MAX_PEERS * UCC_TL_CUDA_MAX_PEERS];
             void                   *copy_done;
-        } alltoall_ce;
+            size_t                 (*get_count)(const ucc_tl_cuda_task_t *task,
+                                                ucc_count_t *cnts,
+                                                ucc_rank_t block);
+            size_t                 (*get_offset)(const ucc_tl_cuda_task_t *task,
+                                                 size_t *displ,
+                                                 ucc_rank_t block);
+        } alltoallv_ce;
         struct {
             int                      stage;
             int                      num_frags;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -1,10 +1,6 @@
 /**
-<<<<<<< HEAD
  * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
-=======
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
->>>>>>> d34656b (TL/CUDA: alltoallv)
  *
  * See file LICENSE for terms.
  */
@@ -30,8 +26,6 @@
     (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                         \
      UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                       \
      UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE_SCATTERV)
-
->>>>>>> d34656b (TL/CUDA: alltoallv)
 
 #define UCC_TL_CUDA_TEAM_LIB(_team)                                            \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_cuda_lib_t))

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -189,7 +189,6 @@ struct ucc_tl_cuda_task {
             ucc_aint_t            *rdispl;
             ucc_ee_executor_task_t
                  *exec_task[UCC_TL_CUDA_MAX_PEERS * UCC_TL_CUDA_MAX_PEERS];
-            void *copy_done;
             size_t (*get_size)(const ucc_tl_cuda_task_t *task, size_t *bytes,
                                ucc_rank_t block);
             size_t (*get_offset)(const ucc_tl_cuda_task_t *task,

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -1,5 +1,10 @@
 /**
+<<<<<<< HEAD
  * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
+=======
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+>>>>>>> d34656b (TL/CUDA: alltoallv)
  *
  * See file LICENSE for terms.
  */
@@ -22,9 +27,13 @@
 
 #define UCC_TL_CUDA_MAX_PEERS 8
 #define UCC_TL_CUDA_SUPPORTED_COLLS                                            \
+<<<<<<< HEAD
     (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLGATHER |                        \
      UCC_COLL_TYPE_ALLGATHERV | UCC_COLL_TYPE_REDUCE_SCATTER |                 \
      UCC_COLL_TYPE_REDUCE_SCATTERV)
+=======
+    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV)
+>>>>>>> d34656b (TL/CUDA: alltoallv)
 
 #define UCC_TL_CUDA_TEAM_LIB(_team)                                            \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_cuda_lib_t))
@@ -32,22 +41,22 @@
 #define UCC_TL_CUDA_TEAM_CTX(_team)                                            \
     (ucc_derived_of((_team)->super.super.context, ucc_tl_cuda_context_t))
 
-#define UCC_TL_CUDA_TEAM_SYNC(_team, _rank, _id)                               \
-    ({                                                                         \
-        size_t _ctrl_size_rank = (sizeof(ucc_tl_cuda_sync_t)  +                \
-                                  sizeof(ucc_tl_cuda_sync_data_t) *            \
-                                  (UCC_TL_TEAM_SIZE(_team) - 1)) ;             \
-        size_t _ctrl_size = _ctrl_size_rank * UCC_TL_TEAM_SIZE(_team);         \
-        void *_sync = PTR_OFFSET(_team->sync, _ctrl_size * (_id) +             \
-                                 _ctrl_size_rank * (_rank));                   \
-        (ucc_tl_cuda_sync_t*)_sync;                                            \
+#define UCC_TL_CUDA_TEAM_SYNC(_team, _rank, _id)                                    \
+    ({                                                                              \
+        size_t _ctrl_size_rank =                                                    \
+            (sizeof(ucc_tl_cuda_sync_t) +                                           \
+             sizeof(ucc_tl_cuda_sync_data_t) * (UCC_TL_TEAM_SIZE(_team) - 1));      \
+        size_t _ctrl_size = _ctrl_size_rank * UCC_TL_TEAM_SIZE(_team);              \
+        void * _sync      = PTR_OFFSET(_team->sync, _ctrl_size * (_id) +            \
+                                                  _ctrl_size_rank * (_rank)); \
+        (ucc_tl_cuda_sync_t *)_sync;                                                \
     })
 
 #define UCC_TL_CUDA_TEAM_BARRIER(_team, _id)                                   \
     ({                                                                         \
         size_t _bar_size = sizeof(ucc_tl_cuda_shm_barrier_t);                  \
-        void *_bar = PTR_OFFSET(_team->bar, _bar_size * (_id));                \
-        (ucc_tl_cuda_shm_barrier_t*)_bar;                                      \
+        void * _bar      = PTR_OFFSET(_team->bar, _bar_size * (_id));          \
+        (ucc_tl_cuda_shm_barrier_t *)_bar;                                     \
     })
 
 #ifdef HAVE_PROFILING_TL_CUDA
@@ -56,10 +65,10 @@
 #include "utils/profile/ucc_profile_off.h"
 #endif
 
-#define UCC_TL_CUDA_PROFILE_FUNC UCC_PROFILE_FUNC
-#define UCC_TL_CUDA_PROFILE_REQUEST_NEW UCC_PROFILE_REQUEST_NEW
+#define UCC_TL_CUDA_PROFILE_FUNC          UCC_PROFILE_FUNC
+#define UCC_TL_CUDA_PROFILE_REQUEST_NEW   UCC_PROFILE_REQUEST_NEW
 #define UCC_TL_CUDA_PROFILE_REQUEST_EVENT UCC_PROFILE_REQUEST_EVENT
-#define UCC_TL_CUDA_PROFILE_REQUEST_FREE UCC_PROFILE_REQUEST_FREE
+#define UCC_TL_CUDA_PROFILE_REQUEST_FREE  UCC_PROFILE_REQUEST_FREE
 
 typedef struct ucc_tl_cuda_iface {
     ucc_tl_iface_t super;
@@ -85,13 +94,13 @@ UCC_CLASS_DECLARE(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);
 
 typedef struct ucc_tl_cuda_context {
-    ucc_tl_context_t              super;
-    ucc_tl_cuda_context_config_t  cfg;
-    int                           device;
-    ucc_tl_cuda_device_pci_id_t   device_id;
-    ucc_tl_cuda_topo_t           *topo;
-    ucc_mpool_t                   req_mp;
-    tl_cuda_ep_hash_t            *ipc_cache;
+    ucc_tl_context_t             super;
+    ucc_tl_cuda_context_config_t cfg;
+    int                          device;
+    ucc_tl_cuda_device_pci_id_t  device_id;
+    ucc_tl_cuda_topo_t *         topo;
+    ucc_mpool_t                  req_mp;
+    tl_cuda_ep_hash_t *          ipc_cache;
 } ucc_tl_cuda_context_t;
 UCC_CLASS_DECLARE(ucc_tl_cuda_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
@@ -111,10 +120,10 @@ typedef struct ucc_tl_cuda_sync_data {
 } ucc_tl_cuda_sync_data_t;
 
 typedef struct ucc_tl_cuda_mem_info {
-    void               *ptr;
-    size_t              length;
-    size_t              offset;
-    cudaIpcMemHandle_t  handle;
+    void *             ptr;
+    size_t             length;
+    size_t             offset;
+    cudaIpcMemHandle_t handle;
 } ucc_tl_cuda_mem_info_t;
 
 typedef struct ucc_tl_cuda_rank_id {
@@ -130,6 +139,10 @@ typedef struct ucc_tl_cuda_sync {
     ucc_tl_cuda_mem_info_t   mem_info_dst;
     cudaEvent_t              ipc_event_local;
     cudaIpcEventHandle_t     ev_handle;
+    ucc_count_t              src_cnts[UCC_TL_CUDA_MAX_PEERS];
+    ucc_count_t              dst_cnts[UCC_TL_CUDA_MAX_PEERS];
+    size_t                   src_displ[UCC_TL_CUDA_MAX_PEERS];
+    size_t                   dst_displ[UCC_TL_CUDA_MAX_PEERS];
     ucc_tl_cuda_sync_data_t  data[1];
 } ucc_tl_cuda_sync_t;
 
@@ -142,15 +155,15 @@ typedef struct ucc_tl_cuda_scratch {
 typedef struct ucc_tl_cuda_team {
     ucc_tl_team_t              super;
     uint32_t                   seq_num;
-    ucc_tl_cuda_team_topo_t   *topo;
-    ucc_tl_cuda_sync_t        *sync;
-    ucc_tl_cuda_sync_state_t  *sync_state;
+    ucc_tl_cuda_team_topo_t *  topo;
+    ucc_tl_cuda_sync_t *       sync;
+    ucc_tl_cuda_sync_state_t * sync_state;
     ucc_tl_cuda_shm_barrier_t *bar;
     ucc_tl_cuda_scratch_t      scratch;
     cudaStream_t               stream;
-    ucc_tl_cuda_rank_id_t     *ids;
+    ucc_tl_cuda_rank_id_t *    ids;
     ucc_team_oob_coll_t        oob;
-    void                      *oob_req;
+    void *                     oob_req;
 } ucc_tl_cuda_team_t;
 
 UCC_CLASS_DECLARE(ucc_tl_cuda_team_t, ucc_base_context_t *,

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -27,12 +27,10 @@
 
 #define UCC_TL_CUDA_MAX_PEERS 8
 #define UCC_TL_CUDA_SUPPORTED_COLLS                                            \
-<<<<<<< HEAD
-    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLGATHER |                        \
-     UCC_COLL_TYPE_ALLGATHERV | UCC_COLL_TYPE_REDUCE_SCATTER |                 \
-     UCC_COLL_TYPE_REDUCE_SCATTERV)
-=======
-    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV)
+    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                         \
+     UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                       \
+     UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE_SCATTERV)
+
 >>>>>>> d34656b (TL/CUDA: alltoallv)
 
 #define UCC_TL_CUDA_TEAM_LIB(_team)                                            \
@@ -47,15 +45,15 @@
             (sizeof(ucc_tl_cuda_sync_t) +                                           \
              sizeof(ucc_tl_cuda_sync_data_t) * (UCC_TL_TEAM_SIZE(_team) - 1));      \
         size_t _ctrl_size = _ctrl_size_rank * UCC_TL_TEAM_SIZE(_team);              \
-        void * _sync      = PTR_OFFSET(_team->sync, _ctrl_size * (_id) +            \
-                                                  _ctrl_size_rank * (_rank)); \
+        void  *_sync      = PTR_OFFSET(_team->sync, _ctrl_size * (_id) +            \
+                                                        _ctrl_size_rank * (_rank)); \
         (ucc_tl_cuda_sync_t *)_sync;                                                \
     })
 
 #define UCC_TL_CUDA_TEAM_BARRIER(_team, _id)                                   \
     ({                                                                         \
         size_t _bar_size = sizeof(ucc_tl_cuda_shm_barrier_t);                  \
-        void * _bar      = PTR_OFFSET(_team->bar, _bar_size * (_id));          \
+        void  *_bar      = PTR_OFFSET(_team->bar, _bar_size * (_id));          \
         (ucc_tl_cuda_shm_barrier_t *)_bar;                                     \
     })
 
@@ -98,9 +96,9 @@ typedef struct ucc_tl_cuda_context {
     ucc_tl_cuda_context_config_t cfg;
     int                          device;
     ucc_tl_cuda_device_pci_id_t  device_id;
-    ucc_tl_cuda_topo_t *         topo;
+    ucc_tl_cuda_topo_t          *topo;
     ucc_mpool_t                  req_mp;
-    tl_cuda_ep_hash_t *          ipc_cache;
+    tl_cuda_ep_hash_t           *ipc_cache;
 } ucc_tl_cuda_context_t;
 UCC_CLASS_DECLARE(ucc_tl_cuda_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);
@@ -120,7 +118,7 @@ typedef struct ucc_tl_cuda_sync_data {
 } ucc_tl_cuda_sync_data_t;
 
 typedef struct ucc_tl_cuda_mem_info {
-    void *             ptr;
+    void              *ptr;
     size_t             length;
     size_t             offset;
     cudaIpcMemHandle_t handle;
@@ -155,15 +153,15 @@ typedef struct ucc_tl_cuda_scratch {
 typedef struct ucc_tl_cuda_team {
     ucc_tl_team_t              super;
     uint32_t                   seq_num;
-    ucc_tl_cuda_team_topo_t *  topo;
-    ucc_tl_cuda_sync_t *       sync;
-    ucc_tl_cuda_sync_state_t * sync_state;
+    ucc_tl_cuda_team_topo_t   *topo;
+    ucc_tl_cuda_sync_t        *sync;
+    ucc_tl_cuda_sync_state_t  *sync_state;
     ucc_tl_cuda_shm_barrier_t *bar;
     ucc_tl_cuda_scratch_t      scratch;
     cudaStream_t               stream;
-    ucc_tl_cuda_rank_id_t *    ids;
+    ucc_tl_cuda_rank_id_t     *ids;
     ucc_team_oob_coll_t        oob;
-    void *                     oob_req;
+    void                      *oob_req;
 } ucc_tl_cuda_team_t;
 
 UCC_CLASS_DECLARE(ucc_tl_cuda_team_t, ucc_base_context_t *,

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -35,8 +35,8 @@ exit:
 }
 
 ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
-                                   ucc_base_team_t *     team,
-                                   ucc_coll_task_t **    task_h)
+                                   ucc_base_team_t      *team,
+                                   ucc_coll_task_t     **task_h)
 {
     switch (coll_args->args.coll_type) {
     case UCC_COLL_TYPE_ALLTOALL:

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -6,6 +6,7 @@
 
 #include "tl_cuda_coll.h"
 #include "alltoall/alltoall.h"
+#include "alltoallv/alltoallv.h"
 #include "allgather/allgather.h"
 #include "allgatherv/allgatherv.h"
 #include "reduce_scatter/reduce_scatter.h"

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -19,10 +19,10 @@ ucc_status_t ucc_tl_cuda_mem_info_get(void *ptr, size_t length,
     ucc_mem_attr_t mem_attr;
     ucc_status_t   status;
 
-    mem_attr.field_mask   = UCC_MEM_ATTR_FIELD_BASE_ADDRESS |
-                            UCC_MEM_ATTR_FIELD_ALLOC_LENGTH;
+    mem_attr.field_mask =
+        UCC_MEM_ATTR_FIELD_BASE_ADDRESS | UCC_MEM_ATTR_FIELD_ALLOC_LENGTH;
     mem_attr.alloc_length = length;
-    status = ucc_mc_get_mem_attr(ptr, &mem_attr);
+    status                = ucc_mc_get_mem_attr(ptr, &mem_attr);
     if (ucc_unlikely(status != UCC_OK)) {
         return status;
     }
@@ -35,8 +35,8 @@ exit:
 }
 
 ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
-                                   ucc_base_team_t *team,
-                                   ucc_coll_task_t **task_h)
+                                   ucc_base_team_t *     team,
+                                   ucc_coll_task_t **    task_h)
 {
     switch (coll_args->args.coll_type) {
     case UCC_COLL_TYPE_ALLTOALL:
@@ -49,6 +49,8 @@ ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
         return ucc_tl_cuda_reduce_scatter_init(coll_args, team, task_h);
     case UCC_COLL_TYPE_REDUCE_SCATTERV:
         return ucc_tl_cuda_reduce_scatterv_init(coll_args, team, task_h);
+    case UCC_COLL_TYPE_ALLTOALLV:
+        return ucc_tl_cuda_alltoallv_init(coll_args, team, task_h);
     default:
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -58,7 +60,7 @@ ucc_status_t ucc_tl_cuda_shm_barrier_init(ucc_rank_t size, ucc_rank_t rank,
                                           ucc_tl_cuda_shm_barrier_t *barrier)
 {
     if (rank == 0) {
-        barrier->size = size;
+        barrier->size  = size;
         barrier->count = 0;
         barrier->sense = 0;
     }
@@ -67,7 +69,7 @@ ucc_status_t ucc_tl_cuda_shm_barrier_init(ucc_rank_t size, ucc_rank_t rank,
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_cuda_shm_barrier_start(ucc_rank_t rank,
+ucc_status_t ucc_tl_cuda_shm_barrier_start(ucc_rank_t                 rank,
                                            ucc_tl_cuda_shm_barrier_t *barrier)
 {
     ucc_rank_t pos = ucc_atomic_fadd32(&barrier->count, 1);
@@ -81,7 +83,7 @@ ucc_status_t ucc_tl_cuda_shm_barrier_start(ucc_rank_t rank,
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_cuda_shm_barrier_test(ucc_rank_t rank,
+ucc_status_t ucc_tl_cuda_shm_barrier_test(ucc_rank_t                 rank,
                                           ucc_tl_cuda_shm_barrier_t *barrier)
 {
     if (barrier->sense != barrier->local_sense[rank]) {

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -53,6 +53,17 @@
     (((_args)->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&                            \
      ((_args)->flags & UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT))
 
+#define UCC_COLL_IS_SRC_CONTIG(_args)                                          \
+    (((_args)->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&                            \
+     ((_args)->flags & UCC_COLL_ARGS_FLAG_CONTIG_SRC_BUFFER))
+
+#define UCC_COLL_IS_DST_CONTIG(_args)                                          \
+    (((_args)->mask & UCC_COLL_ARGS_FIELD_FLAGS) &&                            \
+     ((_args)->flags & UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER))
+
+#define UCC_COLL_ARGS_CONTIG_BUFFER(_args)                                     \
+    (UCC_COLL_IS_SRC_CONTIG(_args) && UCC_COLL_IS_DST_CONTIG(_args))
+
 static inline size_t
 ucc_coll_args_get_count(const ucc_coll_args_t *args, const ucc_count_t *counts,
                         ucc_rank_t idx)


### PR DESCRIPTION
## What
Implement TL CUDA alltoallv

## Why ?
Missing feature

## How ?
This PR is based on existing the TL CUDA Alltoall implementation and has the following differences to support Alltoallv.
- use info_v to get correct buffer ptr, counts, displacements, etc...
- extend shared memory region to store additional info for Alltoallv, e.g., counts, displacements, for proxies to access if applicable
