### PR TITLE
API: Add pt2pt send/recv

### DIFF
--- a/docs/doxygen/collectives.md
+++ b/docs/doxygen/collectives.md
@@ -10,8 +10,9 @@ operations.
 **Invocation semantics**: The ucc\_collective\_init routine is a non-blocking
 collective operation to initialize the buffers, operation type, reduction type,
 and other information required for the collective operation. All participants of
-the team should call the initialize operation. The collective operation
-is invoked using a ucc\_collective\_post operation.
+the team should call the initialize operation (with the exception of SEND and
+RECV, which only require participation from two the callers). The collective
+operation is invoked using a ucc\_collective\_post operation.
 ucc\_collective\_init\_and\_post operation initializes as well as post the
 collective operation.
 
@@ -19,13 +20,14 @@ collective operation.
 enumeration ucc\_coll\_type\_t. The semantics are briefly described here,
 however in most cases it agrees with the semantics of collective operations in
 the popular programming models such as MPI and OpenSHMEM. When they differ, the
-semantics changes are documented. All collective operations execute on the team.
+semantics changes are documented. All collective operations execute on the team
+(with the exception of SEND and RECV, which only operate among participants).
 For the collective operations defined by ucc\_coll\_type\_t, all participants of
 the team are required to participate in the collective operations. Further the
 team should be created with endpoints, where the “eps” should be ordered and
 contiguous.
 
-UCC supports three types of collective operations: (a) UCC\_{ALLTOALL, ALLTOALLV,
+UCC supports four types of collective operations: (a) UCC\_{ALLTOALL, ALLTOALLV,
 ALLGATHER, ALLGATHERV, ALLREDUCE, REDUCE_SCATTER, REDUCE_SCATTERV, BARRIER}
 operations where all participants contribute to the results and receive the
 results (b) UCC\_{REDUCE, GATHER, GATHERV, FANIN} where all participants
@@ -33,7 +35,9 @@ contribute to the result and one participant receives the result. The
 participant receiving the result is designated as root. (c) UCC\_{BROADCAST,
 SCATTER, SCATTERV, FANOUT} where one participant contributes to the result, and
 all participants receive the result. The participant contributing to the result
-is designated as root.
+is designated as root. (d) UCC\_{SEND, RECV} which only involve the two
+partipating processes and uses the usual send/recv semantics expressed in other
+programming models.
 
 + The UCC\_COLL\_TYPE\_BCAST operation moves the data from the root participant
 to all participants in the team.

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
- * Copyright (c) Facebook, Inc. and its affiliates. 2021.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -115,7 +115,8 @@ typedef struct ucc_tl_nccl_task {
      UCC_COLL_TYPE_ALLREDUCE      | UCC_COLL_TYPE_BCAST      |                 \
      UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE     |                 \
      UCC_COLL_TYPE_BARRIER        | UCC_COLL_TYPE_GATHER     |                 \
-     UCC_COLL_TYPE_GATHERV)
+     UCC_COLL_TYPE_GATHERV        | UCC_COLL_TYPE_SEND       |                 \
+     UCC_COLL_TYPE_RECV)
 
 UCC_CLASS_DECLARE(ucc_tl_nccl_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
- * Copyright (c) Facebook, Inc. and its affiliates. 2021.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -166,6 +166,12 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
         break;
     case UCC_COLL_TYPE_GATHERV:
         status = ucc_tl_nccl_gatherv_init(task);
+        break;
+    case UCC_COLL_TYPE_SEND:
+        status = ucc_tl_nccl_send_init(task);
+        break;
+    case UCC_COLL_TYPE_RECV:
+        status = ucc_tl_nccl_recv_init(task);
         break;
     default:
         tl_error(UCC_TASK_LIB(task),

--- a/src/components/tl/ucp/recv/recv.c
+++ b/src/components/tl/ucp/recv/recv.c
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
+ * See file LICENSE for terms.
+ */
+#include "config.h"
+#include "tl_ucp.h"
+#include "tl_ucp_coll.h"
+#include "tl_ucp_sendrecv.h"
+#include "recv.h"
+
+ucc_status_t ucc_tl_ucp_recv_init(ucc_tl_ucp_task_t *task)
+{
+    task->super.post     = ucc_tl_ucp_recv_start;
+    task->super.progress = ucc_tl_ucp_recv_progress;
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_ucp_recv_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t   *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t   *team       = TASK_TEAM(task);
+    ucc_coll_args_t     *args       = &TASK_ARGS(task);
+    uint64_t             peer       = args->root;
+    void                *rbuf       = args->dst.info.buffer;
+    ucc_memory_type_t    mem_type   = args->dst.info.mem_type;
+    size_t               count      = args->dst.info.count;
+    ucc_datatype_t       dt         = args->dst.info.datatype;
+    size_t               dt_size    = ucc_dt_size(dt);
+    size_t               data_size  = count * dt_size;
+
+    UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(rbuf, data_size, mem_type, peer, team, task), task, out);
+
+    task->super.status = UCC_INPROGRESS;
+    ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+    return UCC_OK;
+
+out:
+    return task->super.status;
+}
+
+void ucc_tl_ucp_recv_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t   *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+
+    task->super.status = ucc_tl_ucp_test(task);
+}

--- a/src/components/tl/ucp/recv/recv.h
+++ b/src/components/tl/ucp/recv/recv.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef RECV_H_
+#define RECV_H_
+
+#include "../tl_ucp.h"
+#include "../tl_ucp_coll.h"
+
+ucc_status_t ucc_tl_ucp_recv_init(ucc_tl_ucp_task_t *task);
+ucc_status_t ucc_tl_ucp_recv_start(ucc_coll_task_t *coll_task);
+void ucc_tl_ucp_recv_progress(ucc_coll_task_t *coll_task);
+
+#endif

--- a/src/components/tl/ucp/send/send.c
+++ b/src/components/tl/ucp/send/send.c
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
+ * See file LICENSE for terms.
+ */
+#include "config.h"
+#include "tl_ucp.h"
+#include "tl_ucp_coll.h"
+#include "tl_ucp_sendrecv.h"
+#include "send.h"
+
+ucc_status_t ucc_tl_ucp_send_init(ucc_tl_ucp_task_t *task)
+{
+    task->super.post     = ucc_tl_ucp_send_start;
+    task->super.progress = ucc_tl_ucp_send_progress;
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_ucp_send_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t   *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t   *team       = TASK_TEAM(task);
+    ucc_coll_args_t     *args       = &TASK_ARGS(task);
+    uint64_t             peer       = args->root;
+    void                *sbuf       = args->src.info.buffer;
+    ucc_memory_type_t    mem_type   = args->src.info.mem_type;
+    size_t               count      = args->src.info.count;
+    ucc_datatype_t       dt         = args->src.info.datatype;
+    size_t               dt_size    = ucc_dt_size(dt);
+    size_t               data_size  = count * dt_size;
+
+    UCPCHECK_GOTO(ucc_tl_ucp_send_nb(sbuf, data_size, mem_type, peer, team, task), task, out);
+
+    task->super.status = UCC_INPROGRESS;
+    ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+    return UCC_OK;
+
+out:
+    return task->super.status;
+}
+
+void ucc_tl_ucp_send_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t   *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+
+    task->super.status = ucc_tl_ucp_test(task);
+}

--- a/src/components/tl/ucp/send/send.h
+++ b/src/components/tl/ucp/send/send.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef SEND_H_
+#define SEND_H_
+
+#include "../tl_ucp.h"
+#include "../tl_ucp_coll.h"
+
+ucc_status_t ucc_tl_ucp_send_init(ucc_tl_ucp_task_t *task);
+ucc_status_t ucc_tl_ucp_send_start(ucc_coll_task_t *coll_task);
+void ucc_tl_ucp_send_progress(ucc_coll_task_t *coll_task);
+
+#endif

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -125,7 +126,8 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
      UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                      \
      UCC_COLL_TYPE_ALLREDUCE | UCC_COLL_TYPE_BCAST | UCC_COLL_TYPE_BARRIER |   \
      UCC_COLL_TYPE_REDUCE | UCC_COLL_TYPE_FANIN | UCC_COLL_TYPE_FANOUT |       \
-     UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE_SCATTERV)
+     UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE_SCATTERV |            \
+     UCC_COLL_TYPE_SEND | UCC_COLL_TYPE_RECV)
 
 #define UCC_TL_UCP_TEAM_LIB(_team)                                             \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_ucp_lib_t))

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -20,6 +21,8 @@
 #include "reduce/reduce.h"
 #include "fanin/fanin.h"
 #include "fanout/fanout.h"
+#include "recv/recv.h"
+#include "send/send.h"
 
 const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR] = {
@@ -128,6 +131,12 @@ ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_args_t *coll_args,
         break;
     case UCC_COLL_TYPE_FANOUT:
         status = ucc_tl_ucp_fanout_init(task);
+        break;
+    case UCC_COLL_TYPE_RECV:
+        status = ucc_tl_ucp_recv_init(task);
+        break;
+    case UCC_COLL_TYPE_SEND:
+        status = ucc_tl_ucp_send_init(task);
         break;
     default:
         status = UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -187,8 +188,17 @@ ucc_tl_ucp_init_task(ucc_base_coll_args_t *coll_args, ucc_base_team_t *team)
     ucc_tl_ucp_task_t *task    = ucc_tl_ucp_get_task(tl_team);
 
     ucc_coll_task_init(&task->super, coll_args, team);
-    tl_team->seq_num = (tl_team->seq_num + 1) % UCC_TL_UCP_MAX_COLL_TAG;
-    task->tagged.tag           = tl_team->seq_num;
+    if (coll_args->mask & UCC_COLL_ARGS_FIELD_TAG) {
+        task->tagged.tag           = task->tagged.tag;
+    } else if (coll_args->args.coll_type == UCC_COLL_TYPE_SEND ||
+               coll_args->args.coll_type == UCC_COLL_TYPE_RECV) {
+        /* Use the maximum tag with the point-to-point bit set as a reserved tag
+         * for point-to-point messages that do not otherwies have a tag set. */
+        task->tagged.tag           = UCC_TL_UCP_MAX_TAG;
+    } else {
+        tl_team->seq_num = (tl_team->seq_num + 1) % UCC_TL_UCP_MAX_COLL_TAG;
+        task->tagged.tag           = tl_team->seq_num;
+    }
     task->super.finalize       = ucc_tl_ucp_coll_finalize;
     task->super.triggered_post = ucc_triggered_post;
     return task;

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -27,25 +28,27 @@ void ucc_tl_ucp_recv_completion_cb(void *request, ucs_status_t status,
                                    const ucp_tag_recv_info_t *info,
                                    void *user_data);
 
-#define UCC_TL_UCP_MAKE_TAG(_tag, _rank, _id, _scope_id, _scope)               \
-    ((((uint64_t) (_tag))      << UCC_TL_UCP_TAG_BITS_OFFSET)      |           \
+#define UCC_TL_UCP_MAKE_TAG(_user_tag, _tag, _rank, _id, _scope_id, _scope)    \
+    ((((uint64_t) (_user_tag)) << UCC_TL_UCP_USER_TAG_BITS_OFFSET) |           \
+     (((uint64_t) (_tag))      << UCC_TL_UCP_TAG_BITS_OFFSET)      |           \
      (((uint64_t) (_rank))     << UCC_TL_UCP_SENDER_BITS_OFFSET)   |           \
      (((uint64_t) (_scope))    << UCC_TL_UCP_SCOPE_BITS_OFFSET)    |           \
      (((uint64_t) (_scope_id)) << UCC_TL_UCP_SCOPE_ID_BITS_OFFSET) |           \
      (((uint64_t) (_id))       << UCC_TL_UCP_ID_BITS_OFFSET))
 
-#define UCC_TL_UCP_MAKE_SEND_TAG(_tag, _rank, _id, _scope_id, _scope)          \
-    UCC_TL_UCP_MAKE_TAG(_tag, _rank, _id, _scope_id, _scope)
+#define UCC_TL_UCP_MAKE_SEND_TAG(_user_tag, _tag, _rank, _id, _scope_id, _scope)          \
+    UCC_TL_UCP_MAKE_TAG(_user_tag, _tag, _rank, _id, _scope_id, _scope)
 
-#define UCC_TL_UCP_MAKE_RECV_TAG(_ucp_tag, _ucp_tag_mask, _tag, _src, _id,     \
-                                 _scope_id, _scope)                            \
+#define UCC_TL_UCP_MAKE_RECV_TAG(_ucp_tag, _ucp_tag_mask, _user_tag, _tag,     \
+                                 _src, _id, _scope_id, _scope)                 \
     do {                                                                       \
         ucc_assert((_tag) <= UCC_TL_UCP_MAX_TAG);                              \
         ucc_assert((_src) <= UCC_TL_UCP_MAX_SENDER);                           \
         ucc_assert((_id) <= UCC_TL_UCP_MAX_ID);                                \
         (_ucp_tag_mask) = (uint64_t)(-1);                                      \
         (_ucp_tag) =                                                           \
-            UCC_TL_UCP_MAKE_TAG((_tag), (_src), (_id), (_scope_id), (_scope)); \
+            UCC_TL_UCP_MAKE_TAG((_user_tag), (_tag), (_src), (_id),            \
+                                (_scope_id), (_scope)); \
     } while (0)
 
 #define UCC_TL_UCP_CHECK_REQ_STATUS()                                          \
@@ -71,12 +74,13 @@ ucc_tl_ucp_send_common(void *buffer, size_t msglen, ucc_memory_type_t mtype,
     ucc_status_t        status;
     ucp_ep_h            ep;
     ucp_tag_t           ucp_tag;
+    ucc_coll_args_t    *args = &TASK_ARGS(task);
 
     status = ucc_tl_ucp_get_ep(team, dest_group_rank, &ep);
     if (ucc_unlikely(UCC_OK != status)) {
         return UCS_STATUS_PTR(UCS_ERR_NO_MESSAGE);
     }
-    ucp_tag = UCC_TL_UCP_MAKE_SEND_TAG(
+    ucp_tag = UCC_TL_UCP_MAKE_SEND_TAG((args->mask & UCC_COLL_ARGS_FIELD_TAG),
         task->tagged.tag, UCC_TL_TEAM_RANK(team), team->super.super.params.id,
         team->super.super.params.scope_id, team->super.super.params.scope);
     req_param.op_attr_mask =
@@ -131,9 +135,12 @@ ucc_tl_ucp_recv_common(void *buffer, size_t msglen, ucc_memory_type_t mtype,
 {
     ucp_request_param_t req_param;
     ucp_tag_t           ucp_tag, ucp_tag_mask;
+    ucc_coll_args_t    *args = &TASK_ARGS(task);
 
-    UCC_TL_UCP_MAKE_RECV_TAG(ucp_tag, ucp_tag_mask, task->tagged.tag,
-                             dest_group_rank, team->super.super.params.id,
+    UCC_TL_UCP_MAKE_RECV_TAG(ucp_tag, ucp_tag_mask,
+                             (args->mask & UCC_COLL_ARGS_FIELD_TAG),
+                             task->tagged.tag, dest_group_rank,
+                             team->super.super.params.id,
                              team->super.super.params.scope_id,
                              team->super.super.params.scope);
     req_param.op_attr_mask =

--- a/src/components/tl/ucp/tl_ucp_tag.h
+++ b/src/components/tl/ucp/tl_ucp_tag.h
@@ -1,5 +1,7 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
  * See file LICENSE for terms.
  */
 #ifndef UCC_TL_UCP_TAG_H_
@@ -9,21 +11,26 @@
 /*
  * UCP tag structure:
  *
- *  01        | 01234567 01234567 |    234   |      567    | 01234567 01234567 01234567 | 01234567 01234567
- *            |                   |          |             |                            |
- *  RESERV(2) | message tag (16)  | SCOPE(3) | SCOPE_ID(3) |     source rank (24)       |    team id (16)
+ *     01     |      2       | 34567 01234567 01 |    234   |      567    | 01234567 01234567 01234567 | 01234567 01234567
+ *            |              |                   |          |             |                            |
+ *  RESERV(2) | user tag (1) |  message tag (15) | SCOPE(3) | SCOPE_ID(3) |     source rank (24)       |    team id (16)
  */
 
 #define UCC_TL_UCP_RESERVED_BITS 2
 #define UCC_TL_UCP_SCOPE_BITS    3
 #define UCC_TL_UCP_SCOPE_ID_BITS 3
-#define UCC_TL_UCP_TAG_BITS      16
+#define UCC_TL_UCP_USER_TAG_BITS 1
+#define UCC_TL_UCP_TAG_BITS      15
 #define UCC_TL_UCP_SENDER_BITS   24
 #define UCC_TL_UCP_ID_BITS       16
 
 #define UCC_TL_UCP_RESERVED_BITS_OFFSET                                        \
     (UCC_TL_UCP_ID_BITS + UCC_TL_UCP_SENDER_BITS + UCC_TL_UCP_SCOPE_ID_BITS +  \
-     UCC_TL_UCP_SCOPE_BITS + UCC_TL_UCP_TAG_BITS )
+     UCC_TL_UCP_SCOPE_BITS + UCC_TL_UCP_TAG_BITS + UCC_TL_UCP_USER_TAG_BITS)
+
+#define UCC_TL_UCP_USER_TAG_BITS_OFFSET                                        \
+    (UCC_TL_UCP_ID_BITS + UCC_TL_UCP_SENDER_BITS + UCC_TL_UCP_SCOPE_ID_BITS +  \
+     UCC_TL_UCP_SCOPE_BITS + UCC_TL_UCP_TAG_BITS)
 
 #define UCC_TL_UCP_TAG_BITS_OFFSET                                             \
     (UCC_TL_UCP_ID_BITS + UCC_TL_UCP_SENDER_BITS + UCC_TL_UCP_SCOPE_ID_BITS +  \

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -1,5 +1,7 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
  * See file LICENSE for terms.
  */
 
@@ -76,6 +78,7 @@ static ucc_status_t ucc_coll_args_check_mem_type(ucc_coll_args_t *coll_args,
     case UCC_COLL_TYPE_FANOUT:
         return UCC_OK;
     case UCC_COLL_TYPE_BCAST:
+    case UCC_COLL_TYPE_RECV:
         UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->src.info);
         return UCC_OK;
     case UCC_COLL_TYPE_ALLREDUCE:
@@ -142,6 +145,9 @@ static ucc_status_t ucc_coll_args_check_mem_type(ucc_coll_args_t *coll_args,
         if (!(UCC_IS_INPLACE(*coll_args) && UCC_IS_ROOT(*coll_args, rank))) {
             UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info);
         }
+        return UCC_OK;
+    case UCC_COLL_TYPE_SEND:
+        UCC_BUFFER_INFO_CHECK_MEM_TYPE(coll_args->dst.info);
         return UCC_OK;
     default:
         ucc_error("unknown collective type");

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
  * @copyright Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
  * @copyright Copyright (C) UChicago Argonne, LLC. 2022.  ALL RIGHTS RESERVED.
+ * @copyright Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -154,6 +155,8 @@ typedef enum {
     UCC_COLL_TYPE_REDUCE_SCATTERV    = UCC_BIT(13),
     UCC_COLL_TYPE_SCATTER            = UCC_BIT(14),
     UCC_COLL_TYPE_SCATTERV           = UCC_BIT(15),
+    UCC_COLL_TYPE_RECV               = UCC_BIT(16),
+    UCC_COLL_TYPE_SEND               = UCC_BIT(17),
     UCC_COLL_TYPE_LAST
 } ucc_coll_type_t;
 

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
  */
@@ -29,10 +30,12 @@ ucc_coll_type_t ucc_coll_type_from_str(const char *str)
     STR_COLL_TYPE_CHECK(str, GATHER);
     STR_COLL_TYPE_CHECK(str, GATHERV);
     STR_COLL_TYPE_CHECK(str, REDUCE);
+    STR_COLL_TYPE_CHECK(str, RECV);
     STR_COLL_TYPE_CHECK(str, REDUCE_SCATTER);
     STR_COLL_TYPE_CHECK(str, REDUCE_SCATTERV);
     STR_COLL_TYPE_CHECK(str, SCATTER);
     STR_COLL_TYPE_CHECK(str, SCATTERV);
+    STR_COLL_TYPE_CHECK(str, SEND);
     return UCC_COLL_TYPE_LAST;
 }
 
@@ -63,6 +66,8 @@ ucc_coll_args_is_mem_symmetric(const ucc_base_coll_args_t *bargs)
     case UCC_COLL_TYPE_BCAST:
     case UCC_COLL_TYPE_FANIN:
     case UCC_COLL_TYPE_FANOUT:
+    case UCC_COLL_TYPE_RECV:
+    case UCC_COLL_TYPE_SEND:
         return 1;
     case UCC_COLL_TYPE_ALLTOALL:
     case UCC_COLL_TYPE_ALLREDUCE:
@@ -106,11 +111,13 @@ ucc_memory_type_t ucc_coll_args_mem_type(const ucc_base_coll_args_t *bargs)
     case UCC_COLL_TYPE_FANOUT:
         return UCC_MEMORY_TYPE_NOT_APPLY;
     case UCC_COLL_TYPE_BCAST:
+    case UCC_COLL_TYPE_SEND:
         return args->src.info.mem_type;
     case UCC_COLL_TYPE_ALLTOALL:
     case UCC_COLL_TYPE_ALLREDUCE:
     case UCC_COLL_TYPE_ALLGATHER:
     case UCC_COLL_TYPE_REDUCE_SCATTER:
+    case UCC_COLL_TYPE_RECV:
         return args->dst.info.mem_type;
     case UCC_COLL_TYPE_ALLGATHERV:
     case UCC_COLL_TYPE_REDUCE_SCATTERV:
@@ -148,11 +155,13 @@ size_t ucc_coll_args_msgsize(const ucc_base_coll_args_t *bargs)
     case UCC_COLL_TYPE_FANOUT:
         return 0;
     case UCC_COLL_TYPE_BCAST:
+    case UCC_COLL_TYPE_SEND:
         return args->src.info.count * ucc_dt_size(args->src.info.datatype);
     case UCC_COLL_TYPE_ALLREDUCE:
     case UCC_COLL_TYPE_ALLTOALL:
     case UCC_COLL_TYPE_ALLGATHER:
     case UCC_COLL_TYPE_REDUCE_SCATTER:
+    case UCC_COLL_TYPE_RECV:
         return args->dst.info.count * ucc_dt_size(args->dst.info.datatype);
     case UCC_COLL_TYPE_ALLGATHERV:
     case UCC_COLL_TYPE_REDUCE_SCATTERV:

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -1,5 +1,7 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
  * See file LICENSE for terms.
  */
 
@@ -85,6 +87,10 @@ static inline const char* ucc_coll_type_str(ucc_coll_type_t ct)
         return "Reduce_scatter";
     case UCC_COLL_TYPE_REDUCE_SCATTERV:
         return "Reduce_scatterv";
+    case UCC_COLL_TYPE_RECV:
+        return "Recv";
+    case UCC_COLL_TYPE_SEND:
+        return "Send";
     default:
         break;
     }


### PR DESCRIPTION
## What
This PR proposes new interfaces for point-to-point send/recv using the existing collective infrastructure for simplicity.

## Why ?
There are many users of UCC that would benefit from simple pt2pt interfaces and indeed some of them even go around UCC to get them from UCX directly (e.g., [Torch-UCC](https://github.com/openucx/torch-ucc)). Some of the libraries underlying the TLs even support pt2pt operations, which makes implementing them in the TL themselves often relatively simple (e.g., NCCL and UCP).

## How ?
Rather than designing an entirely new API for the point-to-point operations which would largely duplicate the existing infrastructure, this work treats pt2pt send/recv calls as if they are simply another type of collective. These operations only require the participation of the two involved processes instead of the entire team and obey all of the usual semantics of point-to-point communication generally and UCC collectives specifically (e.g., using the same operation lifecycle).

The alternative implementation would have been to create new functions to initialize and start pt2pt operations, which would have required a significant amount of code duplication, both at the interface level and the underlying data structures. This seemed to be an unnecessary cost for something that otherwise had no need for new interfaces.