### PR TITLE
EC/CUDA: use multiple streams

### DIFF
--- a/src/components/ec/cuda/Makefile.am
+++ b/src/components/ec/cuda/Makefile.am
@@ -6,10 +6,12 @@ if HAVE_CUDA
 SUBDIRS = kernel
 
 sources =    \
-	ec_cuda.h          \
-	ec_cuda.c          \
-	ec_cuda_executor.h \
-	ec_cuda_executor.c
+	ec_cuda.h                        \
+	ec_cuda.c                        \
+	ec_cuda_executor.h               \
+	ec_cuda_executor.c               \
+	ec_cuda_executor_interruptible.c \
+	ec_cuda_executor_persistent.c
 
 module_LTLIBRARIES         = libucc_ec_cuda.la
 libucc_ec_cuda_la_SOURCES  = $(sources)

--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -63,6 +63,11 @@ static ucc_config_field_t ucc_ec_cuda_config_table[] = {
      ucc_offsetof(ucc_ec_cuda_config_t, exec_max_tasks),
      UCC_CONFIG_TYPE_ULUNITS},
 
+    {"EXEC_NUM_STREAMS", "16",
+     "Number of streams used by interruptible executor",
+     ucc_offsetof(ucc_ec_cuda_config_t, exec_num_streams),
+     UCC_CONFIG_TYPE_ULUNITS},
+
     {NULL}
 
 };
@@ -224,6 +229,13 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
     }
     CUDA_CHECK(cudaGetDevice(&device));
     /*create event pool */
+    ucc_ec_cuda.exec_streams = ucc_calloc(cfg->exec_num_streams,
+                                          sizeof(cudaStream_t),
+                                          "ec cuda streams");
+    if (!ucc_ec_cuda.exec_streams) {
+        ec_error(&ucc_ec_cuda.super, "failed to allocate streams array");
+        return UCC_ERR_NO_MEMORY;
+    }
     status = ucc_mpool_init(&ucc_ec_cuda.events, 0, sizeof(ucc_ec_cuda_event_t),
                             0, UCC_CACHE_LINE_SIZE, 16, UINT_MAX,
                             &ucc_ec_cuda_event_mpool_ops, UCC_THREAD_MULTIPLE,
@@ -428,13 +440,24 @@ ucc_status_t ucc_ec_cuda_event_test(void *event)
 
 static ucc_status_t ucc_ec_cuda_finalize()
 {
+    int i;
+
     if (ucc_ec_cuda.stream != NULL) {
         CUDA_CHECK(cudaStreamDestroy(ucc_ec_cuda.stream));
         ucc_ec_cuda.stream = NULL;
     }
+
+    if (ucc_ec_cuda.exec_streams[0] != NULL) {
+        for (i = 0; i < EC_CUDA_CONFIG->exec_num_streams; i++) {
+            cudaStreamDestroy(ucc_ec_cuda.exec_streams[i]);
+        }
+    }
+
     ucc_mpool_cleanup(&ucc_ec_cuda.events, 1);
     ucc_mpool_cleanup(&ucc_ec_cuda.strm_reqs, 1);
     ucc_mpool_cleanup(&ucc_ec_cuda.executors, 1);
+    ucc_free(ucc_ec_cuda.exec_streams);
+
     return UCC_OK;
 }
 

--- a/src/components/ec/cuda/ec_cuda.h
+++ b/src/components/ec/cuda/ec_cuda.h
@@ -71,12 +71,14 @@ typedef struct ucc_ec_cuda_config {
     unsigned long                  exec_num_workers;
     unsigned long                  exec_num_threads;
     unsigned long                  exec_max_tasks;
+    unsigned long                  exec_num_streams;
 } ucc_ec_cuda_config_t;
 
 typedef struct ucc_ec_cuda {
     ucc_ec_base_t                  super;
     int                            stream_initialized;
     cudaStream_t                   stream;
+    cudaStream_t                  *exec_streams;
     ucc_mpool_t                    events;
     ucc_mpool_t                    strm_reqs;
     ucc_mpool_t                    executors;

--- a/src/components/ec/cuda/ec_cuda.h
+++ b/src/components/ec/cuda/ec_cuda.h
@@ -78,6 +78,7 @@ typedef struct ucc_ec_cuda {
     ucc_ec_base_t                  super;
     int                            stream_initialized;
     cudaStream_t                   stream;
+    int                            exec_streams_initialized;
     cudaStream_t                  *exec_streams;
     ucc_mpool_t                    events;
     ucc_mpool_t                    strm_reqs;

--- a/src/components/ec/cuda/ec_cuda_executor.c
+++ b/src/components/ec/cuda/ec_cuda_executor.c
@@ -5,8 +5,15 @@
  */
 
 #include "ec_cuda_executor.h"
-#include "utils/arch/cpu.h"
-#include "components/mc/ucc_mc.h"
+
+ucc_status_t ucc_cuda_executor_persistent_start(ucc_ee_executor_t *executor,
+                                                void *ee_context);
+
+ucc_status_t ucc_cuda_executor_persistent_stop(ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_cuda_executor_interruptible_start(ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_cuda_executor_interruptible_stop(ucc_ee_executor_t *executor);
 
 ucc_status_t ucc_cuda_executor_init(const ucc_ee_executor_params_t *params,
                                     ucc_ee_executor_t **executor)
@@ -17,7 +24,7 @@ ucc_status_t ucc_cuda_executor_init(const ucc_ee_executor_params_t *params,
         ec_error(&ucc_ec_cuda.super, "failed to allocate executor");
         return UCC_ERR_NO_MEMORY;
     }
-    UCC_EC_CUDA_INIT_STREAM();
+
     ec_debug(&ucc_ec_cuda.super, "executor init, eee: %p", eee);
     eee->super.ee_type = params->ee_type;
     eee->state         = UCC_EC_CUDA_EXECUTOR_INITIALIZED;
@@ -56,145 +63,6 @@ ucc_status_t ucc_cuda_executor_finalize(ucc_ee_executor_t *executor)
     return UCC_OK;
 }
 
-ucc_status_t
-ucc_cuda_executor_interruptible_task_post(ucc_ee_executor_t *executor,
-                                         const ucc_ee_executor_task_args_t *task_args,
-                                         ucc_ee_executor_task_t **task)
-{
-    ucc_ec_cuda_executor_interruptible_task_t *ee_task;
-    ucc_status_t status;
-
-    ee_task = ucc_mpool_get(&ucc_ec_cuda.executor_interruptible_tasks);
-    if (ucc_unlikely(!ee_task)) {
-        return UCC_ERR_NO_MEMORY;
-    }
-
-    status  = ucc_ec_cuda_event_create(&ee_task->event);
-    if (ucc_unlikely(status != UCC_OK)) {
-        ucc_mpool_put(ee_task);
-        return status;
-    }
-    ee_task->super.status = UCC_INPROGRESS;
-    ee_task->super.eee    = executor;
-    memcpy(&ee_task->super.args, task_args, sizeof(ucc_ee_executor_task_args_t));
-    switch (task_args->task_type) {
-    case UCC_EE_EXECUTOR_TASK_TYPE_COPY:
-        status = CUDA_FUNC(cudaMemcpyAsync(task_args->bufs[0],
-                                           task_args->bufs[1],
-                                           task_args->count, cudaMemcpyDefault,
-                                           ucc_ec_cuda.stream));
-        if (ucc_unlikely(status != UCC_OK)) {
-            ec_error(&ucc_ec_cuda.super, "failed to start memcpy op");
-            goto free_task;
-        }
-
-        break;
-    case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE:
-        /* temp workaround to avoid code duplication*/
-        status = ucc_mc_reduce(task_args->bufs[1], task_args->bufs[2],
-                               task_args->bufs[0], task_args->count,
-                               task_args->dt, task_args->op,
-                               UCC_MEMORY_TYPE_CUDA);
-        if (ucc_unlikely(status != UCC_OK)) {
-            ec_error(&ucc_ec_cuda.super, "failed to start reduce op");
-            goto free_task;
-        }
-
-        break;
-    default:
-        ec_error(&ucc_ec_cuda.super, "executor operation is not supported");
-        status = UCC_ERR_INVALID_PARAM;
-        goto free_task;
-    }
-
-    status = ucc_ec_cuda_event_post(ucc_ec_cuda.stream, ee_task->event);
-    if (ucc_unlikely(status != UCC_OK)) {
-        goto free_task;
-    }
-
-    *task = &ee_task->super;
-    return UCC_OK;
-
-free_task:
-    ucc_ec_cuda_event_destroy(ee_task->event);
-    ucc_mpool_put(ee_task);
-    return status;
-}
-
-ucc_status_t
-ucc_cuda_executor_interruptible_task_test(const ucc_ee_executor_task_t *task)
-{
-    ucc_ec_cuda_executor_interruptible_task_t *ee_task =
-        ucc_derived_of(task, ucc_ec_cuda_executor_interruptible_task_t);
-
-    ee_task->super.status = ucc_ec_cuda_event_test(ee_task->event);
-    return ee_task->super.status;
-}
-
-ucc_status_t
-ucc_cuda_executor_interruptible_task_finalize(ucc_ee_executor_task_t *task)
-{
-    ucc_ec_cuda_executor_interruptible_task_t *ee_task =
-        ucc_derived_of(task, ucc_ec_cuda_executor_interruptible_task_t);
-    ucc_status_t status;
-
-    status = ucc_ec_cuda_event_destroy(ee_task->event);
-    ucc_mpool_put(task);
-    return status;
-}
-
-ucc_status_t
-ucc_cuda_executor_persistent_task_post(ucc_ee_executor_t *executor,
-                                       const ucc_ee_executor_task_args_t *task_args,
-                                       ucc_ee_executor_task_t **task)
-{
-    ucc_ec_cuda_executor_t *eee       = ucc_derived_of(executor,
-                                                       ucc_ec_cuda_executor_t);
-    int                     max_tasks = EC_CUDA_CONFIG->exec_max_tasks;
-    ucc_ee_executor_task_t *ee_task;
-
-    if (task_args->task_type == UCC_EE_EXECUTOR_TASK_TYPE_REDUCE) {
-        if (task_args->op != UCC_OP_SUM) {
-            return UCC_ERR_NOT_SUPPORTED;
-        }
-        if ((task_args->dt != UCC_DT_FLOAT32) &&
-            (task_args->dt != UCC_DT_FLOAT64) &&
-            (task_args->dt != UCC_DT_INT32)) {
-            return UCC_ERR_NOT_SUPPORTED;
-        }
-    }
-    if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
-        ucc_spin_lock(&eee->tasks_lock);
-    }
-    ee_task         = &(eee->tasks[eee->pidx % max_tasks]);
-    ee_task->eee    = executor;
-    ee_task->status = UCC_OPERATION_INITIALIZED;
-    memcpy(&ee_task->args, task_args, sizeof(ucc_ee_executor_task_args_t));
-    ucc_memory_cpu_store_fence();
-    eee->pidx += 1;
-    if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
-        ucc_spin_unlock(&eee->tasks_lock);
-    }
-    ec_debug(&ucc_ec_cuda.super, "executor task post, eee: %p", eee);
-
-    *task = ee_task;
-    return UCC_OK;
-}
-
-
-ucc_status_t
-ucc_cuda_executor_persistent_task_test(const ucc_ee_executor_task_t *task)
-{
-    CUDA_CHECK(cudaGetLastError());
-    return task->status;
-}
-
-ucc_status_t
-ucc_cuda_executor_persistent_task_finalize(ucc_ee_executor_task_t *task)
-{
-    return UCC_OK;
-}
-
 ucc_status_t ucc_cuda_executor_task_post(ucc_ee_executor_t *executor,
                                          const ucc_ee_executor_task_args_t *task_args,
                                          ucc_ee_executor_task_t **task)
@@ -219,47 +87,6 @@ ucc_status_t ucc_cuda_executor_task_finalize(ucc_ee_executor_task_t *task)
     return eee->ops.task_finalize(task);
 }
 
-ucc_status_t ucc_cuda_executor_interruptible_start(ucc_ee_executor_t *executor)
-{
-    ucc_ec_cuda_executor_t *eee = ucc_derived_of(executor,
-                                                 ucc_ec_cuda_executor_t);
-
-    eee->mode  = UCC_EC_CUDA_EXECUTOR_MODE_INTERRUPTIBLE;
-    eee->state = UCC_EC_CUDA_EXECUTOR_STARTED;
-
-    eee->ops.task_post     = ucc_cuda_executor_interruptible_task_post;
-    eee->ops.task_test     = ucc_cuda_executor_interruptible_task_test;
-    eee->ops.task_finalize = ucc_cuda_executor_interruptible_task_finalize;
-
-    return UCC_OK;
-}
-
-ucc_status_t ucc_cuda_executor_persistent_start(ucc_ee_executor_t *executor,
-                                                void *ee_context)
-{
-    ucc_ec_cuda_executor_t *eee = ucc_derived_of(executor,
-                                                 ucc_ec_cuda_executor_t);
-    ucc_status_t status;
-
-    ucc_assert(eee->state == UCC_EC_CUDA_EXECUTOR_INITIALIZED);
-    ec_debug(&ucc_ec_cuda.super, "executor start, eee: %p", eee);
-    eee->super.ee_context = ee_context;
-    eee->state            = UCC_EC_CUDA_EXECUTOR_POSTED;
-    eee->pidx             = 0;
-    eee->mode             = UCC_EC_CUDA_EXECUTOR_MODE_PERSISTENT;
-
-    status = ucc_ec_cuda_persistent_kernel_start(eee);
-    if (status != UCC_OK) {
-        ec_error(&ucc_ec_cuda.super, "failed to launch executor kernel");
-        return status;
-    }
-
-    eee->ops.task_post     = ucc_cuda_executor_persistent_task_post;
-    eee->ops.task_test     = ucc_cuda_executor_persistent_task_test;
-    eee->ops.task_finalize = ucc_cuda_executor_persistent_task_finalize;
-    return UCC_OK;
-}
-
 ucc_status_t ucc_cuda_executor_start(ucc_ee_executor_t *executor,
                                      void *ee_context)
 {
@@ -268,34 +95,6 @@ ucc_status_t ucc_cuda_executor_start(ucc_ee_executor_t *executor,
     } else {
         return ucc_cuda_executor_persistent_start(executor, ee_context);
     }
-}
-
-ucc_status_t ucc_cuda_executor_interruptible_stop(ucc_ee_executor_t *executor)
-{
-    ucc_ec_cuda_executor_t *eee = ucc_derived_of(executor,
-                                                 ucc_ec_cuda_executor_t);
-
-    eee->state = UCC_EC_CUDA_EXECUTOR_INITIALIZED;
-    return UCC_OK;
-}
-
-ucc_status_t ucc_cuda_executor_persistent_stop(ucc_ee_executor_t *executor)
-{
-    ucc_ec_cuda_executor_t *eee = ucc_derived_of(executor,
-                                                 ucc_ec_cuda_executor_t);
-    volatile ucc_ec_cuda_executor_state_t *st = &eee->state;
-
-    ec_debug(&ucc_ec_cuda.super, "executor stop, eee: %p", eee);
-    /* can be safely ended only if it's in STARTED or COMPLETED_ACK state */
-    ucc_assert((*st != UCC_EC_CUDA_EXECUTOR_POSTED) &&
-               (*st != UCC_EC_CUDA_EXECUTOR_SHUTDOWN));
-    *st = UCC_EC_CUDA_EXECUTOR_SHUTDOWN;
-    eee->pidx = -1;
-    while(*st != UCC_EC_CUDA_EXECUTOR_SHUTDOWN_ACK) { }
-    eee->super.ee_context = NULL;
-    eee->state = UCC_EC_CUDA_EXECUTOR_INITIALIZED;
-
-    return UCC_OK;
 }
 
 ucc_status_t ucc_cuda_executor_stop(ucc_ee_executor_t *executor)

--- a/src/components/ec/cuda/ec_cuda_executor_interruptible.c
+++ b/src/components/ec/cuda/ec_cuda_executor_interruptible.c
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ec_cuda_executor.h"
+#include "components/mc/ucc_mc.h"
+
+ucc_status_t ucc_cuda_executor_interruptible_get_stream(cudaStream_t *stream)
+{
+    static int last_used = 0;
+    cudaError_t cuda_st;
+    int i, j;
+
+    ucc_spin_lock(&ucc_ec_cuda.init_spinlock);
+    if (ucc_unlikely(ucc_ec_cuda.exec_streams[0] == NULL)) {
+        for(i = 0; i < EC_CUDA_CONFIG->exec_num_streams; i++) {
+            cuda_st = cudaStreamCreateWithFlags(&ucc_ec_cuda.exec_streams[i],
+                                                cudaStreamNonBlocking);
+            if (ucc_unlikely(cuda_st != cudaSuccess)) {
+                ec_error(&ucc_ec_cuda.super,
+                         "failed to allocate cuda stream %d(%s)",
+                         cuda_st, cudaGetErrorString(cuda_st));
+                for (j = 0; j < i; j++) {
+                    cudaStreamDestroy(ucc_ec_cuda.exec_streams[j]);
+                    ucc_ec_cuda.exec_streams[j] = NULL;
+                }
+                ucc_spin_unlock(&ucc_ec_cuda.init_spinlock);
+                return UCC_ERR_NO_RESOURCE;
+            }
+        }
+    }
+    *stream = ucc_ec_cuda.exec_streams[last_used %
+                                       EC_CUDA_CONFIG->exec_num_streams];
+    last_used++;
+    ucc_spin_unlock(&ucc_ec_cuda.init_spinlock);
+    return UCC_OK;
+}
+
+ucc_status_t
+ucc_cuda_executor_interruptible_task_post(ucc_ee_executor_t *executor,
+                                         const ucc_ee_executor_task_args_t *task_args,
+                                         ucc_ee_executor_task_t **task)
+{
+    ucc_ec_cuda_executor_interruptible_task_t *ee_task;
+    cudaStream_t stream;
+    ucc_status_t status;
+
+    status = ucc_cuda_executor_interruptible_get_stream(&stream);
+    if (ucc_unlikely(status != UCC_OK)) {
+        return status;
+    }
+
+    ee_task = ucc_mpool_get(&ucc_ec_cuda.executor_interruptible_tasks);
+    if (ucc_unlikely(!ee_task)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    status  = ucc_ec_cuda_event_create(&ee_task->event);
+    if (ucc_unlikely(status != UCC_OK)) {
+        ucc_mpool_put(ee_task);
+        return status;
+    }
+
+    ee_task->super.status = UCC_INPROGRESS;
+    ee_task->super.eee    = executor;
+    memcpy(&ee_task->super.args, task_args, sizeof(ucc_ee_executor_task_args_t));
+    switch (task_args->task_type) {
+    case UCC_EE_EXECUTOR_TASK_TYPE_COPY:
+        status = CUDA_FUNC(cudaMemcpyAsync(task_args->bufs[0],
+                                           task_args->bufs[1],
+                                           task_args->count, cudaMemcpyDefault,
+                                           stream));
+        if (ucc_unlikely(status != UCC_OK)) {
+            ec_error(&ucc_ec_cuda.super, "failed to start memcpy op");
+            goto free_task;
+        }
+
+        break;
+    case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE:
+        /* temp workaround to avoid code duplication*/
+        status = ucc_mc_reduce(task_args->bufs[1], task_args->bufs[2],
+                               task_args->bufs[0], task_args->count,
+                               task_args->dt, task_args->op,
+                               UCC_MEMORY_TYPE_CUDA);
+        if (ucc_unlikely(status != UCC_OK)) {
+            ec_error(&ucc_ec_cuda.super, "failed to start reduce op");
+            goto free_task;
+        }
+
+        break;
+    default:
+        ec_error(&ucc_ec_cuda.super, "executor operation is not supported");
+        status = UCC_ERR_INVALID_PARAM;
+        goto free_task;
+    }
+
+    status = ucc_ec_cuda_event_post(stream, ee_task->event);
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto free_task;
+    }
+
+    *task = &ee_task->super;
+    return UCC_OK;
+
+free_task:
+    ucc_ec_cuda_event_destroy(ee_task->event);
+    ucc_mpool_put(ee_task);
+    return status;
+}
+
+ucc_status_t
+ucc_cuda_executor_interruptible_task_test(const ucc_ee_executor_task_t *task)
+{
+    ucc_ec_cuda_executor_interruptible_task_t *ee_task =
+        ucc_derived_of(task, ucc_ec_cuda_executor_interruptible_task_t);
+
+    ee_task->super.status = ucc_ec_cuda_event_test(ee_task->event);
+    return ee_task->super.status;
+}
+
+ucc_status_t
+ucc_cuda_executor_interruptible_task_finalize(ucc_ee_executor_task_t *task)
+{
+    ucc_ec_cuda_executor_interruptible_task_t *ee_task =
+        ucc_derived_of(task, ucc_ec_cuda_executor_interruptible_task_t);
+    ucc_status_t status;
+
+    status = ucc_ec_cuda_event_destroy(ee_task->event);
+    ucc_mpool_put(task);
+    return status;
+}
+
+ucc_status_t ucc_cuda_executor_interruptible_start(ucc_ee_executor_t *executor)
+{
+    ucc_ec_cuda_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_cuda_executor_t);
+
+    eee->mode  = UCC_EC_CUDA_EXECUTOR_MODE_INTERRUPTIBLE;
+    eee->state = UCC_EC_CUDA_EXECUTOR_STARTED;
+
+    eee->ops.task_post     = ucc_cuda_executor_interruptible_task_post;
+    eee->ops.task_test     = ucc_cuda_executor_interruptible_task_test;
+    eee->ops.task_finalize = ucc_cuda_executor_interruptible_task_finalize;
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cuda_executor_interruptible_stop(ucc_ee_executor_t *executor)
+{
+    ucc_ec_cuda_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_cuda_executor_t);
+
+    eee->state = UCC_EC_CUDA_EXECUTOR_INITIALIZED;
+    return UCC_OK;
+}

--- a/src/components/ec/cuda/ec_cuda_executor_persistent.c
+++ b/src/components/ec/cuda/ec_cuda_executor_persistent.c
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ec_cuda_executor.h"
+#include "utils/arch/cpu.h"
+
+ucc_status_t
+ucc_cuda_executor_persistent_task_post(ucc_ee_executor_t *executor,
+                                       const ucc_ee_executor_task_args_t *task_args,
+                                       ucc_ee_executor_task_t **task)
+{
+    ucc_ec_cuda_executor_t *eee       = ucc_derived_of(executor,
+                                                       ucc_ec_cuda_executor_t);
+    int                     max_tasks = EC_CUDA_CONFIG->exec_max_tasks;
+    ucc_ee_executor_task_t *ee_task;
+
+    if (task_args->task_type == UCC_EE_EXECUTOR_TASK_TYPE_REDUCE) {
+        if (task_args->op != UCC_OP_SUM) {
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+        if ((task_args->dt != UCC_DT_FLOAT32) &&
+            (task_args->dt != UCC_DT_FLOAT64) &&
+            (task_args->dt != UCC_DT_INT32)) {
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+    }
+    if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spin_lock(&eee->tasks_lock);
+    }
+    ee_task         = &(eee->tasks[eee->pidx % max_tasks]);
+    ee_task->eee    = executor;
+    ee_task->status = UCC_OPERATION_INITIALIZED;
+    memcpy(&ee_task->args, task_args, sizeof(ucc_ee_executor_task_args_t));
+    ucc_memory_cpu_store_fence();
+    eee->pidx += 1;
+    if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spin_unlock(&eee->tasks_lock);
+    }
+    ec_debug(&ucc_ec_cuda.super, "executor task post, eee: %p", eee);
+
+    *task = ee_task;
+    return UCC_OK;
+}
+
+
+ucc_status_t
+ucc_cuda_executor_persistent_task_test(const ucc_ee_executor_task_t *task)
+{
+    CUDA_CHECK(cudaGetLastError());
+    return task->status;
+}
+
+ucc_status_t
+ucc_cuda_executor_persistent_task_finalize(ucc_ee_executor_task_t *task)
+{
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cuda_executor_persistent_start(ucc_ee_executor_t *executor,
+                                                void *ee_context)
+{
+    ucc_ec_cuda_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_cuda_executor_t);
+    ucc_status_t status;
+
+    ucc_assert(eee->state == UCC_EC_CUDA_EXECUTOR_INITIALIZED);
+    ec_debug(&ucc_ec_cuda.super, "executor start, eee: %p", eee);
+    eee->super.ee_context = ee_context;
+    eee->state            = UCC_EC_CUDA_EXECUTOR_POSTED;
+    eee->pidx             = 0;
+    eee->mode             = UCC_EC_CUDA_EXECUTOR_MODE_PERSISTENT;
+
+    status = ucc_ec_cuda_persistent_kernel_start(eee);
+    if (status != UCC_OK) {
+        ec_error(&ucc_ec_cuda.super, "failed to launch executor kernel");
+        return status;
+    }
+
+    eee->ops.task_post     = ucc_cuda_executor_persistent_task_post;
+    eee->ops.task_test     = ucc_cuda_executor_persistent_task_test;
+    eee->ops.task_finalize = ucc_cuda_executor_persistent_task_finalize;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cuda_executor_persistent_stop(ucc_ee_executor_t *executor)
+{
+    ucc_ec_cuda_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_cuda_executor_t);
+    volatile ucc_ec_cuda_executor_state_t *st = &eee->state;
+
+    ec_debug(&ucc_ec_cuda.super, "executor stop, eee: %p", eee);
+    /* can be safely ended only if it's in STARTED or COMPLETED_ACK state */
+    ucc_assert((*st != UCC_EC_CUDA_EXECUTOR_POSTED) &&
+               (*st != UCC_EC_CUDA_EXECUTOR_SHUTDOWN));
+    *st = UCC_EC_CUDA_EXECUTOR_SHUTDOWN;
+    eee->pidx = -1;
+    while(*st != UCC_EC_CUDA_EXECUTOR_SHUTDOWN_ACK) { }
+    eee->super.ee_context = NULL;
+    eee->state = UCC_EC_CUDA_EXECUTOR_INITIALIZED;
+
+    return UCC_OK;
+}

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -13,19 +13,6 @@
 #include "utils/arch/cuda_def.h"
 #include <cuda_runtime.h>
 
-static inline ucc_status_t cuda_error_to_ucc_status(cudaError_t cu_err)
-{
-    switch(cu_err) {
-    case cudaSuccess:
-        return UCC_OK;
-    case cudaErrorNotReady:
-        return UCC_INPROGRESS;
-    default:
-        break;
-    }
-    return UCC_ERR_NO_MESSAGE;
-}
-
 typedef struct ucc_mc_cuda_config {
     ucc_mc_config_t                super;
     unsigned long                  reduce_num_blocks;


### PR DESCRIPTION
## What
Use multiple streams in EC CUDA executor.

## Why ?
Algorithms in TL CUDA use executor for communication. While executor api supports nonblocking operations executor tasks are synchronized because interruptible executor submits them to the same stream. This PR adds multiple streams to EC CUDA and executor assigns tasks to different streams in round robin manner.
