### PR TITLE
TL/UCP: bug fix

### DIFF
--- a/src/components/tl/ucp/coll_plugins/example/example.c
+++ b/src/components/tl/ucp/coll_plugins/example/example.c
@@ -72,7 +72,7 @@ ucc_status_t ucc_tlcp_ucp_example_coll_init(ucc_base_coll_args_t *coll_args,
     ucc_tl_ucp_task_t    *task    = ucc_tl_ucp_get_task(tl_team);
 
     ucc_coll_task_init(&task->super, coll_args, team);
-    task->tag            = tl_team->seq_num;
+    task->tagged.tag     = tl_team->seq_num;
     tl_team->seq_num     = (tl_team->seq_num + 1) % UCC_TL_UCP_MAX_COLL_TAG;
     task->super.finalize = ucc_tl_ucp_coll_finalize;
     task->super.post     = ucc_tlcp_ucp_example_start;


### PR DESCRIPTION
## What
fix compilation error

## Why ?
as data structure of `ucc_tl_ucp_task_t ` changed in #429, `task->tag` is no longer valid.

## How ?
`task->tag` -> `task->tagged.tag` to avoid build-time error 
