### PR TITLE
CORE: suppress warn from tl ctx fail

### DIFF
--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -243,7 +243,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_context_t,
 
     int ret = sharp_coll_init(&init_spec, &self->sharp_context);
     if (ret < 0 ) {
-        tl_error(self->super.super.lib, "Failed to initialize SHARP "
+        tl_debug(self->super.super.lib, "Failed to initialize SHARP "
                  "collectives:%s(%d) job ID:%" PRIu64"\n",
                  sharp_coll_strerror(ret), ret, init_spec.job_id);
         status = UCC_ERR_NO_RESOURCE;

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -379,8 +379,13 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
             /* UCC_ERR_LAST means component was disabled via TUNE param:
                don't print warning. */
             if (UCC_ERR_LAST != status) {
-                ucc_warn("failed to create tl context for %s",
-                         tl_lib->iface->super.name);
+                if (ucc_tl_is_requested(lib, tl_lib->iface)) {
+                    ucc_error("failed to create tl context for %s",
+                              tl_lib->iface->super.name);
+                } else {
+                    ucc_debug("failed to create tl context for %s",
+                              tl_lib->iface->super.name);
+                }
             }
             continue;
         }

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -14,6 +14,7 @@
 typedef struct ucc_cl_lib      ucc_cl_lib_t;
 typedef struct ucc_tl_lib      ucc_tl_lib_t;
 typedef struct ucc_cl_lib_attr ucc_cl_lib_attr_t;
+typedef struct ucc_tl_iface    ucc_tl_iface_t;
 
 typedef struct ucc_lib_config {
     char                    *full_prefix;
@@ -38,5 +39,9 @@ void ucc_get_version(unsigned *major_version, unsigned *minor_version,
                      unsigned *release_number);
 
 const char *ucc_get_version_string(void);
+
+/* Checks if a TL is explicitely requested by user via UCC_TLS
+   parameter */
+int ucc_tl_is_requested(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface);
 
 #endif


### PR DESCRIPTION
## What
Changes the way CORE UCC processes failures of tl_context_create. Before the change CORE would always print warning cluttering the output. Now, we check if TL is explicitly requested by user. In that case the error is printed otherwise the error is under "Debug" log level.

TODO: we can't suppress errors coming from libsharp_coll.so @bureddy we might want to fix that in libsharp. at least allow setting log level to 0 from tl/sharp. We want to be able to test sharp availability silently.

