### PR TITLE
UTIL: ep_map_nested

### DIFF
--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -210,6 +210,12 @@ ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size);
 /* Creates an inverse mapping for a given map */
 ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map);
 
+ucc_status_t ucc_ep_map_create_nested(ucc_ep_map_t *base_map,
+                                      ucc_ep_map_t *sub_map,
+                                      ucc_ep_map_t *out);
+
+void ucc_ep_map_destroy_nested(ucc_ep_map_t *out);
+
 void ucc_ep_map_destroy(ucc_ep_map_t *map);
 
 /* The two helper routines below are used to partition a buffer

--- a/test/gtest/utils/test_ep_map.cc
+++ b/test/gtest/utils/test_ep_map.cc
@@ -103,6 +103,29 @@ UCC_TEST_F(test_ep_map, reverse)
     }
 }
 
+UCC_TEST_F(test_ep_map, nested)
+{
+    auto map1 = EpMap(100); //full map, size 100
+    auto map2 = EpMap(0, 2, 50, 100); // submap even only
+    auto map3 = EpMap(1, 2, 25, 50); // submap odd only from 50
+    ucc_ep_map_t nested1, nested2;
+
+    EXPECT_EQ(UCC_OK, ucc_ep_map_create_nested(&map1.map, &map2.map, &nested1));
+    EXPECT_EQ(50, nested1.ep_num);
+    for (int i = 0; i < nested1.ep_num; i++) {
+        EXPECT_EQ(0 + i * 2, ucc_ep_map_eval(nested1, i));
+    }
+
+    EXPECT_EQ(UCC_OK, ucc_ep_map_create_nested(&nested1, &map3.map, &nested2));
+    EXPECT_EQ(25, nested2.ep_num);
+    for (int i = 0; i < nested2.ep_num; i++) {
+        EXPECT_EQ(2 + i * 4, ucc_ep_map_eval(nested2, i));
+    }
+
+    ucc_ep_map_destroy(&nested1);
+    ucc_ep_map_destroy(&nested2);
+}
+
 class test_ep_map_inv : public test_ep_map {
   public:
     void check_inv(EpMap map)


### PR DESCRIPTION
## What
Adds utility to build "nested" ep_maps 

## Why ?
TL team can be a subset of CORE team, CORE team can be a subset of context. Core team has team->ctx_map that maps core team rank to ctx rank. TL team also has map (passed by CL via params) which maps TL team rank to CORE team rank. Nested ep_map is used to create ctx_map for TL team, to map TL team rank directly to context rank. It is used in TL/SHM.

