### PR TITLE
TEST: enable tl cuda alltoallv tests

### DIFF
--- a/test/mpi/test_alltoallv.cc
+++ b/test/mpi/test_alltoallv.cc
@@ -61,12 +61,13 @@ TestAlltoallv::TestAlltoallv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
         return;
     }
 
+    args.mask  = UCC_COLL_ARGS_FIELD_FLAGS;
+    args.flags |= UCC_COLL_ARGS_FLAG_CONTIG_SRC_BUFFER |
+                  UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER;
     if (count_bits == TEST_FLAG_VSIZE_64BIT) {
-        args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags |= UCC_COLL_ARGS_FLAG_COUNT_64BIT;
     }
     if (displ_bits == TEST_FLAG_VSIZE_64BIT) {
-        args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
         args.flags |= UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
     }
 

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -13,15 +13,16 @@ ucc_pt_coll_alltoallv::ucc_pt_coll_alltoallv(ucc_datatype_t dt,
     has_range_     = true;
     has_bw_        = false;
 
-    coll_args.mask = 0;
-    coll_args.coll_type = UCC_COLL_TYPE_ALLTOALLV;
+    coll_args.mask                = UCC_COLL_ARGS_FIELD_FLAGS;
+    coll_args.coll_type           = UCC_COLL_TYPE_ALLTOALLV;
     coll_args.src.info_v.datatype = dt;
     coll_args.src.info_v.mem_type = mt;
     coll_args.dst.info_v.datatype = dt;
     coll_args.dst.info_v.mem_type = mt;
+    coll_args.flags               = UCC_COLL_ARGS_FLAG_CONTIG_SRC_BUFFER |
+                                    UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER;
     if (is_inplace) {
-        coll_args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
-        coll_args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+        coll_args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
 }
 


### PR DESCRIPTION
## What
Set UCC_COLL_ARGS_FLAG_CONTIG_SRC_BUFFER  and UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER for alltoallv tests

## Why ?
Enables TL CUDA alltoallv in ucc_test_mpi and ucc_perftest
