### PR TITLE
BUILD: take libucm from user defined dir

### DIFF
--- a/config/m4/ucx.m4
+++ b/config/m4/ucx.m4
@@ -56,7 +56,7 @@ AS_IF([test "x$ucx_checked" != "xyes"],[
         [
             ucx_happy="no"
         ])
-        
+
         AC_CHECK_HEADERS([ucs/sys/uid.h],
         [
             AC_CHECK_LIB([ucs], [ucs_get_system_id],
@@ -88,6 +88,7 @@ AS_IF([test "x$ucx_checked" != "xyes"],[
             [
                 AC_SUBST(UCX_LDFLAGS, "-L$check_ucx_libdir")
                 AC_SUBST(UCS_LDFLAGS, "-L$check_ucx_libdir")
+                AC_SUBST(UCS_LIBDIR, $check_ucx_libdir)
             ])
 
             AC_SUBST(UCX_LIBADD, "-lucp -lucm")

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -55,7 +55,9 @@ gtest_CPPFLAGS = \
 	-I$(top_srcdir)/test/gtest \
 	$(GTEST_CPPFLAGS)
 
-gtest_LDFLAGS  = $(GTEST_LDFLAGS) -pthread -no-install -Wl,-dynamic-list-data
+gtest_LDFLAGS = $(GTEST_LDFLAGS) -pthread -no-install -Wl,-dynamic-list-data \
+    -Wl,--rpath-link=${UCS_LIBDIR}
+
 gtest_CFLAGS   = $(BASE_CFLAGS) $(AM_CPPFLAGS)
 gtest_CXXFLAGS = -std=gnu++11 \
 	$(BASE_CXXFLAGS) $(GTEST_CXXFLAGS) \

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -32,12 +32,13 @@ ucc_test_mpi_SOURCES = \
 
 CXX=$(MPICXX)
 LD=$(MPICXX)
-ucc_test_mpi_CPPFLAGS=$(BASE_CPPFLAGS)
-ucc_test_mpi_CXXFLAGS=$(BASE_CXXFLAGS) -std=gnu++11
-ucc_test_mpi_LDADD=$(UCC_TOP_BUILDDIR)/src/libucc.la
+ucc_test_mpi_CPPFLAGS = $(BASE_CPPFLAGS)
+ucc_test_mpi_CXXFLAGS = $(BASE_CXXFLAGS) -std=gnu++11
+ucc_test_mpi_LDFLAGS = -Wl,--rpath-link=${UCS_LIBDIR}
+ucc_test_mpi_LDADD = $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 if HAVE_CUDA
-ucc_test_mpi_CPPFLAGS+=$(CUDA_CPPFLAGS)
-ucc_test_mpi_LDFLAGS=$(CUDA_LDFLAGS)
-ucc_test_mpi_LDADD+=$(CUDA_LIBS)
+ucc_test_mpi_CPPFLAGS += $(CUDA_CPPFLAGS)
+ucc_test_mpi_LDFLAGS += $(CUDA_LDFLAGS)
+ucc_test_mpi_LDADD += $(CUDA_LIBS)
 endif

--- a/tools/info/Makefile.am
+++ b/tools/info/Makefile.am
@@ -28,5 +28,6 @@ nodist_ucc_info_SOURCES = \
 
 ucc_info_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) -I${UCC_TOP_BUILDDIR}/src
 ucc_info_CFLAGS = $(BASE_CFLAGS)
+ucc_info_LDFLAGS = -Wl,--rpath-link=${UCS_LIBDIR}
 ucc_info_LDADD = \
 	$(UCC_TOP_BUILDDIR)/src/libucc.la

--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -28,12 +28,13 @@ ucc_perftest_SOURCES =            \
 
 CXX=$(MPICXX)
 LD=$(MPICXX)
-ucc_perftest_CPPFLAGS=$(BASE_CPPFLAGS)
-ucc_perftest_CXXFLAGS=-std=gnu++11 $(BASE_CXXFLAGS)
-ucc_perftest_LDADD=$(UCC_TOP_BUILDDIR)/src/libucc.la
+ucc_perftest_CPPFLAGS = $(BASE_CPPFLAGS)
+ucc_perftest_CXXFLAGS = -std=gnu++11 $(BASE_CXXFLAGS)
+ucc_perftest_LDFLAGS = -Wl,--rpath-link=${UCS_LIBDIR}
+ucc_perftest_LDADD = $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 if HAVE_CUDA
-ucc_perftest_CPPFLAGS+=$(CUDA_CPPFLAGS)
-ucc_perftest_LDFLAGS=$(CUDA_LDFLAGS)
-ucc_perftest_LDADD+=$(CUDA_LIBS)
+ucc_perftest_CPPFLAGS += $(CUDA_CPPFLAGS)
+ucc_perftest_LDFLAGS += $(CUDA_LDFLAGS)
+ucc_perftest_LDADD += $(CUDA_LIBS)
 endif


### PR DESCRIPTION
## What
Since UCS depends on UCM and UCS/UCM compatibility reasons we need to take libucm from the same place where we find libucs.

## Why ?
Fixes #476 