### PR TITLE
TEST: mpi barrier progress

### DIFF
--- a/test/mpi/test_barrier.cc
+++ b/test/mpi/test_barrier.cc
@@ -73,9 +73,11 @@ void TestBarrier::run()
             if (0 == rank && !completed) {
                 MPI_Test(&rreq, &completed, MPI_STATUS_IGNORE);
             }
+            mpi_progress();
         } while(UCC_OK != status);
-        if  (0 == rank && !completed) {
-            MPI_Wait(&rreq, MPI_STATUS_IGNORE);
+        while (0 == rank && !completed) {
+            MPI_Test(&rreq, &completed, MPI_STATUS_IGNORE);
+            mpi_progress();
         }
         if (i < size - 1) {
             UCC_CHECK(ucc_collective_finalize(req));


### PR DESCRIPTION
Need to call mpi_progress otherwise a hang is possible in MPI_Ssend when root will be stuck in ucc collective.

