### PR TITLE
CORE: add ucc task internal status

### DIFF
--- a/src/components/tl/cuda/allgatherv/allgatherv.h
+++ b/src/components/tl/cuda/allgatherv/allgatherv.h
@@ -15,7 +15,7 @@ ucc_status_t ucc_tl_cuda_allgatherv_ring_init(ucc_tl_cuda_task_t *task);
 
 ucc_status_t ucc_tl_cuda_allgatherv_ring_start(ucc_coll_task_t *task);
 
-ucc_status_t ucc_tl_cuda_allgatherv_ring_progress(ucc_coll_task_t *task);
+void ucc_tl_cuda_allgatherv_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_cuda_allgatherv_ring_finalize(ucc_coll_task_t *task);
 

--- a/src/components/tl/cuda/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv_ring.c
@@ -167,7 +167,7 @@ ucc_status_t ucc_tl_cuda_allgatherv_ring_progress_ring(ucc_tl_cuda_task_t * task
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_cuda_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_cuda_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task    = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team    = TASK_TEAM(task);
@@ -176,33 +176,33 @@ ucc_status_t ucc_tl_cuda_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
     switch (task->allgatherv_ring.stage) {
     case RING_STAGE_SYNC:
         if (ucc_tl_cuda_get_sync(task) != UCC_OK) {
-            task->super.super.status = UCC_INPROGRESS;
-            return task->super.super.status;
+            task->super.status = UCC_INPROGRESS;
+            return;
         }
         st = ucc_tl_cuda_allgatherv_ring_setup_start(task);
         if (st != UCC_OK) {
-            task->super.super.status = st;
-            return task->super.super.status;
+            task->super.status = st;
+            return;
         }
         task->allgatherv_ring.stage = RING_STAGE_SETUP;
     case RING_STAGE_SETUP:
         st = ucc_tl_cuda_allgatherv_ring_setup_test(task);
         if (st != UCC_OK) {
-            task->super.super.status = st;
-            return task->super.super.status;
+            task->super.status = st;
+            return;
         }
         task->allgatherv_ring.stage = RING_STAGE_RING;
     case RING_STAGE_RING:
         /* TODO: add support for multiple rings, only ring 0 is used so far */
         st = ucc_tl_cuda_allgatherv_ring_progress_ring(task, 0);
         if (st != UCC_OK) {
-            return task->super.super.status;
+            return;
         }
 
         st = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
         if (ucc_unlikely(st != UCC_OK)) {
-            task->super.super.status = st;
-            return task->super.super.status;
+            task->super.status = st;
+            return;
         }
 
         task->allgatherv_ring.stage = RING_STAGE_BARRIER;
@@ -211,12 +211,11 @@ ucc_status_t ucc_tl_cuda_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
         break;
     }
 
-    task->super.super.status = ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team),
-                                                            task->bar);
-    if (task->super.super.status == UCC_OK) {
+    task->super.status = ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team),
+                                                      task->bar);
+    if (task->super.status == UCC_OK) {
         ucc_tl_cuda_put_sync(task);
     }
-    return task->super.super.status;
 }
 
 ucc_status_t ucc_tl_cuda_allgatherv_ring_start(ucc_coll_task_t *coll_task)
@@ -255,12 +254,7 @@ ucc_status_t ucc_tl_cuda_allgatherv_ring_start(ucc_coll_task_t *coll_task)
     }
 
     task->allgatherv_ring.stage = RING_STAGE_SYNC;
-    st = ucc_tl_cuda_allgatherv_ring_progress(coll_task);
-    if (task->super.super.status == UCC_INPROGRESS) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
 size_t ucc_tl_cuda_allgatherv_get_count(const ucc_tl_cuda_task_t *task,

--- a/src/components/tl/cuda/reduce_scatterv/reduce_scatterv.h
+++ b/src/components/tl/cuda/reduce_scatterv/reduce_scatterv.h
@@ -14,7 +14,7 @@ ucc_status_t ucc_tl_cuda_reduce_scatterv_ring_init(ucc_tl_cuda_task_t *task);
 
 ucc_status_t ucc_tl_cuda_reduce_scatterv_ring_start(ucc_coll_task_t *task);
 
-ucc_status_t ucc_tl_cuda_reduce_scatterv_ring_progress(ucc_coll_task_t *task);
+void ucc_tl_cuda_reduce_scatterv_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_cuda_reduce_scatterv_ring_finalize(ucc_coll_task_t *task);
 

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -43,7 +43,7 @@
 
 static inline void ucc_tl_cuda_task_reset(ucc_tl_cuda_task_t *task)
 {
-    task->super.super.status = UCC_INPROGRESS;
+    task->super.status = UCC_INPROGRESS;
 }
 
 static inline ucc_tl_cuda_task_t *ucc_tl_cuda_task_get(ucc_tl_cuda_team_t *team)
@@ -52,9 +52,9 @@ static inline ucc_tl_cuda_task_t *ucc_tl_cuda_task_get(ucc_tl_cuda_team_t *team)
     ucc_tl_cuda_task_t    *task = ucc_mpool_get(&ctx->req_mp);
 
     UCC_TL_CUDA_PROFILE_REQUEST_NEW(task, "tl_cuda_task", 0);
-    task->super.super.status = UCC_OPERATION_INITIALIZED;
-    task->super.flags        = 0;
-    task->super.team         = &team->super.super;
+    task->super.status = UCC_OPERATION_INITIALIZED;
+    task->super.flags  = 0;
+    task->super.team   = &team->super.super;
     ucc_tl_cuda_task_reset(task);
     return task;
 }

--- a/src/components/tl/nccl/allgatherv/allgatherv.c
+++ b/src/components/tl/nccl/allgatherv/allgatherv.c
@@ -63,9 +63,9 @@ ucc_status_t ucc_tl_nccl_allgatherv_p2p_start(ucc_coll_task_t *coll_task)
     size_t sdt_size, rdt_size, count, displ;
     ucc_rank_t peer;
 
-    task->super.super.status = UCC_INPROGRESS;
-    sdt_size                 = ucc_dt_size(args->src.info.datatype);
-    rdt_size                 = ucc_dt_size(args->dst.info_v.datatype);
+    task->super.status = UCC_INPROGRESS;
+    sdt_size           = ucc_dt_size(args->src.info.datatype);
+    rdt_size           = ucc_dt_size(args->dst.info_v.datatype);
     UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_allgatherv_start", 0);
     NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
     count = args->src.info.count;
@@ -130,7 +130,7 @@ ucc_status_t ucc_tl_nccl_allgatherv_bcopy_start(ucc_coll_task_t *coll_task)
     size_t              max_count, rdt_size, sdt_size, displ, scount, rcount;
     ucc_rank_t          peer;
 
-    task->super.super.status = UCC_INPROGRESS;
+    task->super.status = UCC_INPROGRESS;
     UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_allgatherv_start", 0);
     max_count = task->allgatherv_bcopy.max_count;
     scount    = args->src.info.count;
@@ -237,8 +237,8 @@ ucc_status_t ucc_tl_nccl_allgatherv_bcast_start(ucc_coll_task_t *coll_task)
     size_t rdt_size, count, displ;
     ucc_rank_t peer;
 
-    task->super.super.status = UCC_INPROGRESS;
-    rdt_size                 = ucc_dt_size(args->dst.info_v.datatype);
+    task->super.status = UCC_INPROGRESS;
+    rdt_size           = ucc_dt_size(args->dst.info_v.datatype);
     UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_allgatherv_start", 0);
     NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
     for (peer = 0; peer < size; peer++) {

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -11,33 +11,31 @@
 #include "core/ucc_ee.h"
 #include "utils/arch/cpu.h"
 
-ucc_status_t ucc_tl_nccl_event_collective_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_nccl_event_collective_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
     ucc_status_t status;
 
     ucc_assert(task->completed != NULL);
     status = ucc_ec_event_test(task->completed, UCC_EE_CUDA_STREAM);
-    coll_task->super.status = status;
+    coll_task->status = status;
 #ifdef HAVE_PROFILING_TL_NCCL
-    if (coll_task->super.status == UCC_OK) {
+    if (coll_task->status == UCC_OK) {
         UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_coll_done", 0);
     }
 #endif
-    return coll_task->super.status;
 }
 
-ucc_status_t ucc_tl_nccl_driver_collective_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_nccl_driver_collective_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_nccl_task_t *task = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
 
-    coll_task->super.status = task->host_status;
+    coll_task->status = task->host_status;
 #ifdef HAVE_PROFILING_TL_NCCL
-    if (coll_task->super.status == UCC_OK) {
+    if (coll_task->status == UCC_OK) {
         UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_coll_done", 0);
     }
 #endif
-    return coll_task->super.status;
 }
 
 static void ucc_tl_nccl_req_mpool_obj_init(ucc_mpool_t *mp, void *obj,
@@ -83,7 +81,7 @@ static void ucc_tl_nccl_req_mapped_mpool_obj_init(ucc_mpool_t *mp, void *obj,
     st = cudaHostGetDevicePointer((void **)(&req->dev_status),
                                   (void *)&req->host_status, 0);
     if (st != cudaSuccess) {
-        req->super.super.status = UCC_ERR_NO_MESSAGE;
+        req->super.status = UCC_ERR_NO_MESSAGE;
     }
     req->super.progress = ucc_tl_nccl_driver_collective_progress;
 }

--- a/src/components/tl/sharp/tl_sharp_coll.c
+++ b/src/components/tl/sharp/tl_sharp_coll.c
@@ -115,7 +115,7 @@ ucc_tl_sharp_mem_deregister(ucc_tl_sharp_context_t *ctx,
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_sharp_collective_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_sharp_collective_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_sharp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_sharp_task_t);
     int completed;
@@ -125,18 +125,18 @@ ucc_status_t ucc_tl_sharp_collective_progress(ucc_coll_task_t *coll_task)
         if (completed) {
             if (TASK_ARGS(task).coll_type == UCC_COLL_TYPE_ALLREDUCE) {
                 if (!UCC_IS_INPLACE(TASK_ARGS(task))) {
-                    ucc_tl_sharp_mem_deregister(TASK_CTX(task), task->allreduce.s_mem_h);
+                    ucc_tl_sharp_mem_deregister(TASK_CTX(task),
+                                                task->allreduce.s_mem_h);
                 }
-                ucc_tl_sharp_mem_deregister(TASK_CTX(task), task->allreduce.r_mem_h);
+                ucc_tl_sharp_mem_deregister(TASK_CTX(task),
+                                            task->allreduce.r_mem_h);
             }
             sharp_coll_req_free(task->req_handle);
-            coll_task->super.status = UCC_OK;
+            coll_task->status = UCC_OK;
             UCC_TL_SHARP_PROFILE_REQUEST_EVENT(coll_task,
                                                "sharp_collective_done", 0);
         }
     }
-
-    return coll_task->super.status;
 }
 
 ucc_status_t ucc_tl_sharp_barrier_start(ucc_coll_task_t *coll_task)
@@ -145,23 +145,17 @@ ucc_status_t ucc_tl_sharp_barrier_start(ucc_coll_task_t *coll_task)
     ucc_tl_sharp_team_t *team  = TASK_TEAM(task);
     int                  ret;
 
-    task->super.super.status = UCC_INPROGRESS;
     UCC_TL_SHARP_PROFILE_REQUEST_EVENT(coll_task, "sharp_barrier_start", 0);
 
     ret = sharp_coll_do_barrier_nb(team->sharp_comm, &task->req_handle);
     if (ret != SHARP_COLL_SUCCESS) {
         tl_error(UCC_TASK_LIB(task), "sharp_coll_do_barrier_nb failed:%s",
                  sharp_coll_strerror(ret));
-        coll_task->super.status = UCC_ERR_NO_RESOURCE;
+        coll_task->status = UCC_ERR_NO_RESOURCE;
         return ucc_task_complete(coll_task);
     }
 
-    if (UCC_INPROGRESS == ucc_tl_sharp_collective_progress(coll_task)) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
 ucc_status_t ucc_tl_sharp_allreduce_start(ucc_coll_task_t *coll_task)
@@ -177,7 +171,6 @@ ucc_status_t ucc_tl_sharp_allreduce_start(ucc_coll_task_t *coll_task)
     size_t                        data_size;
     int                           ret;
 
-    task->super.super.status = UCC_INPROGRESS;
     UCC_TL_SHARP_PROFILE_REQUEST_EVENT(coll_task, "sharp_allreduce_start", 0);
 
     sharp_type = ucc_to_sharp_dtype[UCC_DT_PREDEFINED_ID(dt)];
@@ -217,16 +210,11 @@ ucc_status_t ucc_tl_sharp_allreduce_start(ucc_coll_task_t *coll_task)
     if (ret != SHARP_COLL_SUCCESS) {
         tl_error(UCC_TASK_LIB(task), "sharp_coll_do_allreduce_nb failed:%s",
                  sharp_coll_strerror(ret));
-        coll_task->super.status = UCC_ERR_NO_RESOURCE;
+        coll_task->status = UCC_ERR_NO_RESOURCE;
         return ucc_task_complete(coll_task);
     }
 
-    if (UCC_INPROGRESS == ucc_tl_sharp_collective_progress(coll_task)) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
 ucc_status_t ucc_tl_sharp_allreduce_init(ucc_tl_sharp_task_t *task)

--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -7,9 +7,6 @@
 #include "tl_ucp.h"
 #include "allgather.h"
 
-ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
-
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
 {
     if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info.datatype)) ||

--- a/src/components/tl/ucp/allgather/allgather.h
+++ b/src/components/tl/ucp/allgather/allgather.h
@@ -9,7 +9,9 @@
 #include "../tl_ucp_coll.h"
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task);
-ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
+
+void  ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
+
 ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *task);
 
 /* Uses allgather_kn_radix from config */

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -13,7 +13,7 @@
 #include "utils/ucc_coll_utils.h"
 #include "components/mc/ucc_mc.h"
 
-ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team       = TASK_TEAM(task);
@@ -30,7 +30,7 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
     void              *buf;
 
     if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
-        return task->super.super.status;
+        return;
     }
     sendto   = ucc_ep_map_eval(task->subset.map, sendto);
     recvfrom = ucc_ep_map_eval(task->subset.map, recvfrom);
@@ -50,14 +50,14 @@ ucc_status_t ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
             ucc_tl_ucp_recv_nb(buf, data_size, rmem, recvfrom, team, task),
             task, out);
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
-            return task->super.super.status;
+            return;
         }
     }
     ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
-    task->super.super.status = UCC_OK;
+    task->super.status = UCC_OK;
 out:
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_ring_done", 0);
-    return task->super.super.status;
+    return;
 }
 
 ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
@@ -75,7 +75,7 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_ring_start", 0);
-    ucc_tl_ucp_task_reset(task);
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
 
     if (!UCC_IS_INPLACE(TASK_ARGS(task))) {
         status =
@@ -86,10 +86,5 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
         }
     }
 
-    status = ucc_tl_ucp_allgather_ring_progress(&task->super);
-    if (UCC_INPROGRESS == status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }

--- a/src/components/tl/ucp/allgatherv/allgatherv.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv.c
@@ -10,7 +10,8 @@
 #include "utils/ucc_coll_utils.h"
 
 ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
+
+void ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task)
 {

--- a/src/components/tl/ucp/allreduce/allreduce.h
+++ b/src/components/tl/ucp/allreduce/allreduce.h
@@ -38,16 +38,23 @@ ucc_status_t ucc_tl_ucp_allreduce_init(ucc_tl_ucp_task_t *task);
 ucc_status_t ucc_tl_ucp_allreduce_knomial_init(ucc_base_coll_args_t *coll_args,
                                                ucc_base_team_t *     team,
                                                ucc_coll_task_t **    task_h);
+
 ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task);
+
 ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_allreduce_knomial_progress(ucc_coll_task_t *task);
+
+void ucc_tl_ucp_allreduce_knomial_progress(ucc_coll_task_t *task);
+
 ucc_status_t ucc_tl_ucp_allreduce_knomial_finalize(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
                                                    ucc_base_team_t *     team,
                                                    ucc_coll_task_t **    task_h);
+
 ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_start(ucc_coll_task_t *task);
+
 ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_progress(ucc_coll_task_t *task);
+
 static inline int ucc_tl_ucp_allreduce_alg_from_str(const char *str)
 {
     int i;

--- a/src/components/tl/ucp/alltoall/alltoall.c
+++ b/src/components/tl/ucp/alltoall/alltoall.c
@@ -9,10 +9,10 @@
 #include "alltoall.h"
 
 ucc_status_t ucc_tl_ucp_alltoall_pairwise_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *task);
+void ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_alltoall_onesided_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_alltoall_onesided_progress(ucc_coll_task_t *task);
+void ucc_tl_ucp_alltoall_onesided_progress(ucc_coll_task_t *task);
 
 ucc_base_coll_alg_info_t
     ucc_tl_ucp_alltoall_algs[UCC_TL_UCP_ALLTOALL_ALG_LAST + 1] = {
@@ -84,4 +84,3 @@ ucc_status_t ucc_tl_ucp_alltoall_onesided_init(ucc_base_coll_args_t *coll_args,
 out:
     return status;
 }
-

--- a/src/components/tl/ucp/alltoall/alltoall_pairwise.c
+++ b/src/components/tl/ucp/alltoall/alltoall_pairwise.c
@@ -23,7 +23,7 @@ static inline ucc_rank_t get_send_peer(ucc_rank_t rank, ucc_rank_t size,
     return (rank - step + size) % size;
 }
 
-ucc_status_t ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
@@ -33,8 +33,8 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *coll_task)
     ucc_memory_type_t  rmem  = TASK_ARGS(task).dst.info.mem_type;
     ucc_rank_t         grank = UCC_TL_TEAM_RANK(team);
     ucc_rank_t         gsize = UCC_TL_TEAM_SIZE(team);
-    ucc_rank_t         peer;
     int                polls = 0;
+    ucc_rank_t         peer;
     int                posts, nreqs;
     size_t             data_size;
 
@@ -67,16 +67,16 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_progress(ucc_coll_task_t *coll_task)
     }
     if ((task->tagged.send_posted < gsize) ||
         (task->tagged.recv_posted < gsize)) {
-        return task->super.super.status;
+        return;
     }
 
-    task->super.super.status = ucc_tl_ucp_test(task);
+    task->super.status = ucc_tl_ucp_test(task);
 out:
-    if (task->super.super.status != UCC_INPROGRESS) {
+    if (task->super.status != UCC_INPROGRESS) {
         UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task,
                                          "ucp_alltoall_pairwise_done", 0);
     }
-    return task->super.super.status;
+    return;
 }
 
 ucc_status_t ucc_tl_ucp_alltoall_pairwise_start(ucc_coll_task_t *coll_task)
@@ -85,14 +85,9 @@ ucc_status_t ucc_tl_ucp_alltoall_pairwise_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_alltoall_pairwise_start", 0);
-    ucc_tl_ucp_task_reset(task);
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
 
-    ucc_tl_ucp_alltoall_pairwise_progress(&task->super);
-    if (UCC_INPROGRESS == task->super.super.status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
 ucc_status_t ucc_tl_ucp_alltoall_pairwise_init_common(ucc_tl_ucp_task_t *task)

--- a/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
@@ -24,7 +24,7 @@ static inline ucc_rank_t get_send_peer(ucc_rank_t rank, ucc_rank_t size,
     return (rank - step + size) % size;
 }
 
-ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
@@ -36,7 +36,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
     ucc_rank_t         gsize = UCC_TL_TEAM_SIZE(team);
     int                polls = 0;
     ucc_rank_t         peer;
-    int                posts, nreqs;//, count_stride, displ_stride;
+    int                posts, nreqs;
     size_t             rdt_size, sdt_size, data_size, data_displ;
 
     posts    = UCC_TL_UCP_TEAM_LIB(team)->cfg.alltoallv_pairwise_num_posts;
@@ -84,16 +84,14 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
     }
     if ((task->tagged.send_posted < gsize) ||
         (task->tagged.recv_posted < gsize)) {
-        return task->super.super.status;
+        return;
     }
-    task->super.super.status = ucc_tl_ucp_test(task);
+    task->super.status = ucc_tl_ucp_test(task);
 out:
-    if (task->super.super.status != UCC_INPROGRESS) {
+    if (task->super.status != UCC_INPROGRESS) {
         UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task,
                                          "ucp_alltoallv_pairwise_done", 0);
     }
-
-    return task->super.super.status;
 }
 
 ucc_status_t ucc_tl_ucp_alltoallv_pairwise_start(ucc_coll_task_t *coll_task)
@@ -103,14 +101,8 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_start(ucc_coll_task_t *coll_task)
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_alltoallv_pairwise_start",
                                      0);
-    ucc_tl_ucp_task_reset(task);
-
-    ucc_tl_ucp_alltoallv_pairwise_progress(&task->super);
-    if (UCC_INPROGRESS == task->super.super.status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
 ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task)

--- a/src/components/tl/ucp/barrier/barrier.c
+++ b/src/components/tl/ucp/barrier/barrier.c
@@ -8,7 +8,7 @@
 #include "barrier.h"
 
 ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *task);
+void ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_barrier_init(ucc_tl_ucp_task_t *task)
 {

--- a/src/components/tl/ucp/barrier/barrier_knomial.c
+++ b/src/components/tl/ucp/barrier/barrier_knomial.c
@@ -17,7 +17,7 @@
         task->barrier.phase = _phase;                                 \
     } while (0)
 
-ucc_status_t ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_ucp_barrier_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t     *team       = TASK_TEAM(task);
@@ -49,7 +49,7 @@ UCC_KN_PHASE_EXTRA:
     if (KN_NODE_PROXY == node_type || KN_NODE_EXTRA == node_type) {
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
             SAVE_STATE(UCC_KN_PHASE_EXTRA);
-            return UCC_INPROGRESS;
+            return;
         }
         if (KN_NODE_EXTRA == node_type) {
             goto completion;
@@ -77,7 +77,7 @@ UCC_KN_PHASE_EXTRA:
     UCC_KN_PHASE_LOOP:
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
             SAVE_STATE(UCC_KN_PHASE_LOOP);
-            return UCC_INPROGRESS;
+            return;
         }
         ucc_knomial_pattern_next_iteration(p);
     }
@@ -93,15 +93,15 @@ UCC_KN_PHASE_EXTRA:
 UCC_KN_PHASE_PROXY:
     if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
         SAVE_STATE(UCC_KN_PHASE_PROXY);
-        return UCC_INPROGRESS;
+        return;
     }
 
 completion:
     ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
-    task->super.super.status = UCC_OK;
+    task->super.status = UCC_OK;
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_barrier_kn_done", 0);
 out:
-    return task->super.super.status;
+    return;
 }
 
 ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_task_t *coll_task)
@@ -110,19 +110,13 @@ ucc_status_t ucc_tl_ucp_barrier_knomial_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);
     ucc_rank_t         rank = UCC_TL_TEAM_RANK(team);
     ucc_rank_t         size = UCC_TL_TEAM_SIZE(team);
-    ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_barrier_kn_start", 0);
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
     task->barrier.phase = UCC_KN_PHASE_INIT;
     ucc_knomial_pattern_init(size, rank,
                              ucc_min(UCC_TL_UCP_TEAM_LIB(team)->
                                      cfg.barrier_kn_radix, size),
                              &task->barrier.p);
-    task->super.super.status = UCC_INPROGRESS;
-    status = ucc_tl_ucp_barrier_knomial_progress(&task->super);
-    if (UCC_INPROGRESS == status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }

--- a/src/components/tl/ucp/bcast/bcast.h
+++ b/src/components/tl/ucp/bcast/bcast.h
@@ -16,16 +16,20 @@ enum {
 
 extern ucc_base_coll_alg_info_t
              ucc_tl_ucp_bcast_algs[UCC_TL_UCP_BCAST_ALG_LAST + 1];
+
 ucc_status_t ucc_tl_ucp_bcast_init(ucc_tl_ucp_task_t *task);
+
 ucc_status_t
 ucc_tl_ucp_bcast_knomial_init(ucc_base_coll_args_t *coll_args,
                               ucc_base_team_t *team, ucc_coll_task_t **task_h);
+
 ucc_status_t
 ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
                               ucc_base_team_t *team, ucc_coll_task_t **task_h);
 
 ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *task);
+
+void ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *task);
 
 
 #define UCC_TL_UCP_BCAST_DEFAULT_ALG_SELECT_STR              \

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -11,7 +11,7 @@
 #include "tl_ucp_sendrecv.h"
 #include "utils/ucc_math.h"
 
-ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
@@ -29,7 +29,7 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
     uint32_t i;
 
     if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
-        return task->super.super.status;
+        return;
     }
     while (dist >= 1) {
         if (vrank % dist == 0) {
@@ -56,15 +56,15 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
         dist /= radix;
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
             task->bcast_kn.dist = dist;
-            return task->super.super.status;
+            return;
         }
     }
 
     ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
-    task->super.super.status = UCC_OK;
+    task->super.status = UCC_OK;
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_bcast_kn_done", 0);
 out:
-    return task->super.super.status;
+    return;
 }
 
 ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *coll_task)
@@ -72,17 +72,11 @@ ucc_status_t ucc_tl_ucp_bcast_knomial_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);
     ucc_rank_t         size = UCC_TL_TEAM_SIZE(team);
-    ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_bcast_kn_start", 0);
-    ucc_tl_ucp_task_reset(task);
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
 
     CALC_KN_TREE_DIST(size, task->bcast_kn.radix, task->bcast_kn.dist);
 
-    status = ucc_tl_ucp_bcast_knomial_progress(&task->super);
-    if (UCC_INPROGRESS == status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }

--- a/src/components/tl/ucp/coll_plugins/example/example.c
+++ b/src/components/tl/ucp/coll_plugins/example/example.c
@@ -39,16 +39,14 @@ UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_tlcp_ucp_example_cfg_entry,
                                 &ucc_config_global_list);
 
 #define UCC_TLCP_UCP_EXAMPLE_SCORE 100
-ucc_status_t ucc_tlcp_ucp_example_progress(ucc_coll_task_t *coll_task)
+void ucc_tlcp_ucp_example_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
 
     tl_info(TASK_LIB(task), "completing tl_ucp_example coll task");
 
     ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
-    task->super.super.status = UCC_OK;
-
-    return task->super.super.status;
+    task->super.status = UCC_OK;
 }
 
 ucc_status_t ucc_tlcp_ucp_example_start(ucc_coll_task_t *coll_task)
@@ -58,7 +56,7 @@ ucc_status_t ucc_tlcp_ucp_example_start(ucc_coll_task_t *coll_task)
 
     tl_info(TASK_LIB(task), "starting tl_ucp_example coll task");
 
-    task->super.super.status = UCC_INPROGRESS;
+    task->super.status = UCC_INPROGRESS;
     ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 
     return UCC_OK;

--- a/src/components/tl/ucp/reduce/reduce.h
+++ b/src/components/tl/ucp/reduce/reduce.h
@@ -31,7 +31,9 @@ enum {
 ucc_status_t ucc_tl_ucp_reduce_init(ucc_tl_ucp_task_t *task);
 
 ucc_status_t ucc_tl_ucp_reduce_knomial_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_reduce_knomial_progress(ucc_coll_task_t *task);
+
+void ucc_tl_ucp_reduce_knomial_progress(ucc_coll_task_t *task);
+
 ucc_status_t ucc_tl_ucp_reduce_knomial_finalize(ucc_coll_task_t *task);
 
 #endif

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -17,8 +17,7 @@
         task->reduce_scatter_kn.phase = _phase;                                \
     } while (0)
 
-ucc_status_t
-ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_coll_args_t       *args  = &TASK_ARGS(task);
@@ -69,7 +68,7 @@ UCC_KN_PHASE_EXTRA:
     if ((KN_NODE_PROXY == node_type) || (KN_NODE_EXTRA == node_type)) {
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
             SAVE_STATE(UCC_KN_PHASE_EXTRA);
-            return task->super.super.status;
+            return;
         }
         if (KN_NODE_EXTRA == node_type) {
             goto out;
@@ -77,8 +76,8 @@ UCC_KN_PHASE_EXTRA:
             if (UCC_OK != (status = ucc_dt_reduce(sbuf, scratch, rbuf, count,
                                                   dt, mem_type, args))) {
                 tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
-                task->super.super.status = status;
-                return status;
+                task->super.status = status;
+                return;
             }
         }
     }
@@ -128,7 +127,7 @@ UCC_KN_PHASE_EXTRA:
     UCC_KN_PHASE_LOOP:
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
             SAVE_STATE(UCC_KN_PHASE_LOOP);
-            return task->super.super.status;
+            return;
         }
         if (task->tagged.send_posted > p->iteration * (radix - 1)) {
             sbuf       = (ucc_knomial_pattern_loop_first_iteration(p))
@@ -160,8 +159,8 @@ UCC_KN_PHASE_EXTRA:
                 is_avg);
             if (ucc_unlikely(UCC_OK != status)) {
                 tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
-                task->super.super.status = status;
-                return status;
+                task->super.status = status;
+                return;
             }
         }
         ucc_knomial_pattern_next_iteration(p);
@@ -172,15 +171,16 @@ UCC_KN_PHASE_EXTRA:
                            task->reduce_scatter_kn.scratch,
                            local_seg_count * dt_size, mem_type, mem_type);
 
-    if (UCC_OK != status) {
-        return status;
+    if (ucc_unlikely(UCC_OK != status)) {
+        task->super.status = status;
+        return;
     }
 UCC_KN_PHASE_PROXY: /* unused label */
 out:
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_reduce_scatter_kn_done",
                                      0);
-    task->super.super.status = UCC_OK;
-    return task->super.super.status;
+    task->super.status = UCC_OK;
+    return;
 }
 
 ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
@@ -190,13 +190,11 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);
     ucc_rank_t         rank = UCC_TL_TEAM_RANK(team);
     ucc_rank_t         size = UCC_TL_TEAM_SIZE(team);
-    ucc_status_t       status;
     uint8_t            node_type;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_reduce_scatter_kn_start",
                                      0);
-    ucc_tl_ucp_task_reset(task);
-
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
     ucc_knomial_pattern_init(size, rank, task->reduce_scatter_kn.p.radix,
                              &task->reduce_scatter_kn.p);
     node_type = task->reduce_scatter_kn.p.node_type;
@@ -205,12 +203,7 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
     }
     task->reduce_scatter_kn.phase = UCC_KN_PHASE_INIT;
 
-    status = ucc_tl_ucp_reduce_scatter_knomial_progress(&task->super);
-    if (UCC_INPROGRESS == status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
 ucc_status_t

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -20,7 +20,7 @@ static inline void send_completion_common(void *request, ucs_status_t status,
     if (ucc_unlikely(UCS_OK != status)) {
         tl_error(UCC_TASK_LIB(task), "failure in rs ring completion %s",
                  ucs_status_string(status));
-        task->super.super.status = ucs_status_to_ucc_status(status);
+        task->super.status = ucs_status_to_ucc_status(status);
     }
     task->tagged.send_completed++;
     if (request) {
@@ -93,8 +93,7 @@ static inline ucc_status_t ucc_tl_ucp_test_ring(ucc_tl_ucp_task_t *task)
     return UCC_INPROGRESS;
 }
 
-static ucc_status_t
-ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
+static void ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t      *task     = ucc_derived_of(coll_task,
                                                       ucc_tl_ucp_task_t);
@@ -135,7 +134,7 @@ ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
     s_scratch[1]   = PTR_OFFSET(s_scratch[0], max_block_size);
 
     if (UCC_INPROGRESS == ucc_tl_ucp_test_ring(task)) {
-        return task->super.super.status;
+        return;
     }
     while (task->tagged.recv_posted > 0) {
         /* always have at least 1 send completion, ie 1 free slot */
@@ -166,8 +165,8 @@ ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
                  reduce_target, 1, frag_count, 0, dt, mem_type, task,
                  is_avg))) {
             tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
-            task->super.super.status = status;
-            return status;
+            task->super.status = status;
+            return;
         }
         if (task->tagged.recv_completed == size - 1) {
             task->tagged.recv_posted = task->tagged.recv_completed = 0;
@@ -192,15 +191,15 @@ ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
                       task, out);
 
         if (UCC_INPROGRESS == ucc_tl_ucp_test_ring(task)) {
-            return task->super.super.status;
+            return;
         }
     }
     if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
-        return task->super.super.status;
+        return;
     }
-    task->super.super.status = UCC_OK;
+    task->super.status = UCC_OK;
 out:
-    return task->super.super.status;
+    return;
 }
 
 static ucc_status_t
@@ -219,17 +218,15 @@ ucc_tl_ucp_reduce_scatter_ring_start(ucc_coll_task_t *coll_task)
     ucc_memory_type_t  mem_type = args->dst.info.mem_type;
     void *             sbuf     = args->src.info.buffer;
     int                step     = 0;
-    ucc_status_t       status;
     size_t             block_offset, frag_count, frag_offset;
     void              *r_scratch;
     ucc_rank_t         send_block, recv_block;
 
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
     if (UCC_IS_INPLACE(*args)) {
         sbuf = args->dst.info.buffer;
         count /= size;
     }
-    task->super.super.status = UCC_INPROGRESS;
-    ucc_tl_ucp_task_reset(task);
 
     sendto     = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, sendto);
     recvfrom   = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recvfrom);
@@ -252,14 +249,9 @@ ucc_tl_ucp_reduce_scatter_ring_start(ucc_coll_task_t *coll_task)
                       frag_count * dt_size, mem_type, sendto, team, task),
                   task, out);
 
-    status = ucc_tl_ucp_reduce_scatter_ring_progress(&task->super);
-    if (UCC_INPROGRESS == status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 out:
-    return task->super.super.status;
+    return task->super.status;
 }
 
 static ucc_status_t

--- a/src/components/tl/ucp/scatter/scatter_knomial.c
+++ b/src/components/tl/ucp/scatter/scatter_knomial.c
@@ -49,8 +49,7 @@ ucc_rank_t calc_recv_dist(ucc_rank_t team_size, ucc_rank_t rank,
     return dist;
 }
 
-ucc_status_t
-ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t     *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_coll_args_t       *args = &TASK_ARGS(task);
@@ -159,7 +158,7 @@ ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 UCC_SCATTER_KN_PHASE_LOOP:
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
             SAVE_STATE(UCC_SCATTER_KN_PHASE_LOOP);
-            return task->super.super.status;
+            return;
         }
         ucc_knomial_pattern_next_iteration(p);
     }
@@ -170,15 +169,15 @@ UCC_SCATTER_KN_PHASE_LOOP:
         status = ucc_mc_memcpy(PTR_OFFSET(args->dst.info.buffer, offset),
                                PTR_OFFSET(rbuf, task->scatter_kn.send_offset),
                                local_seg_count * dt_size, mem_type, mem_type);
-        if (UCC_OK != status) {
-            task->super.super.status = status;
-            return task->super.super.status;
+        if (ucc_unlikely(UCC_OK != status)) {
+            task->super.status = status;
+            return;
         }
     }
 out:
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_scatter_kn_done", 0);
-    task->super.super.status = UCC_OK;
-    return task->super.super.status;
+    task->super.status = UCC_OK;
+    return;
 }
 
 ucc_status_t ucc_tl_ucp_scatter_knomial_start(ucc_coll_task_t *coll_task)
@@ -189,10 +188,9 @@ ucc_status_t ucc_tl_ucp_scatter_knomial_start(ucc_coll_task_t *coll_task)
     ucc_rank_t             rank = UCC_TL_TEAM_RANK(team);
     ucc_knomial_pattern_t *p    = &task->scatter_kn.p;
     ucc_rank_t             vrank, vroot, root;
-    ucc_status_t           status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_scatter_kn_start", 0);
-    ucc_tl_ucp_task_reset(task);
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
 
     root = coll_task->bargs.args.root;
     ucc_knomial_pattern_init(size, VRANK(rank, root, size),
@@ -204,12 +202,7 @@ ucc_status_t ucc_tl_ucp_scatter_knomial_start(ucc_coll_task_t *coll_task)
                                                 p->radix, vroot);
     task->scatter_kn.send_offset = 0;
 
-    status = ucc_tl_ucp_scatter_knomial_progress(&task->super);
-    if (UCC_INPROGRESS == status) {
-        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        return UCC_OK;
-    }
-    return ucc_task_complete(coll_task);
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
 ucc_status_t

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -36,7 +36,7 @@ void ucc_tl_ucp_send_completion_cb(void *request, ucs_status_t status,
     if (ucc_unlikely(UCS_OK != status)) {
         tl_error(UCC_TASK_LIB(task), "failure in send completion %s",
                  ucs_status_string(status));
-        task->super.super.status = ucs_status_to_ucc_status(status);
+        task->super.status = ucs_status_to_ucc_status(status);
     }
     task->tagged.send_completed++;
     ucp_request_free(request);
@@ -49,7 +49,7 @@ void ucc_tl_ucp_put_completion_cb(void *request, ucs_status_t status,
     if (ucc_unlikely(UCS_OK != status)) {
         tl_error(UCC_TASK_LIB(task), "failure in put completion %s",
                  ucs_status_string(status));
-        task->super.super.status = ucs_status_to_ucc_status(status);
+        task->super.status = ucs_status_to_ucc_status(status);
     }
     task->onesided.put_completed++;
     ucp_request_free(request);
@@ -62,7 +62,7 @@ void ucc_tl_ucp_get_completion_cb(void *request, ucs_status_t status,
     if (ucc_unlikely(UCS_OK != status)) {
         tl_error(UCC_TASK_LIB(task), "failure in get completion %s",
                  ucs_status_string(status));
-        task->super.super.status = ucs_status_to_ucc_status(status);
+        task->super.status = ucs_status_to_ucc_status(status);
     }
     task->onesided.get_completed++;
     ucp_request_free(request);
@@ -76,7 +76,7 @@ void ucc_tl_ucp_recv_completion_cb(void *request, ucs_status_t status,
     if (ucc_unlikely(UCS_OK != status)) {
         tl_error(UCC_TASK_LIB(task), "failure in send completion %s",
                  ucs_status_string(status));
-        task->super.super.status = ucs_status_to_ucc_status(status);
+        task->super.status = ucs_status_to_ucc_status(status);
     }
     task->tagged.recv_completed++;
     ucp_request_free(request);

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -437,7 +437,7 @@ static inline ucc_status_t ucc_tl_ucp_atomic_inc(void *     target,
     do {                                                                       \
         ucc_status_t _status = (_cmd);                                         \
         if (UCC_OK != _status) {                                               \
-            _task->super.super.status = _status;                               \
+            _task->super.status = _status;                                     \
             goto _label;                                                       \
         }                                                                      \
     } while (0)

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -305,6 +305,11 @@ static ucc_status_t ucc_triggered_task_finalize(ucc_coll_task_t *task)
     return UCC_OK;
 }
 
+static void ucc_triggered_task_cb(void *task, ucc_status_t st)
+{
+    ucc_triggered_task_finalize((ucc_coll_task_t*)task);
+}
+
 static ucc_status_t ucc_triggered_coll_complete(ucc_coll_task_t *parent_task, //NOLINT
                                                 ucc_coll_task_t *task)
 {
@@ -351,7 +356,7 @@ static ucc_status_t ucc_trigger_complete(ucc_coll_task_t *parent_task,
     return UCC_OK;
 }
 
-static ucc_status_t ucc_trigger_test(ucc_coll_task_t *task)
+static void ucc_trigger_test(ucc_coll_task_t *task)
 {
     ucc_status_t              status;
     ucc_ev_t                  post_event;
@@ -369,7 +374,8 @@ static ucc_status_t ucc_trigger_test(ucc_coll_task_t *task)
             task->ev      = ev;
             task->ee_task = NULL;
         } else {
-            return UCC_OK;
+            task->status = UCC_OK;
+            return;
         }
     }
 
@@ -379,8 +385,8 @@ static ucc_status_t ucc_trigger_test(ucc_coll_task_t *task)
             if (ucc_unlikely(status != UCC_OK)) {
                 ucc_error("error in triggered post setup, %s",
                           ucc_status_string(status));
-                task->super.status = status;
-                return status;
+                task->status = status;
+                return;
             }
         }
         if (task->triggered_task->executor) {
@@ -395,16 +401,16 @@ static ucc_status_t ucc_trigger_test(ucc_coll_task_t *task)
             if (ucc_unlikely(status != UCC_OK)) {
                 ucc_error("error in ee executor init, %s",
                            ucc_status_string(status));
-                task->super.status = status;
-                return status;
+                task->status = status;
+                return;
             }
         }
         status = ucc_ee_executor_start(task->executor, task->ee->ee_context);
         if (ucc_unlikely(status != UCC_OK)) {
             ucc_error("error in ee executor start, %s",
                       ucc_status_string(status));
-            task->super.status = status;
-            return status;
+            task->status = status;
+            return;
         }
 
         post_event.ev_type         = UCC_EVENT_COLLECTIVE_POST;
@@ -416,16 +422,14 @@ static ucc_status_t ucc_trigger_test(ucc_coll_task_t *task)
 
     if (task->executor == NULL ||
         (ucc_ee_executor_status(task->executor) == UCC_OK)) {
-        task->super.status = UCC_OK;
+        task->status = UCC_OK;
     }
-    return task->super.status;
 }
 
 ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
                                 ucc_coll_task_t *task)
 {
     ucc_coll_task_t *ev_task;
-    ucc_status_t     status;
 
     if (ev->ev_type != UCC_EVENT_COMPUTE_COMPLETE) {
         ucc_error("event type %d is not supported", ev->ev_type);
@@ -443,10 +447,12 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
     ev_task->ee             = ee;
     ev_task->ev             = NULL;
     ev_task->triggered_task = task;
-    ev_task->flags          = UCC_COLL_TASK_FLAG_INTERNAL;
+    ev_task->flags          = UCC_COLL_TASK_FLAG_CB;
+    ev_task->cb.cb          = ucc_triggered_task_cb;
+    ev_task->cb.data        = ev_task;
     ev_task->finalize       = ucc_triggered_task_finalize;
     ev_task->progress       = ucc_trigger_test;
-    ev_task->super.status   = UCC_INPROGRESS;
+    ev_task->status         = UCC_INPROGRESS;
 
     if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
         UCC_COLL_SET_TIMEOUT(ev_task, task->bargs.args.timeout);
@@ -454,21 +460,7 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
     ucc_event_manager_subscribe(&ev_task->em, UCC_EVENT_COMPLETED, task,
                                 ucc_trigger_complete);
 
-    status = ucc_trigger_test(ev_task);
-    if (ucc_unlikely(status < 0)) {
-        ucc_free(ev_task);
-        task->super.status = status;
-        ucc_task_complete(task);
-        return status;
-    }
-
-    if (ev_task->super.status == UCC_OK) {
-        ucc_trigger_complete(ev_task, task);
-        ucc_free(ev_task);
-    } else {
-        ucc_progress_enqueue(UCC_TASK_CORE_CTX(ev_task)->pq, ev_task);
-    }
-    return UCC_OK;
+    return ucc_progress_queue_enqueue(UCC_TASK_CORE_CTX(ev_task)->pq, ev_task);
 }
 
 ucc_status_t ucc_collective_triggered_post(ucc_ee_h ee, ucc_ev_t *ev)

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -76,14 +76,14 @@ static int ucc_pq_mt_progress(ucc_progress_queue_t *pq)
         if (task->progress) {
             task->progress(task);
         }
-        if (UCC_INPROGRESS == task->super.status) {
+        if (UCC_INPROGRESS == task->status) {
             if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
                 if (timestamp < 0) {
                     timestamp = ucc_get_time();
                 }
                 if (ucc_unlikely(timestamp - task->start_time >
                                  task->bargs.args.timeout)) {
-                    task->super.status = UCC_ERR_TIMED_OUT;
+                    task->status = UCC_ERR_TIMED_OUT;
                     ucc_task_complete(task);
                     return UCC_ERR_TIMED_OUT;
                 }

--- a/src/core/ucc_progress_queue_st.c
+++ b/src/core/ucc_progress_queue_st.c
@@ -24,18 +24,20 @@ static int ucc_pq_st_progress(ucc_progress_queue_t *pq)
     ucc_status_t     status;
 
     ucc_list_for_each_safe(task, tmp, &pq_st->list, list_elem) {
+        ucc_assert((task->status != UCC_OPERATION_INITIALIZED) &&
+                   (task->super.status != UCC_OPERATION_INITIALIZED));
         if (task->progress) {
-            ucc_assert(task->super.status != UCC_OK);
+            ucc_assert(task->status != UCC_OK);
             task->progress(task);
         }
-        if (UCC_INPROGRESS == task->super.status) {
+        if (UCC_INPROGRESS == task->status) {
             if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
                 if (timestamp < 0) {
                     timestamp = ucc_get_time();
                 }
                 if (ucc_unlikely(timestamp - task->start_time >
                                  task->bargs.args.timeout)) {
-                    task->super.status = UCC_ERR_TIMED_OUT;
+                    task->status = UCC_ERR_TIMED_OUT;
                     ucc_list_del(&task->list_elem);
                     ucc_task_complete(task);
                     return UCC_ERR_TIMED_OUT;

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -123,9 +123,11 @@ ucc_schedule_completed_handler(ucc_coll_task_t *parent_task, //NOLINT
 {
     ucc_schedule_t *self = ucc_container_of(task, ucc_schedule_t, super);
 
+    // TODO: do we need lock here?
+    // if tasks in schedule are independet and completes concurently
     self->n_completed_tasks += 1;
     if (self->n_completed_tasks == self->n_tasks) {
-        self->super.super.status = UCC_OK;
+        self->super.status = UCC_OK;
         ucc_task_complete(&self->super);
     }
     return UCC_OK;
@@ -158,6 +160,7 @@ void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task)
 ucc_status_t ucc_schedule_start(ucc_schedule_t *schedule)
 {
     schedule->n_completed_tasks  = 0;
+    schedule->super.status       = UCC_INPROGRESS;
     schedule->super.super.status = UCC_INPROGRESS;
     return ucc_event_manager_notify(&schedule->super,
                                     UCC_EVENT_SCHEDULE_STARTED);

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -32,7 +32,7 @@ typedef struct ucc_base_team ucc_base_team_t;
 
 typedef ucc_status_t (*ucc_coll_post_fn_t)(ucc_coll_task_t *task);
 
-typedef ucc_status_t (*ucc_coll_progress_fn_t)(ucc_coll_task_t *task);
+typedef void (*ucc_coll_progress_fn_t)(ucc_coll_task_t *task);
 
 typedef ucc_status_t (*ucc_coll_finalize_fn_t)(ucc_coll_task_t *task);
 
@@ -57,18 +57,23 @@ typedef struct ucc_event_manager {
 } ucc_event_manager_t;
 
 enum {
-    UCC_COLL_TASK_FLAG_INTERNAL      = UCC_BIT(0),
-    UCC_COLL_TASK_FLAG_CB            = UCC_BIT(1),
+    UCC_COLL_TASK_FLAG_CB            = UCC_BIT(0),
     /* executor is required for collective*/
-    UCC_COLL_TASK_FLAG_EXECUTOR      = UCC_BIT(2),
+    UCC_COLL_TASK_FLAG_EXECUTOR      = UCC_BIT(1),
     /* user visible task */
-    UCC_COLL_TASK_FLAG_TOP_LEVEL     = UCC_BIT(3),
+    UCC_COLL_TASK_FLAG_TOP_LEVEL     = UCC_BIT(2),
     /* stop executor in task complete*/
-    UCC_COLL_TASK_FLAG_EXECUTOR_STOP = UCC_BIT(4)
+    UCC_COLL_TASK_FLAG_EXECUTOR_STOP = UCC_BIT(3)
 };
 
 typedef struct ucc_coll_task {
     ucc_coll_req_t                     super;
+    /**
+     *  Task internal status, TLs and CLs should use it to track collective
+     *  state. super.status is visible to user and should be updated only
+     *  by core level to avoid potential races
+     */
+    ucc_status_t                       status;
     ucc_event_manager_t                em;
     ucc_base_coll_args_t               bargs;
     ucc_base_team_t                   *team; //CL/TL team pointer
@@ -147,9 +152,10 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
 
 static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
 {
-    ucc_status_t status = task->super.status;
+    ucc_status_t        status      = task->status;
+    ucc_coll_callback_t cb          = task->cb;
+    int                 has_cb      = task->flags & UCC_COLL_TASK_FLAG_CB;
 
-    ucc_trace("task complete %p", task);
     ucc_assert((status == UCC_OK) || (status < 0));
     if (ucc_likely(status == UCC_OK)) {
         status = ucc_event_manager_notify(task, UCC_EVENT_COMPLETED);
@@ -162,28 +168,22 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
                      task->bargs.args.timeout, coll_str);
         } else {
             ucc_error("failure in task %p, %s", task,
-                      ucc_status_string(task->super.status));
+                      ucc_status_string(task->status));
         }
-        ucc_assert(task->super.status < 0);
         ucc_event_manager_notify(task, UCC_EVENT_ERROR);
-        status = task->super.status;
     }
 
-    if (task->executor && (task->flags & UCC_COLL_TASK_FLAG_EXECUTOR_STOP)) {
+    if ((task->executor) && (task->flags & UCC_COLL_TASK_FLAG_EXECUTOR_STOP)) {
         status = ucc_ee_executor_stop(task->executor);
         if (ucc_unlikely(status != UCC_OK)) {
             ucc_error("failed to stop executor %s", ucc_status_string(status));
         }
     }
 
-    if (task->flags & UCC_COLL_TASK_FLAG_CB) {
-        task->cb.cb(task->cb.data, status);
+    task->super.status = status;
+    if (has_cb) {
+        cb.cb(cb.data, status);
     }
-
-    if (task->flags & UCC_COLL_TASK_FLAG_INTERNAL) {
-        task->finalize(task);
-    }
-
     return status;
 }
 

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -35,7 +35,7 @@ static ucc_status_t ucc_frag_start_handler(ucc_coll_task_t *parent,
 }
 
 static ucc_status_t
-ucc_schedule_pipelined_completed_handler(ucc_coll_task_t *parent_task, //NOLINT
+ucc_schedule_pipelined_completed_handler(ucc_coll_task_t *parent_task,
                                          ucc_coll_task_t *task)
 {
     ucc_schedule_pipelined_t *schedule =
@@ -49,24 +49,24 @@ ucc_schedule_pipelined_completed_handler(ucc_coll_task_t *parent_task, //NOLINT
         "sched %p completed frag %p, n_completed %d, n_started %d, n_total %d",
         schedule, frag, schedule->super.n_completed_tasks,
         schedule->n_frags_started, schedule->super.n_tasks);
-    ucc_assert(frag->super.super.status == UCC_OK);
+    ucc_assert(frag->super.status == UCC_OK);
     if (schedule->super.n_completed_tasks == schedule->super.n_tasks) {
-        schedule->super.super.super.status = UCC_OK;
+        schedule->super.super.status = UCC_OK;
         ucc_task_complete(task);
         return UCC_OK;
     }
     while ((schedule->super.n_completed_tasks + schedule->n_frags_in_pipeline <
             schedule->super.n_tasks) &&
-           (frag->super.super.status == UCC_OK)) {
+           (frag->super.status == UCC_OK)) {
         /* need to post more frags*/
         if (frag == schedule->frags[schedule->next_frag_to_post]) {
             ucc_trace_req("sched %p restarting frag %d %p", schedule,
                           schedule->next_frag_to_post, frag);
-            frag->super.super.status = UCC_OPERATION_INITIALIZED;
+            frag->super.status = UCC_OPERATION_INITIALIZED;
             frag->n_completed_tasks  = 0;
             for (i = 0; i < frag->n_tasks; i++) {
                 frag->tasks[i]->n_deps += frag->tasks[i]->n_deps_base;
-                frag->tasks[i]->super.status = UCC_OPERATION_INITIALIZED;
+                frag->tasks[i]->status = UCC_OPERATION_INITIALIZED;
             }
             ucc_frag_start_handler(&schedule->super.super, &frag->super);
         }
@@ -162,6 +162,7 @@ ucc_status_t ucc_schedule_pipelined_init(
         if (frags[i]->super.flags & UCC_COLL_TASK_FLAG_EXECUTOR) {
             schedule->super.super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
         }
+        frags[i]->super.status       = UCC_OPERATION_INITIALIZED;
         frags[i]->super.super.status = UCC_OPERATION_INITIALIZED;
     }
     for (i = 0; i < n_frags; i++) {

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1981,6 +1981,9 @@ static inline ucc_status_t ucc_collective_test(ucc_coll_req_h request)
  *
  *  @ref ucc_collective_finalize operation releases all resources
  *  associated with the collective operation represented by the request handle.
+ *  In UCC_THREAD_MULTIPLE mode, the user is responsible for ensuring that
+ *  @ref ucc_collective_finalize is called after the status is UCC_OK and after
+ *  completing the execution of any callback registered with @ref ucc_coll_args_t.
  *
  *  @endparblock
  *

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -595,9 +595,13 @@ UccReq::~UccReq()
 
 void UccReq::start()
 {
+    ucc_status_t st;
     ASSERT_NE(0, reqs.size());
     for (auto r : reqs) {
-        ASSERT_EQ(UCC_OK, ucc_collective_post(r));
+        st = ucc_collective_post(r);
+        ASSERT_EQ(UCC_OK, st);
+        st = ucc_collective_test(r);
+        ASSERT_NE(UCC_OPERATION_INITIALIZED, st);
     }
 }
 


### PR DESCRIPTION
## What
Fix mt race condition with cb.

## How ?
Added ucc task internal status. Each TL/CL use internal status to represent collective state, while user visible status is updated only after all work is done and request ownership is moved to user code.

Also some other small fixes:
1. Double free in onesided alltoall
2. Persistent barrier task reset
3. Incorrect TL UCP status after ucc_collective_initialized