### PR TITLE
Multithreading fixes

### DIFF
--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -148,7 +148,7 @@ ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule,
 
 void ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task)
 {
-    ucc_event_manager_subscribe(&task->em, UCC_EVENT_COMPLETED,
+    ucc_event_manager_subscribe(&task->em, UCC_EVENT_COMPLETED_SCHEDULE,
                                 &schedule->super,
                                 ucc_schedule_completed_handler);
     task->schedule                       = schedule;

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -6,6 +6,7 @@
 #include "utils/ucc_compiler_def.h"
 #include "components/base/ucc_base_iface.h"
 #include "coll_score/ucc_coll_score.h"
+#include "core/ucc_context.h"
 
 ucc_status_t ucc_event_manager_init(ucc_event_manager_t *em)
 {
@@ -122,11 +123,11 @@ ucc_schedule_completed_handler(ucc_coll_task_t *parent_task, //NOLINT
                                ucc_coll_task_t *task)
 {
     ucc_schedule_t *self = ucc_container_of(task, ucc_schedule_t, super);
+    uint32_t        n_completed_tasks;
 
-    // TODO: do we need lock here?
-    // if tasks in schedule are independet and completes concurently
-    self->n_completed_tasks += 1;
-    if (self->n_completed_tasks == self->n_tasks) {
+    n_completed_tasks = ucc_atomic_fadd32(&self->n_completed_tasks, 1);
+
+    if (n_completed_tasks + 1 == self->n_tasks) {
         self->super.status = UCC_OK;
         ucc_task_complete(&self->super);
     }

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -200,4 +200,5 @@ static inline void ucc_task_subscribe_dep(ucc_coll_task_t *target,
 #define UCC_TASK_CORE_CTX(_task)                                               \
     (((ucc_coll_task_t *)_task)->team->context->ucc_context)
 
+#define UCC_TASK_THREAD_MODE(_task) (UCC_TASK_CORE_CTX(_task)->thread_mode)
 #endif

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -20,6 +20,8 @@ typedef enum {
     UCC_EVENT_COMPLETED = 0,
     UCC_EVENT_SCHEDULE_STARTED,
     UCC_EVENT_TASK_STARTED,
+    UCC_EVENT_COMPLETED_SCHEDULE, /*< Event is used to notify SCHEDULE that
+                                    one of its task has completed */
     UCC_EVENT_ERROR,
     UCC_EVENT_LAST
 } ucc_event_t;
@@ -110,8 +112,8 @@ typedef struct ucc_context ucc_context_t;
 
 typedef struct ucc_schedule {
     ucc_coll_task_t  super;
-    int              n_completed_tasks;
-    int              n_tasks;
+    uint32_t         n_completed_tasks;
+    uint32_t         n_tasks;
     ucc_context_t   *ctx;
     ucc_coll_task_t *tasks[UCC_SCHEDULE_MAX_TASKS];
 } ucc_schedule_t;
@@ -150,13 +152,46 @@ ucc_status_t ucc_dependency_handler(ucc_coll_task_t *parent, /* NOLINT */
 ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
                                 ucc_coll_task_t *task);
 
+static inline void ucc_task_complete_notify(ucc_coll_task_t *task,
+                                            ucc_event_t   event,
+                                            ucc_status_t *status)
+{
+    if (ucc_likely(*status == UCC_OK)) {
+        *status = ucc_event_manager_notify(task, event);
+    } else {
+        /* error in task status */
+        if (UCC_ERR_TIMED_OUT == *status) {
+            char coll_str[256];
+            ucc_coll_str(task, coll_str, sizeof(coll_str));
+            ucc_warn("timeout %g sec has expired on %s",
+                     task->bargs.args.timeout, coll_str);
+        } else {
+            ucc_error("failure in task %p, %s", task,
+                      ucc_status_string(task->status));
+        }
+        ucc_event_manager_notify(task, UCC_EVENT_ERROR);
+    }
+}
+
 static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
 {
-    ucc_status_t        status      = task->status;
-    ucc_coll_callback_t cb          = task->cb;
-    int                 has_cb      = task->flags & UCC_COLL_TASK_FLAG_CB;
+    ucc_status_t        status    = task->status;
+    ucc_coll_callback_t cb        = task->cb;
+    int                 has_cb    = task->flags & UCC_COLL_TASK_FLAG_CB;
+    int                 has_sched = task->schedule != NULL;
 
     ucc_assert((status == UCC_OK) || (status < 0));
+
+    /* If task is part of a  schedule then it can be
+       released during ucc_event_manager_notify(EVENT_COMPLETED_SCHEDULE) below.
+       Sequence: notify => schedule->n_completed_tasks++ =>
+       shedule->super.status = UCC_OK => user releases schedule from another
+       thread => schedule_finalize => schedule finalizes all the tasks.
+       After that the task ptr should not be accessed.
+       This is why notification of schedule is done separatly in the end of
+       this function. Internal implementation must make sure that tasks
+       with schedules are not released during a callabck (if set). */
+
     if (ucc_likely(status == UCC_OK)) {
         status = ucc_event_manager_notify(task, UCC_EVENT_COMPLETED);
     } else {
@@ -184,6 +219,10 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
     if (has_cb) {
         cb.cb(cb.data, status);
     }
+    if (has_sched && status == UCC_OK) {
+        status = ucc_event_manager_notify(task, UCC_EVENT_COMPLETED_SCHEDULE);
+    }
+
     return status;
 }
 

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -194,8 +194,9 @@ ucc_status_t ucc_schedule_pipelined_init(
                                     UCC_EVENT_SCHEDULE_STARTED,
                                     &frags[i]->super, ucc_frag_start_handler);
         ucc_event_manager_subscribe(
-            &frags[i]->super.em, UCC_EVENT_COMPLETED, &schedule->super.super,
-                        ucc_schedule_pipelined_completed_handler);
+            &frags[i]->super.em, UCC_EVENT_COMPLETED_SCHEDULE,
+            &schedule->super.super,
+            ucc_schedule_pipelined_completed_handler);
     }
     return UCC_OK;
 err:

--- a/src/schedule/ucc_schedule_pipelined.h
+++ b/src/schedule/ucc_schedule_pipelined.h
@@ -46,6 +46,7 @@ typedef struct ucc_schedule_pipelined {
     int                          sequential;
     int                          next_frag_to_post;
     ucc_schedule_frag_setup_fn_t frag_setup;
+    ucc_recursive_spinlock_t     lock;
 } ucc_schedule_pipelined_t;
 
 /* Creates a pipelined schedule for the algorithm defined by "frag_init".


### PR DESCRIPTION
## What
Fixes a set of bugs in the multithreaded test cases

1. Atomically increment n_completed_tasks in schedule_completed_handler since it can be called from multiple threads if the schedule consists of at least 2 independent tasks (both can be placed into the progress queue and then processed concurrently by different threads)
2. Protect pipelined_schedule_finalize handler with recursive lock. The lock is required since multiple threads can process multiple outstanding fragments of pipeline and thus update the same pipelined_schedule object. The lock must be recursive since a thread may restart fragment from the handler and re-enter it again in case of immediate completion
3. Fixes race in the ucc_task_complete when a task is part of a schedule (detailed description comment is in the code).