### PR TITLE
TL/UCP: add error return in allreduce kn

### DIFF
--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -79,6 +79,7 @@ UCC_KN_PHASE_EXTRA:
                                                      dt, mem_type, args)))) {
                 tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
                 task->super.status = status;
+                return;
             }
         }
     }


### PR DESCRIPTION
## What
Fix - Adding return in case of reduction error in allreduce knomial 