### PR TITLE
TL/NCCL: add scatterv

### DIFF
--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -115,7 +115,8 @@ typedef struct ucc_tl_nccl_task {
      UCC_COLL_TYPE_ALLREDUCE      | UCC_COLL_TYPE_BCAST      |                 \
      UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE     |                 \
      UCC_COLL_TYPE_BARRIER        | UCC_COLL_TYPE_GATHER     |                 \
-     UCC_COLL_TYPE_GATHERV        | UCC_COLL_TYPE_SCATTER)
+     UCC_COLL_TYPE_GATHERV        | UCC_COLL_TYPE_SCATTER    |                 \
+     UCC_COLL_TYPE_SCATTERV)
 
 UCC_CLASS_DECLARE(ucc_tl_nccl_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -811,6 +811,94 @@ ucc_status_t ucc_tl_nccl_scatter_init(ucc_tl_nccl_task_t *task)
     return UCC_OK;
 }
 
+ucc_status_t ucc_tl_nccl_scatterv_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_coll_args_t    *args   = &TASK_ARGS(task);
+    ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
+    ucc_rank_t          rank   = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t          size   = UCC_TL_TEAM_SIZE(team);
+    ucc_ee_h            ee     = coll_task->ee;
+    cudaStream_t        stream = (ee) ? (cudaStream_t) ee->ee_context : team->stream;
+    void               *dst    = args->dst.info.buffer;
+    void               *src    = args->src.info_v.buffer;
+    ucc_status_t        status = UCC_OK;
+    size_t count, displ, dt_size;
+    ucc_rank_t peer;
+
+    if (rank == args->root) {
+        dt_size = ucc_dt_size(args->src.info_v.datatype);
+    } else {
+        dt_size = ucc_dt_size(args->dst.info.datatype);
+    }
+
+    UCC_TL_NCCL_PROFILE_REQUEST_EVENT(coll_task, "nccl_scatterv_start", 0);
+    if (rank == args->root) {
+        if (!UCC_IS_INPLACE(*args)) {
+            count = ucc_coll_args_get_count(args, args->src.info_v.counts, rank);
+            displ = ucc_coll_args_get_displacement(args,
+                                                   args->src.info_v.displacements,
+                                                   rank);
+            CUDA_CHECK_GOTO(cudaMemcpyAsync(dst,
+                                            PTR_OFFSET(src, displ * dt_size),
+                                            count * dt_size,
+                                            cudaMemcpyDeviceToDevice,
+                                            stream),
+                            exit_coll, status);
+        }
+        NCCLCHECK_GOTO(ncclGroupStart(), exit_coll, status,
+                       UCC_TL_TEAM_LIB(team));
+        for (peer = 0; peer < size; peer++) {
+            if (peer == args->root) {
+                continue;
+            }
+            count = ucc_coll_args_get_count(args, args->src.info_v.counts, peer);
+            displ = ucc_coll_args_get_displacement(args,
+                                                   args->src.info_v.displacements,
+                                                   peer);
+            NCCLCHECK_GOTO(ncclSend(PTR_OFFSET(src, displ * dt_size),
+                                    count * dt_size, ncclChar, peer,
+                                    team->nccl_comm, stream),
+                           exit_coll, status, UCC_TL_TEAM_LIB(team));
+        }
+        NCCLCHECK_GOTO(ncclGroupEnd(), exit_coll, status,
+                       UCC_TL_TEAM_LIB(team));
+    } else {
+        NCCLCHECK_GOTO(ncclRecv(dst, args->dst.info.count * dt_size, ncclChar,
+                                args->root, team->nccl_comm, stream),
+                       exit_coll, status, UCC_TL_TEAM_LIB(team));
+    }
+    task->super.status = UCC_INPROGRESS;
+    status = ucc_tl_nccl_collective_sync(task, stream);
+exit_coll:
+    return status;
+}
+
+ucc_status_t ucc_tl_nccl_scatterv_init(ucc_tl_nccl_task_t *task)
+{
+    ucc_tl_nccl_team_t *team = TASK_TEAM(task);
+    ucc_coll_args_t    *args = &TASK_ARGS(task);
+
+    if (UCC_TL_TEAM_RANK(team) == args->root) {
+        if (!UCC_DT_IS_PREDEFINED(args->src.info_v.datatype)) {
+            tl_error(UCC_TASK_LIB(task),
+                     "user defined datatype is not supported");
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+    }
+    if ((UCC_TL_TEAM_RANK(team) != args->root) ||
+        (!UCC_IS_INPLACE(*args))) {
+        if (!UCC_DT_IS_PREDEFINED(args->dst.info.datatype)) {
+            tl_error(UCC_TASK_LIB(task),
+                     "user defined datatype is not supported");
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+    }
+
+    task->super.post = ucc_tl_nccl_scatterv_start;
+    return UCC_OK;
+}
+
 static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
 {
     switch (coll_type) {

--- a/src/components/tl/nccl/tl_nccl_coll.h
+++ b/src/components/tl/nccl/tl_nccl_coll.h
@@ -55,4 +55,7 @@ ucc_status_t ucc_tl_nccl_gather_init(ucc_tl_nccl_task_t *task);
 ucc_status_t ucc_tl_nccl_gatherv_init(ucc_tl_nccl_task_t *task);
 
 ucc_status_t ucc_tl_nccl_scatter_init(ucc_tl_nccl_task_t *task);
+
+ucc_status_t ucc_tl_nccl_scatterv_init(ucc_tl_nccl_task_t *task);
+
 #endif

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -170,6 +170,9 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
     case UCC_COLL_TYPE_SCATTER:
         status = ucc_tl_nccl_scatter_init(task);
         break;
+    case UCC_COLL_TYPE_SCATTERV:
+        status = ucc_tl_nccl_scatterv_init(task);
+        break;
     default:
         tl_error(UCC_TASK_LIB(task),
                  "collective %d is not supported by nccl tl",

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -27,7 +27,8 @@ ucc_test_mpi_SOURCES = \
 	test_reduce.cc          \
 	test_gather.cc          \
 	test_gatherv.cc         \
-	test_scatter.cc
+	test_scatter.cc         \
+	test_scatterv.cc
 
 CXX=$(MPICXX)
 LD=$(MPICXX)

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -13,7 +13,7 @@ static std::vector<ucc_coll_type_t> colls = {
     UCC_COLL_TYPE_ALLTOALL,       UCC_COLL_TYPE_ALLTOALLV,
     UCC_COLL_TYPE_REDUCE_SCATTER, UCC_COLL_TYPE_REDUCE_SCATTERV,
     UCC_COLL_TYPE_GATHER,         UCC_COLL_TYPE_GATHERV,
-    UCC_COLL_TYPE_SCATTER};
+    UCC_COLL_TYPE_SCATTER,        UCC_COLL_TYPE_SCATTERV};
 static std::vector<ucc_coll_type_t> onesided_colls = {UCC_COLL_TYPE_ALLTOALL};
 static std::vector<ucc_memory_type_t> mtypes = {UCC_MEMORY_TYPE_HOST};
 static std::vector<ucc_datatype_t> dtypes = {UCC_DT_INT32, UCC_DT_INT64,
@@ -60,7 +60,7 @@ void PrintHelp()
     std::cout <<
        "-c, --colls            <c1,c2,..>\n\tlist of collectives: "
             "barrier, allreduce, allgather, allgatherv, bcast, alltoall, alltoallv "
-            "reduce, reduce_scatter, reduce_scatterv, gather, gatherv, scatter\n\n"
+            "reduce, reduce_scatter, reduce_scatterv, gather, gatherv, scatter, scatterv\n\n"
        "-t, --teams            <t1,t2,..>\n\tlist of teams: world,half,reverse,odd_even\n\n"
        "-M, --mtypes           <m1,m2,..>\n\tlist of mtypes: host,cuda\n\n"
        "-d, --dtypes           <d1,d2,..>\n\tlist of dtypes: (u)int8(16,32,64),float32(64)\n\n"
@@ -136,6 +136,8 @@ static ucc_coll_type_t coll_str_to_type(std::string coll)
         return UCC_COLL_TYPE_GATHERV;
     } else if (coll == "scatter") {
         return UCC_COLL_TYPE_SCATTER;
+    } else if (coll == "scatterv") {
+        return UCC_COLL_TYPE_SCATTERV;
     } else {
         std::cerr << "incorrect coll type: " << coll << std::endl;
         PrintHelp();

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -86,6 +86,9 @@ std::shared_ptr<TestCase> TestCase::init_single(
     case UCC_COLL_TYPE_SCATTER:
         return std::make_shared<TestScatter>(msgsize, inplace, mt, root, _team,
                                              max_size);
+    case UCC_COLL_TYPE_SCATTERV:
+        return std::make_shared<TestScatterv>(msgsize, inplace, mt, root, _team,
+                                              max_size);
     default:
         break;
     }

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -486,4 +486,18 @@ ucc_status_t compare_buffers(void *rst, void *expected, size_t count,
 
 ucc_status_t divide_buffer(void *expected, size_t divider, size_t count,
                            ucc_datatype_t dt);
+
+class TestScatterv : public TestCase {
+    uint32_t *counts;
+    uint32_t *displacements;
+public:
+    TestScatterv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
+                 ucc_memory_type_t _mt, int root, ucc_test_team_t &team,
+                 size_t _max_size);
+    ucc_status_t set_input() override;
+    ucc_status_t reset_sbuf() override;
+    ucc_status_t check();
+    ~TestScatterv();
+};
+
 #endif

--- a/test/mpi/test_scatterv.cc
+++ b/test/mpi/test_scatterv.cc
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "test_mpi.h"
+#include "mpi_util.h"
+
+#define TEST_DT UCC_DT_UINT32
+
+static void fill_counts_and_displacements(int size, int count,
+                                          uint32_t *counts, uint32_t *displs)
+{
+    int bias = count / 2;
+    int i;
+
+    counts[0] = count - bias;
+    displs[0] = 0;
+    for (i = 1; i < size - 1; i++) {
+        if (i % 2 == 0) {
+            counts[i] = count - bias;
+        } else {
+            counts[i] = count + bias;
+        }
+        displs[i] = displs[i - 1] + counts[i - 1];
+    }
+    if (size % 2 == 0) {
+        counts[size - 1] = count + bias;
+    } else {
+        counts[size - 1] = count;
+    }
+    displs[size - 1] = displs[size - 2] + counts[size - 2];
+}
+
+TestScatterv::TestScatterv(size_t _msgsize, ucc_test_mpi_inplace_t _inplace,
+                           ucc_memory_type_t _mt, int _root,
+                           ucc_test_team_t &_team, size_t _max_size) :
+    TestCase(_team, UCC_COLL_TYPE_SCATTERV, _mt, _msgsize, _inplace, _max_size)
+{
+    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t count   = _msgsize / dt_size;
+    int    rank, size;
+
+    root          = _root;
+    counts        = NULL;
+    displacements = NULL;
+    MPI_Comm_rank(team.comm, &rank);
+    MPI_Comm_size(team.comm, &size);
+
+    if (TEST_SKIP_NONE != skip_reduce(test_max_size < (_msgsize*size),
+                                      TEST_SKIP_MEM_LIMIT, team.comm)) {
+        return;
+    }
+
+    counts = (uint32_t *) ucc_malloc(size * sizeof(uint32_t),
+                                     "counts buf");
+    UCC_MALLOC_CHECK(counts);
+    displacements = (uint32_t *) ucc_malloc(size * sizeof(uint32_t),
+                                            "displacements buf");
+    UCC_MALLOC_CHECK(displacements);
+    fill_counts_and_displacements(size, count, counts, displacements);
+
+    if (rank == root) {
+        UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, count * size * dt_size, _mt));
+        sbuf = sbuf_mc_header->addr;
+        if (TEST_NO_INPLACE == inplace) {
+            UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, counts[rank] * dt_size,
+                                   _mt));
+            rbuf = rbuf_mc_header->addr;
+        } else {
+            rbuf_mc_header = NULL;
+            rbuf = NULL;
+        }
+    } else {
+        UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, counts[rank] * dt_size, _mt));
+        rbuf = rbuf_mc_header->addr;
+        sbuf_mc_header = NULL;
+        sbuf = NULL;
+    }
+
+    check_buf = ucc_malloc(count * size * dt_size, "check buf");
+    UCC_MALLOC_CHECK(check_buf);
+
+    if (TEST_INPLACE == inplace) {
+        args.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        args.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+
+    args.root = root;
+    if (rank == root) {
+        args.src.info_v.buffer        = sbuf;
+        args.src.info_v.counts        = (ucc_count_t*)counts;
+        args.src.info_v.displacements = (ucc_aint_t*)displacements;
+        args.src.info_v.datatype      = TEST_DT;
+        args.src.info_v.mem_type      = _mt;
+        if (TEST_NO_INPLACE == inplace) {
+            args.dst.info.buffer   = rbuf;
+            args.dst.info.count    = counts[rank];
+            args.dst.info.datatype = TEST_DT;
+            args.dst.info.mem_type = _mt;
+        }
+    } else {
+        args.dst.info.buffer   = rbuf;
+        args.dst.info.count    = counts[rank];
+        args.dst.info.datatype = TEST_DT;
+        args.dst.info.mem_type = _mt;
+    }
+
+    UCC_CHECK(set_input());
+    UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
+}
+
+ucc_status_t TestScatterv::set_input()
+{
+    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t count   = msgsize / dt_size;
+    int    rank, size;
+
+    MPI_Comm_rank(team.comm, &rank);
+    MPI_Comm_size(team.comm, &size);
+
+    if (rank == root) {
+        init_buffer(sbuf, count * size, TEST_DT, mem_type, rank);
+        UCC_CHECK(ucc_mc_memcpy(check_buf, sbuf, count * size * dt_size,
+                                UCC_MEMORY_TYPE_HOST, mem_type));
+    }
+    return UCC_OK;
+}
+
+ucc_status_t TestScatterv::reset_sbuf()
+{
+    return UCC_OK;
+}
+
+TestScatterv::~TestScatterv()
+{
+    if (counts) {
+        ucc_free(counts);
+    }
+    if (displacements) {
+        ucc_free(displacements);
+    }
+}
+
+ucc_status_t TestScatterv::check()
+{
+    size_t        dt_size = ucc_dt_size(TEST_DT);
+    size_t        count   = msgsize / dt_size;
+    MPI_Datatype  dt      = ucc_dt_to_mpi(TEST_DT);
+    MPI_Request   req;
+    int           size, rank, completed;
+
+    MPI_Comm_size(team.comm, &size);
+    MPI_Comm_rank(team.comm, &rank);
+
+    MPI_Iscatterv(check_buf, (int*)counts, (int*)displacements, dt,
+                  (rank == root) ? MPI_IN_PLACE : check_buf, counts[rank],
+                  dt, root, team.comm, &req);
+    do {
+        MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
+        ucc_context_progress(team.ctx);
+    } while(!completed);
+
+    if (rank == root) {
+        if (TEST_INPLACE == inplace) {
+            return compare_buffers(sbuf, check_buf, count * size,
+                                   TEST_DT, mem_type);
+        } else {
+            return compare_buffers(rbuf,
+                                   PTR_OFFSET(check_buf, displacements[rank] * dt_size),
+                                   counts[rank], TEST_DT, mem_type);
+        }
+    } else {
+        return compare_buffers(rbuf, check_buf, counts[rank], TEST_DT,
+                               mem_type);
+    }
+}


### PR DESCRIPTION
## What
Adding support for UCC_COLL_TYPE_SCATTERV to TL NCCL and adding scatterv test to ucc_test_mpi

## How ?
NCCL doesn't have native support for scatterv operation, implementation in TL NCCL is base on ncclSend/ncclRecv