### PR TITLE
UTIL: removing memory_bus_fence

### DIFF
--- a/src/components/ec/cuda/ec_cuda_executor.c
+++ b/src/components/ec/cuda/ec_cuda_executor.c
@@ -170,7 +170,7 @@ ucc_cuda_executor_persistent_task_post(ucc_ee_executor_t *executor,
     ee_task->eee    = executor;
     ee_task->status = UCC_OPERATION_INITIALIZED;
     memcpy(&ee_task->args, task_args, sizeof(ucc_ee_executor_task_args_t));
-    ucc_memory_bus_fence();
+    ucc_memory_cpu_store_fence();
     eee->pidx += 1;
     if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
         ucc_spin_unlock(&eee->tasks_lock);

--- a/src/components/tl/cuda/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv_ring.c
@@ -31,7 +31,7 @@ ucc_status_t ucc_tl_cuda_allgatherv_ring_setup_start(ucc_tl_cuda_task_t *task)
     } else {
         set_rank_step(task, trank, -1, 0);
     }
-    ucc_memory_bus_fence();
+    ucc_memory_cpu_store_fence();
     status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -41,7 +41,7 @@ ucc_status_t ucc_tl_cuda_alltoall_setup_start(ucc_tl_cuda_task_t *task)
            sizeof(ucc_tl_cuda_mem_info_t));
     CUDA_CHECK_GOTO(cudaEventRecord(sync->ipc_event_local, team->stream),
                     exit_err, status);
-    ucc_memory_bus_fence();
+    ucc_memory_cpu_store_fence();
     status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;

--- a/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_ring.c
@@ -26,7 +26,7 @@ ucc_status_t ucc_tl_cuda_reduce_scatterv_ring_setup_start(ucc_tl_cuda_task_t *ta
     ucc_rank_t          trank = UCC_TL_TEAM_RANK(team);
 
     set_rank_step(task, trank, 0, 0);
-    ucc_memory_bus_fence();
+    ucc_memory_cpu_store_fence();
     return ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
 }
 

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -75,7 +75,7 @@ ucc_status_t ucc_tl_cuda_shm_barrier_start(ucc_rank_t rank,
     barrier->state[rank] = UCC_INPROGRESS;
     if (pos == barrier->size - 1) {
         barrier->count = 0;
-        ucc_memory_bus_fence();
+        ucc_memory_cpu_store_fence();
         barrier->sense = barrier->local_sense[rank];
     }
     return UCC_OK;

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -287,7 +287,7 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
                         exit_err, status);
     }
 
-    ucc_memory_bus_fence();
+    ucc_memory_cpu_store_fence();
     bar = UCC_TL_CUDA_TEAM_BARRIER(team, 0);
     status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), bar);
     if (status != UCC_OK) {

--- a/src/utils/arch/aarch64/cpu.h
+++ b/src/utils/arch/aarch64/cpu.h
@@ -27,7 +27,6 @@
  * of DSB. The barrier used for synchronization of access between write back
  * and device mapped memory (PCIe BAR).
  */
-#define ucc_memory_bus_fence()        ucc_aarch64_dmb(oshsy)
 #define ucc_memory_bus_store_fence()  ucc_aarch64_dmb(oshst)
 #define ucc_memory_bus_load_fence()   ucc_aarch64_dmb(oshld)
 

--- a/src/utils/arch/x86_64/cpu.h
+++ b/src/utils/arch/x86_64/cpu.h
@@ -16,7 +16,6 @@
  * In x86_64, there is strong ordering of each processor with respect to another
  * processor, but weak ordering with respect to the bus.
  */
-#define ucc_memory_bus_fence()        asm volatile ("mfence"::: "memory")
 #define ucc_memory_bus_store_fence()  asm volatile ("sfence" ::: "memory")
 #define ucc_memory_bus_load_fence()   asm volatile ("lfence" ::: "memory")
 


### PR DESCRIPTION
## What
Removal of ucc_memory_bus_fence() in x86 and aarch64

## Why ?
Keeping alinged with UCS, in continuation with PR #8023
