### PR TITLE
TL/UCP: correct address parsing

### DIFF
--- a/src/components/tl/ucp/tl_ucp_ep.c
+++ b/src/components/tl/ucp/tl_ucp_ep.c
@@ -47,7 +47,7 @@ ucc_status_t ucc_tl_ucp_connect_team_ep(ucc_tl_ucp_team_t *team,
 
     addr = ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), UCC_TL_CORE_TEAM(team),
                                 core_rank, ucc_tl_ucp.super.super.id);
-    return ucc_tl_ucp_connect_ep(ctx, ep, addr);
+    return ucc_tl_ucp_connect_ep(ctx, ep, TL_UCP_EP_ADDR_WORKER(addr));
 }
 
 /* Finds next non-NULL ep in the storage and returns that handle

--- a/src/components/tl/ucp/tl_ucp_ep.h
+++ b/src/components/tl/ucp/tl_ucp_ep.h
@@ -12,6 +12,17 @@
 #include "tl_ucp.h"
 #include "core/ucc_team.h"
 
+/* TL/UCP endpoint address layout: (ucp_addrlen may very per proc)
+
+   [ucp_addrlen][ucp_worker_address][onesided_info]
+       8 bytes    ucp_addrlen bytes
+*/
+#define TL_UCP_EP_ADDRLEN_SIZE 8
+#define TL_UCP_EP_ADDR_WORKER_LEN(_addr) (*((uint64_t*)(_addr)))
+#define TL_UCP_EP_ADDR_WORKER(_addr) PTR_OFFSET((_addr), 8)
+#define TL_UCP_EP_ADDR_ONESIDED_INFO(_addr) \
+    PTR_OFFSET((_addr), 8 + TL_UCP_EP_ADDR_WORKER_LEN(_addr))
+
 typedef struct ucc_tl_ucp_context ucc_tl_ucp_context_t;
 typedef struct ucc_tl_ucp_team    ucc_tl_ucp_team_t;
 

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -237,7 +237,8 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
 
     offset = ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), UCC_TL_CORE_TEAM(team),
                                   core_rank, ucc_tl_ucp.super.super.id);
-    base_offset = (ptrdiff_t)PTR_OFFSET(offset, ctx->ucp_addrlen);
+
+    base_offset = (ptrdiff_t)TL_UCP_EP_ADDR_ONESIDED_INFO(offset);
     rvas        = (uint64_t *)base_offset;
     key_sizes   = PTR_OFFSET(base_offset, (section_offset * 2));
     keys        = PTR_OFFSET(base_offset, (section_offset * 3));


### PR DESCRIPTION
UCP worker address can be different on each process in  runtime. Hence we can not use local worker address when getting onesided segment info -> this can lead to a memory corruption. Size of the worker address must be packed as part of TL/UCP ep address.

