### PR TITLE
CL/HIER: enable alltoall(v)

### DIFF
--- a/src/components/cl/hier/alltoallv/alltoallv.c
+++ b/src/components/cl/hier/alltoallv/alltoallv.c
@@ -108,6 +108,7 @@ ucc_status_t ucc_cl_hier_alltoallv_triggered_post_setup(ucc_coll_task_t *task)
     for (i = 0; i < n_tasks; ++i) {
         ucc_coll_task_t *sub_task = schedule->super.super.tasks[i];
         if (sub_task->triggered_post_setup != NULL) {
+            sub_task->ee = task->ee;
             sub_task->triggered_post_setup(sub_task);
         }
     }

--- a/src/components/cl/hier/alltoallv/alltoallv.c
+++ b/src/components/cl/hier/alltoallv/alltoallv.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -26,8 +27,8 @@ static ucc_status_t ucc_cl_hier_alltoallv_start(ucc_coll_task_t *task)
 
 static ucc_status_t ucc_cl_hier_alltoallv_finalize(ucc_coll_task_t *task)
 {
-    ucc_cl_hier_schedule_t *schedule = ucc_derived_of(task,
-                                                      ucc_cl_hier_schedule_t);
+    ucc_cl_hier_schedule_t *schedule =
+        ucc_derived_of(task, ucc_cl_hier_schedule_t);
     ucc_status_t status;
 
     UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_alltoallv_finalize", 0);
@@ -96,6 +97,23 @@ static ucc_status_t ucc_cl_hier_alltoallv_finalize(ucc_coll_task_t *task)
         }                                                                      \
     } while (0)
 
+ucc_status_t ucc_cl_hier_alltoallv_triggered_post_setup(ucc_coll_task_t *task)
+{
+    ucc_cl_hier_schedule_t *schedule =
+        ucc_derived_of(task, ucc_cl_hier_schedule_t);
+    ucc_status_t status  = UCC_OK;
+    int          n_tasks = schedule->super.super.n_tasks;
+    int          i       = 0;
+
+    for (i = 0; i < n_tasks; ++i) {
+        ucc_coll_task_t *sub_task = schedule->super.super.tasks[i];
+        if (sub_task->triggered_post_setup != NULL) {
+            sub_task->triggered_post_setup(sub_task);
+        }
+    }
+    return status;
+}
+
 UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoallv_init,
                          (coll_args, team, task),
                          ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
@@ -150,9 +168,9 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoallv_init,
     node_size = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp->group_size;
 
     elem_size = c64 ? 8 : 4;
-    status = ucc_mc_alloc(&cl_schedule->scratch,
-                          elem_size * (full_size + node_size) * 4,
-                          UCC_MEMORY_TYPE_HOST);
+    status    = ucc_mc_alloc(&cl_schedule->scratch,
+                             elem_size * (full_size + node_size) * 4,
+                             UCC_MEMORY_TYPE_HOST);
     if (ucc_unlikely(UCC_OK != status)) {
         cl_error(team->context->lib,
                  "failed to allocate %zd bytes for full counts",
@@ -230,7 +248,9 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoallv_init,
     schedule->super.progress       = NULL;
     schedule->super.finalize       = ucc_cl_hier_alltoallv_finalize;
     schedule->super.triggered_post = ucc_triggered_post;
-    *task                          = &schedule->super;
+    schedule->super.triggered_post_setup =
+        ucc_cl_hier_alltoallv_triggered_post_setup;
+    *task = &schedule->super;
     return UCC_OK;
 
 err_init_2:

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -111,7 +112,8 @@ typedef struct ucc_cl_hier_team {
 UCC_CLASS_DECLARE(ucc_cl_hier_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
 
-#define UCC_CL_HIER_SUPPORTED_COLLS 0
+#define UCC_CL_HIER_SUPPORTED_COLLS \
+    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV)
 
 ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t      *team,


### PR DESCRIPTION
## What
Fully enable CL HIER Alltoall and Alltoallv

## Why ?
Enable HIER Alltoall(v) such as TL/UCP and TL/CUDA

## How ?
Enabled in the code and added triggered_post_setup function in CL/HIER
