### PR TITLE
TL/CUDA: rsv/agv restart

### DIFF
--- a/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_ring.c
@@ -203,12 +203,28 @@ void ucc_tl_cuda_reduce_scatterv_ring_progress(ucc_coll_task_t *coll_task)
 
 ucc_status_t ucc_tl_cuda_reduce_scatterv_ring_start(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_cuda_task_t *task    = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
-    ucc_tl_cuda_team_t *team    = TASK_TEAM(task);
+    ucc_tl_cuda_task_t *task  = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+    ucc_tl_cuda_team_t *team  = TASK_TEAM(task);
+    ucc_rank_t          tsize = UCC_TL_TEAM_SIZE(team);
+    size_t              ssize = UCC_TL_CUDA_TEAM_LIB(team)->cfg.scratch_size;
+    ucc_coll_args_t    *args  = &TASK_ARGS(task);
+    ucc_datatype_t      dt    = args->dst.info_v.datatype;
+    size_t              send_size, frag_size;
+    ucc_rank_t          i;
 
+    task->reduce_scatterv_ring.sbuf = args->src.info.buffer;
+    task->reduce_scatterv_ring.rbuf = args->dst.info_v.buffer;
+
+    send_size = task->reduce_scatterv_ring.get_count(task, 0);
+    for (i = 1; i < tsize; i++) {
+        send_size = ucc_max(send_size,
+                            task->reduce_scatterv_ring.get_count(task, i));
+    }
+    frag_size = ucc_min(ssize / ucc_dt_size(dt) / 2, send_size);
+
+    task->reduce_scatterv_ring.num_frags = ucc_div_round_up(send_size, frag_size);
     task->reduce_scatterv_ring.exec_task = NULL;
     task->reduce_scatterv_ring.stage     = RING_STAGE_SYNC;
-
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
@@ -235,34 +251,17 @@ size_t ucc_tl_cuda_reduce_scatterv_ring_get_offset(const ucc_tl_cuda_task_t *tas
 
 ucc_status_t ucc_tl_cuda_reduce_scatterv_ring_init(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t *team   = TASK_TEAM(task);
     ucc_coll_args_t    *args   = &TASK_ARGS(task);
-    ucc_rank_t          tsize  = UCC_TL_TEAM_SIZE(team);
-    size_t              ssize  = UCC_TL_CUDA_TEAM_LIB(team)->cfg.scratch_size;
-    ucc_datatype_t      dt     = args->dst.info_v.datatype;
-    size_t send_size, frag_size;
-    ucc_rank_t i;
 
+    task->super.flags                    |= UCC_COLL_TASK_FLAG_EXECUTOR;
+    task->super.post                      = ucc_tl_cuda_reduce_scatterv_ring_start;
+    task->super.triggered_post            = ucc_triggered_post;
+    task->super.progress                  = ucc_tl_cuda_reduce_scatterv_ring_progress;
+    task->super.finalize                  = ucc_tl_cuda_reduce_scatterv_ring_finalize;
     task->reduce_scatterv_ring.get_count  = ucc_tl_cuda_reduce_scatterv_ring_get_count;
     task->reduce_scatterv_ring.get_offset = ucc_tl_cuda_reduce_scatterv_ring_get_offset;
     task->reduce_scatterv_ring.dt         = args->dst.info_v.datatype;
-    task->reduce_scatterv_ring.sbuf       = args->src.info.buffer;
-    task->reduce_scatterv_ring.rbuf       = args->dst.info_v.buffer;
-
-    send_size = task->reduce_scatterv_ring.get_count(task, 0);
-    for (i = 1; i < tsize; i++) {
-        send_size = ucc_max(send_size,
-                            task->reduce_scatterv_ring.get_count(task, i));
-    }
-    frag_size = ucc_min(ssize / ucc_dt_size(dt) / 2, send_size);
-
-    task->super.flags                    |= UCC_COLL_TASK_FLAG_EXECUTOR;
-    task->reduce_scatterv_ring.num_frags = ucc_div_round_up(send_size, frag_size);
-    task->super.post                     = ucc_tl_cuda_reduce_scatterv_ring_start;
-    task->super.triggered_post           = ucc_triggered_post;
-    task->super.progress                 = ucc_tl_cuda_reduce_scatterv_ring_progress;
-    task->super.finalize                 = ucc_tl_cuda_reduce_scatterv_ring_finalize;
-    task->bar                            = TASK_BAR(task);
+    task->bar                             = TASK_BAR(task);
 
     return UCC_OK;
 }


### PR DESCRIPTION
## What
Fixes tl/cuda reduce_scatterv and allgatherv ring algs when they are used as part of pipeline.    

## Why ?
In the case of pipeline sbuf/count will be different for each frag. The same "task" object can be used for different tasks, hence need to update buf/counts on start.

## How ?
Move buf/counts initializations to "start" instead of init.
