### PR TITLE
TL/RCCL: introduce support for rccl/rocm

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -37,7 +37,7 @@ jobs:
             fi
           fi
           H1="CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC|EC|SCHEDULE|TOPO"
-          H2="CL/|TL/|MC/|EC/|UCP|NCCL|SHARP|BASIC|HIER|CUDA|CPU|EE"
+          H2="CL/|TL/|MC/|EC/|UCP|NCCL|SHARP|BASIC|HIER|CUDA|CPU|EE|RCCL|ROCM"
           if ! echo $msg | grep -qP '^Merge |^'"(($H1)|($H2))"'+: \w'
           then
             echo "Wrong header"

--- a/config/m4/rccl.m4
+++ b/config/m4/rccl.m4
@@ -1,0 +1,93 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+AC_DEFUN([CHECK_RCCL],[
+AS_IF([test "x$rccl_checked" != "xyes"],[
+    rccl_happy="no"
+
+    AC_ARG_WITH([rccl],
+            [AS_HELP_STRING([--with-rccl=(DIR)], [Enable the use of RCCL (default is guess).])],
+            [], [with_rccl=guess])
+
+    AS_IF([test "x$with_rccl" != "xno"],
+    [
+        save_CPPFLAGS="$CPPFLAGS"
+        save_CFLAGS="$CFLAGS"
+        save_LDFLAGS="$LDFLAGS"
+
+        AS_IF([test ! -z "$with_rccl" -a "x$with_rccl" != "xyes" -a "x$with_rccl" != "xguess"],
+        [
+            AS_IF([test ! -d $with_rccl],
+                  [AC_MSG_ERROR([Provided "--with-rccl=${with_rccl}" location does not exist])], [])])
+            check_rccl_dir="$with_rccl"
+            check_rccl_libdir="$with_rccl/lib"
+            CPPFLAGS="-I$with_rccl/include $save_CPPFLAGS"
+            LDFLAGS="-L$check_rccl_libdir $save_LDFLAGS"
+        ])
+
+        AS_IF([test ! -z "$with_rccl_libdir" -a "x$with_rccl_libdir" != "xyes"],
+        [
+            check_rccl_libdir="$with_rccl_libdir"
+            LDFLAGS="-L$check_rccl_libdir $save_LDFLAGS"
+        ])
+
+        AS_IF([test "x$rocm_happy" = "xyes"],
+        [
+            CPPFLAGS="$HIP_CPPFLAGS $CPPFLAGS"
+            LDFLAGS="$ROCM_LDFLAGS $LDFLAGS"
+            AC_CHECK_HEADER([rccl.h],
+            [
+                AC_CHECK_LIB([rccl], [ncclCommInitRank],
+                [
+                    rccl_happy="yes"
+                ],
+                [
+                    rccl_happy="no"
+                ])
+            ],
+            [
+                rccl_happy="no"
+            ])
+        ],
+        [
+            rccl_happy="no"
+        ])
+
+        AS_IF([test "x$rccl_happy" = "xyes"],
+        [
+            AS_IF([test "x$check_rccl_dir" != "x"],
+            [
+                AC_MSG_RESULT([RCCL dir: $check_rccl_dir])
+                AC_SUBST(RCCL_CPPFLAGS, "-I$check_rccl_dir/include/")
+            ])
+
+            AS_IF([test "x$check_rccl_libdir" != "x"],
+            [
+                AC_SUBST(RCCL_LDFLAGS, "-L$check_rccl_libdir")
+            ])
+
+            AC_SUBST(RCCL_LIBADD, "-lrccl")
+        ],
+        [
+            AS_IF([test "x$with_rccl" != "xguess"],
+            [
+                AC_MSG_ERROR([RCCL support is requested but RCCL packages cannot be found! $CPPFLAGS $LDFLAGS])
+            ],
+            [
+                AC_MSG_WARN([RCCL not found])
+            ])
+        ])
+
+        CFLAGS="$save_CFLAGS -D__HIP_PLATFORM_AMD__"
+        CPPFLAGS="$save_CPPFLAGS"
+        LDFLAGS="$save_LDFLAGS"
+    ],
+    [
+        AC_MSG_WARN([RCCL was explicitly disabled])
+    ])
+
+    rccl_checked=yes
+])

--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -1,0 +1,143 @@
+#
+# Copyright (C) Advanced Micro Devices, Inc. 2016 - 2022. ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2022.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+# ROCM_PARSE_FLAGS(ARG, VAR_LIBS, VAR_LDFLAGS, VAR_CPPFLAGS)
+# ----------------------------------------------------------
+# Parse whitespace-separated ARG into appropriate LIBS, LDFLAGS, and
+# CPPFLAGS variables.
+AC_DEFUN([ROCM_PARSE_FLAGS],
+[for arg in $$1 ; do
+    AS_CASE([$arg],
+        [yes],               [],
+        [no],                [],
+        [-l*|*.a|*.so],      [$2="$$2 $arg"],
+        [-L*|-WL*|-Wl*],     [$3="$$3 $arg"],
+        [-I*],               [$4="$$4 $arg"],
+        [*lib|*lib/|*lib64|*lib64/],[AS_IF([test -d $arg], [$3="$$3 -L$arg"],
+                                 [AC_MSG_WARN([$arg of $1 not parsed])])],
+        [*include|*include/],[AS_IF([test -d $arg], [$4="$$4 -I$arg"],
+                                 [AC_MSG_WARN([$arg of $1 not parsed])])],
+        [AC_MSG_WARN([$arg of $1 not parsed])])
+done])
+
+# ROCM_BUILD_FLAGS(ARG, VAR_LIBS, VAR_LDFLAGS, VAR_CPPFLAGS, VAR_ROOT)
+# ----------------------------------------------------------
+# Parse value of ARG into appropriate LIBS, LDFLAGS, and
+# CPPFLAGS variables.
+AC_DEFUN([ROCM_BUILD_FLAGS],
+    $4="-I$1/include/hsa -I$1/include"
+    $3="-L$1/lib -L$1/lib64 -L$1/hsa/lib"
+    $2="-lhsa-runtime64 -lhsakmt"
+    $5="$1"
+)
+
+# HIP_BUILD_FLAGS(ARG, VAR_LIBS, VAR_LDFLAGS, VAR_CPPFLAGS)
+# ----------------------------------------------------------
+# Parse value of ARG into appropriate LIBS, LDFLAGS, and
+# CPPFLAGS variables.
+AC_DEFUN([HIP_BUILD_FLAGS],
+    $4="-D__HIP_PLATFORM_AMD__ -I$1/include/hip -I$1/include  -I$1/hip/include"
+    $3="-L$1/hip/lib -L$1/lib"
+    $2="-lamdhip64"
+)
+
+#
+# Check for ROCm  support
+#
+AC_DEFUN([CHECK_ROCM],[
+
+AS_IF([test "x$rocm_checked" != "xyes"],[
+
+AC_ARG_WITH([rocm],
+    [AS_HELP_STRING([--with-rocm=(DIR)],
+        [Enable the use of ROCm (default is autodetect).])],
+    [],
+    [with_rocm=guess])
+
+rocm_happy=no
+hip_happy=no
+AS_IF([test "x$with_rocm" != "xno"],
+    [AS_CASE(["x$with_rocm"],
+        [x|xguess|xyes],
+            [AC_MSG_NOTICE([ROCm path was not specified. Guessing ...])
+             with_rocm="/opt/rocm"
+             ROCM_BUILD_FLAGS([$with_rocm],
+                          [ROCM_LIBS], [ROCM_LDFLAGS], [ROCM_CPPFLAGS], [ROCM_ROOT])],
+        [x/*],
+            [AC_MSG_NOTICE([ROCm path given as $with_rocm ...])
+             ROCM_BUILD_FLAGS([$with_rocm],
+                          [ROCM_LIBS], [ROCM_LDFLAGS], [ROCM_CPPFLAGS], [ROCM_ROOT])],
+        [AC_MSG_NOTICE([ROCm flags given ...])
+         ROCM_PARSE_FLAGS([$with_rocm],
+                          [ROCM_LIBS], [ROCM_LDFLAGS], [ROCM_CPPFLAGS])])
+
+    SAVE_CPPFLAGS="$CPPFLAGS"
+    SAVE_LDFLAGS="$LDFLAGS"
+    SAVE_LIBS="$LIBS"
+
+    CPPFLAGS="$ROCM_CPPFLAGS $CPPFLAGS"
+    LDFLAGS="$ROCM_LDFLAGS $LDFLAGS"
+    LIBS="$ROCM_LIBS $LIBS"
+
+    rocm_happy=yes
+    AS_IF([test "x$rocm_happy" = xyes],
+          [AC_CHECK_HEADERS([hsa.h], [rocm_happy=yes], [rocm_happy=no])])
+    AS_IF([test "x$rocm_happy" = xyes],
+          [AC_CHECK_HEADERS([hsa_ext_amd.h], [rocm_happy=yes], [rocm_happy=no])])
+    AS_IF([test "x$rocm_happy" = xyes],
+          [AC_CHECK_LIB([hsa-runtime64], [hsa_init], [rocm_happy=yes], [rocm_happy=no])])
+
+    AS_IF([test "x$rocm_happy" = "xyes"],
+          [AC_DEFINE([HAVE_ROCM], 1, [Enable ROCM support])
+           AC_SUBST([ROCM_CPPFLAGS])
+           AC_SUBST([ROCM_LDFLAGS])
+           AC_SUBST([ROCM_LIBS])
+           AC_SUBST([ROCM_ROOT])],
+          [AC_MSG_WARN([ROCm not found])])
+
+    CPPFLAGS="$SAVE_CPPFLAGS"
+    LDFLAGS="$SAVE_LDFLAGS"
+    LIBS="$SAVE_LIBS"
+
+    HIP_BUILD_FLAGS([$with_rocm], [HIP_LIBS], [HIP_LDFLAGS], [HIP_CPPFLAGS])
+
+    CPPFLAGS="$HIP_CPPFLAGS $CPPFLAGS"
+    LDFLAGS="$HIP_LDFLAGS $LDFLAGS"
+    LIBS="$HIP_LIBS $LIBS"
+
+    hip_happy=no
+    AC_CHECK_LIB([hip_hcc], [hipFree], [AC_MSG_WARN([Please install ROCm-3.7.0 or above])], [hip_happy=yes])
+    AS_IF([test "x$hip_happy" = xyes],
+          [AC_CHECK_HEADERS([hip/hip_runtime.h], [hip_happy=yes], [hip_happy=no])])
+    AS_IF([test "x$hip_happy" = xyes],
+          [AC_CHECK_LIB([amdhip64], [hipFree], [hip_happy=yes], [hip_happy=no])])
+    AS_IF([test "x$hip_happy" = xyes], [HIP_CXXFLAGS="--std=gnu++11"], [])
+
+    CPPFLAGS="$SAVE_CPPFLAGS"
+    LDFLAGS="$SAVE_LDFLAGS"
+    LIBS="$SAVE_LIBS"
+
+    AS_IF([test "x$hip_happy" = "xyes"],
+          [AC_DEFINE([HAVE_HIP], 1, [Enable HIP support])
+           AC_SUBST([HIP_CPPFLAGS])
+           AC_SUBST([HIP_CXXFLAGS])
+           AC_SUBST([HIP_LDFLAGS])
+           AC_SUBST([HIP_LIBS])],
+          [AC_MSG_WARN([HIP Runtime not found])])
+
+    ],
+    [AC_MSG_WARN([ROCm was explicitly disabled])]
+)
+
+
+
+rocm_checked=yes
+AM_CONDITIONAL([HAVE_ROCM], [test "x$rocm_happy" != xno])
+AM_CONDITIONAL([HAVE_HIP], [test "x$hip_happy" != xno])
+
+])
+
+])

--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,8 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_AARCH64_HI1620], [false])
      AM_CONDITIONAL([HAVE_UCX], [false])
      AM_CONDITIONAL([HAVE_CUDA], [false])
+     AM_CONDITIONAL([HAVE_ROCM], [false])
+     AM_CONDITIONAL([HAVE_HIP], [false])
      AM_CONDITIONAL([HAVE_NVML], [false])
      AM_CONDITIONAL([HAVE_MPI], [false])
      AM_CONDITIONAL([HAVE_MPIRUN], [false])
@@ -155,6 +157,8 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/ucx.m4])
      m4_include([config/m4/cuda.m4])
      m4_include([config/m4/nccl.m4])
+     m4_include([config/m4/rocm.m4])
+     m4_include([config/m4/rccl.m4])
      m4_include([config/m4/sharp.m4])
      m4_include([config/m4/mpi.m4])
      m4_include([config/m4/configure.m4])
@@ -178,8 +182,16 @@ AS_IF([test "x$with_docs_only" = xyes],
          mc_modules="${mc_modules}:cuda"
      fi
 
+     CHECK_ROCM
+     AC_MSG_RESULT([ROCM support: $rocm_happy; $ROCM_CPPFLAGS $ROCM_LDFLAGS])
+     AC_MSG_RESULT([HIP support: $hip_happy; $HIP_CPPFLAGS $HIP_LDFLAGS])
+     if test $rocm_happy = "yes"; then
+         mc_modules="${mc_modules}:rocm"
+     fi
+
      CHECK_GTEST
      AC_MSG_RESULT([GTEST support: $gtest_happy])
+
     ]) # Docs only
 
 
@@ -202,7 +214,9 @@ AC_CONFIG_FILES([
                  src/components/ec/cpu/Makefile
                  src/components/ec/cuda/Makefile
                  src/components/ec/cuda/kernel/Makefile
-                 test/mpi/Makefile
+                 src/components/mc/rocm/Makefile
+                 src/components/ec/rocm/Makefile
+		 test/mpi/Makefile
                  test/gtest/Makefile
                  tools/info/Makefile
                  tools/perf/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,6 +13,11 @@ mc_dirs += components/mc/cuda
 ec_dirs += components/ec/cuda
 endif
 
+if HAVE_ROCM
+mc_dirs += components/mc/rocm
+ec_dirs += components/ec/rocm
+endif
+
 SUBDIRS = . $(cl_dirs) $(mc_dirs) $(ec_dirs)
 
 include components/tl/makefile.am

--- a/src/components/ec/rocm/Makefile.am
+++ b/src/components/ec/rocm/Makefile.am
@@ -1,0 +1,21 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+#
+
+if HAVE_ROCM
+
+sources =    \
+	ec_rocm.h \
+	ec_rocm.c
+
+module_LTLIBRARIES         = libucc_ec_rocm.la
+libucc_ec_rocm_la_SOURCES  = $(sources)
+libucc_ec_rocm_la_CPPFLAGS = $(AM_CPPFLAGS) $(HIP_CPPFLAGS) $(ROCM_CPPFLAGS) $(BASE_CPPFLAGS)
+libucc_ec_rocm_la_CFLAGS   = $(BASE_CFLAGS)
+libucc_ec_rocm_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(HIP_LDFLAGS) $(ROCM_LDFLAGS)
+libucc_ec_rocm_la_LIBADD   = $(HIP_LIBS) $(ROCM_LIBS)          \
+                             $(UCC_TOP_BUILDDIR)/src/libucc.la
+
+include $(top_srcdir)/config/module.am
+endif

--- a/src/components/ec/rocm/ec_rocm.c
+++ b/src/components/ec/rocm/ec_rocm.c
@@ -1,0 +1,352 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ec_rocm.h"
+#include "utils/ucc_malloc.h"
+#include "utils/arch/cpu.h"
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+
+static const char *stream_task_modes[] = {
+    [UCC_EC_ROCM_TASK_KERNEL]  = "kernel",
+    [UCC_EC_ROCM_TASK_MEM_OPS] = "driver",
+    [UCC_EC_ROCM_TASK_AUTO]    = "auto",
+    [UCC_EC_ROCM_TASK_LAST]    = NULL
+};
+
+static const char *task_stream_types[] = {
+    [UCC_EC_ROCM_USER_STREAM]      = "user",
+    [UCC_EC_ROCM_INTERNAL_STREAM]  = "ucc",
+    [UCC_EC_ROCM_TASK_STREAM_LAST] = NULL
+};
+
+static ucc_config_field_t ucc_ec_rocm_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_ec_rocm_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_ec_config_table)},
+
+    {"STREAM_TASK_MODE", "auto",
+     "Mechanism to create stream dependency\n"
+     "kernel - use waiting kernel\n"
+     "driver - use driver MEM_OPS\n"
+     "auto   - runtime automatically chooses best one",
+     ucc_offsetof(ucc_ec_rocm_config_t, strm_task_mode),
+     UCC_CONFIG_TYPE_ENUM(stream_task_modes)},
+
+    {"TASK_STREAM", "user",
+     "Stream for rocm task\n"
+     "user - user stream provided in execution engine context\n"
+     "ucc  - ucc library internal stream",
+     ucc_offsetof(ucc_ec_rocm_config_t, task_strm_type),
+     UCC_CONFIG_TYPE_ENUM(task_stream_types)},
+
+    {"STREAM_BLOCKING_WAIT", "1",
+     "Stream is blocked until collective operation is done",
+     ucc_offsetof(ucc_ec_rocm_config_t, stream_blocking_wait),
+     UCC_CONFIG_TYPE_UINT},
+
+    {NULL}
+};
+
+static ucc_status_t ucc_ec_rocm_stream_req_mpool_chunk_malloc(ucc_mpool_t *mp,
+                                                              size_t *size_p,
+                                                              void ** chunk_p)
+{
+    ucc_status_t status;
+
+    status = ROCM_FUNC(hipHostMalloc((void**)chunk_p, *size_p,
+                       hipHostMallocMapped));
+    return status;
+}
+
+static void ucc_ec_rocm_stream_req_mpool_chunk_free(ucc_mpool_t *mp,
+                                                    void *       chunk)
+{
+    hipHostFree(chunk);
+}
+
+static void ucc_ec_rocm_stream_req_init(ucc_mpool_t *mp, void *obj, void *chunk)
+{
+    ucc_ec_rocm_stream_request_t *req = (ucc_ec_rocm_stream_request_t*) obj;
+
+    ROCM_FUNC(hipHostGetDevicePointer(
+                  (void**)(&req->dev_status), (void *)&req->status, 0));
+}
+
+static ucc_mpool_ops_t ucc_ec_rocm_stream_req_mpool_ops = {
+    .chunk_alloc   = ucc_ec_rocm_stream_req_mpool_chunk_malloc,
+    .chunk_release = ucc_ec_rocm_stream_req_mpool_chunk_free,
+    .obj_init      = ucc_ec_rocm_stream_req_init,
+    .obj_cleanup   = NULL
+};
+
+static void ucc_ec_rocm_event_init(ucc_mpool_t *mp, void *obj, void *chunk)
+{
+    ucc_ec_rocm_event_t *base = (ucc_ec_rocm_event_t *) obj;
+
+    if (ucc_unlikely(
+          hipSuccess !=
+          hipEventCreateWithFlags(&base->event, hipEventDisableTiming))) {
+      ec_error(&ucc_ec_rocm.super, "hipEventCreateWithFlags Failed");
+    }
+}
+
+static void ucc_ec_rocm_event_cleanup(ucc_mpool_t *mp, void *obj)
+{
+    ucc_ec_rocm_event_t *base = (ucc_ec_rocm_event_t *) obj;
+
+    if (ucc_unlikely(hipSuccess != hipEventDestroy(base->event))) {
+        ec_error(&ucc_ec_rocm.super, "hipEventDestroy Failed");
+    }
+}
+
+static ucc_mpool_ops_t ucc_ec_rocm_event_mpool_ops = {
+    .chunk_alloc   = ucc_mpool_hugetlb_malloc,
+    .chunk_release = ucc_mpool_hugetlb_free,
+    .obj_init      = ucc_ec_rocm_event_init,
+    .obj_cleanup   = ucc_ec_rocm_event_cleanup,
+};
+
+static ucc_status_t ucc_ec_rocm_post_kernel_stream_task(uint32_t *status,
+                                                 int blocking_wait,
+                                                 hipStream_t stream)
+{
+    return UCC_ERR_NOT_IMPLEMENTED;
+}
+
+static ucc_status_t ucc_ec_rocm_init(const ucc_ec_params_t *ec_params)
+{
+    ucc_ec_rocm_config_t *cfg = EC_ROCM_CONFIG;
+    ucc_status_t status;
+    int device, num_devices;
+    hipError_t rocm_st;
+
+    ucc_ec_rocm.stream             = NULL;
+    ucc_ec_rocm.stream_initialized = 0;
+    ucc_strncpy_safe(ucc_ec_rocm.super.config->log_component.name,
+                     ucc_ec_rocm.super.super.name,
+                     sizeof(ucc_ec_rocm.super.config->log_component.name));
+    ucc_ec_rocm.thread_mode = ec_params->thread_mode;
+    rocm_st = hipGetDeviceCount(&num_devices);
+    if ((rocm_st != hipSuccess) || (num_devices == 0)) {
+        ec_info(&ucc_ec_rocm.super, "rocm devices are not found");
+        return UCC_ERR_NO_RESOURCE;
+    }
+    ROCMCHECK(hipGetDevice(&device));
+
+    /*create event pool */
+    status = ucc_mpool_init(&ucc_ec_rocm.events, 0, sizeof(ucc_ec_rocm_event_t),
+                            0, UCC_CACHE_LINE_SIZE, 16, UINT_MAX,
+                            &ucc_ec_rocm_event_mpool_ops, UCC_THREAD_MULTIPLE,
+                            "ROCM Event Objects");
+    if (status != UCC_OK) {
+        ec_error(&ucc_ec_rocm.super, "Error to create event pool");
+        return status;
+    }
+
+    /* create request pool */
+    status = ucc_mpool_init(
+        &ucc_ec_rocm.strm_reqs, 0, sizeof(ucc_ec_rocm_stream_request_t), 0,
+        UCC_CACHE_LINE_SIZE, 16, UINT_MAX, &ucc_ec_rocm_stream_req_mpool_ops,
+        UCC_THREAD_MULTIPLE, "ROCM Event Objects");
+    if (status != UCC_OK) {
+        ec_error(&ucc_ec_rocm.super, "Error to create event pool");
+        return status;
+    }
+
+    if (cfg->strm_task_mode == UCC_EC_ROCM_TASK_KERNEL) {
+        ucc_ec_rocm.strm_task_mode = UCC_EC_ROCM_TASK_KERNEL;
+        ucc_ec_rocm.post_strm_task = ucc_ec_rocm_post_kernel_stream_task;
+    } else {
+        if (cfg->strm_task_mode == UCC_EC_ROCM_TASK_AUTO) {
+            ucc_ec_rocm.strm_task_mode = UCC_EC_ROCM_TASK_KERNEL;
+            ucc_ec_rocm.post_strm_task = ucc_ec_rocm_post_kernel_stream_task;
+        } else {
+            ec_error(&ucc_ec_rocm.super, "ROCM MEM OPS are not supported");
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+    }
+
+    ucc_ec_rocm.task_strm_type = cfg->task_strm_type;
+    ucc_spinlock_init(&ucc_ec_rocm.init_spinlock, 0);
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_ec_rocm_get_attr(ucc_ec_attr_t *ec_attr)
+{
+    if (ec_attr->field_mask & UCC_EC_ATTR_FIELD_THREAD_MODE) {
+        ec_attr->thread_mode = ucc_ec_rocm.thread_mode;
+    }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_ec_rocm_task_post(void *ee_stream, void **ee_req)
+{
+    ucc_ec_rocm_config_t *cfg = EC_ROCM_CONFIG;
+    ucc_ec_rocm_stream_request_t *req;
+    ucc_ec_rocm_event_t *rocm_event;
+    ucc_status_t status;
+
+    UCC_EC_ROCM_INIT_STREAM();
+    req = ucc_mpool_get(&ucc_ec_rocm.strm_reqs);
+    if (ucc_unlikely(!req)) {
+        ec_error(&ucc_ec_rocm.super, "Failed to allocate stream request");
+	return UCC_ERR_NO_MEMORY;
+    }
+    req->status = UCC_EC_ROCM_TASK_POSTED;
+    req->stream = (hipStream_t)ee_stream;
+
+    if (ucc_ec_rocm.task_strm_type == UCC_EC_ROCM_USER_STREAM) {
+        status = ucc_ec_rocm.post_strm_task(req->dev_status,
+                                            cfg->stream_blocking_wait,
+                                            req->stream);
+        if (status != UCC_OK) {
+            goto free_req;
+        }
+    } else {
+        rocm_event = ucc_mpool_get(&ucc_ec_rocm.events);
+        if (ucc_unlikely(!rocm_event)) {
+	    ec_error(&ucc_ec_rocm.super, "Failed to allocate rocm event");
+	    goto free_event;
+	}
+        ROCMCHECK(hipEventRecord(rocm_event->event, req->stream));
+        ROCMCHECK(hipStreamWaitEvent(ucc_ec_rocm.stream, rocm_event->event, 0));
+        status = ucc_ec_rocm.post_strm_task(req->dev_status,
+                                            cfg->stream_blocking_wait,
+                                            ucc_ec_rocm.stream);
+        if (ucc_unlikely(status != UCC_OK)) {
+            goto free_req;
+        }
+        ROCMCHECK(hipEventRecord(rocm_event->event, ucc_ec_rocm.stream));
+        ROCMCHECK(hipStreamWaitEvent(req->stream, rocm_event->event, 0));
+        ucc_mpool_put(rocm_event);
+    }
+
+    *ee_req = (void *) req;
+
+    ec_info(&ucc_ec_rocm.super, "ROCM stream task posted on \"%s\" stream. req:%p",
+            task_stream_types[ucc_ec_rocm.task_strm_type], req);
+
+    return UCC_OK;
+
+free_event:
+    ucc_mpool_put(rocm_event);
+free_req:
+    ucc_mpool_put(req);
+    return status;
+}
+
+ucc_status_t ucc_ec_rocm_task_query(void *ee_req)
+{
+    ucc_ec_rocm_stream_request_t *req = ee_req;
+
+    /* ee task might be only in POSTED, STARTED or COMPLETED_ACK state
+       COMPLETED state is used by ucc_ee_rocm_task_end function to request
+       stream unblock*/
+    ucc_assert(req->status != UCC_EC_ROCM_TASK_COMPLETED);
+    if (req->status == UCC_EC_ROCM_TASK_POSTED) {
+        return UCC_INPROGRESS;
+    }
+    ec_info(&ucc_ec_rocm.super, "ROCM stream task started. req:%p", req);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_ec_rocm_task_end(void *ee_req)
+{
+    ucc_ec_rocm_stream_request_t *req = ee_req;
+    volatile ucc_ec_task_status_t *st = &req->status;
+
+    /* can be safely ended only if it's in STARTED or COMPLETED_ACK state */
+    ucc_assert((*st != UCC_EC_ROCM_TASK_POSTED) &&
+               (*st != UCC_EC_ROCM_TASK_COMPLETED));
+    if (*st == UCC_EC_ROCM_TASK_STARTED) {
+        *st = UCC_EC_ROCM_TASK_COMPLETED;
+        while(*st != UCC_EC_ROCM_TASK_COMPLETED_ACK) { }
+    }
+    ucc_mpool_put(req);
+    ec_info(&ucc_ec_rocm.super, "ROCM stream task done. req:%p", req);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_ec_rocm_create_event(void **event)
+{
+    ucc_ec_rocm_event_t *rocm_event;
+
+    rocm_event = ucc_mpool_get(&ucc_ec_rocm.events);
+    if (ucc_unlikely(!rocm_event)) {
+	ec_error(&ucc_ec_rocm.super, "Failed to allocate rocm event");
+	return UCC_ERR_NO_MEMORY;
+    }
+    *event = rocm_event;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_ec_rocm_destroy_event(void *event)
+{
+    ucc_ec_rocm_event_t *rocm_event = event;
+
+    ucc_mpool_put(rocm_event);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_ec_rocm_event_post(void *ee_context, void *event)
+{
+    hipStream_t stream              = (hipStream_t) ee_context;
+    ucc_ec_rocm_event_t *rocm_event = event;
+
+    ROCMCHECK(hipEventRecord(rocm_event->event, stream));
+    return UCC_OK;
+}
+
+ucc_status_t ucc_ec_rocm_event_test(void *event)
+{
+    ucc_ec_rocm_event_t *rocm_event = event;
+    hipError_t hip_err;
+
+    hip_err = hipEventQuery(rocm_event->event);
+    if (ucc_unlikely((hip_err != hipSuccess) &&
+                     (hip_err != hipErrorNotReady))) {
+        ROCMCHECK(hip_err);
+    }
+    return hip_error_to_ucc_status(hip_err);
+}
+
+static ucc_status_t ucc_ec_rocm_finalize()
+{
+    if (ucc_ec_rocm.stream != NULL) {
+        ROCMCHECK(hipStreamDestroy(ucc_ec_rocm.stream));
+        ucc_ec_rocm.stream = NULL;
+    }
+    ucc_spinlock_destroy(&ucc_ec_rocm.init_spinlock);
+    return UCC_OK;
+}
+
+ucc_ec_rocm_t ucc_ec_rocm = {
+    .super.super.name             = "rocm ec",
+    .super.ref_cnt                = 0,
+    .super.type                   = UCC_EE_ROCM_STREAM,
+    .super.init                   = ucc_ec_rocm_init,
+    .super.get_attr               = ucc_ec_rocm_get_attr,
+    .super.finalize               = ucc_ec_rocm_finalize,
+    .super.config_table =
+        {
+            .name   = "ROCM execution component",
+            .prefix = "EC_ROCM_",
+            .table  = ucc_ec_rocm_config_table,
+            .size   = sizeof(ucc_ec_rocm_config_t),
+        },
+    .super.ops.task_post     = ucc_ec_rocm_task_post,
+    .super.ops.task_query    = ucc_ec_rocm_task_query,
+    .super.ops.task_end      = ucc_ec_rocm_task_end,
+    .super.ops.create_event  = ucc_ec_rocm_create_event,
+    .super.ops.destroy_event = ucc_ec_rocm_destroy_event,
+    .super.ops.event_post    = ucc_ec_rocm_event_post,
+    .super.ops.event_test    = ucc_ec_rocm_event_test,
+};
+
+UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_ec_rocm.super.config_table,
+                                &ucc_config_global_list);

--- a/src/components/ec/rocm/ec_rocm.h
+++ b/src/components/ec/rocm/ec_rocm.h
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_EC_ROCM_H_
+#define UCC_EC_ROCM_H_
+
+#include "components/ec/base/ucc_ec_base.h"
+#include "components/ec/ucc_ec_log.h"
+#include "utils/ucc_mpool.h"
+#include "utils/arch/rocm_def.h"
+#include <hip/hip_runtime_api.h>
+
+typedef enum ucc_ec_rocm_strm_task_mode {
+    UCC_EC_ROCM_TASK_KERNEL,
+    UCC_EC_ROCM_TASK_MEM_OPS,
+    UCC_EC_ROCM_TASK_AUTO,
+    UCC_EC_ROCM_TASK_LAST,
+} ucc_ec_rocm_strm_task_mode_t;
+
+typedef enum ucc_ec_rocm_task_stream_type {
+    UCC_EC_ROCM_USER_STREAM,
+    UCC_EC_ROCM_INTERNAL_STREAM,
+    UCC_EC_ROCM_TASK_STREAM_LAST
+} ucc_ec_rocm_task_stream_type_t;
+
+typedef enum ucc_ec_task_status {
+    UCC_EC_ROCM_TASK_COMPLETED,
+    UCC_EC_ROCM_TASK_POSTED,
+    UCC_EC_ROCM_TASK_STARTED,
+    UCC_EC_ROCM_TASK_COMPLETED_ACK
+} ucc_ec_task_status_t;
+
+static inline ucc_status_t hip_error_to_ucc_status(hipError_t hip_err)
+{
+    switch(hip_err) {
+    case hipSuccess:
+        return UCC_OK;
+    case hipErrorNotReady:
+        return UCC_INPROGRESS;
+    default:
+        break;
+    }
+    return UCC_ERR_NO_MESSAGE;
+}
+
+typedef ucc_status_t (*ucc_ec_rocm_task_post_fn) (uint32_t *dev_status,
+                                                  int blocking_wait,
+                                                  hipStream_t stream);
+
+typedef struct ucc_ec_rocm_config {
+    ucc_ec_config_t                super;
+    ucc_ec_rocm_strm_task_mode_t   strm_task_mode;
+    ucc_ec_rocm_task_stream_type_t task_strm_type;
+    int                            stream_blocking_wait;
+} ucc_ec_rocm_config_t;
+
+typedef struct ucc_ec_rocm {
+    ucc_ec_base_t                  super;
+    int                            stream_initialized;
+    hipStream_t                    stream;
+    ucc_mpool_t                    events;
+    ucc_mpool_t                    strm_reqs;
+    ucc_thread_mode_t              thread_mode;
+    ucc_ec_rocm_strm_task_mode_t   strm_task_mode;
+    ucc_ec_rocm_task_stream_type_t task_strm_type;
+    ucc_ec_rocm_task_post_fn       post_strm_task;
+    ucc_spinlock_t                 init_spinlock;
+} ucc_ec_rocm_t;
+
+typedef struct ucc_rocm_ec_event {
+    hipEvent_t    event;
+} ucc_ec_rocm_event_t;
+
+typedef struct ucc_ec_rocm_stream_request {
+    uint32_t            status;
+    uint32_t           *dev_status;
+    hipStream_t         stream;
+} ucc_ec_rocm_stream_request_t;
+
+extern ucc_ec_rocm_t ucc_ec_rocm;
+
+#define EC_ROCM_CONFIG                                                         \
+    (ucc_derived_of(ucc_ec_rocm.super.config, ucc_ec_rocm_config_t))
+
+#define UCC_EC_ROCM_INIT_STREAM() do {                                         \
+    if (!ucc_ec_rocm.stream_initialized) {                                     \
+        hipError_t hip_st = hipSuccess;                                        \
+        ucc_spin_lock(&ucc_ec_rocm.init_spinlock);                             \
+        if (!ucc_ec_rocm.stream_initialized) {                                 \
+            hip_st = hipStreamCreateWithFlags(&ucc_ec_rocm.stream,             \
+                                                hipStreamNonBlocking);         \
+            ucc_ec_rocm.stream_initialized = 1;                                \
+        }								       \
+        ucc_spin_unlock(&ucc_ec_rocm.init_spinlock);                           \
+        if(hip_st != hipSuccess) {                                             \
+            ec_error(&ucc_ec_rocm.super, "rocm failed with ret:%d(%s)",        \
+                     hip_st, hipGetErrorString(hip_st));                       \
+            return UCC_ERR_NO_MESSAGE;                                         \
+        }                                                                      \
+    }                                                                          \
+} while(0)
+
+#endif

--- a/src/components/mc/rocm/Makefile.am
+++ b/src/components/mc/rocm/Makefile.am
@@ -1,0 +1,21 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+#
+
+if HAVE_ROCM
+
+sources =    \
+    mc_rocm.h \
+    mc_rocm.c
+
+module_LTLIBRARIES         = libucc_mc_rocm.la
+libucc_mc_rocm_la_SOURCES  = $(sources)
+libucc_mc_rocm_la_CPPFLAGS = $(AM_CPPFLAGS) $(HIP_CPPFLAGS) $(ROCM_CPPFLAGS) $(BASE_CPPFLAGS)
+libucc_mc_rocm_la_CFLAGS   = $(BASE_CFLAGS)
+libucc_mc_rocm_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(HIP_LDFLAGS) $(ROCM_LDFLAGS)
+libucc_mc_rocm_la_LIBADD   = $(HIP_LIBS) $(ROCM_LIBS) \
+                             $(UCC_TOP_BUILDDIR)/src/libucc.la
+
+include $(top_srcdir)/config/module.am
+endif

--- a/src/components/mc/rocm/mc_rocm.c
+++ b/src/components/mc/rocm/mc_rocm.c
@@ -1,0 +1,361 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "mc_rocm.h"
+#include "utils/ucc_malloc.h"
+#include "utils/arch/cpu.h"
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+
+static ucc_config_field_t ucc_mc_rocm_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_mc_rocm_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_mc_config_table)},
+
+    {"REDUCE_NUM_BLOCKS", "auto",
+     "Number of thread blocks to use for reduction",
+     ucc_offsetof(ucc_mc_rocm_config_t, reduce_num_blocks),
+     UCC_CONFIG_TYPE_ULUNITS},
+
+    {"MPOOL_ELEM_SIZE", "1Mb", "The size of each element in mc rocm mpool",
+     ucc_offsetof(ucc_mc_rocm_config_t, mpool_elem_size),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"MPOOL_MAX_ELEMS", "8", "The max amount of elements in mc rocm mpool",
+     ucc_offsetof(ucc_mc_rocm_config_t, mpool_max_elems), UCC_CONFIG_TYPE_UINT},
+
+    {NULL}
+};
+
+
+static ucc_status_t ucc_mc_rocm_init(const ucc_mc_params_t *mc_params)
+{
+    ucc_mc_rocm_config_t *cfg = MC_ROCM_CONFIG;
+    struct hipDeviceProp_t prop;
+    int device, num_devices;
+    hipError_t rocm_st;
+
+    ucc_mc_rocm.stream             = NULL;
+    ucc_mc_rocm.stream_initialized = 0;
+    ucc_strncpy_safe(ucc_mc_rocm.super.config->log_component.name,
+                     ucc_mc_rocm.super.super.name,
+                     sizeof(ucc_mc_rocm.super.config->log_component.name));
+    ucc_mc_rocm.thread_mode = mc_params->thread_mode;
+    rocm_st = hipGetDeviceCount(&num_devices);
+    if ((rocm_st != hipSuccess) || (num_devices == 0)) {
+        mc_info(&ucc_mc_rocm.super, "rocm devices are not found");
+        return hip_error_to_ucc_status(rocm_st);
+    }
+    ROCMCHECK(hipGetDevice(&device));
+    ROCMCHECK(hipGetDeviceProperties(&prop, device));
+    cfg->reduce_num_threads = prop.maxThreadsPerBlock;
+    if (cfg->reduce_num_blocks != UCC_ULUNITS_AUTO) {
+        if (prop.maxGridSize[0] < cfg->reduce_num_blocks) {
+            mc_warn(&ucc_mc_rocm.super, "number of blocks is too large, "
+                    "max supported %d", prop.maxGridSize[0]);
+            cfg->reduce_num_blocks = prop.maxGridSize[0];
+        }
+    }
+
+    // lock assures single mpool initiation when multiple threads concurrently execute
+    // different collective operations thus concurrently entering init function.
+    ucc_spinlock_init(&ucc_mc_rocm.init_spinlock, 0);
+
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_rocm_get_attr(ucc_mc_attr_t *mc_attr)
+{
+    if (mc_attr->field_mask & UCC_MC_ATTR_FIELD_THREAD_MODE) {
+        mc_attr->thread_mode = ucc_mc_rocm.thread_mode;
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_rocm_mem_alloc(ucc_mc_buffer_header_t **h_ptr,
+                                          size_t                   size)
+{
+    hipError_t st;
+
+    ucc_mc_buffer_header_t *h = ucc_malloc(sizeof(ucc_mc_buffer_header_t), "mc rocm");
+    if (ucc_unlikely(!h)) {
+      mc_error(&ucc_mc_rocm.super, "failed to allocate %zd bytes",
+               sizeof(ucc_mc_buffer_header_t));
+    }
+    st = hipMalloc(&h->addr, size);
+    if (ucc_unlikely(st != hipSuccess)) {
+        hipGetLastError();
+        mc_error(&ucc_mc_rocm.super,
+                 "failed to allocate %zd bytes, "
+                 "rocm error %d(%s)",
+                 size, st, hipGetErrorString(st));
+        ucc_free(h);
+        return hip_error_to_ucc_status(st);
+    }
+    h->from_pool = 0;
+    h->mt        = UCC_MEMORY_TYPE_ROCM;
+    *h_ptr       = h;
+    mc_trace(&ucc_mc_rocm.super, "allocated %ld bytes with hipMalloc", size);
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_rocm_mem_pool_alloc(ucc_mc_buffer_header_t **h_ptr,
+                                               size_t                   size)
+{
+    ucc_mc_buffer_header_t *h = NULL;
+
+    if (size <= MC_ROCM_CONFIG->mpool_elem_size) {
+        h = (ucc_mc_buffer_header_t *)ucc_mpool_get(&ucc_mc_rocm.mpool);
+    }
+    if (!h) {
+        // Slow path
+        return ucc_mc_rocm_mem_alloc(h_ptr, size);
+    }
+    if (ucc_unlikely(!h->addr)){
+        return UCC_ERR_NO_MEMORY;
+    }
+    *h_ptr = h;
+    mc_trace(&ucc_mc_rocm.super, "allocated %ld bytes from rocm mpool", size);
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_rocm_chunk_alloc(ucc_mpool_t *mp,
+                                            size_t *size_p,
+                                            void **chunk_p)
+{
+    *chunk_p = ucc_malloc(*size_p, "mc rocm");
+    if (!*chunk_p) {
+        mc_error(&ucc_mc_rocm.super, "failed to allocate %zd bytes", *size_p);
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    return UCC_OK;
+}
+
+static void ucc_mc_rocm_chunk_init(ucc_mpool_t *mp,
+                                   void *obj, void *chunk)
+{
+    ucc_mc_buffer_header_t *h = (ucc_mc_buffer_header_t *)obj;
+    hipError_t st             = hipMalloc(&h->addr, MC_ROCM_CONFIG->mpool_elem_size);
+
+    if (st != hipSuccess) {
+        // h->addr will be 0 so ucc_mc_rocm_mem_alloc_pool function will
+        // return UCC_ERR_NO_MEMORY. As such mc_error message is suffice.
+        hipGetLastError();
+        mc_error(&ucc_mc_rocm.super,
+                 "failed to allocate %zd bytes, "
+                 "rocm error %d(%s)",
+                 MC_ROCM_CONFIG->mpool_elem_size, st, hipGetErrorString(st));
+    }
+    h->from_pool = 1;
+    h->mt        = UCC_MEMORY_TYPE_ROCM;
+}
+
+static void ucc_mc_rocm_chunk_release(ucc_mpool_t *mp, void *chunk)
+{
+    ucc_free(chunk);
+}
+
+static void ucc_mc_rocm_chunk_cleanup(ucc_mpool_t *mp, void *obj)
+{
+    ucc_mc_buffer_header_t *h = (ucc_mc_buffer_header_t *)obj;
+    hipError_t st;
+
+    st = hipFree(h->addr);
+    if (st != hipSuccess) {
+        hipGetLastError();
+        mc_error(&ucc_mc_rocm.super,
+                 "failed to free mem at %p, "
+                 "rocm error %d(%s)",
+                 obj, st, hipGetErrorString(st));
+    }
+}
+
+static ucc_mpool_ops_t ucc_mc_ops = {.chunk_alloc   = ucc_mc_rocm_chunk_alloc,
+                                     .chunk_release = ucc_mc_rocm_chunk_release,
+                                     .obj_init      = ucc_mc_rocm_chunk_init,
+                                     .obj_cleanup   = ucc_mc_rocm_chunk_cleanup};
+
+static ucc_status_t ucc_mc_rocm_mem_free(ucc_mc_buffer_header_t *h_ptr)
+{
+    hipError_t st;
+
+    st = hipFree(h_ptr->addr);
+    if (ucc_unlikely(st != hipSuccess)) {
+        hipGetLastError();
+        mc_error(&ucc_mc_rocm.super,
+                 "failed to free mem at %p, "
+                 "hip error %d(%s)",
+                 h_ptr->addr, st, hipGetErrorString(st));
+        return hip_error_to_ucc_status(st);
+    }
+    ucc_free(h_ptr);
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_rocm_mem_pool_free(ucc_mc_buffer_header_t *h_ptr)
+{
+    if (!h_ptr->from_pool) {
+        return ucc_mc_rocm_mem_free(h_ptr);
+    }
+    ucc_mpool_put(h_ptr);
+    return UCC_OK;
+}
+
+static ucc_status_t
+ucc_mc_rocm_mem_pool_alloc_with_init(ucc_mc_buffer_header_t **h_ptr,
+                                     size_t                   size)
+{
+    // lock assures single mpool initiation when multiple threads concurrently execute
+    // different collective operations thus concurrently entering init function.
+    ucc_spin_lock(&ucc_mc_rocm.init_spinlock);
+
+    if (MC_ROCM_CONFIG->mpool_max_elems == 0) {
+        ucc_mc_rocm.super.ops.mem_alloc = ucc_mc_rocm_mem_alloc;
+        ucc_mc_rocm.super.ops.mem_free  = ucc_mc_rocm_mem_free;
+        ucc_spin_unlock(&ucc_mc_rocm.init_spinlock);
+        return ucc_mc_rocm_mem_alloc(h_ptr, size);
+    }
+
+    if (!ucc_mc_rocm.mpool_init_flag) {
+        ucc_status_t status = ucc_mpool_init(
+            &ucc_mc_rocm.mpool, 0, sizeof(ucc_mc_buffer_header_t), 0,
+            UCC_CACHE_LINE_SIZE, 1, MC_ROCM_CONFIG->mpool_max_elems,
+            &ucc_mc_ops, ucc_mc_rocm.thread_mode, "mc rocm mpool buffers");
+        if (status != UCC_OK) {
+            ucc_spin_unlock(&ucc_mc_rocm.init_spinlock);
+            return status;
+        }
+        ucc_mc_rocm.super.ops.mem_alloc = ucc_mc_rocm_mem_pool_alloc;
+        ucc_mc_rocm.mpool_init_flag     = 1;
+    }
+    ucc_spin_unlock(&ucc_mc_rocm.init_spinlock);
+    return ucc_mc_rocm_mem_pool_alloc(h_ptr, size);
+}
+
+static ucc_status_t ucc_mc_rocm_memcpy(void *dst, const void *src, size_t len,
+                                       ucc_memory_type_t dst_mem,
+                                       ucc_memory_type_t src_mem)
+{
+    hipError_t st;
+
+    ucc_assert(dst_mem == UCC_MEMORY_TYPE_ROCM ||
+               src_mem == UCC_MEMORY_TYPE_ROCM);
+
+    UCC_MC_ROCM_INIT_STREAM();
+    st = hipMemcpyAsync(dst, src, len, hipMemcpyDefault, ucc_mc_rocm.stream);
+    if (ucc_unlikely(st != hipSuccess)) {
+        hipGetLastError();
+        mc_error(&ucc_mc_rocm.super,
+                 "failed to launch hipMemcpyAsync,  dst %p, src %p, len %zd "
+                 "hip error %d(%s)",
+                 dst, src, len, st, hipGetErrorString(st));
+        return hip_error_to_ucc_status(st);
+    }
+    st = hipStreamSynchronize(ucc_mc_rocm.stream);
+    if (ucc_unlikely(st != hipSuccess)) {
+        hipGetLastError();
+        mc_error(&ucc_mc_rocm.super,
+                 "failed to synchronize mc_rocm.stream "
+                 "hip error %d(%s)",
+                 st, hipGetErrorString(st));
+        return hip_error_to_ucc_status(st);
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_rocm_mem_query(const void *ptr,
+                                          ucc_mem_attr_t *mem_attr)
+{
+    struct hipPointerAttribute_t attr;
+    hipError_t                   st;
+    ucc_memory_type_t            mem_type;
+    void                        *base_address;
+    size_t                       alloc_length;
+
+    if (!(mem_attr->field_mask & (UCC_MEM_ATTR_FIELD_MEM_TYPE     |
+                                  UCC_MEM_ATTR_FIELD_BASE_ADDRESS |
+                                  UCC_MEM_ATTR_FIELD_ALLOC_LENGTH))) {
+        return UCC_OK;
+    }
+
+    if (mem_attr->field_mask & UCC_MEM_ATTR_FIELD_MEM_TYPE) {
+        st = hipPointerGetAttributes(&attr, ptr);
+        if (st != hipSuccess) {
+            hipGetLastError();
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+        switch (attr.memoryType) {
+        case hipMemoryTypeHost:
+            mem_type = (attr.isManaged ? UCC_MEMORY_TYPE_ROCM_MANAGED : UCC_MEMORY_TYPE_HOST);
+            break;
+        case hipMemoryTypeDevice:
+            mem_type = UCC_MEMORY_TYPE_ROCM;
+            break;
+        default:
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+        mem_attr->mem_type = mem_type;
+    }
+
+    if (mem_attr->field_mask & (UCC_MEM_ATTR_FIELD_ALLOC_LENGTH |
+                                UCC_MEM_ATTR_FIELD_BASE_ADDRESS)) {
+      st = hipMemGetAddressRange((hipDeviceptr_t*)&base_address,
+                                      &alloc_length, (hipDeviceptr_t)ptr);
+      if (st != hipSuccess) {
+        mc_error(&ucc_mc_rocm.super,
+                 "hipMemGetAddressRange(%p) error: %d(%s)",
+                 ptr, st, hipGetErrorString(st));
+        return hip_error_to_ucc_status(st);
+      }
+
+      mem_attr->base_address = base_address;
+      mem_attr->alloc_length = alloc_length;
+    }
+
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_mc_rocm_finalize()
+{
+    if (ucc_mc_rocm.stream != NULL) {
+        ROCMCHECK(hipStreamDestroy(ucc_mc_rocm.stream));
+        ucc_mc_rocm.stream = NULL;
+    }
+    if (ucc_mc_rocm.mpool_init_flag) {
+        ucc_mpool_cleanup(&ucc_mc_rocm.mpool, 1);
+        ucc_mc_rocm.mpool_init_flag     = 0;
+        ucc_mc_rocm.super.ops.mem_alloc = ucc_mc_rocm_mem_pool_alloc_with_init;
+    }
+    ucc_spinlock_destroy(&ucc_mc_rocm.init_spinlock);
+    return UCC_OK;
+}
+
+ucc_mc_rocm_t ucc_mc_rocm = {
+    .super.super.name             = "rocm mc",
+    .super.ref_cnt                = 0,
+    .super.ee_type                = UCC_EE_ROCM_STREAM,
+    .super.type                   = UCC_MEMORY_TYPE_ROCM,
+    .super.init                   = ucc_mc_rocm_init,
+    .super.get_attr               = ucc_mc_rocm_get_attr,
+    .super.finalize               = ucc_mc_rocm_finalize,
+    .super.ops.mem_query          = ucc_mc_rocm_mem_query,
+    .super.ops.mem_alloc          = ucc_mc_rocm_mem_pool_alloc_with_init,
+    .super.ops.mem_free           = ucc_mc_rocm_mem_pool_free,
+    .super.ops.memcpy             = ucc_mc_rocm_memcpy,
+    .super.config_table =
+        {
+            .name   = "ROCM memory component",
+            .prefix = "MC_ROCM_",
+            .table  = ucc_mc_rocm_config_table,
+            .size   = sizeof(ucc_mc_rocm_config_t),
+        },
+    .mpool_init_flag               = 0,
+};
+
+UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_mc_rocm.super.config_table,
+                                &ucc_config_global_list);

--- a/src/components/mc/rocm/mc_rocm.h
+++ b/src/components/mc/rocm/mc_rocm.h
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_MC_ROCM_H_
+#define UCC_MC_ROCM_H_
+
+#include "components/mc/base/ucc_mc_base.h"
+#include "components/mc/ucc_mc_log.h"
+#include "utils/ucc_mpool.h"
+#include "utils/arch/rocm_def.h"
+#include <hip/hip_runtime_api.h>
+
+static inline ucc_status_t hip_error_to_ucc_status(hipError_t hip_err)
+{
+    switch(hip_err) {
+    case hipSuccess:
+        return UCC_OK;
+    case hipErrorNotReady:
+        return UCC_INPROGRESS;
+    default:
+        break;
+    }
+    return UCC_ERR_NO_MESSAGE;
+}
+
+typedef ucc_status_t (*ucc_mc_rocm_task_post_fn) (uint32_t *dev_status,
+                                                  int blocking_wait,
+                                                  hipStream_t stream);
+
+typedef struct ucc_mc_rocm_config {
+    ucc_mc_config_t                super;
+    unsigned long                  reduce_num_blocks;
+    int                            reduce_num_threads;
+    size_t                         mpool_elem_size;
+    int                            mpool_max_elems;
+} ucc_mc_rocm_config_t;
+
+typedef struct ucc_mc_rocm {
+    ucc_mc_base_t                  super;
+    int                            stream_initialized;
+    hipStream_t                    stream;
+    ucc_mpool_t                    events;
+    ucc_mpool_t                    strm_reqs;
+    ucc_mpool_t                    mpool;
+    int                            mpool_init_flag;
+    ucc_spinlock_t                 init_spinlock;
+    ucc_thread_mode_t              thread_mode;
+} ucc_mc_rocm_t;
+
+
+extern ucc_mc_rocm_t ucc_mc_rocm;
+
+#define MC_ROCM_CONFIG                                                         \
+    (ucc_derived_of(ucc_mc_rocm.super.config, ucc_mc_rocm_config_t))
+
+#define UCC_MC_ROCM_INIT_STREAM() do {                                         \
+    if (!ucc_mc_rocm.stream_initialized) {                                     \
+        hipError_t hip_st = hipSuccess;                                        \
+        ucc_spin_lock(&ucc_mc_rocm.init_spinlock);                             \
+        if (!ucc_mc_rocm.stream_initialized) {                                 \
+            hip_st = hipStreamCreateWithFlags(&ucc_mc_rocm.stream,             \
+                                                hipStreamNonBlocking);         \
+            ucc_mc_rocm.stream_initialized = 1;                                \
+        }								       \
+        ucc_spin_unlock(&ucc_mc_rocm.init_spinlock);                           \
+        if(hip_st != hipSuccess) {                                             \
+            mc_error(&ucc_mc_rocm.super, "rocm failed with ret:%d(%s)",        \
+                     hip_st, hipGetErrorString(hip_st));                       \
+            return hip_error_to_ucc_status(hip_st);	                       \
+        }                                                                      \
+    }                                                                          \
+} while(0)
+
+#endif

--- a/src/components/tl/rccl/Makefile.am
+++ b/src/components/tl/rccl/Makefile.am
@@ -1,0 +1,30 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+#
+if TL_RCCL_ENABLED
+
+allgatherv =                      \
+	allgatherv/allgatherv.h       \
+	allgatherv/allgatherv.c
+
+sources =             \
+	tl_rccl.h         \
+	tl_rccl.c         \
+	tl_rccl_lib.c     \
+	tl_rccl_context.c \
+	tl_rccl_team.c    \
+	tl_rccl_coll.h    \
+	tl_rccl_coll.c    \
+	$(allgatherv)
+
+module_LTLIBRARIES = libucc_tl_rccl.la
+libucc_tl_rccl_la_SOURCES  = $(sources)
+libucc_tl_rccl_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS) $(HIP_CPPFLAGS) $(RCCL_CPPFLAGS)
+libucc_tl_rccl_la_CFLAGS   = $(BASE_CFLAGS)
+libucc_tl_rccl_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(ROCM_LDFLAGS) $(HIP_LDFLAGS) $(RCCL_LDFLAGS)
+libucc_tl_rccl_la_LIBADD   = $(ROCM_LIBS) $(HIP_LIBS) $(RCCL_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
+
+include $(top_srcdir)/config/module.am
+
+endif

--- a/src/components/tl/rccl/allgatherv/allgatherv.c
+++ b/src/components/tl/rccl/allgatherv/allgatherv.c
@@ -1,0 +1,279 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_rccl.h"
+#include "allgatherv.h"
+#include "components/mc/ucc_mc.h"
+#include "core/ucc_ee.h"
+
+ucc_base_coll_alg_info_t
+    ucc_tl_rccl_allgatherv_algs[UCC_TL_RCCL_ALLGATHERV_ALG_LAST + 1] = {
+        [UCC_TL_RCCL_ALLGATHERV_ALG_P2P] =
+            {.id   = UCC_TL_RCCL_ALLGATHERV_ALG_P2P,
+             .name = "p2p",
+             .desc = "allgatherv based on rccl point-to-point"},
+        [UCC_TL_RCCL_ALLGATHERV_ALG_BCOPY] =
+            {.id   = UCC_TL_RCCL_ALLGATHERV_ALG_BCOPY,
+             .name = "bcopy",
+             .desc = "allgatherv with buffered copy"},
+        [UCC_TL_RCCL_ALLGATHERV_ALG_BCAST] =
+            {.id   = UCC_TL_RCCL_ALLGATHERV_ALG_BCAST,
+             .name = "bcast",
+             .desc = "allgatherv based on rccl bcast"},
+        [UCC_TL_RCCL_ALLGATHERV_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};
+
+#define CHECK_INPLACE(_args, _team)                                            \
+    do {                                                                       \
+        if (UCC_IS_INPLACE((_args))) {                                         \
+            tl_error(UCC_TL_TEAM_LIB((_team)),                                 \
+                     "inplace allgatherv is not supported");                   \
+            status = UCC_ERR_NOT_SUPPORTED;                                    \
+            goto out;                                                          \
+        }                                                                      \
+    } while(0)
+
+#define CHECK_USERDEFINED_DT(_args, _team)                                     \
+    do {                                                                       \
+        if (!UCC_DT_IS_PREDEFINED((_args).src.info.datatype) ||                \
+            !UCC_DT_IS_PREDEFINED((_args).dst.info_v.datatype)) {              \
+            tl_error(UCC_TL_TEAM_LIB((_team)),                                 \
+                     "user defined datatype is not supported");                \
+            status = UCC_ERR_NOT_SUPPORTED;                                    \
+            goto out;                                                          \
+        }                                                                      \
+    } while(0)
+
+ucc_status_t ucc_tl_rccl_allgatherv_p2p_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team   = TASK_TEAM(task);
+    ucc_rank_t          size   = UCC_TL_TEAM_SIZE(team);
+    ucc_ee_h            ee     = coll_task->ee;
+    hipStream_t         stream = (ee) ? (hipStream_t) ee->ee_context :
+                                                       team->stream;
+    ucc_status_t        status = UCC_OK;
+    void               *sbuf   = args->src.info.buffer;
+    void               *rbuf   = args->dst.info_v.buffer;
+    size_t sdt_size, rdt_size, count, displ;
+    ucc_rank_t peer;
+
+    task->super.super.status = UCC_INPROGRESS;
+    sdt_size                 = ucc_dt_size(args->src.info.datatype);
+    rdt_size                 = ucc_dt_size(args->dst.info_v.datatype);
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_allgatherv_start", 0);
+    RCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    count = args->src.info.count;
+    if (count != 0) {
+        for (peer = 0; peer < size; peer++) {
+            RCCLCHECK_GOTO(ncclSend(sbuf, count * sdt_size, ncclChar, peer,
+                                    team->rccl_comm, stream),
+                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+        }
+    }
+    for (peer = 0; peer < size; peer++) {
+        count = ucc_coll_args_get_count(args, args->dst.info_v.counts, peer);
+        if (count != 0) {
+            displ = ucc_coll_args_get_displacement(
+                args, args->dst.info_v.displacements, peer);
+            RCCLCHECK_GOTO(ncclRecv(PTR_OFFSET(rbuf, displ * rdt_size),
+                                    count * rdt_size, ncclChar, peer,
+                                    team->rccl_comm, stream),
+                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+        }
+    }
+    RCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_allgatherv_p2p_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t *     team,
+                                             ucc_coll_task_t **    task_h)
+{
+    ucc_tl_rccl_team_t *rccl_team = ucc_derived_of(team, ucc_tl_rccl_team_t);
+    ucc_coll_args_t    *args      = &coll_args->args;
+    ucc_status_t        status    = UCC_OK;
+    ucc_tl_rccl_task_t *task;
+
+    CHECK_INPLACE(*args, rccl_team);
+    CHECK_USERDEFINED_DT(*args, rccl_team);
+    task = ucc_tl_rccl_init_task(coll_args, team);
+    if (!task) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    task->super.post     = ucc_tl_rccl_allgatherv_p2p_start;
+    *task_h = &task->super;
+out:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_allgatherv_bcopy_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task    = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args    = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team    = TASK_TEAM(task);
+    ucc_rank_t          size    = UCC_TL_TEAM_SIZE(team);
+    ucc_ee_h            ee      = coll_task->ee;
+    hipStream_t        stream  = (ee) ? (hipStream_t) ee->ee_context :
+                                                        team->stream;
+    ucc_status_t        status  = UCC_OK;
+    void               *sbuf    = args->src.info.buffer;
+    void               *rbuf    = args->dst.info_v.buffer;
+    void               *scratch = task->allgatherv_bcopy.scratch->addr;
+    size_t              max_count, rdt_size, sdt_size, displ, scount, rcount;
+    ucc_rank_t          peer;
+
+    task->super.super.status = UCC_INPROGRESS;
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_allgatherv_start", 0);
+    max_count = task->allgatherv_bcopy.max_count;
+    scount    = args->src.info.count;
+    rdt_size  = ucc_dt_size(args->dst.info_v.datatype);
+    sdt_size  = ucc_dt_size(args->src.info.datatype);
+    if (max_count * rdt_size > scount * sdt_size) {
+        HIPCHECK_GOTO(hipMemcpyAsync(PTR_OFFSET(scratch,
+                                     max_count * rdt_size * size), sbuf,
+                                     scount * sdt_size,
+                                     hipMemcpyDeviceToDevice, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
+        sbuf = PTR_OFFSET(scratch, max_count * rdt_size * size);
+    }
+    RCCLCHECK_GOTO(ncclAllGather(sbuf, scratch, max_count * rdt_size,
+                                 ncclChar, team->rccl_comm, stream),
+                   exit_coll, status, UCC_TL_TEAM_LIB(team));
+    for (peer = 0; peer < size; peer++) {
+        rcount = ucc_coll_args_get_count(args,
+                                         args->dst.info_v.counts, peer);
+        displ  = ucc_coll_args_get_displacement(args,
+                                                args->dst.info_v.displacements,
+                                                peer);
+        HIPCHECK_GOTO(hipMemcpyAsync(PTR_OFFSET(rbuf, displ * rdt_size),
+                                     PTR_OFFSET(scratch,
+                                                peer * max_count * rdt_size),
+                                     rcount * rdt_size,
+                                     hipMemcpyDeviceToDevice, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
+    }
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_allgatherv_bcopy_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+
+    ucc_mc_free(task->allgatherv_bcopy.scratch);
+    return ucc_tl_rccl_coll_finalize(coll_task);
+}
+
+ucc_status_t ucc_tl_rccl_allgatherv_bcopy_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t *     team,
+                                               ucc_coll_task_t **    task_h)
+{
+    ucc_tl_rccl_team_t *rccl_team = ucc_derived_of(team, ucc_tl_rccl_team_t);
+    ucc_coll_args_t    *args      = &coll_args->args;
+    ucc_status_t        status    = UCC_OK;
+    ucc_tl_rccl_task_t *task;
+    size_t              max_count, sdt_size, rdt_size;
+    ucc_rank_t          peer;
+
+    CHECK_INPLACE(*args, rccl_team);
+    CHECK_USERDEFINED_DT(*args, rccl_team);
+    task = ucc_tl_rccl_init_task(coll_args, team);
+    if (ucc_unlikely(!task)) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    sdt_size = ucc_dt_size(args->src.info.datatype);
+    rdt_size = ucc_dt_size(args->dst.info_v.datatype);
+    max_count = ucc_coll_args_get_max_count(args, args->dst.info_v.counts, UCC_TL_TEAM_SIZE(rccl_team));
+    for (peer = 1; peer < team->params.size; peer++) {
+        max_count = ucc_max(ucc_coll_args_get_count(args,
+                            args->dst.info_v.counts, peer), max_count);
+    }
+    task->allgatherv_bcopy.max_count = max_count;
+    if (max_count * rdt_size > args->src.info.count * sdt_size) {
+        status = ucc_mc_alloc(&task->allgatherv_bcopy.scratch,
+                              (team->params.size + 1) * max_count *
+                              ucc_dt_size(args->dst.info_v.datatype),
+                              UCC_MEMORY_TYPE_ROCM);
+
+    } else {
+        status = ucc_mc_alloc(&task->allgatherv_bcopy.scratch, max_count *
+                              team->params.size *
+                              ucc_dt_size(args->dst.info_v.datatype),
+                              UCC_MEMORY_TYPE_ROCM);
+    }
+    if (ucc_unlikely(status != UCC_OK)) {
+        ucc_tl_rccl_free_task(task);
+        return status;
+    }
+    task->super.post     = ucc_tl_rccl_allgatherv_bcopy_start;
+    task->super.finalize = ucc_tl_rccl_allgatherv_bcopy_finalize;
+    *task_h = &task->super;
+out:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_allgatherv_bcast_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team   = TASK_TEAM(task);
+    ucc_rank_t          size   = UCC_TL_TEAM_SIZE(team);
+    ucc_ee_h            ee     = coll_task->ee;
+    hipStream_t        stream  = (ee) ? (hipStream_t) ee->ee_context :
+	                                              team->stream;
+    ucc_status_t        status = UCC_OK;
+    void               *sbuf   = args->src.info.buffer;
+    ptrdiff_t           rbuf   = (ptrdiff_t)args->dst.info_v.buffer;
+    size_t rdt_size, count, displ;
+    ucc_rank_t peer;
+
+    task->super.super.status = UCC_INPROGRESS;
+    rdt_size                 = ucc_dt_size(args->dst.info_v.datatype);
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_allgatherv_start", 0);
+    RCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    for (peer = 0; peer < size; peer++) {
+        count = ucc_coll_args_get_count(args, args->dst.info_v.counts, peer);
+        displ = ucc_coll_args_get_displacement(args,
+                                               args->dst.info_v.displacements,
+                                               peer);
+        RCCLCHECK_GOTO(ncclBroadcast(sbuf, PTR_OFFSET(rbuf, displ * rdt_size),
+                                     count * rdt_size, ncclChar, peer,
+                                     team->rccl_comm, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
+    }
+    RCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_allgatherv_bcast_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t *     team,
+                                               ucc_coll_task_t **    task_h)
+{
+    ucc_tl_rccl_team_t *rccl_team = ucc_derived_of(team, ucc_tl_rccl_team_t);
+    ucc_coll_args_t    *args      = &coll_args->args;
+    ucc_status_t        status    = UCC_OK;
+    ucc_tl_rccl_task_t *task;
+
+    CHECK_INPLACE(*args, rccl_team);
+    CHECK_USERDEFINED_DT(*args, rccl_team);
+    task = ucc_tl_rccl_init_task(coll_args, team);
+    if (ucc_unlikely(!task)) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+    task->super.post = ucc_tl_rccl_allgatherv_bcast_start;
+    *task_h          = &task->super;
+out:
+    return status;
+}

--- a/src/components/tl/rccl/allgatherv/allgatherv.h
+++ b/src/components/tl/rccl/allgatherv/allgatherv.h
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef RCCL_ALLGATHERV_H_
+#define RCCL_ALLGATHERV_H_
+
+#include "tl_rccl_coll.h"
+
+enum {
+    UCC_TL_RCCL_ALLGATHERV_ALG_P2P,
+    UCC_TL_RCCL_ALLGATHERV_ALG_BCOPY,
+    UCC_TL_RCCL_ALLGATHERV_ALG_BCAST,
+    UCC_TL_RCCL_ALLGATHERV_ALG_LAST
+};
+
+#define UCC_TL_RCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR                          \
+    "allgatherv:0-16k:@0#allgatherv:16k-1M:@1#allgatherv:1M-inf:@2"
+
+extern ucc_base_coll_alg_info_t
+             ucc_tl_rccl_allgatherv_algs[UCC_TL_RCCL_ALLGATHERV_ALG_LAST + 1];
+
+ucc_status_t ucc_tl_rccl_allgatherv_p2p_start(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_rccl_allgatherv_p2p_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t *     team,
+                                             ucc_coll_task_t **    task_h);
+
+ucc_status_t ucc_tl_rccl_allgatherv_bcopy_start(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_rccl_allgatherv_bcopy_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t *     team,
+                                               ucc_coll_task_t **    task_h);
+
+ucc_status_t ucc_tl_rccl_allgatherv_bcast_start(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_rccl_allgatherv_bcast_init(ucc_base_coll_args_t *coll_args,
+                                               ucc_base_team_t *     team,
+                                               ucc_coll_task_t **    task_h);
+
+static inline int ucc_tl_rccl_allgatherv_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_TL_RCCL_ALLGATHERV_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_tl_rccl_allgatherv_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
+
+#endif

--- a/src/components/tl/rccl/configure.m4
+++ b/src/components/tl/rccl/configure.m4
@@ -1,0 +1,19 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+#
+
+tl_rccl_enabled=n
+CHECK_TLS_REQUIRED(["rccl"])
+AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
+[
+    CHECK_RCCL
+    AC_MSG_RESULT([RCCL support: $rccl_happy])
+    if test $rccl_happy = "yes"; then
+        tl_modules="${tl_modules}:rccl"
+        tl_rccl_enabled=y
+    fi
+], [])
+
+AM_CONDITIONAL([TL_RCCL_ENABLED], [test "$tl_rccl_enabled" = "y"])
+AC_CONFIG_FILES([src/components/tl/rccl/Makefile])

--- a/src/components/tl/rccl/tl_rccl.c
+++ b/src/components/tl/rccl/tl_rccl.c
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_rccl.h"
+#include "components/mc/base/ucc_mc_base.h"
+#include "allgatherv/allgatherv.h"
+
+ucc_status_t ucc_tl_rccl_get_lib_attr(const ucc_base_lib_t *lib,
+                                      ucc_base_lib_attr_t  *base_attr);
+
+ucc_status_t ucc_tl_rccl_get_context_attr(const ucc_base_context_t *context,
+                                          ucc_base_ctx_attr_t      *base_attr);
+
+static ucc_config_field_t ucc_tl_rccl_lib_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_tl_rccl_lib_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)},
+
+    {NULL}};
+
+const char* ucc_tl_rccl_completion_sync_names[] = {
+    [UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT]  = "event",
+    [UCC_TL_RCCL_COMPLETION_SYNC_TYPE_MEMOPS] = "driver",
+    [UCC_TL_RCCL_COMPLETION_SYNC_TYPE_AUTO]   = "auto",
+    [UCC_TL_RCCL_COMPLETION_SYNC_TYPE_LAST]   = NULL
+};
+
+static ucs_config_field_t ucc_tl_rccl_context_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_tl_rccl_context_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_tl_context_config_table)},
+
+    {"SYNC", "auto",
+     "Determines how UCC tests completion of RCCL collective",
+     ucs_offsetof(ucc_tl_rccl_context_config_t, sync_type),
+     UCS_CONFIG_TYPE_ENUM(ucc_tl_rccl_completion_sync_names)
+    },
+
+    {NULL}};
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_rccl_lib_t, ucc_base_lib_t,
+                          const ucc_base_lib_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_rccl_lib_t, ucc_base_lib_t);
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_rccl_context_t, ucc_base_context_t,
+                          const ucc_base_context_params_t *,
+                          const ucc_base_config_t *);
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_rccl_context_t, ucc_base_context_t);
+
+UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_rccl_team_t, ucc_base_team_t,
+                          ucc_base_context_t *, const ucc_base_team_params_t *);
+
+ucc_status_t ucc_tl_rccl_team_create_test(ucc_base_team_t *tl_team);
+
+ucc_status_t ucc_tl_rccl_team_destroy(ucc_base_team_t *tl_team);
+
+ucc_status_t ucc_tl_rccl_coll_init(ucc_base_coll_args_t *coll_args,
+                                   ucc_base_team_t *team,
+                                   ucc_coll_task_t **task);
+
+ucc_status_t ucc_tl_rccl_team_get_scores(ucc_base_team_t   *tl_team,
+                                         ucc_coll_score_t **score_p);
+UCC_TL_IFACE_DECLARE(rccl, RCCL);
+
+__attribute__((constructor)) static void tl_rccl_iface_init(void)
+{
+    ucc_tl_rccl.super.alg_info[ucc_ilog2(UCC_COLL_TYPE_ALLGATHERV)] =
+        ucc_tl_rccl_allgatherv_algs;
+}

--- a/src/components/tl/rccl/tl_rccl.h
+++ b/src/components/tl/rccl/tl_rccl.h
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Facebook, Inc. and its affiliates. 2021.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_RCCL_H_
+#define UCC_TL_RCCL_H_
+
+#include "components/mc/base/ucc_mc_base.h"
+#include "components/tl/ucc_tl.h"
+#include "components/tl/ucc_tl_log.h"
+#include "utils/ucc_mpool.h"
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <rccl/rccl.h>
+
+#ifndef UCC_TL_RCCL_DEFAULT_SCORE
+#define UCC_TL_RCCL_DEFAULT_SCORE 20
+#endif
+
+#ifdef HAVE_PROFILING_TL_RCCL
+#include "utils/profile/ucc_profile.h"
+#else
+#include "utils/profile/ucc_profile_off.h"
+#endif
+
+#define UCC_TL_RCCL_PROFILE_FUNC UCC_PROFILE_FUNC
+#define UCC_TL_RCCL_PROFILE_FUNC_VOID UCC_PROFILE_FUNC_VOID
+#define UCC_TL_RCCL_PROFILE_REQUEST_NEW UCC_PROFILE_REQUEST_NEW
+#define UCC_TL_RCCL_PROFILE_REQUEST_EVENT UCC_PROFILE_REQUEST_EVENT
+#define UCC_TL_RCCL_PROFILE_REQUEST_FREE UCC_PROFILE_REQUEST_FREE
+
+typedef struct ucc_tl_rccl_iface {
+    ucc_tl_iface_t super;
+} ucc_tl_rccl_iface_t;
+
+extern ucc_tl_rccl_iface_t ucc_tl_rccl;
+
+typedef struct ucc_tl_rccl_lib_config {
+    ucc_tl_lib_config_t super;
+} ucc_tl_rccl_lib_config_t;
+
+typedef enum ucc_tl_rccl_completion_sync_type {
+    UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT,
+    UCC_TL_RCCL_COMPLETION_SYNC_TYPE_MEMOPS,
+    UCC_TL_RCCL_COMPLETION_SYNC_TYPE_AUTO,
+    UCC_TL_RCCL_COMPLETION_SYNC_TYPE_LAST
+} ucc_tl_rccl_completion_sync_type_t;
+
+typedef struct ucc_tl_rccl_context_config {
+    ucc_tl_context_config_t            super;
+    ucc_tl_rccl_completion_sync_type_t sync_type;
+} ucc_tl_rccl_context_config_t;
+
+typedef struct ucc_tl_rccl_lib {
+    ucc_tl_lib_t super;
+} ucc_tl_rccl_lib_t;
+UCC_CLASS_DECLARE(ucc_tl_rccl_lib_t, const ucc_base_lib_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_rccl_context {
+    ucc_tl_context_t             super;
+    ucc_tl_rccl_context_config_t cfg;
+    ucc_mpool_t                  req_mp;
+    void                        *scratch_buf;
+} ucc_tl_rccl_context_t;
+UCC_CLASS_DECLARE(ucc_tl_rccl_context_t, const ucc_base_context_params_t *,
+                  const ucc_base_config_t *);
+
+typedef struct ucc_tl_rccl_team {
+    ucc_tl_team_t        super;
+    ncclUniqueId        *unique_id;
+    void                *oob_req;
+    ncclComm_t           rccl_comm;
+    hipStream_t          stream;
+} ucc_tl_rccl_team_t;
+
+typedef struct ucc_tl_rccl_task {
+    ucc_coll_task_t         super;
+    ucc_status_t            host_status;
+    ucc_status_t           *dev_status;
+    void                   *completed;
+    union {
+        struct {
+            ucc_mc_buffer_header_t *scratch;
+            size_t                  max_count;
+        } allgatherv_bcopy;
+    };
+} ucc_tl_rccl_task_t;
+
+#define TASK_TEAM(_task)                                                       \
+    (ucc_derived_of((_task)->super.team, ucc_tl_rccl_team_t))
+#define TASK_CTX(_task)                                                        \
+    (ucc_derived_of((_task)->super.team->context, ucc_tl_rccl_context_t))
+#define TASK_LIB(_task)                                                        \
+    (ucc_derived_of((_task)->super.team->context->lib, ucc_tl_rccl_lib_t))
+#define TASK_ARGS(_task) (_task)->super.bargs.args
+
+#define UCC_TL_RCCL_SUPPORTED_COLLS                                            \
+    (UCC_COLL_TYPE_ALLTOALL       | UCC_COLL_TYPE_ALLTOALLV  |                 \
+     UCC_COLL_TYPE_ALLGATHER      | UCC_COLL_TYPE_ALLGATHERV |                 \
+     UCC_COLL_TYPE_ALLREDUCE      | UCC_COLL_TYPE_BCAST      |                 \
+     UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE     |                 \
+     UCC_COLL_TYPE_BARRIER)
+
+UCC_CLASS_DECLARE(ucc_tl_rccl_team_t, ucc_base_context_t *,
+                  const ucc_base_team_params_t *);
+
+#define RCCLCHECK_GOTO(_cmd, _label, _status, _lib)                            \
+    do {                                                                       \
+        ncclResult_t e = _cmd;                                                 \
+        if (ncclSuccess != e) {                                                \
+            tl_error(_lib, "RCCL error %d %s", e, ncclGetErrorString(e));      \
+            _status = UCC_ERR_NO_MESSAGE;                                      \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
+
+#define HIPCHECK_GOTO(_cmd, _label, _status, _lib)                             \
+    do {                                                                       \
+        hipError_t e = _cmd;                                                   \
+        if (hipSuccess != e) {                                                 \
+            tl_error(_lib, "HIP error %d %s", e, hipGetErrorName(e));          \
+            _status = UCC_ERR_NO_MESSAGE;                                      \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
+
+#define UCC_TL_RCCL_TEAM_LIB(_team)                                            \
+    (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_rccl_lib_t))
+
+#endif

--- a/src/components/tl/rccl/tl_rccl_coll.c
+++ b/src/components/tl/rccl/tl_rccl_coll.c
@@ -1,0 +1,609 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Facebook, Inc. and its affiliates. 2021.
+ # Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_rccl_coll.h"
+#include "components/mc/ucc_mc.h"
+#include "components/ec/ucc_ec.h"
+#include "core/ucc_ee.h"
+#include "utils/ucc_compiler_def.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
+#include "allgatherv/allgatherv.h"
+
+#define ncclOpUnsupported (ncclNumOps + 1)
+#define ncclDataTypeUnsupported (ncclNumTypes + 1)
+
+ncclDataType_t ucc_to_rccl_dtype[] = {
+    [UCC_DT_PREDEFINED_ID(UCC_DT_INT8)]     = (ncclDataType_t)ncclInt8,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_INT16)]    = (ncclDataType_t)ncclDataTypeUnsupported,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_INT32)]    = (ncclDataType_t)ncclInt32,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_INT64)]    = (ncclDataType_t)ncclInt64,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_INT128)]   = (ncclDataType_t)ncclDataTypeUnsupported,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_UINT8)]    = (ncclDataType_t)ncclUint8,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_UINT16)]   = (ncclDataType_t)ncclDataTypeUnsupported,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_UINT32)]   = (ncclDataType_t)ncclUint32,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_UINT64)]   = (ncclDataType_t)ncclUint64,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_UINT128)]  = (ncclDataType_t)ncclDataTypeUnsupported,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT16)]  = (ncclDataType_t)ncclFloat16,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT32)]  = (ncclDataType_t)ncclFloat32,
+    [UCC_DT_PREDEFINED_ID(UCC_DT_FLOAT64)]  = (ncclDataType_t)ncclFloat64,
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,10,3)
+    [UCC_DT_PREDEFINED_ID(UCC_DT_BFLOAT16)] = (ncclDataType_t)ncclBfloat16,
+#else
+    [UCC_DT_PREDEFINED_ID(UCC_DT_BFLOAT16)] = (ncclDataType_t)ncclDataTypeUnsupported,
+#endif
+};
+
+ncclRedOp_t ucc_to_rccl_reduce_op[] = {
+    [UCC_OP_SUM]         = (ncclRedOp_t)ncclSum,
+    [UCC_OP_PROD]        = (ncclRedOp_t)ncclProd,
+    [UCC_OP_MAX]         = (ncclRedOp_t)ncclMax,
+    [UCC_OP_MIN]         = (ncclRedOp_t)ncclMin,
+#if NCCL_VERSION_CODE < NCCL_VERSION(2,10,3)
+    [UCC_OP_AVG]         = (ncclRedOp_t)ncclOpUnsupported,
+#else
+    [UCC_OP_AVG]         = (ncclRedOp_t)ncclAvg,
+#endif
+    [UCC_OP_LAND]        = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_LOR]         = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_LXOR]        = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_BAND]        = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_BOR]         = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_BXOR]        = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_MAXLOC]      = (ncclRedOp_t)ncclOpUnsupported,
+    [UCC_OP_MINLOC]      = (ncclRedOp_t)ncclOpUnsupported,
+};
+
+const char
+    *ucc_tl_rccl_default_alg_select_str[UCC_TL_RCCL_N_DEFAULT_ALG_SELECT_STR] = {
+        UCC_TL_RCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR};
+
+static inline ucc_status_t ucc_rccl_check_dt_supported(ucc_datatype_t dt1,
+                                                       ucc_datatype_t dt2)
+{
+    if (ucc_unlikely((dt1 != dt2) || !UCC_DT_IS_PREDEFINED(dt1) ||
+                     (ucc_to_rccl_dtype[UCC_DT_PREDEFINED_ID(dt1)]
+                      == ncclDataTypeUnsupported))) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    return UCC_OK;
+}
+
+ucc_tl_rccl_task_t * ucc_tl_rccl_init_task(ucc_base_coll_args_t *coll_args,
+                                           ucc_base_team_t *team)
+{
+    ucc_tl_rccl_context_t *rccl_ctx  = ucc_derived_of(team->context,
+                                                      ucc_tl_rccl_context_t);
+    ucc_tl_rccl_task_t    *task;
+    ucc_status_t           status;
+
+    task = ucc_mpool_get(&rccl_ctx->req_mp);
+    if (ucc_unlikely(!task)) {
+	tl_error(UCC_TASK_LIB(task),"Failed to allocate task");
+	return NULL;
+    }
+    ucc_coll_task_init(&task->super, coll_args, team);
+    UCC_TL_RCCL_PROFILE_REQUEST_NEW(task, "tl_rccl_task", 0);
+    task->super.finalize           = ucc_tl_rccl_coll_finalize;
+    task->super.triggered_post     = ucc_tl_rccl_triggered_post;
+    task->completed                = NULL;
+    if (rccl_ctx->cfg.sync_type == UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT) {
+        status = ucc_ec_create_event(&task->completed, UCC_EE_ROCM_STREAM);
+        if (ucc_unlikely(status != UCC_OK)) {
+            ucc_mpool_put(task);
+            return NULL;
+        }
+    }
+    return task;
+}
+
+void ucc_tl_rccl_free_task(ucc_tl_rccl_task_t *task)
+{
+    UCC_TL_RCCL_PROFILE_REQUEST_FREE(task);
+    ucc_mpool_put(task);
+}
+
+ucc_status_t ucc_tl_rccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
+                                        ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task  = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_status_t status;
+    ucc_ev_t *post_event;
+
+    ucc_assert(ee->ee_type == UCC_EE_ROCM_STREAM);
+    coll_task->ee = ee;
+    tl_info(UCC_TASK_LIB(task), "triggered post. task:%p", coll_task);
+
+    status = coll_task->post(coll_task);
+    if (ucc_likely(status == UCC_OK)) {
+        /* TODO: mpool */
+        post_event = ucc_malloc(sizeof(ucc_ev_t), "event");
+        if (ucc_unlikely(post_event == NULL)) {
+            tl_error(UCC_TASK_LIB(task), "failed to allocate memory for event");
+            return UCC_ERR_NO_MEMORY;
+        }
+
+        post_event->ev_type = UCC_EVENT_COLLECTIVE_POST;
+        post_event->ev_context_size = 0;
+        post_event->req = &coll_task->super;
+        ucc_ee_set_event_internal(coll_task->ee, post_event,
+                                  &coll_task->ee->event_out_queue);
+    }
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_coll_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task  = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_status_t       status = UCC_OK ;
+
+    tl_info(UCC_TASK_LIB(task), "finalizing coll task %p", task);
+    if (task->completed) {
+        ucc_ec_destroy_event(task->completed, UCC_EE_ROCM_STREAM);
+    }
+    ucc_tl_rccl_free_task(task);
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_collective_sync(ucc_tl_rccl_task_t *task,
+                                         hipStream_t stream)
+{
+    ucc_tl_rccl_context_t *ctx    = TASK_CTX(task);
+    ucc_status_t           status = UCC_OK;
+
+    task->host_status = task->super.super.status;
+    if (ctx->cfg.sync_type != UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT) {
+        tl_error(UCC_TASK_LIB(task), "RCCL only supports stream synchronization events");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    status = ucc_ec_event_post(stream, task->completed,
+                               UCC_EE_ROCM_STREAM);
+    if (ucc_unlikely(status != UCC_OK)) {
+      return status;
+    }
+
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(TASK_TEAM(task))->pq,
+				      &task->super);
+}
+
+ucc_status_t ucc_tl_rccl_alltoall_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team   = TASK_TEAM(task);
+    ucc_ee_h            ee     = coll_task->ee;
+    hipStream_t         stream = (ee) ? (hipStream_t) ee->ee_context : team->stream;
+    ucc_rank_t          gsize  = UCC_TL_TEAM_SIZE(team);
+    ucc_status_t        status = UCC_OK;
+    ptrdiff_t           sbuf   = (ptrdiff_t)args->src.info.buffer;
+    ptrdiff_t           rbuf   = (ptrdiff_t)args->dst.info.buffer;
+    size_t              data_size;
+    ucc_rank_t          peer;
+    ncclDataType_t      dt;
+    
+    task->super.super.status = UCC_INPROGRESS;
+    data_size                = (size_t)(args->src.info.count / gsize) *
+                ucc_dt_size(args->src.info.datatype);
+    ucc_assert(args->src.info.count % gsize == 0);
+    if (data_size == 0) {
+        task->super.super.status = UCC_OK;
+        return UCC_OK;
+    }
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_alltoall_start", 0);
+    if (args->src.info.datatype == args->dst.info.datatype) {
+        dt = ucc_to_rccl_dtype[UCC_DT_PREDEFINED_ID(args->dst.info.datatype)];
+        RCCLCHECK_GOTO(ncclAllToAll((void *)sbuf, (void *)rbuf,
+                                    (size_t)(args->src.info.count / gsize),
+                                    dt, team->rccl_comm, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));        
+    } else {
+	RCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+        for (peer = 0; peer < gsize; peer++) {
+            RCCLCHECK_GOTO(ncclSend((void *)(sbuf + peer * data_size), data_size,
+                                             ncclChar, peer, team->rccl_comm, stream),
+                           exit_coll, status, UCC_TL_TEAM_LIB(team));
+            RCCLCHECK_GOTO(ncclRecv((void *)(rbuf + peer * data_size), data_size,
+                                    ncclChar, peer, team->rccl_comm, stream),
+                           exit_coll, status, UCC_TL_TEAM_LIB(team));
+        }
+        RCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    }
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_alltoall_init(ucc_tl_rccl_task_t *task)
+{
+    if (UCC_IS_INPLACE(TASK_ARGS(task))) {
+        tl_error(UCC_TASK_LIB(task), "inplace alltoallv is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info.datatype))) {
+        tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    task->super.post     = ucc_tl_rccl_alltoall_start;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_rccl_alltoallv_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team   = TASK_TEAM(task);
+    ucc_ee_h            ee     = coll_task->ee;
+    hipStream_t         stream = (ee) ? (hipStream_t) ee->ee_context : team->stream;
+    ucc_status_t        status = UCC_OK;
+    ptrdiff_t           sbuf   = (ptrdiff_t)args->src.info_v.buffer;
+    ptrdiff_t           rbuf   = (ptrdiff_t)args->dst.info_v.buffer;
+    size_t sdt_size, rdt_size, count, displ;
+    ucc_rank_t peer;
+
+    task->super.super.status = UCC_INPROGRESS;
+    sdt_size                 = ucc_dt_size(args->src.info_v.datatype);
+    rdt_size                 = ucc_dt_size(args->dst.info_v.datatype);
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_alltoallv_start", 0);
+    RCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    for (peer = 0; peer < UCC_TL_TEAM_SIZE(team); peer++) {
+        count = ucc_coll_args_get_count(args, args->src.info_v.counts, peer);
+        if (count != 0) {
+            displ = ucc_coll_args_get_displacement(
+                args, args->src.info_v.displacements, peer);
+            RCCLCHECK_GOTO(ncclSend((void *)(sbuf + displ * sdt_size),
+                                    count * sdt_size, ncclChar, peer,
+                                    team->rccl_comm, stream),
+                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+        }
+        count = ucc_coll_args_get_count(args, args->dst.info_v.counts, peer);
+        if (count != 0) {
+            displ = ucc_coll_args_get_displacement(
+                args, args->dst.info_v.displacements, peer);
+            RCCLCHECK_GOTO(ncclRecv((void *)(rbuf + displ * rdt_size),
+                                    count * rdt_size, ncclChar, peer,
+                                    team->rccl_comm, stream),
+                        exit_coll, status, UCC_TL_TEAM_LIB(team));
+        }
+    }
+    RCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_alltoallv_init(ucc_tl_rccl_task_t *task)
+{
+    if (UCC_IS_INPLACE(TASK_ARGS(task))) {
+        tl_error(UCC_TASK_LIB(task), "inplace alltoall is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info_v.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info_v.datatype))) {
+        tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    task->super.post = ucc_tl_rccl_alltoallv_start;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_rccl_allreduce_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team   = TASK_TEAM(task);
+    ucc_ee_h            ee     = coll_task->ee;
+    hipStream_t        stream = (ee) ? (hipStream_t) ee->ee_context : team->stream;
+    void               *dst    = args->dst.info.buffer;
+    void               *src    =
+        UCC_IS_INPLACE(*args) ? args->dst.info.buffer : args->src.info.buffer;
+    ucc_status_t        status = UCC_OK;
+    ncclRedOp_t         op     = ucc_to_rccl_reduce_op[args->op];
+    size_t              count  = args->dst.info.count;
+    ncclDataType_t      dt;
+
+    dt = ucc_to_rccl_dtype[UCC_DT_PREDEFINED_ID(args->dst.info.datatype)];
+    task->super.super.status = UCC_INPROGRESS;
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task,
+                                      args->coll_type == UCC_COLL_TYPE_BARRIER
+                                          ? "rccl_barrier_start"
+                                          : "rccl_allreduce_start",
+                                      0);
+    RCCLCHECK_GOTO(ncclAllReduce(src, dst, count, dt, op, team->rccl_comm,
+                                 stream),
+                   exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_allreduce_init(ucc_tl_rccl_task_t *task)
+{
+    if (UCC_OK !=
+        ucc_rccl_check_dt_supported(TASK_ARGS(task).dst.info.datatype,
+                                    TASK_ARGS(task).dst.info.datatype)) {
+        tl_debug(UCC_TASK_LIB(task), "datatype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    if (ucc_to_rccl_reduce_op[TASK_ARGS(task).op] == ncclOpUnsupported) {
+        tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    task->super.post     = ucc_tl_rccl_allreduce_start;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_rccl_allgather_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team   = TASK_TEAM(task);
+    ucc_rank_t          rank   = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t          size   = UCC_TL_TEAM_SIZE(team);
+    ucc_ee_h            ee     = coll_task->ee;
+    hipStream_t        stream  = (ee) ? (hipStream_t) ee->ee_context : team->stream;
+    void               *dst    = args->dst.info.buffer;
+    void               *src    = args->src.info.buffer;
+    ucc_status_t        status = UCC_OK;
+    size_t              count  = args->dst.info.count;
+    ncclDataType_t      dt;
+
+    dt = ucc_to_rccl_dtype[UCC_DT_PREDEFINED_ID(args->dst.info.datatype)];
+    if (UCC_IS_INPLACE(*args)) {
+        src = (void *)((ptrdiff_t)args->dst.info.buffer + (count / size) *
+                       ucc_dt_size(args->dst.info.datatype) * rank);
+    }
+    task->super.super.status = UCC_INPROGRESS;
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_allgather_start", 0);
+    RCCLCHECK_GOTO(ncclAllGather(src, dst, count / size, dt,
+                                 team->rccl_comm, stream),
+                   exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_allgather_init(ucc_tl_rccl_task_t *task)
+{
+    ucc_datatype_t dt1 = UCC_IS_INPLACE(TASK_ARGS(task))
+                             ? TASK_ARGS(task).dst.info.datatype
+                             : TASK_ARGS(task).src.info.datatype;
+    ucc_datatype_t dt2 = TASK_ARGS(task).dst.info.datatype;
+
+    if (UCC_OK != ucc_rccl_check_dt_supported(dt1, dt2)) {
+        tl_error(UCC_TASK_LIB(task), "dataype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    task->super.post = ucc_tl_rccl_allgather_start;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_rccl_allgatherv_init(ucc_tl_rccl_task_t *task)
+{
+    if (UCC_IS_INPLACE(TASK_ARGS(task))) {
+        tl_error(UCC_TASK_LIB(task), "inplace allgatherv is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info_v.datatype) ||
+        !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info_v.datatype))) {
+        tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    task->super.post = ucc_tl_rccl_allgatherv_p2p_start;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_rccl_bcast_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team   = TASK_TEAM(task);
+    ucc_ee_h            ee     = coll_task->ee;
+    hipStream_t        stream  = (ee) ? (hipStream_t) ee->ee_context : team->stream;
+    void               *src    = args->src.info.buffer;
+    ucc_status_t        status = UCC_OK;
+    size_t              count  = args->src.info.count;
+    ucc_rank_t          root   = args->root;
+    ncclDataType_t      dt;
+
+    dt = ucc_to_rccl_dtype[UCC_DT_PREDEFINED_ID(args->src.info.datatype)];
+    task->super.super.status = UCC_INPROGRESS;
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_bcast_start", 0);
+    RCCLCHECK_GOTO(ncclBroadcast(src, src, count, dt, root, team->rccl_comm,
+                                 stream),
+                   exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_bcast_init(ucc_tl_rccl_task_t *task)
+{
+    if (UCC_OK !=
+        ucc_rccl_check_dt_supported(TASK_ARGS(task).src.info.datatype,
+                                    TASK_ARGS(task).src.info.datatype)) {
+        /* TODO: can we use rcclChar if datatype is not supported? */
+        tl_error(UCC_TASK_LIB(task), "dataype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    task->super.post = ucc_tl_rccl_bcast_start;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_rccl_reduce_scatter_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team   = TASK_TEAM(task);
+    ucc_ee_h            ee     = coll_task->ee;
+    hipStream_t        stream  = (ee) ? (hipStream_t) ee->ee_context : team->stream;
+    void               *dst    = args->dst.info.buffer;
+    void               *src    = args->src.info.buffer;
+    ucc_status_t        status = UCC_OK;
+    ncclRedOp_t         op     = ucc_to_rccl_reduce_op[args->op];
+    size_t              count  = args->dst.info.count;
+    ncclDataType_t      dt;
+
+    dt = ucc_to_rccl_dtype[UCC_DT_PREDEFINED_ID(args->dst.info.datatype)];
+    task->super.super.status = UCC_INPROGRESS;
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_reduce_scatter_start", 0);
+    if (UCC_IS_INPLACE(*args)) {
+        count /= UCC_TL_TEAM_SIZE(team);
+        src = args->dst.info.buffer;
+        dst = PTR_OFFSET(src, UCC_TL_TEAM_RANK(team) * count
+                         * ucc_dt_size(args->dst.info.datatype));
+    }
+    RCCLCHECK_GOTO(ncclReduceScatter(src, dst, count, dt, op, team->rccl_comm,
+                                     stream),
+                   exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_reduce_scatter_init(ucc_tl_rccl_task_t *task)
+{
+    if (UCC_OK !=
+        ucc_rccl_check_dt_supported(TASK_ARGS(task).dst.info.datatype,
+                                    TASK_ARGS(task).dst.info.datatype)) {
+        tl_debug(UCC_TASK_LIB(task), "dataype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    if (ucc_to_rccl_reduce_op[TASK_ARGS(task).op] == ncclOpUnsupported) {
+        tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    task->super.post = ucc_tl_rccl_reduce_scatter_start;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_rccl_reduce_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task    = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_coll_args_t    *args    = &TASK_ARGS(task);
+    ucc_tl_rccl_team_t *team    = TASK_TEAM(task);
+    ucc_ee_h            ee      = coll_task->ee;
+    hipStream_t        stream   = (ee) ? (hipStream_t) ee->ee_context : team->stream;
+    void               *dst     = args->dst.info.buffer;
+    void               *src     = args->src.info.buffer;
+    ucc_datatype_t      ucc_dt  = args->src.info.datatype;
+    size_t              count   = args->src.info.count;
+    ncclRedOp_t         op      = ucc_to_rccl_reduce_op[args->op];
+    ucc_status_t        status  = UCC_OK;
+    ncclDataType_t      rccl_dt;
+
+    UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_reduce_start", 0);
+    if (args->root == UCC_TL_TEAM_RANK(team)) {
+        ucc_dt = TASK_ARGS(task).dst.info.datatype;
+        count = TASK_ARGS(task).dst.info.count;
+        if (UCC_IS_INPLACE(*args)) {
+            src = args->dst.info.buffer;
+        }
+    }
+    rccl_dt = ucc_to_rccl_dtype[UCC_DT_PREDEFINED_ID(ucc_dt)];
+    task->super.super.status = UCC_INPROGRESS;
+    RCCLCHECK_GOTO(ncclReduce(src, dst, count, rccl_dt, op, args->root,
+                              team->rccl_comm, stream),
+                   exit_coll, status, UCC_TL_TEAM_LIB(team));
+    status = ucc_tl_rccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_reduce_init(ucc_tl_rccl_task_t *task)
+{
+    ucc_tl_rccl_team_t *team = TASK_TEAM(task);
+    ucc_datatype_t dt;
+
+    dt = (TASK_ARGS(task).root == UCC_TL_TEAM_RANK(team))
+        ? TASK_ARGS(task).dst.info.datatype
+        : TASK_ARGS(task).src.info.datatype;
+
+    if (UCC_OK !=
+        ucc_rccl_check_dt_supported(dt, dt)) {
+        tl_debug(UCC_TASK_LIB(task), "dataype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    if (ucc_to_rccl_reduce_op[TASK_ARGS(task).op] == ncclOpUnsupported) {
+        tl_debug(UCC_TASK_LIB(task), "reduction operation is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    task->super.post = ucc_tl_rccl_reduce_start;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_rccl_barrier_init(ucc_tl_rccl_task_t *task)
+{
+    /* use 4-byte allreduce to accomplish barrier */
+    ucc_coll_args_t *args = &TASK_ARGS(task);
+
+    args->mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
+    args->flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+    args->op     = UCC_OP_SUM;
+
+    args->dst.info.buffer   = TASK_CTX(task)->scratch_buf;
+    args->src.info.buffer   = args->dst.info.buffer;
+    args->dst.info.datatype = args->src.info.datatype = UCC_DT_FLOAT32;
+    args->dst.info.count    = args->src.info.count = 1;
+
+    task->super.post = ucc_tl_rccl_allreduce_start;
+
+    return UCC_OK;
+}
+
+static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
+{
+    switch (coll_type) {
+    case UCC_COLL_TYPE_ALLGATHERV:
+        return ucc_tl_rccl_allgatherv_alg_from_str(str);
+    default:
+        break;
+    }
+    return -1;
+}
+
+ucc_status_t ucc_tl_rccl_alg_id_to_init(int alg_id, const char *alg_id_str,
+                                        ucc_coll_type_t   coll_type,
+                                        ucc_memory_type_t mem_type, //NOLINT
+                                        ucc_base_coll_init_fn_t *init)
+{
+    ucc_status_t status = UCC_OK;
+    if (alg_id_str) {
+        alg_id = alg_id_from_str(coll_type, alg_id_str);
+    }
+
+    switch (coll_type) {
+    case UCC_COLL_TYPE_ALLGATHERV:
+        switch (alg_id) {
+        case UCC_TL_RCCL_ALLGATHERV_ALG_P2P:
+            *init = ucc_tl_rccl_allgatherv_p2p_init;
+            break;
+        case UCC_TL_RCCL_ALLGATHERV_ALG_BCOPY:
+            *init = ucc_tl_rccl_allgatherv_bcopy_init;
+            break;
+        case UCC_TL_RCCL_ALLGATHERV_ALG_BCAST:
+            *init = ucc_tl_rccl_allgatherv_bcast_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    default:
+        status = UCC_ERR_NOT_SUPPORTED;
+        break;
+    }
+    return status;
+}

--- a/src/components/tl/rccl/tl_rccl_coll.h
+++ b/src/components/tl/rccl/tl_rccl_coll.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Facebook, Inc. and its affiliates. 2021.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_RCCL_COLL_H_
+#define UCC_TL_RCCL_COLL_H_
+
+#include "tl_rccl.h"
+
+#define UCC_TL_RCCL_N_DEFAULT_ALG_SELECT_STR 1
+extern const char
+    *ucc_tl_rccl_default_alg_select_str[UCC_TL_RCCL_N_DEFAULT_ALG_SELECT_STR];
+
+ucc_status_t ucc_tl_rccl_alg_id_to_init(int alg_id, const char *alg_id_str,
+                                        ucc_coll_type_t   coll_type,
+                                        ucc_memory_type_t mem_type,
+                                        ucc_base_coll_init_fn_t *init);
+
+ucc_tl_rccl_task_t * ucc_tl_rccl_init_task(ucc_base_coll_args_t *coll_args,
+                                           ucc_base_team_t *team);
+
+void ucc_tl_rccl_free_task(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
+                                        ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_rccl_coll_finalize(ucc_coll_task_t *coll_task);
+
+ucc_status_t ucc_tl_rccl_collective_sync(ucc_tl_rccl_task_t *task,
+                                         hipStream_t stream);
+
+ucc_status_t ucc_tl_rccl_allgather_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_allgatherv_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_allreduce_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_alltoall_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_alltoallv_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_bcast_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_reduce_scatter_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_reduce_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_barrier_init(ucc_tl_rccl_task_t *task);
+
+#endif

--- a/src/components/tl/rccl/tl_rccl_context.c
+++ b/src/components/tl/rccl/tl_rccl_context.c
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Facebook, Inc. and its affiliates. 2021.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_rccl.h"
+#include "components/mc/ucc_mc.h"
+#include "components/ec/ucc_ec.h"
+#include "utils/arch/cpu.h"
+
+void ucc_tl_rccl_event_collective_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+    ucc_status_t status;
+
+    ucc_assert(task->completed != NULL);
+    status = ucc_ec_event_test(task->completed, UCC_EE_ROCM_STREAM);
+    coll_task->status = status;
+#ifdef HAVE_PROFILING_TL_RCCL
+    if (coll_task->status == UCC_OK) {
+        UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_coll_done", 0);
+    }
+#endif
+}
+
+void ucc_tl_rccl_driver_collective_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_rccl_task_t *task = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
+
+    coll_task->status = task->host_status;
+#ifdef HAVE_PROFILING_TL_RCCL
+    if (coll_task->status == UCC_OK) {
+        UCC_TL_RCCL_PROFILE_REQUEST_EVENT(coll_task, "rccl_coll_done", 0);
+    }
+#endif
+}
+
+static void ucc_tl_rccl_req_mpool_obj_init(ucc_mpool_t *mp, void *obj,
+                                           void *chunk)
+{
+    ucc_tl_rccl_task_t *req = (ucc_tl_rccl_task_t*) obj;
+
+    req->super.progress = ucc_tl_rccl_event_collective_progress;
+}
+
+
+static ucc_mpool_ops_t ucc_tl_rccl_req_mpool_ops = {
+    .chunk_alloc   = ucc_mpool_hugetlb_malloc,
+    .chunk_release = ucc_mpool_hugetlb_free,
+    .obj_init      = ucc_tl_rccl_req_mpool_obj_init,
+    .obj_cleanup   = NULL
+};
+
+UCC_CLASS_INIT_FUNC(ucc_tl_rccl_context_t,
+                    const ucc_base_context_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    ucc_tl_rccl_context_config_t *tl_rccl_config =
+	ucc_derived_of(config, ucc_tl_rccl_context_config_t);
+    ucc_status_t status;
+
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_rccl_config->super,
+			      params->context);
+    memcpy(&self->cfg, tl_rccl_config, sizeof(*tl_rccl_config));
+
+    // RCCL does not currently support memops for synchronization
+    if (self->cfg.sync_type == UCC_TL_RCCL_COMPLETION_SYNC_TYPE_MEMOPS) {
+        tl_error(self->super.super.lib, "memops not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    if (self->cfg.sync_type != UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT) {
+        tl_info(self->super.super.lib, "fallback to event completion sync");
+        self->cfg.sync_type = UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT;
+    }
+
+    ucc_assert(self->cfg.sync_type == UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT);
+    tl_info(self->super.super.lib, "using event completion sync");
+    status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_rccl_task_t), 0,
+                            UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
+                            &ucc_tl_rccl_req_mpool_ops, params->thread_mode,
+                            "tl_rccl_req_mp");
+    if (status != UCC_OK) {
+        tl_error(self->super.super.lib,
+                 "failed to initialize tl_rccl_req mpool");
+        return status;
+    }
+    // scratch buffer for barrier
+    hipError_t hip_st = hipMalloc(&self->scratch_buf, sizeof(float));
+    if (hip_st != hipSuccess) {
+        return UCC_ERR_NO_MEMORY;
+    }
+    tl_info(self->super.super.lib, "initialized tl context: %p", self);
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_rccl_context_t)
+{
+    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    ucc_mpool_cleanup(&self->req_mp, 1);
+    hipFree(self->scratch_buf);
+    self->scratch_buf = NULL;
+}
+
+UCC_CLASS_DEFINE(ucc_tl_rccl_context_t, ucc_tl_context_t);
+
+ucc_status_t
+ucc_tl_rccl_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
+                             ucc_base_ctx_attr_t      *attr)
+{
+    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
+        attr->attr.ctx_addr_len = 0;
+    }
+    attr->topo_required = 0;
+    return UCC_OK;
+}

--- a/src/components/tl/rccl/tl_rccl_lib.c
+++ b/src/components/tl/rccl/tl_rccl_lib.c
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_rccl.h"
+
+/* NOLINTNEXTLINE  params is not used*/
+UCC_CLASS_INIT_FUNC(ucc_tl_rccl_lib_t, const ucc_base_lib_params_t *params,
+                    const ucc_base_config_t *config)
+{
+    const ucc_tl_lib_config_t *tl_config =
+        ucc_derived_of(config, ucc_tl_lib_config_t);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_rccl.super, tl_config);
+
+    tl_info(&self->super, "initialized lib object: %p", self);
+    return UCC_OK;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_rccl_lib_t)
+{
+    tl_info(&self->super, "finalizing lib object: %p", self);
+}
+
+UCC_CLASS_DEFINE(ucc_tl_rccl_lib_t, ucc_tl_lib_t);
+
+ucc_status_t ucc_tl_rccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
+                                      ucc_base_lib_attr_t  *base_attr)
+{
+    ucc_tl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
+
+    attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
+    attr->super.attr.coll_types  = UCC_TL_RCCL_SUPPORTED_COLLS;
+    attr->super.flags            = 0;
+    return UCC_OK;
+}

--- a/src/components/tl/rccl/tl_rccl_team.c
+++ b/src/components/tl/rccl/tl_rccl_team.c
@@ -1,0 +1,241 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Facebook, Inc. and its affiliates. 2021.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_rccl.h"
+#include "tl_rccl_coll.h"
+#include "components/mc/ucc_mc.h"
+#include "components/ec/ucc_ec.h"
+#include "coll_score/ucc_coll_score.h"
+
+UCC_CLASS_INIT_FUNC(ucc_tl_rccl_team_t, ucc_base_context_t *tl_context,
+                    const ucc_base_team_params_t *params)
+{
+    ucc_tl_rccl_context_t *ctx    =
+        ucc_derived_of(tl_context, ucc_tl_rccl_context_t);
+    ucc_status_t status;
+    ucc_rank_t size;
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
+
+    size = UCC_TL_TEAM_SIZE(self);
+    self->unique_id = ucc_malloc(sizeof(ncclUniqueId) * (size + 1),
+                                 "tl_rccl_unique_id");
+    if (!self->unique_id) {
+        tl_error(ctx->super.super.lib,
+                 "failed to allocate %zd bytes for unique_id array",
+                 sizeof(ncclUniqueId) * (size + 1));
+        return UCC_ERR_NO_MEMORY;
+    }
+    if (UCC_TL_TEAM_RANK(self) == 0) {
+        ncclResult_t st;
+        st = ncclGetUniqueId(&self->unique_id[size]);
+        if (st != ncclSuccess) {
+            tl_error(ctx->super.super.lib, "failed to get unique id");
+            memset(&self->unique_id[size], 0, sizeof(ncclUniqueId));
+        }
+    }
+    status = UCC_TL_TEAM_OOB(self).allgather(
+        &self->unique_id[size], self->unique_id,
+        sizeof(ncclUniqueId), UCC_TL_TEAM_OOB(self).coll_info,
+        &self->oob_req);
+    if (status != UCC_OK) {
+        tl_error(ctx->super.super.lib, "failed to start oob allgather");
+        goto free_unique_id;
+    }
+    return UCC_OK;
+
+free_unique_id:
+    ucc_free(self->unique_id);
+    return status;
+}
+
+UCC_CLASS_CLEANUP_FUNC(ucc_tl_rccl_team_t)
+{
+    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    if (self->rccl_comm) {
+        ncclCommDestroy(self->rccl_comm);
+        hipStreamDestroy(self->stream);
+    }
+}
+
+UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_rccl_team_t, ucc_base_team_t);
+UCC_CLASS_DEFINE(ucc_tl_rccl_team_t, ucc_tl_team_t);
+
+ucc_status_t ucc_tl_rccl_team_destroy(ucc_base_team_t *tl_team)
+{
+    UCC_CLASS_DELETE_FUNC_NAME(ucc_tl_rccl_team_t)(tl_team);
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_rccl_team_create_test(ucc_base_team_t *tl_team)
+{
+    ucc_tl_rccl_team_t *team = ucc_derived_of(tl_team, ucc_tl_rccl_team_t);
+    ucc_status_t status;
+    ncclResult_t rccl_status;
+    ncclUniqueId errorid;
+
+    status = UCC_TL_TEAM_OOB(team).req_test(team->oob_req);
+    if (status == UCC_INPROGRESS) {
+        return UCC_INPROGRESS;
+    }
+    if (status != UCC_OK) {
+        UCC_TL_TEAM_OOB(team).req_free(team->oob_req);
+        tl_error(tl_team->context->lib, "oob req test failed");
+        goto free_unique_id;
+    }
+    status = UCC_TL_TEAM_OOB(team).req_free(team->oob_req);
+    if (status != UCC_OK) {
+        tl_error(tl_team->context->lib, "oob req free failed");
+        goto free_unique_id;
+    }
+    /* check unique id is valid */
+    memset(&errorid, 0, sizeof(errorid));
+    if (!memcmp(&errorid, team->unique_id, sizeof(errorid))) {
+        tl_error(tl_team->context->lib, "incorrect unique id");
+        goto free_unique_id;
+    }
+
+    HIPCHECK_GOTO(hipStreamCreateWithFlags(&team->stream,
+                   hipStreamNonBlocking), free_unique_id, status,
+                   tl_team->context->lib);
+    rccl_status = ncclCommInitRank(&team->rccl_comm, UCC_TL_TEAM_SIZE(team),
+                                   team->unique_id[0], UCC_TL_TEAM_RANK(team));
+    if (rccl_status != ncclSuccess) {
+        tl_info(tl_team->context->lib, "RCCL error %d %s",
+                rccl_status, ncclGetErrorString(rccl_status));
+        status = UCC_ERR_NO_MESSAGE;
+        goto free_stream;
+    }
+    ucc_free(team->unique_id);
+    tl_info(tl_team->context->lib, "initialized tl team: %p", team);
+    return UCC_OK;
+
+free_stream:
+    hipStreamDestroy(team->stream);
+free_unique_id:
+    ucc_free(team->unique_id);
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_coll_init(ucc_base_coll_args_t *coll_args,
+                                   ucc_base_team_t *team,
+                                   ucc_coll_task_t **task_h)
+{
+    ucc_tl_rccl_task_t *task;
+    ucc_status_t        status;
+
+    task = ucc_tl_rccl_init_task(coll_args, team);
+    if (ucc_unlikely(!task)) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    switch (coll_args->args.coll_type)
+    {
+    case UCC_COLL_TYPE_ALLGATHER:
+        status = ucc_tl_rccl_allgather_init(task);
+        break;
+    case UCC_COLL_TYPE_ALLGATHERV:
+        status = ucc_tl_rccl_allgatherv_init(task);
+        break;
+    case UCC_COLL_TYPE_ALLREDUCE:
+        status = ucc_tl_rccl_allreduce_init(task);
+        break;
+    case UCC_COLL_TYPE_ALLTOALL:
+        status = ucc_tl_rccl_alltoall_init(task);
+        break;
+    case UCC_COLL_TYPE_ALLTOALLV:
+        status = ucc_tl_rccl_alltoallv_init(task);
+        break;
+    case UCC_COLL_TYPE_BCAST:
+        status = ucc_tl_rccl_bcast_init(task);
+        break;
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        status = ucc_tl_rccl_reduce_scatter_init(task);
+        break;
+    case UCC_COLL_TYPE_REDUCE:
+        status = ucc_tl_rccl_reduce_init(task);
+        break;
+    case UCC_COLL_TYPE_BARRIER:
+        status = ucc_tl_rccl_barrier_init(task);
+        break;
+    default:
+        tl_error(UCC_TASK_LIB(task),
+                 "collective %d is not supported by rccl tl",
+                 coll_args->args.coll_type);
+        status = UCC_ERR_NOT_SUPPORTED;
+    }
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto free_task;
+    }
+    tl_info(UCC_TASK_LIB(task), "init coll task %p", task);
+    *task_h = &task->super;
+    return status;
+
+free_task:
+    ucc_tl_rccl_free_task(task);
+    return status;
+}
+
+ucc_status_t ucc_tl_rccl_team_get_scores(ucc_base_team_t   *tl_team,
+                                         ucc_coll_score_t **score_p)
+{
+    ucc_tl_rccl_team_t *team = ucc_derived_of(tl_team, ucc_tl_rccl_team_t);
+    ucc_base_context_t *ctx  = UCC_TL_TEAM_CTX(team);
+    ucc_memory_type_t   mt   = UCC_MEMORY_TYPE_ROCM;
+    ucc_coll_score_t   *score;
+    ucc_status_t        status;
+    int                 i;
+
+    /* There can be a different logic for different coll_type/mem_type.
+       Right now just init everything the same way. */
+    status =
+        ucc_coll_score_build_default(tl_team, UCC_TL_RCCL_DEFAULT_SCORE,
+                           ucc_tl_rccl_coll_init, UCC_TL_RCCL_SUPPORTED_COLLS,
+                           &mt, 1, &score);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+
+    for (i = 0; i < UCC_TL_RCCL_N_DEFAULT_ALG_SELECT_STR; i++) {
+        status = ucc_coll_score_update_from_str(
+            ucc_tl_rccl_default_alg_select_str[i], score, UCC_TL_TEAM_SIZE(team),
+            ucc_tl_rccl_coll_init, &team->super.super, UCC_TL_RCCL_DEFAULT_SCORE,
+            ucc_tl_rccl_alg_id_to_init);
+        if (ucc_unlikely(UCC_OK != status)) {
+            tl_error(tl_team->context->lib,
+                     "failed to apply default coll select setting: %s",
+                     ucc_tl_rccl_default_alg_select_str[i]);
+            goto err;
+        }
+    }
+
+    // add barrier, which might be triggered from host memory type
+    // use lower score
+    status = ucc_coll_score_add_range(score, UCC_COLL_TYPE_BARRIER,
+                                      UCC_MEMORY_TYPE_HOST, 0, UCC_MSG_MAX, 1,
+                                      ucc_tl_rccl_coll_init, tl_team);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+
+    if (strlen(ctx->score_str) > 0) {
+        status = ucc_coll_score_update_from_str(
+            ctx->score_str, score, UCC_TL_TEAM_SIZE(team),
+            ucc_tl_rccl_coll_init, &team->super.super,
+            UCC_TL_RCCL_DEFAULT_SCORE, ucc_tl_rccl_alg_id_to_init);
+        /* If INVALID_PARAM - User provided incorrect input - try to proceed */
+        if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
+            (status != UCC_ERR_NOT_SUPPORTED)) {
+            goto err;
+        }
+    }
+    *score_p = score;
+    return UCC_OK;
+err:
+    ucc_coll_score_free(score);
+    return status;
+}

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -365,7 +365,7 @@ static void ucc_trigger_test(ucc_coll_task_t *task)
     ucc_ee_executor_params_t  params;
 
     if (task->ev == NULL) {
-        if (task->ee->ee_type == UCC_EE_CUDA_STREAM) {
+        if (task->ee->ee_type == UCC_EE_CUDA_STREAM || task->ee->ee_type == UCC_EE_ROCM_STREAM) {
             /* implicit event triggered */
             task->ev = (ucc_ev_t *) 0xFFFF; /* dummy event */
             task->executor = NULL;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -2009,6 +2009,7 @@ typedef enum ucc_event_type {
 typedef enum ucc_ee_type {
     UCC_EE_CUDA_STREAM = 0,
     UCC_EE_CPU_THREAD,
+    UCC_EE_ROCM_STREAM,
     UCC_EE_LAST,
     UCC_EE_UNKNOWN = UCC_EE_LAST
 } ucc_ee_type_t;

--- a/src/utils/arch/rocm_def.h
+++ b/src/utils/arch/rocm_def.h
@@ -1,0 +1,44 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCC_ROCM_DEF_H
+#define UCC_ROCM_DEF_H
+
+#include "config.h"
+
+#if HAVE_ROCM
+
+#include "utils/ucc_log.h"
+#include <hip/hip_runtime_api.h>
+
+#define ROCMCHECK(cmd) do {                                                    \
+        hipError_t e = cmd;                                                    \
+        if(e != hipSuccess) {                                                  \
+            ucc_error("ROCm failed with ret:%d(%s)", e,                        \
+                      hipGetErrorString(e));                                   \
+            return UCC_ERR_NO_MESSAGE;                                         \
+        }                                                                      \
+} while(0)
+
+#define ROCM_FUNC(_func)                                                       \
+    ({                                                                         \
+        ucc_status_t _status = UCC_OK;                                         \
+        do {                                                                   \
+            hipError_t _result = (_func);                                      \
+            if (hipSuccess != _result) {                                       \
+                ucc_error("%s() failed: %d(%s)",                               \
+                          #_func, _result, hipGetErrorString(_result));        \
+                _status = UCC_ERR_INVALID_PARAM;                               \
+            }                                                                  \
+        } while (0);                                                           \
+        _status;                                                               \
+    })
+
+
+#endif  /* HAVE_ROCM */
+
+#endif /* UCC_ROCM_DEF_H */

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -110,6 +110,14 @@ gtest_LDADD += \
 	$(CUDA_LIBS)
 endif
 
+if HAVE_ROCM
+gtest_SOURCES  += core/test_mc_rocm.cc
+gtest_CPPFLAGS += $(HIP_CPPFLAGS)
+gtest_LDFLAGS  += $(HIP_LDFLAGS)
+gtest_LDADD    += $(HIP_LIBS)
+endif
+
+
 noinst_HEADERS =            \
 	common/gtest.h          \
 	common/test.h           \

--- a/test/gtest/core/test_mc_rocm.cc
+++ b/test/gtest/core/test_mc_rocm.cc
@@ -1,0 +1,201 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include <components/mc/ucc_mc.h>
+#include <pthread.h>
+}
+#include <common/test.h>
+#include <hip/hip_runtime.h>
+#include <vector>
+
+void *mt_ucc_mc_rocm_allocs(void *args)
+{
+    // Final size will be:
+    // size * (quantifier^(num_of_allocs/2))
+    // and should be larger than mpool buffer size which is 1MB by default,
+    // to assure testing both fast and slow ucc_mc_alloc path.
+    // if num_of_allocs is changed, change quantifier accordingly.
+    int                                   quantifier    = 2;
+    size_t                                size          = 4;
+    int                                   num_of_allocs = 40;
+    std::vector<ucc_mc_buffer_header_t *> headers;
+    std::vector<void *>                   pointers;
+    headers.resize(num_of_allocs);
+    pointers.resize(num_of_allocs);
+
+    for (int i = 0; i < num_of_allocs; i++) {
+        EXPECT_EQ(UCC_OK,
+                  ucc_mc_alloc(&headers[i], size, UCC_MEMORY_TYPE_ROCM));
+        pointers[i] = headers[i]->addr;
+        EXPECT_EQ(hipSuccess, hipMemset(pointers[i], 0, size));
+        EXPECT_EQ(UCC_OK, ucc_mc_free(headers[i]));
+        if (i % 2) {
+            size *= quantifier;
+        }
+    }
+    return 0;
+}
+
+class test_mc_rocm : public ucc::test {
+  protected:
+    const int               TEST_ALLOC_SIZE = 1024;
+    ucc_mc_buffer_header_t *mc_header;
+    void *                  test_ptr;
+    ucc_memory_type_t       test_mtype;
+    void TestMCRocmSetUp(ucc_mc_params_t mc_params)
+    {
+        ucc::test::SetUp();
+        ucc_constructor();
+        ucc_mc_init(&mc_params);
+        test_ptr   = NULL;
+        test_mtype = UCC_MEMORY_TYPE_UNKNOWN;
+    }
+    virtual void SetUp() override
+    {
+        ucc_mc_params_t mc_params = {
+            .thread_mode = UCC_THREAD_SINGLE,
+        };
+        TestMCRocmSetUp(mc_params);
+    }
+    virtual void TearDown() override
+    {
+        ucc_mc_finalize();
+        ucc::test::TearDown();
+    }
+};
+
+class test_mc_rocm_mt : public test_mc_rocm {
+  protected:
+    virtual void SetUp() override
+    {
+        ucc_mc_params_t mc_params = {
+            .thread_mode = UCC_THREAD_MULTIPLE,
+        };
+        TestMCRocmSetUp(mc_params);
+    }
+};
+
+UCC_TEST_F(test_mc_rocm, mc_rocm_load)
+{
+    EXPECT_EQ(UCC_OK, ucc_mc_available(UCC_MEMORY_TYPE_ROCM));
+}
+
+UCC_TEST_F(test_mc_rocm, can_alloc_and_free_mem)
+{
+    // mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1MB and is configurable at runtime.
+    EXPECT_EQ(UCC_OK,
+              ucc_mc_alloc(&mc_header, TEST_ALLOC_SIZE, UCC_MEMORY_TYPE_ROCM));
+    test_ptr = mc_header->addr;
+    EXPECT_EQ(hipSuccess, hipMemset(test_ptr, 0, TEST_ALLOC_SIZE));
+    EXPECT_EQ(UCC_OK, ucc_mc_free(mc_header));
+}
+
+// Disabled because can't reinit mc with different thread mode
+UCC_TEST_F(test_mc_rocm_mt, DISABLED_can_alloc_and_free_mem_mt)
+{
+    // mpool will be used only if size is smaller than UCC_MC_CPU_ELEM_SIZE, which by default set to 1MB and is configurable at runtime.
+    int                    num_of_threads = 10;
+    std::vector<pthread_t> threads;
+    threads.resize(num_of_threads);
+
+    for (int i = 0; i < num_of_threads; i++) {
+        pthread_create(&threads[i], NULL, &mt_ucc_mc_rocm_allocs, NULL);
+    }
+    for (int i = 0; i < num_of_threads; i++) {
+        pthread_join(threads[i], NULL);
+    }
+}
+
+UCC_TEST_F(test_mc_rocm, can_detect_host_mem)
+{
+    ucc_mem_attr_t mem_attr;
+
+    mem_attr.field_mask = UCC_MEM_ATTR_FIELD_MEM_TYPE;
+    test_ptr = malloc(TEST_ALLOC_SIZE);
+    if (test_ptr == NULL) {
+        ADD_FAILURE() << "failed to allocate host memory";
+    }
+    EXPECT_EQ(UCC_OK, ucc_mc_get_mem_attr(test_ptr, &mem_attr));
+    EXPECT_EQ(UCC_MEMORY_TYPE_HOST, mem_attr.mem_type);
+    free(test_ptr);
+}
+
+UCC_TEST_F(test_mc_rocm, can_detect_rocm_mem)
+{
+    ucc_mem_attr_t mem_attr;
+    hipError_t st;
+
+    mem_attr.field_mask = UCC_MEM_ATTR_FIELD_MEM_TYPE;
+    st = hipMalloc(&test_ptr, TEST_ALLOC_SIZE);
+    if (st != hipSuccess) {
+        ADD_FAILURE() << "failed to allocate device memory";
+    }
+    EXPECT_EQ(UCC_OK, ucc_mc_get_mem_attr(test_ptr, &mem_attr));
+    EXPECT_EQ(UCC_MEMORY_TYPE_ROCM, mem_attr.mem_type);
+    hipFree(test_ptr);
+    ucc_mc_finalize();
+}
+
+UCC_TEST_F(test_mc_rocm, can_query_rocm_mem)
+{
+    ucc_mem_attr_t mem_attr;
+    hipError_t st;
+    void *ptr;
+
+    st = hipMalloc(&test_ptr, TEST_ALLOC_SIZE);
+    if (st != hipSuccess) {
+        ADD_FAILURE() << "failed to allocate device memory";
+    }
+
+    mem_attr.field_mask = UCC_MEM_ATTR_FIELD_MEM_TYPE;
+    EXPECT_EQ(UCC_OK, ucc_mc_get_mem_attr(test_ptr, &mem_attr));
+    EXPECT_EQ(UCC_MEMORY_TYPE_ROCM, mem_attr.mem_type);
+
+    /* query base addr and length */
+    mem_attr.field_mask   = UCC_MEM_ATTR_FIELD_MEM_TYPE |
+                            UCC_MEM_ATTR_FIELD_BASE_ADDRESS |
+                            UCC_MEM_ATTR_FIELD_ALLOC_LENGTH;
+    mem_attr.alloc_length = 1;
+    ptr = (char *)test_ptr + TEST_ALLOC_SIZE/2;
+    EXPECT_EQ(UCC_OK, ucc_mc_get_mem_attr(ptr, &mem_attr));
+    EXPECT_EQ(UCC_MEMORY_TYPE_ROCM, mem_attr.mem_type);
+    EXPECT_EQ(test_ptr, mem_attr.base_address);
+    EXPECT_EQ(TEST_ALLOC_SIZE, mem_attr.alloc_length);
+
+    hipFree(test_ptr);
+    ucc_mc_finalize();
+}
+
+UCC_TEST_F(test_mc_rocm, can_detect_managed_mem)
+{
+    hipError_t st;
+    ucc_mem_attr_t mem_attr;
+
+    st = hipMallocManaged(&test_ptr, TEST_ALLOC_SIZE);
+    if (st != hipSuccess) {
+        ADD_FAILURE() << "failed to allocate managed memory";
+    }
+    mem_attr.field_mask = UCC_MEM_ATTR_FIELD_MEM_TYPE;
+    EXPECT_EQ(UCC_OK, ucc_mc_get_mem_attr(test_ptr, &mem_attr));
+    EXPECT_EQ(UCC_MEMORY_TYPE_ROCM_MANAGED, mem_attr.mem_type);
+    hipFree(test_ptr);
+}
+
+UCC_TEST_F(test_mc_rocm, can_detect_host_alloc_mem)
+{
+    hipError_t st;
+    ucc_mem_attr_t mem_attr;
+
+    st = hipHostMalloc(&test_ptr, TEST_ALLOC_SIZE, hipHostMallocDefault);
+    if (st != hipSuccess) {
+        ADD_FAILURE() << "failed to allocate host mapped memory";
+    }
+    mem_attr.field_mask = UCC_MEM_ATTR_FIELD_MEM_TYPE;
+    EXPECT_EQ(UCC_OK, ucc_mc_get_mem_attr(test_ptr, &mem_attr));
+    EXPECT_EQ(UCC_MEMORY_TYPE_HOST, mem_attr.mem_type);
+    hipFreeHost(test_ptr);
+}

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -42,3 +42,9 @@ ucc_test_mpi_CPPFLAGS += $(CUDA_CPPFLAGS)
 ucc_test_mpi_LDFLAGS += $(CUDA_LDFLAGS)
 ucc_test_mpi_LDADD += $(CUDA_LIBS)
 endif
+
+if HAVE_ROCM
+ucc_test_mpi_CPPFLAGS += $(HIP_CPPFLAGS)
+ucc_test_mpi_LDFLAGS += $(HIP_LDFLAGS)
+ucc_test_mpi_LDADD += $(HIP_LIBS)
+endif

--- a/test/mpi/buffer.cc
+++ b/test/mpi/buffer.cc
@@ -27,7 +27,7 @@ void init_buffer(void *_buf, size_t count, ucc_datatype_t dt,
                  ucc_memory_type_t mt, int value)
 {
     void *buf = NULL;
-    if (mt == UCC_MEMORY_TYPE_CUDA) {
+    if (mt == UCC_MEMORY_TYPE_CUDA || mt == UCC_MEMORY_TYPE_ROCM) {
         buf = ucc_malloc(count * ucc_dt_size(dt), "buf");
         UCC_MALLOC_CHECK(buf);
     } else if (mt == UCC_MEMORY_TYPE_HOST) {
@@ -105,7 +105,7 @@ ucc_status_t compare_buffers(void *_rst, void *expected, size_t count,
 
     if (UCC_MEMORY_TYPE_HOST == mt) {
         rst = _rst;
-    } else if (UCC_MEMORY_TYPE_CUDA == mt) {
+    } else if (UCC_MEMORY_TYPE_CUDA == mt || UCC_MEMORY_TYPE_ROCM == mt) {
         UCC_ALLOC_COPY_BUF(rst_mc_header, UCC_MEMORY_TYPE_HOST, _rst, mt,
                            count * ucc_dt_size(dt));
         rst = rst_mc_header->addr;

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -321,11 +321,11 @@ void UccTestMpi::set_displ_vsizes(std::vector<ucc_test_vsize_flag_t> &_displs_vs
     displs_vsize = _displs_vsize;
 }
 
-#ifdef HAVE_CUDA
-void set_cuda_device(test_set_cuda_device_t set_device)
+#if defined(HAVE_CUDA) || defined(HAVE_HIP)
+void set_gpu_device(test_set_gpu_device_t set_device)
 {
     MPI_Comm local_comm;
-    int cuda_dev_count;
+    int gpu_dev_count;
     int local_rank;
     int device_id;
 
@@ -336,25 +336,33 @@ void set_cuda_device(test_set_cuda_device_t set_device)
     MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
                         &local_comm);
     MPI_Comm_rank(local_comm, &local_rank);
-
-    CUDA_CHECK(cudaGetDeviceCount(&cuda_dev_count));
+#if defined(HAVE_CUDA)
+    CUDA_CHECK(cudaGetDeviceCount(&gpu_dev_count));
+#elif defined(HAVE_HIP)
+    HIP_CHECK(hipGetDeviceCount(&gpu_dev_count));
+#endif
     switch (set_device) {
     case TEST_SET_DEV_LRANK:
-        if(local_rank >= cuda_dev_count) {
+        if(local_rank >= gpu_dev_count) {
             std::cerr << "*** UCC TEST FAIL: "
-                      << "not enough CUDA devices on the node to map processes.\n";
+                      << "not enough GPU devices on the node to map processes.\n";
             MPI_Abort(MPI_COMM_WORLD, -1);
         }
         device_id = local_rank;
         break;
     case TEST_SET_DEV_LRANK_ROUND:
-        device_id = local_rank % cuda_dev_count;
+        device_id = local_rank % gpu_dev_count;
         break;
     case TEST_SET_DEV_NONE:
     default:
         return;
     }
+#if defined(HAVE_CUDA)
     CUDA_CHECK(cudaSetDevice(device_id));
+#elif defined(HAVE_HIP)
+    HIP_CHECK(hipSetDevice(device_id));
+#endif
+
 }
 #endif
 

--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -14,6 +14,7 @@ ucc_perftest_SOURCES =            \
 	ucc_pt_config.cc              \
 	ucc_pt_comm.cc                \
 	ucc_pt_cuda.cc                \
+	ucc_pt_rocm.cc                \
 	ucc_pt_benchmark.cc           \
 	ucc_pt_bootstrap_mpi.cc       \
 	ucc_pt_coll.cc                \

--- a/tools/perf/ucc_perftest.cc
+++ b/tools/perf/ucc_perftest.cc
@@ -3,6 +3,7 @@
 #include "ucc_pt_config.h"
 #include "ucc_pt_coll.h"
 #include "ucc_pt_cuda.h"
+#include "ucc_pt_rocm.h"
 #include "ucc_pt_benchmark.h"
 
 int main(int argc, char *argv[])
@@ -14,6 +15,7 @@ int main(int argc, char *argv[])
 
     pt_config.process_args(argc, argv);
     ucc_pt_cuda_init();
+    ucc_pt_rocm_init();
     try {
         comm = new ucc_pt_comm(pt_config.comm);
     } catch(std::exception &e) {

--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -4,6 +4,7 @@
 #include "ucc_pt_bootstrap_mpi.h"
 #include "ucc_perftest.h"
 #include "ucc_pt_cuda.h"
+#include "ucc_pt_rocm.h"
 extern "C" {
 #include "utils/ucc_coll_utils.h"
 #include "components/mc/ucc_mc.h"
@@ -23,12 +24,15 @@ void ucc_pt_comm::set_gpu_device()
 {
     int dev_count = 0;
 
-    if (ucc_pt_cudaGetDeviceCount(&dev_count) || !dev_count)
-    if (dev_count == 0) {
-        return;
+    if (ucc_pt_cudaGetDeviceCount(&dev_count) == 0 && dev_count != 0) {
+	ucc_pt_cudaSetDevice(bootstrap->get_local_rank() % dev_count);
+	return;
     }
 
-    ucc_pt_cudaSetDevice(bootstrap->get_local_rank() % dev_count);
+    if (ucc_pt_rocmGetDeviceCount(&dev_count) == 0 && dev_count != 0) {
+	ucc_pt_rocmSetDevice(bootstrap->get_local_rank() % dev_count);
+    }
+
     return;
 }
 

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -40,6 +40,7 @@ const std::map<std::string, ucc_coll_type_t> ucc_pt_coll_map = {
 const std::map<std::string, ucc_memory_type_t> ucc_pt_memtype_map = {
     {"host", UCC_MEMORY_TYPE_HOST},
     {"cuda", UCC_MEMORY_TYPE_CUDA},
+    {"rocm", UCC_MEMORY_TYPE_ROCM},
 };
 
 const std::map<std::string, ucc_datatype_t> ucc_pt_datatype_map = {

--- a/tools/perf/ucc_pt_rocm.cc
+++ b/tools/perf/ucc_pt_rocm.cc
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_pt_rocm.h"
+#include <iostream>
+#include <dlfcn.h>
+#include <stdlib.h>
+
+ucc_pt_rocm_iface_t ucc_pt_rocm_iface = {
+    .available = 0,
+};
+
+#define LOAD_ROCM_SYM(_sym, _pt_sym) ({                                    \
+            void *h = dlsym(handle, _sym);                                 \
+            if ((error = dlerror()) != NULL)  {                            \
+                return;                                                    \
+            }                                                              \
+            ucc_pt_rocm_iface. _pt_sym =                                   \
+                reinterpret_cast<decltype(ucc_pt_rocm_iface. _pt_sym)>(h); \
+        })
+
+void ucc_pt_rocm_init(void)
+{
+    char *error;
+    void *handle;
+
+    handle = dlopen ("libamdhip64.so", RTLD_LAZY);
+    if (!handle) {
+        return;
+    }
+    LOAD_ROCM_SYM("hipGetDeviceCount", getDeviceCount);
+    LOAD_ROCM_SYM("hipSetDevice", setDevice);
+    LOAD_ROCM_SYM("hipGetErrorString", getErrorString);
+    ucc_pt_rocm_iface.available = 1;
+}

--- a/tools/perf/ucc_pt_rocm.h
+++ b/tools/perf/ucc_pt_rocm.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PT_ROCM_H
+#define UCC_PT_ROCM_H
+#include <iostream>
+
+typedef struct ucc_pt_rocm_iface {
+    int available;
+    int (*getDeviceCount)(int* count);
+    int (*setDevice)(int device);
+    char* (*getErrorString)(int err);
+} ucc_pt_rocm_iface_t;
+
+extern ucc_pt_rocm_iface_t ucc_pt_rocm_iface;
+void ucc_pt_rocm_init(void);
+
+#define hipSuccess 0
+
+#define STR(x) #x
+#define HIP_CHECK(_call)                                        \
+    do {                                                        \
+        int _status = (_call);                                  \
+        if (hipSuccess != _status) {                            \
+            std::cerr << "UCC perftest error: " <<              \
+                ucc_pt_rocm_iface.getErrorString(_status)       \
+                      << " in " << STR(_call) << "\n";          \
+            return _status;                                     \
+        }                                                       \
+    } while (0)
+
+static inline int ucc_pt_rocmGetDeviceCount(int *count)
+{
+    if (!ucc_pt_rocm_iface.available) {
+        return 1;
+    }
+    HIP_CHECK(ucc_pt_rocm_iface.getDeviceCount(count));
+    return 0;
+}
+
+static inline int ucc_pt_rocmSetDevice(int device)
+{
+    if (!ucc_pt_rocm_iface.available) {
+        return 1;
+    }
+    HIP_CHECK(ucc_pt_rocm_iface.setDevice(device));
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## What
This commit introduces support for rccl in ucc. The core contribution are three components:
- tl/rccl
- mc/rocm
- ec/rocm

Furthermore, the commit updates gtest, ucc_pertest, and ucc_test_mpi to support ROCm memory.

## Why ?


## How ?
Code is based on example set by mc/cuda, ec/cuda and tl/nccl.
