### PR TITLE
TL/UCP: use executor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,7 @@ AC_CONFIG_FILES([
                  src/components/mc/cpu/Makefile
                  src/components/mc/cuda/Makefile
                  src/components/mc/cuda/kernel/Makefile
+                 src/components/ec/cpu/Makefile
                  src/components/ec/cuda/Makefile
                  src/components/ec/cuda/kernel/Makefile
                  test/mpi/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,12 +1,12 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
 #
 
 cl_dirs = components/cl/basic \
 		  components/cl/hier
 
 mc_dirs = components/mc/cpu
-ec_dirs =
+ec_dirs = components/ec/cpu
 
 if HAVE_CUDA
 mc_dirs += components/mc/cuda

--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -184,7 +184,7 @@ enum {
     UCC_KN_PHASE_REDUCE,       /* reduce data received from peer */
     UCC_KN_PHASE_EXTRA,        /* recv from extra rank */
     UCC_KN_PHASE_EXTRA_REDUCE, /* reduce data received from extra rank */
-    UCC_KN_PHASE_PROXY,        /* recv from extra rank */
+    UCC_KN_PHASE_PROXY,        /* recv from proxy rank */
     UCC_KN_PHASE_COMPLETE,     /* any work after main loop, e.g. memcpy */
 };
 

--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -180,15 +180,32 @@ ucc_knomial_pattern_get_min_radix(ucc_kn_radix_t cfg_radix,
    of the algorithms that use kn pattern */
 enum {
     UCC_KN_PHASE_INIT,
-    UCC_KN_PHASE_LOOP,  /* main loop of recursive k-ing */
-    UCC_KN_PHASE_EXTRA, /* recv from extra rank */
-    UCC_KN_PHASE_PROXY  /* recv from extra rank */
+    UCC_KN_PHASE_LOOP,         /* main loop of recursive k-ing */
+    UCC_KN_PHASE_REDUCE,       /* reduce data received from peer */
+    UCC_KN_PHASE_EXTRA,        /* recv from extra rank */
+    UCC_KN_PHASE_EXTRA_REDUCE, /* reduce data received from extra rank */
+    UCC_KN_PHASE_PROXY,        /* recv from extra rank */
+    UCC_KN_PHASE_COMPLETE,     /* any work after main loop, e.g. memcpy */
 };
 
 #define UCC_KN_CHECK_PHASE(_p)                                                 \
     case _p:                                                                   \
         goto _p;                                                               \
         break;
+
+#define UCC_KN_REDUCE_GOTO_PHASE(_phase)                                       \
+    do {                                                                       \
+        switch (_phase) {                                                      \
+            UCC_KN_CHECK_PHASE(UCC_KN_PHASE_EXTRA);                            \
+            UCC_KN_CHECK_PHASE(UCC_KN_PHASE_EXTRA_REDUCE);                     \
+            UCC_KN_CHECK_PHASE(UCC_KN_PHASE_LOOP);                             \
+            UCC_KN_CHECK_PHASE(UCC_KN_PHASE_REDUCE);                           \
+            UCC_KN_CHECK_PHASE(UCC_KN_PHASE_PROXY);                            \
+            UCC_KN_CHECK_PHASE(UCC_KN_PHASE_COMPLETE);                         \
+        case UCC_KN_PHASE_INIT:                                                \
+            break;                                                             \
+        };                                                                     \
+    } while (0)
 
 #define UCC_KN_GOTO_PHASE(_phase)                                              \
     do {                                                                       \

--- a/src/components/ec/base/ucc_ec_base.h
+++ b/src/components/ec/base/ucc_ec_base.h
@@ -63,8 +63,10 @@ enum ucc_ee_executor_params_field {
 };
 
 typedef enum ucc_ee_executor_task_type {
-    UCC_EE_EXECUTOR_TASK_TYPE_COPY   = UCC_BIT(0),
-    UCC_EE_EXECUTOR_TASK_TYPE_REDUCE = UCC_BIT(1),
+    UCC_EE_EXECUTOR_TASK_TYPE_COPY               = UCC_BIT(0),
+    UCC_EE_EXECUTOR_TASK_TYPE_REDUCE             = UCC_BIT(1),
+    UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI       = UCC_BIT(2),
+    UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI_ALPHA = UCC_BIT(3),
 } ucc_ee_executor_task_type_t;
 
 typedef struct ucc_ee_executor_params {
@@ -84,7 +86,9 @@ typedef struct ucc_ee_executor_params {
 typedef struct ucc_ee_executor_task_args {
     ucc_ee_executor_task_type_t  task_type;
     void                        *bufs[UCC_EE_EXECUTOR_NUM_BUFS];
+    double                       alpha;
     ucc_count_t                  count;
+    size_t                       stride;
     uint32_t                     size;
     ucc_datatype_t               dt;
     ucc_reduction_op_t           op;

--- a/src/components/ec/cpu/Makefile.am
+++ b/src/components/ec/cpu/Makefile.am
@@ -1,0 +1,16 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+#
+
+sources =    \
+	ec_cpu.h \
+	ec_cpu.c
+
+module_LTLIBRARIES        = libucc_ec_cpu.la
+libucc_ec_cpu_la_SOURCES  = $(sources)
+libucc_ec_cpu_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS)
+libucc_ec_cpu_la_CFLAGS   = $(BASE_CFLAGS)
+libucc_ec_cpu_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
+libucc_ec_cpu_la_LIBADD   = $(UCC_TOP_BUILDDIR)/src/libucc.la
+
+include $(top_srcdir)/config/module.am

--- a/src/components/ec/cpu/ec_cpu.c
+++ b/src/components/ec/cpu/ec_cpu.c
@@ -1,0 +1,215 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ec_cpu.h"
+#include "utils/arch/cpu.h"
+#include "components/mc/ucc_mc.h"
+#include <limits.h>
+
+static ucc_config_field_t ucc_ec_cpu_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_ec_cpu_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_ec_config_table)},
+
+    {NULL}
+
+};
+
+static ucc_status_t ucc_ec_cpu_init(const ucc_ec_params_t *ec_params)
+{
+    ucc_status_t status;
+
+    ucc_strncpy_safe(ucc_ec_cpu.super.config->log_component.name,
+                     ucc_ec_cpu.super.super.name,
+                     sizeof(ucc_ec_cpu.super.config->log_component.name));
+    ucc_ec_cpu.thread_mode = ec_params->thread_mode;
+
+    status = ucc_mpool_init(&ucc_ec_cpu.executors, 0, sizeof(ucc_ee_executor_t),
+                            0, UCC_CACHE_LINE_SIZE, 16, UINT_MAX, NULL,
+                            UCC_THREAD_MULTIPLE, "ec cpu executors");
+    if (status != UCC_OK) {
+        ec_error(&ucc_ec_cpu.super, "failed to created ec cpu executors mpool");
+        return status;
+    }
+
+    status = ucc_mpool_init(&ucc_ec_cpu.executor_tasks, 0,
+                            sizeof(ucc_ee_executor_task_t),
+                            0, UCC_CACHE_LINE_SIZE, 16, UINT_MAX, NULL,
+                            UCC_THREAD_MULTIPLE, "ec cpu executor tasks");
+    if (status != UCC_OK) {
+        ec_error(&ucc_ec_cpu.super,
+                 "failed to created ec cpu executor tasks mpool");
+        ucc_mpool_cleanup(&ucc_ec_cpu.executors, 1);
+        return status;
+    }
+
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_ec_cpu_get_attr(ucc_ec_attr_t *ec_attr)
+{
+    if (ec_attr->field_mask & UCC_EC_ATTR_FIELD_THREAD_MODE) {
+        ec_attr->thread_mode = ucc_ec_cpu.thread_mode;
+    }
+
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_ec_cpu_finalize()
+{
+    ucc_mpool_cleanup(&ucc_ec_cpu.executors, 1);
+    ucc_mpool_cleanup(&ucc_ec_cpu.executor_tasks, 1);
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cpu_executor_init(const ucc_ee_executor_params_t *params,
+                                   ucc_ee_executor_t **executor)
+{
+    ucc_ee_executor_t *eee = ucc_mpool_get(&ucc_ec_cpu.executors);
+
+    ec_debug(&ucc_ec_cpu.super, "executor finalize, eee: %p", eee);
+    if (ucc_unlikely(!eee)) {
+        ec_error(&ucc_ec_cpu.super, "failed to allocate executor");
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    eee->ee_type = params->ee_type;
+    *executor = eee;
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cpu_executor_start(ucc_ee_executor_t *executor,
+                                     void *ee_context)
+{
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cpu_executor_status(const ucc_ee_executor_t *executor)
+{
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cpu_executor_stop(ucc_ee_executor_t *executor)
+{
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cpu_executor_task_post(ucc_ee_executor_t *executor,
+                                        const ucc_ee_executor_task_args_t *task_args,
+                                        ucc_ee_executor_task_t **task)
+{
+    ucc_ee_executor_task_t *eee_task;
+    ucc_status_t status;
+
+    eee_task = ucc_mpool_get(&ucc_ec_cpu.executor_tasks);
+    if (ucc_unlikely(!eee_task)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    eee_task->eee = executor;
+    switch (task_args->task_type) {
+    case UCC_EE_EXECUTOR_TASK_TYPE_COPY:
+        memcpy(task_args->bufs[0], task_args->bufs[1], task_args->count);
+        break;
+    case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE:
+        status = ucc_mc_reduce(task_args->bufs[1], task_args->bufs[2],
+                               task_args->bufs[0], task_args->count,
+                               task_args->dt, task_args->op,
+                               UCC_MEMORY_TYPE_HOST);
+        if (ucc_unlikely(status != UCC_OK)) {
+            ec_error(&ucc_ec_cpu.super, "reduce op failed");
+            goto free_task;
+        }
+        break;
+    case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI:
+        status = ucc_mc_reduce_multi(task_args->bufs[1], task_args->bufs[2],
+                                     task_args->bufs[0], task_args->size,
+                                     task_args->count, task_args->stride,
+                                     task_args->dt, task_args->op,
+                                     UCC_MEMORY_TYPE_HOST);
+        if (ucc_unlikely(status != UCC_OK)) {
+            ec_error(&ucc_ec_cpu.super, "reduce multi op failed");
+            goto free_task;
+        }
+        break;
+    case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI_ALPHA:
+        status = ucc_mc_reduce_multi_alpha(task_args->bufs[1],
+                                           task_args->bufs[2],
+                                           task_args->bufs[0],
+                                           task_args->size, task_args->count,
+                                           task_args->stride, task_args->dt,
+                                           task_args->op, UCC_OP_PROD,
+                                           task_args->alpha,
+                                           UCC_MEMORY_TYPE_HOST);
+        if (ucc_unlikely(status != UCC_OK)) {
+            ec_error(&ucc_ec_cpu.super, "reduce multi alpha op failed");
+            goto free_task;
+        }
+        break;
+    }
+    eee_task->status = UCC_OK;
+    *task = eee_task;
+
+    return UCC_OK;
+
+free_task:
+    ucc_mpool_put(eee_task);
+    return status;
+}
+
+ucc_status_t ucc_cpu_executor_task_test(const ucc_ee_executor_task_t *task)
+{
+    return task->status;
+}
+
+ucc_status_t ucc_cpu_executor_task_finalize(ucc_ee_executor_task_t *task)
+{
+    ucc_mpool_put(task);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cpu_executor_finalize(ucc_ee_executor_t *executor)
+{
+    ec_debug(&ucc_ec_cpu.super, "executor finalize, eee: %p", executor);
+    ucc_mpool_put(executor);
+
+    return UCC_OK;
+}
+
+ucc_ec_cpu_t ucc_ec_cpu = {
+    .super.super.name                 = "cpu ec",
+    .super.ref_cnt                    = 0,
+    .super.type                       = UCC_EE_CPU_THREAD,
+    .super.init                       = ucc_ec_cpu_init,
+    .super.get_attr                   = ucc_ec_cpu_get_attr,
+    .super.finalize                   = ucc_ec_cpu_finalize,
+    .super.config_table =
+        {
+            .name   = "CPU execution component",
+            .prefix = "EC_CPU_",
+            .table  = ucc_ec_cpu_config_table,
+            .size   = sizeof(ucc_ec_cpu_config_t),
+        },
+    .super.ops.task_post              = NULL,
+    .super.ops.task_query             = NULL,
+    .super.ops.task_end               = NULL,
+    .super.ops.create_event           = NULL,
+    .super.ops.destroy_event          = NULL,
+    .super.ops.event_post             = NULL,
+    .super.ops.event_test             = NULL,
+    .super.executor_ops.init          = ucc_cpu_executor_init,
+    .super.executor_ops.start         = ucc_cpu_executor_start,
+    .super.executor_ops.status        = ucc_cpu_executor_status,
+    .super.executor_ops.stop          = ucc_cpu_executor_stop,
+    .super.executor_ops.task_post     = ucc_cpu_executor_task_post,
+    .super.executor_ops.task_test     = ucc_cpu_executor_task_test,
+    .super.executor_ops.task_finalize = ucc_cpu_executor_task_finalize,
+    .super.executor_ops.finalize      = ucc_cpu_executor_finalize,
+};
+
+UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_ec_cpu.super.config_table,
+                                &ucc_config_global_list);

--- a/src/components/ec/cpu/ec_cpu.c
+++ b/src/components/ec/cpu/ec_cpu.c
@@ -28,7 +28,7 @@ static ucc_status_t ucc_ec_cpu_init(const ucc_ec_params_t *ec_params)
 
     status = ucc_mpool_init(&ucc_ec_cpu.executors, 0, sizeof(ucc_ee_executor_t),
                             0, UCC_CACHE_LINE_SIZE, 16, UINT_MAX, NULL,
-                            UCC_THREAD_MULTIPLE, "ec cpu executors");
+                            ec_params->thread_mode, "ec cpu executors");
     if (status != UCC_OK) {
         ec_error(&ucc_ec_cpu.super, "failed to created ec cpu executors mpool");
         return status;
@@ -37,7 +37,7 @@ static ucc_status_t ucc_ec_cpu_init(const ucc_ec_params_t *ec_params)
     status = ucc_mpool_init(&ucc_ec_cpu.executor_tasks, 0,
                             sizeof(ucc_ee_executor_task_t),
                             0, UCC_CACHE_LINE_SIZE, 16, UINT_MAX, NULL,
-                            UCC_THREAD_MULTIPLE, "ec cpu executor tasks");
+                            ec_params->thread_mode, "ec cpu executor tasks");
     if (status != UCC_OK) {
         ec_error(&ucc_ec_cpu.super,
                  "failed to created ec cpu executor tasks mpool");
@@ -70,7 +70,7 @@ ucc_status_t ucc_cpu_executor_init(const ucc_ee_executor_params_t *params,
 {
     ucc_ee_executor_t *eee = ucc_mpool_get(&ucc_ec_cpu.executors);
 
-    ec_debug(&ucc_ec_cpu.super, "executor finalize, eee: %p", eee);
+    ec_debug(&ucc_ec_cpu.super, "executor init, eee: %p", eee);
     if (ucc_unlikely(!eee)) {
         ec_error(&ucc_ec_cpu.super, "failed to allocate executor");
         return UCC_ERR_NO_MEMORY;
@@ -82,18 +82,18 @@ ucc_status_t ucc_cpu_executor_init(const ucc_ee_executor_params_t *params,
     return UCC_OK;
 }
 
-ucc_status_t ucc_cpu_executor_start(ucc_ee_executor_t *executor,
-                                     void *ee_context)
+ucc_status_t ucc_cpu_executor_start(ucc_ee_executor_t *executor, //NOLINT
+                                    void *ee_context)            //NOLINT
 {
     return UCC_OK;
 }
 
-ucc_status_t ucc_cpu_executor_status(const ucc_ee_executor_t *executor)
+ucc_status_t ucc_cpu_executor_status(const ucc_ee_executor_t *executor) //NOLINT
 {
     return UCC_OK;
 }
 
-ucc_status_t ucc_cpu_executor_stop(ucc_ee_executor_t *executor)
+ucc_status_t ucc_cpu_executor_stop(ucc_ee_executor_t *executor) //NOLINT
 {
     return UCC_OK;
 }
@@ -103,7 +103,7 @@ ucc_status_t ucc_cpu_executor_task_post(ucc_ee_executor_t *executor,
                                         ucc_ee_executor_task_t **task)
 {
     ucc_ee_executor_task_t *eee_task;
-    ucc_status_t status;
+    ucc_status_t            status;
 
     eee_task = ucc_mpool_get(&ucc_ec_cpu.executor_tasks);
     if (ucc_unlikely(!eee_task)) {

--- a/src/components/ec/cpu/ec_cpu.h
+++ b/src/components/ec/cpu/ec_cpu.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_EC_CPU_H_
+#define UCC_EC_CPU_H_
+
+#include "components/ec/base/ucc_ec_base.h"
+#include "components/ec/ucc_ec_log.h"
+#include "utils/ucc_mpool.h"
+
+typedef struct ucc_ec_cpu_config {
+    ucc_ec_config_t super;
+} ucc_ec_cpu_config_t;
+
+typedef struct ucc_ec_cpu {
+    ucc_ec_base_t     super;
+    ucc_thread_mode_t thread_mode;
+    ucc_mpool_t       executors;
+    ucc_mpool_t       executor_tasks;
+    ucc_spinlock_t    init_spinlock;
+} ucc_ec_cpu_t;
+
+extern ucc_ec_cpu_t ucc_ec_cpu;
+
+#endif

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -201,10 +201,10 @@ __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
                                              args.count);
                     break;
                 case UCC_DT_INT32:
-                    executor_reduce<int>((int*)args.bufs[1],
-                                         (int*)args.bufs[2],
-                                         (int*)args.bufs[0],
-                                          args.count);
+                    executor_reduce<int32_t>((int32_t*)args.bufs[1],
+                                             (int32_t*)args.bufs[2],
+                                             (int32_t*)args.bufs[0],
+                                              args.count);
                     break;
 
                 default:
@@ -228,11 +228,11 @@ __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
                                                   args.stride);
                     break;
                 case UCC_DT_INT32:
-                    executor_reduce_multi<int>((int*)args.bufs[1],
-                                               (int*)args.bufs[2],
-                                               (int*)args.bufs[0],
-                                               args.count, args.size,
-                                               args.stride);
+                    executor_reduce_multi<int32_t>((int32_t*)args.bufs[1],
+                                                   (int32_t*)args.bufs[2],
+                                                   (int32_t*)args.bufs[0],
+                                                   args.count, args.size,
+                                                   args.stride);
                     break;
                 }
                 break;

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -104,13 +104,31 @@ __device__ void executor_reduce(const T* __restrict__ s1,
     }
 }
 
+template <typename T>
+__device__ void executor_reduce_multi(const T* __restrict__ s1,
+                                      const T* __restrict__ s2,
+                                      T* __restrict__ d, size_t count,
+                                      size_t size, size_t stride)
+{
+    const size_t step  = blockDim.x;
+    const size_t start = threadIdx.x;
+    const size_t ld    = stride / sizeof(T);
+
+    for (size_t i = start; i < count; i+=step) {
+        d[i] = s1[i] + s2[i];
+        for (size_t j = 1; j < size; j++) {
+            d[i] = d[i] + s2[i + j*ld];
+        }
+    }
+}
+
 __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
                                 int q_size)
 {
     const uint32_t  worker_id   = blockIdx.x;
     const uint32_t  num_workers = gridDim.x;
     bool            is_master   = (threadIdx.x == 0) ? true: false;
-    int             cidx_local, pidx_local;
+    int cidx_local, pidx_local;
     volatile int *pidx, *cidx;
     ucc_ee_executor_task_t *tasks;
     __shared__ ucc_ee_executor_task_args_t args;
@@ -192,6 +210,32 @@ __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
                 default:
                     break;
                 }
+                break;
+            case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI:
+                switch(args.dt) {
+                case UCC_DT_FLOAT32:
+                    executor_reduce_multi<float>((float*)args.bufs[1],
+                                                 (float*)args.bufs[2],
+                                                 (float*)args.bufs[0],
+                                                 args.count, args.size,
+                                                 args.stride);
+                    break;
+                case UCC_DT_FLOAT64:
+                    executor_reduce_multi<double>((double*)args.bufs[1],
+                                                  (double*)args.bufs[2],
+                                                  (double*)args.bufs[0],
+                                                  args.count, args.size,
+                                                  args.stride);
+                    break;
+                case UCC_DT_INT32:
+                    executor_reduce_multi<int>((int*)args.bufs[1],
+                                               (int*)args.bufs[2],
+                                               (int*)args.bufs[0],
+                                               args.count, args.size,
+                                               args.stride);
+                    break;
+                }
+                break;
             default: break;
         }
         __syncthreads();

--- a/src/components/mc/ucc_mc.h
+++ b/src/components/mc/ucc_mc.h
@@ -104,52 +104,7 @@ static inline ucc_status_t ucc_mc_reduce_userdefined(void *src1, void *src2,
         .dt        = dt
     };
 
-    return dt->ops.reduce.cb(&params);}
-
-
-static inline ucc_status_t ucc_dt_reduce(void *src1, void *src2,
-                                         void *dst, size_t count,
-                                         ucc_datatype_t dt,
-                                         ucc_memory_type_t mem_type,
-                                         ucc_coll_args_t *args)
-{
-    if (!UCC_DT_IS_PREDEFINED(dt)) {
-        ucc_assert(UCC_DT_HAS_REDUCE(dt));
-        return ucc_mc_reduce_userdefined(src1, src2, dst, 1, count,
-                                         0, ucc_dt_to_generic(dt));
-    } else {
-        return ucc_mc_reduce(src1, src2, dst, count,
-                             dt, args->op, mem_type);
-    }
-}
-
-static inline ucc_status_t
-ucc_dt_reduce_multi(void *src1, void *src2, void *dst, size_t n_vectors,
-                    size_t count, size_t stride, ucc_datatype_t dt,
-                    ucc_memory_type_t mem_type, ucc_coll_args_t *args)
-{
-    if (!UCC_DT_IS_PREDEFINED(dt)) {
-        ucc_assert(UCC_DT_HAS_REDUCE(dt));
-        return ucc_mc_reduce_userdefined(src1, src2, dst, n_vectors, count,
-                                         stride, ucc_dt_to_generic(dt));
-    } else {
-        return ucc_mc_reduce_multi(src1, src2, dst, n_vectors, count, stride,
-                                   dt, args->op, mem_type);
-    }
-}
-
-static inline ucc_status_t
-ucc_dt_reduce_multi_alpha(void *src1, void *src2, void *dst, size_t n_vectors,
-                          size_t count, size_t stride, ucc_datatype_t dt,
-                          ucc_reduction_op_t vector_op, double alpha,
-                          ucc_memory_type_t mem_type, ucc_coll_args_t *args)
-{
-    /* reduce_multi is used for OP_AVG implementation that can only be
-       used with predefined dtypes */
-    ucc_assert(UCC_DT_IS_PREDEFINED(dt));
-    return ucc_mc_reduce_multi_alpha(src1, src2, dst, n_vectors, count,
-                                     stride, dt, args->op,
-                                     vector_op, alpha, mem_type);
+    return dt->ops.reduce.cb(&params);
 }
 
 #endif

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -183,7 +183,7 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
         status = ucc_coll_task_get_executor(&task->super, &exec);
         if (ucc_unlikely(status != UCC_OK)) {
             task->super.status = status;
-            return;
+            return status;
         }
         eargs.task_type = UCC_EE_EXECUTOR_TASK_TYPE_COPY;
         eargs.bufs[0]   = PTR_OFFSET(args->dst.info.buffer, offset);
@@ -194,7 +194,7 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
                                            &task->allgather_kn.etask);
         if (ucc_unlikely(status != UCC_OK)) {
             task->super.status = status;
-            return;
+            return status;
         }
     }
     task->allgather_kn.sbuf = PTR_OFFSET(args->dst.info.buffer, offset);

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2021-2022.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -89,20 +89,9 @@ UCC_KN_PHASE_EXTRA:
                 return;
             }
 UCC_KN_PHASE_EXTRA_REDUCE:
-            if (task->allreduce_kn.etask != NULL) {
-                status = ucc_ee_executor_task_test(task->allreduce_kn.etask);
-                if (status == UCC_INPROGRESS) {
-                    SAVE_STATE(UCC_KN_PHASE_EXTRA_REDUCE);
-                    return;
-                }
-                ucc_ee_executor_task_finalize(task->allreduce_kn.etask);
-                if (ucc_unlikely(status < 0)) {
-                    tl_error(UCC_TASK_LIB(task),
-                             "failed to perform dt reduction");
-                    task->super.status = status;
-                    return
-                }
-            }
+            EXEC_TASK_TEST(UCC_KN_PHASE_EXTRA_REDUCE,
+                           "failed to perform dt reduction",
+                           task->allreduce_kn.etask);
         }
     }
     while(!ucc_knomial_pattern_loop_done(p)) {
@@ -163,20 +152,9 @@ UCC_KN_PHASE_EXTRA_REDUCE:
                 return;
             }
 UCC_KN_PHASE_REDUCE:
-            if (task->allreduce_kn.etask != NULL) {
-                status = ucc_ee_executor_task_test(task->allreduce_kn.etask);
-                if (status == UCC_INPROGRESS) {
-                    SAVE_STATE(UCC_KN_PHASE_REDUCE);
-                    return;
-                }
-                ucc_ee_executor_task_finalize(task->allreduce_kn.etask);
-                if (ucc_unlikely(status < 0)) {
-                    tl_error(UCC_TASK_LIB(task),
-                             "failed to perform dt reduction");
-                    task->super.status = status;
-                    return
-                }
-            }
+            EXEC_TASK_TEST(UCC_KN_PHASE_REDUCE,
+                           "failed to perform dt reduction",
+                           task->allreduce_kn.etask);
         }
         ucc_knomial_pattern_next_iteration(p);
     }

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -11,6 +11,7 @@
 #include "coll_patterns/recursive_knomial.h"
 #include "utils/ucc_math.h"
 #include "utils/ucc_coll_utils.h"
+#include "components/ec/ucc_ec.h"
 
 #define SAVE_STATE(_phase)                                                     \
     do {                                                                       \
@@ -41,11 +42,17 @@ void ucc_tl_ucp_allreduce_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_status_t           status;
     ucc_kn_radix_t         loop_step;
     int                    is_avg;
+    ucc_ee_executor_t     *exec;
 
+    status = ucc_coll_task_get_executor(&task->super, &exec);
+    if (ucc_unlikely(status != UCC_OK)) {
+        task->super.status = status;
+        return;
+    }
     if (UCC_IS_INPLACE(*args)) {
         sbuf = rbuf;
     }
-    UCC_KN_GOTO_PHASE(task->allreduce_kn.phase);
+    UCC_KN_REDUCE_GOTO_PHASE(task->allreduce_kn.phase);
 
     if (KN_NODE_EXTRA == node_type) {
         peer = ucc_ep_map_eval(task->subset.map,
@@ -74,12 +81,27 @@ UCC_KN_PHASE_EXTRA:
         if (KN_NODE_EXTRA == node_type) {
             goto completion;
         } else {
-            if (ucc_unlikely(UCC_OK !=
-                             (status = ucc_dt_reduce(sbuf, scratch, rbuf, count,
-                                                     dt, mem_type, args)))) {
+            status = ucc_dt_reduce_nb(sbuf, scratch, rbuf, count, dt, args,
+                                      exec, &task->allreduce_kn.etask);
+            if (ucc_unlikely(status != UCC_OK)) {
                 tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
                 task->super.status = status;
                 return;
+            }
+UCC_KN_PHASE_EXTRA_REDUCE:
+            if (task->allreduce_kn.etask != NULL) {
+                status = ucc_ee_executor_task_test(task->allreduce_kn.etask);
+                if (status == UCC_INPROGRESS) {
+                    SAVE_STATE(UCC_KN_PHASE_EXTRA_REDUCE);
+                    return;
+                }
+                ucc_ee_executor_task_finalize(task->allreduce_kn.etask);
+                if (ucc_unlikely(status < 0)) {
+                    tl_error(UCC_TASK_LIB(task),
+                             "failed to perform dt reduction");
+                    task->super.status = status;
+                    return
+                }
             }
         }
     }
@@ -130,14 +152,30 @@ UCC_KN_PHASE_EXTRA:
             is_avg = args->op == UCC_OP_AVG &&
                      (avg_pre_op ? ucc_knomial_pattern_loop_first_iteration(p)
                                  : ucc_knomial_pattern_loop_last_iteration(p));
-            status = ucc_tl_ucp_reduce_multi(
+            status = ucc_tl_ucp_reduce_multi_nb(
                 send_buf, scratch, rbuf,
                 task->tagged.send_posted - p->iteration * (radix - 1), count,
-                data_size, dt, mem_type, task, is_avg);
+                data_size, dt, task, is_avg, exec,
+                &task->allreduce_kn.etask);
             if (ucc_unlikely(UCC_OK != status)) {
                 tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
                 task->super.status = status;
                 return;
+            }
+UCC_KN_PHASE_REDUCE:
+            if (task->allreduce_kn.etask != NULL) {
+                status = ucc_ee_executor_task_test(task->allreduce_kn.etask);
+                if (status == UCC_INPROGRESS) {
+                    SAVE_STATE(UCC_KN_PHASE_REDUCE);
+                    return;
+                }
+                ucc_ee_executor_task_finalize(task->allreduce_kn.etask);
+                if (ucc_unlikely(status < 0)) {
+                    tl_error(UCC_TASK_LIB(task),
+                             "failed to perform dt reduction");
+                    task->super.status = status;
+                    return
+                }
             }
         }
         ucc_knomial_pattern_next_iteration(p);
@@ -163,6 +201,7 @@ completion:
     ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
     task->super.status = UCC_OK;
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allreduce_kn_done", 0);
+UCC_KN_PHASE_COMPLETE: /* unused label */
 out:
     return;
 }
@@ -197,6 +236,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
         ucc_min(TASK_LIB(task)->cfg.allreduce_kn_radix, size);
     ucc_status_t       status;
 
+    task->super.flags    |= UCC_COLL_TASK_FLAG_EXECUTOR;
     task->super.post     = ucc_tl_ucp_allreduce_knomial_start;
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;

--- a/src/components/tl/ucp/reduce/reduce_knomial.c
+++ b/src/components/tl/ucp/reduce/reduce_knomial.c
@@ -88,7 +88,6 @@ UCC_REDUCE_KN_PHASE_MULTI:
                              (avg_pre_op ? (task->reduce_kn.dist == 1)
                                          : (task->reduce_kn.dist ==
                                             task->reduce_kn.max_dist));
-
                     status = ucc_tl_ucp_reduce_multi(
                         (task->reduce_kn.dist == 1) ? args->src.info.buffer
                                                     : rbuf,

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -11,6 +11,7 @@
 #include "schedule/ucc_schedule_pipelined.h"
 #include "coll_patterns/recursive_knomial.h"
 #include "components/mc/base/ucc_mc_base.h"
+#include "components/ec/ucc_ec.h"
 #include "tl_ucp_tag.h"
 
 #define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 5
@@ -60,12 +61,14 @@ typedef struct ucc_tl_ucp_task {
             ucc_knomial_pattern_t   p;
             void                   *scratch;
             ucc_mc_buffer_header_t *scratch_mc_header;
+            ucc_ee_executor_task_t *etask;
         } allreduce_kn;
         struct {
             int                     phase;
             ucc_knomial_pattern_t   p;
             void                   *scratch;
             ucc_mc_buffer_header_t *scratch_mc_header;
+            ucc_ee_executor_task_t *etask;
         } reduce_scatter_kn;
         struct {
             void                   *scratch;
@@ -93,6 +96,7 @@ typedef struct ucc_tl_ucp_task {
             int                     phase;
             ucc_knomial_pattern_t   p;
             void                   *sbuf;
+            ucc_ee_executor_task_t *etask;
         } allgather_kn;
         struct {
             ucc_rank_t              dist;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -32,6 +32,23 @@ extern const char
 #define INV_VRANK(_rank, _root, _team_size)                                   \
     (((_rank) + (_root)) % (_team_size))
 
+#define EXEC_TASK_TEST(_phase, _errmsg, _etask) do {                           \
+    if (_etask != NULL) {                                                      \
+        status = ucc_ee_executor_task_test(_etask);                            \
+        if (status == UCC_INPROGRESS) {                                        \
+            SAVE_STATE(_phase);                                                \
+            return;                                                            \
+        }                                                                      \
+        ucc_ee_executor_task_finalize(_etask);                                 \
+        if (ucc_unlikely(status < 0)) {                                        \
+            tl_error(UCC_TASK_LIB(task), _errmsg);                             \
+            task->super.status = status;                                       \
+            return;                                                            \
+        }                                                                      \
+    }                                                                          \
+} while(0)
+
+
 typedef struct ucc_tl_ucp_task {
     ucc_coll_task_t super;
     union {

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -29,6 +29,8 @@ static ucc_status_t ucc_tl_ucp_service_coll_start_executor(ucc_coll_task_t *task
         return status;
     }
 
+    task->flags |= UCC_COLL_TASK_FLAG_EXECUTOR_STOP;
+
     return UCC_OK;
 }
 

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -10,14 +10,56 @@
 #include "allreduce/allreduce.h"
 #include "allgather/allgather.h"
 
+static ucc_status_t ucc_tl_ucp_service_coll_start_executor(ucc_coll_task_t *task)
+{
+    ucc_ee_executor_params_t eparams;
+    ucc_status_t status;
+
+    eparams.mask    = UCC_EE_EXECUTOR_PARAM_FIELD_TYPE;
+    eparams.ee_type = UCC_EE_CPU_THREAD;
+
+    status = ucc_ee_executor_init(&eparams, &task->executor);
+    if (status != UCC_OK) {
+        return status;
+    }
+
+    status = ucc_ee_executor_start(task->executor, NULL);
+    if (status != UCC_OK) {
+        ucc_ee_executor_finalize(task->executor);
+        return status;
+    }
+
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_tl_ucp_service_coll_stop_executor(ucc_coll_task_t *task)
+{
+    ucc_status_t status, gl_status;
+
+    gl_status = UCC_OK;
+    status = ucc_ee_executor_stop(task->executor);
+    if (status != UCC_OK) {
+        gl_status = status;
+    }
+
+    status = ucc_ee_executor_finalize(task->executor);
+    if (status != UCC_OK) {
+        gl_status = status;
+    }
+
+    return gl_status;
+}
+
 ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
                                           void *rbuf, ucc_datatype_t dt,
                                           size_t count, ucc_reduction_op_t op,
                                           ucc_subset_t      subset,
                                           ucc_coll_task_t **task_p)
 {
-    ucc_tl_ucp_team_t   *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_tl_ucp_task_t   *task    = ucc_tl_ucp_get_task(tl_team);
+    ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_tl_ucp_task_t *task    = ucc_tl_ucp_get_task(tl_team);
+    ucc_status_t       status;
+
     ucc_base_coll_args_t bargs   = {
         .args = {
             .coll_type    = UCC_COLL_TYPE_ALLREDUCE,
@@ -36,7 +78,6 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
             }
         }
     };
-    ucc_status_t status;
 
     status = ucc_coll_task_init(&task->super, &bargs, team);
     if (status != UCC_OK) {
@@ -52,6 +93,12 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
     if (status != UCC_OK) {
         goto free_task;
     }
+
+    status = ucc_tl_ucp_service_coll_start_executor(&task->super);
+    if (status != UCC_OK) {
+        goto free_task;
+    }
+
     status = ucc_tl_ucp_allreduce_knomial_start(&task->super);
     if (status != UCC_OK) {
         goto finalize_coll;
@@ -59,8 +106,10 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
 
     *task_p = &task->super;
     return status;
+
 finalize_coll:
-   ucc_tl_ucp_allreduce_knomial_finalize(*task_p);
+    ucc_tl_ucp_allreduce_knomial_finalize(&task->super);
+    ucc_tl_ucp_service_coll_stop_executor(&task->super);
 free_task:
     ucc_tl_ucp_put_task(task);
     return status;

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -9,8 +9,8 @@
 #include "config.h"
 #include "ucc_datastruct.h"
 #include "ucc_math.h"
-#include <string.h>
 #include "utils/ucc_time.h"
+#include <string.h>
 
 #define UCC_COLL_TYPE_NUM (ucc_ilog2(UCC_COLL_TYPE_LAST - 1) + 1)
 
@@ -245,4 +245,5 @@ static inline size_t ucc_buffer_block_offset(size_t     total_count,
 
     return (block < left) ? offset - (left - block) : offset;
 }
+
 #endif

--- a/src/utils/ucc_dt_reduce.h
+++ b/src/utils/ucc_dt_reduce.h
@@ -14,13 +14,13 @@ ucc_dt_reduce(void *src1, void *src2, void *dst, size_t count,
               ucc_datatype_t dt, ucc_memory_type_t mem_type,
               ucc_coll_args_t *args)
 {
-    if (!UCC_DT_IS_PREDEFINED(dt)) {
+    if (UCC_DT_IS_PREDEFINED(dt)) {
+        return ucc_mc_reduce(src1, src2, dst, count,
+                             dt, args->op, mem_type);
+    } else {
         ucc_assert(UCC_DT_HAS_REDUCE(dt));
         return ucc_mc_reduce_userdefined(src1, src2, dst, 1, count,
                                          0, ucc_dt_to_generic(dt));
-    } else {
-        return ucc_mc_reduce(src1, src2, dst, count,
-                             dt, args->op, mem_type);
     }
 }
 
@@ -117,6 +117,7 @@ ucc_dt_reduce_multi_alpha_nb(void *src1, void *src2, void *dst,
 
     /* reduce_multi is used for OP_AVG implementation that can only be
        used with predefined dtypes */
+    ucc_assert(UCC_DT_IS_PREDEFINED(dt));
     eargs.task_type = UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI_ALPHA;
     eargs.bufs[0]   = dst;
     eargs.bufs[1]   = src1;

--- a/src/utils/ucc_dt_reduce.h
+++ b/src/utils/ucc_dt_reduce.h
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_DT_REDUCE_H_
+#define UCC_DT_REDUCE_H_
+
+#include "components/mc/ucc_mc.h"
+#include "components/ec/ucc_ec.h"
+
+static inline ucc_status_t
+ucc_dt_reduce(void *src1, void *src2, void *dst, size_t count,
+              ucc_datatype_t dt, ucc_memory_type_t mem_type,
+              ucc_coll_args_t *args)
+{
+    if (!UCC_DT_IS_PREDEFINED(dt)) {
+        ucc_assert(UCC_DT_HAS_REDUCE(dt));
+        return ucc_mc_reduce_userdefined(src1, src2, dst, 1, count,
+                                         0, ucc_dt_to_generic(dt));
+    } else {
+        return ucc_mc_reduce(src1, src2, dst, count,
+                             dt, args->op, mem_type);
+    }
+}
+
+static inline ucc_status_t
+ucc_dt_reduce_nb(void *src1, void *src2, void *dst, size_t count,
+                 ucc_datatype_t dt, ucc_coll_args_t *args,
+                 ucc_ee_executor_t *exec, ucc_ee_executor_task_t **task)
+{
+    ucc_ee_executor_task_args_t eargs;
+
+    if (!UCC_DT_IS_PREDEFINED(dt)) {
+        ucc_assert(UCC_DT_HAS_REDUCE(dt));
+        *task = NULL;
+        return ucc_mc_reduce_userdefined(src1, src2, dst, 1, count,
+                                         0, ucc_dt_to_generic(dt));
+    } else {
+        eargs.task_type = UCC_EE_EXECUTOR_TASK_TYPE_REDUCE;
+        eargs.bufs[0]   = dst;
+        eargs.bufs[1]   = src1;
+        eargs.bufs[2]   = src2;
+        eargs.count     = count;
+        eargs.dt        = dt;
+        eargs.op        = args->op;
+
+        return ucc_ee_executor_task_post(exec, &eargs, task);
+    }
+}
+
+static inline ucc_status_t
+ucc_dt_reduce_multi(void *src1, void *src2, void *dst, size_t n_vectors,
+                    size_t count, size_t stride, ucc_datatype_t dt,
+                    ucc_memory_type_t mem_type, ucc_coll_args_t *args)
+{
+    if (!UCC_DT_IS_PREDEFINED(dt)) {
+        ucc_assert(UCC_DT_HAS_REDUCE(dt));
+        return ucc_mc_reduce_userdefined(src1, src2, dst, n_vectors, count,
+                                         stride, ucc_dt_to_generic(dt));
+    } else {
+        return ucc_mc_reduce_multi(src1, src2, dst, n_vectors, count, stride,
+                                   dt, args->op, mem_type);
+    }
+}
+
+static inline ucc_status_t
+ucc_dt_reduce_multi_nb(void *src1, void *src2, void *dst,  size_t n_vectors,
+                       size_t count, size_t stride, ucc_datatype_t dt,
+                       ucc_coll_args_t *args, ucc_ee_executor_t *exec,
+                       ucc_ee_executor_task_t **task)
+{
+    ucc_ee_executor_task_args_t eargs;
+
+    if (!UCC_DT_IS_PREDEFINED(dt)) {
+        ucc_assert(UCC_DT_HAS_REDUCE(dt));
+        *task = NULL;
+        return ucc_mc_reduce_userdefined(src1, src2, dst, n_vectors, count,
+                                         stride, ucc_dt_to_generic(dt));
+    } else {
+        eargs.task_type = UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI;
+        eargs.bufs[0]   = dst;
+        eargs.bufs[1]   = src1;
+        eargs.bufs[2]   = src2;
+        eargs.count     = count;
+        eargs.size      = n_vectors;
+        eargs.stride    = stride;
+        eargs.dt        = dt;
+        eargs.op        = args->op;
+
+        return ucc_ee_executor_task_post(exec, &eargs, task);
+    }
+}
+
+static inline ucc_status_t
+ucc_dt_reduce_multi_alpha(void *src1, void *src2, void *dst, size_t n_vectors,
+                          size_t count, size_t stride, ucc_datatype_t dt,
+                          ucc_reduction_op_t vector_op, double alpha,
+                          ucc_memory_type_t mem_type, ucc_coll_args_t *args)
+{
+    /* reduce_multi is used for OP_AVG implementation that can only be
+       used with predefined dtypes */
+    ucc_assert(UCC_DT_IS_PREDEFINED(dt));
+    return ucc_mc_reduce_multi_alpha(src1, src2, dst, n_vectors, count,
+                                     stride, dt, args->op,
+                                     vector_op, alpha, mem_type);
+}
+
+static inline ucc_status_t
+ucc_dt_reduce_multi_alpha_nb(void *src1, void *src2, void *dst,
+                             size_t n_vectors, size_t count, size_t stride,
+                             ucc_datatype_t dt, double alpha,
+                             ucc_coll_args_t *args, ucc_ee_executor_t *exec,
+                             ucc_ee_executor_task_t **task)
+{
+    ucc_ee_executor_task_args_t eargs;
+
+    /* reduce_multi is used for OP_AVG implementation that can only be
+       used with predefined dtypes */
+    eargs.task_type = UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI_ALPHA;
+    eargs.bufs[0]   = dst;
+    eargs.bufs[1]   = src1;
+    eargs.bufs[2]   = src2;
+    eargs.alpha     = alpha;
+    eargs.count     = count;
+    eargs.size      = n_vectors;
+    eargs.stride    = stride;
+    eargs.dt        = dt;
+    eargs.op        = args->op;
+
+    return ucc_ee_executor_task_post(exec, &eargs, task);
+}
+
+#endif


### PR DESCRIPTION
## What
Use executor in TL UCP allreduce

## Why ?
Required by CL HIER split rail allreduce in order to share the same executor between multiple TLs
