### PR TITLE
Use UCS_ALLOW_LIST for TLS parameter

### DIFF
--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -31,7 +31,6 @@ typedef struct ucc_cl_basic_context_config {
 
 typedef struct ucc_cl_basic_lib {
     ucc_cl_lib_t             super;
-    ucc_config_names_array_t tls_forced;
 } ucc_cl_basic_lib_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -30,7 +30,8 @@ typedef struct ucc_cl_basic_context_config {
 } ucc_cl_basic_context_config_t;
 
 typedef struct ucc_cl_basic_lib {
-    ucc_cl_lib_t super;
+    ucc_cl_lib_t             super;
+    ucc_config_names_array_t tls_forced;
 } ucc_cl_basic_lib_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -13,7 +13,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
 {
     const ucc_cl_context_config_t *cl_config =
         ucc_derived_of(config, ucc_cl_context_config_t);
-    ucc_config_names_array_t      *tls       = &cl_config->cl_lib->tls;
+    ucc_config_names_array_t      *tls       = &cl_config->cl_lib->tls.array;
     ucc_status_t status;
     int          i;
 

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -13,7 +13,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
 {
     const ucc_cl_context_config_t *cl_config =
         ucc_derived_of(config, ucc_cl_context_config_t);
-    ucc_config_names_array_t      *tls       = &cl_config->cl_lib->tls.array;
+    ucc_config_names_array_t *tls = &cl_config->cl_lib->tls.array;
     ucc_status_t status;
     int          i;
 

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -53,9 +53,9 @@ static inline ucc_status_t check_tl_lib_attr(const ucc_base_lib_t *lib,
 ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
                                        ucc_base_lib_attr_t  *base_attr)
 {
-    ucc_cl_lib_attr_t       *attr   = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
-    ucc_cl_basic_lib_t      *cl_lib = ucc_derived_of(lib, ucc_cl_basic_lib_t);
-    ucc_config_allow_list_t *tls    = &cl_lib->super.tls;
+    ucc_cl_lib_attr_t  *attr     = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
+    ucc_cl_basic_lib_t *cl_lib   = ucc_derived_of(lib, ucc_cl_basic_lib_t);
+    ucc_config_allow_list_t *tls = &cl_lib->super.tls;
     ucc_tl_iface_t          *tl_iface;
     int                      i;
     ucc_status_t             status;
@@ -79,10 +79,10 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
     for (i = 0; i < tls->array.count; i++) {
         /* Check TLs proveded in CL_BASIC_TLS. Not all of them could be
            available, check for NULL. */
-        tl_iface = ucc_derived_of(
-            ucc_get_component(&ucc_global_config.tl_framework,
-                              tls->array.names[i]),
-            ucc_tl_iface_t);
+        tl_iface =
+            ucc_derived_of(ucc_get_component(&ucc_global_config.tl_framework,
+                                             tls->array.names[i]),
+                           ucc_tl_iface_t);
         if (!tl_iface) {
             cl_warn(lib, "tl %s is not available", tls->array.names[i]);
             continue;

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -24,7 +24,6 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *params,
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 {
     cl_info(&self->super, "finalizing lib object: %p", self);
-    ucc_config_names_array_free(&self->tls_forced);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
@@ -55,22 +54,20 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
 {
     ucc_cl_lib_attr_t  *attr     = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
     ucc_cl_basic_lib_t *cl_lib   = ucc_derived_of(lib, ucc_cl_basic_lib_t);
-    ucc_config_allow_list_t *tls = &cl_lib->super.tls;
+    ucc_config_names_list_t *tls = &cl_lib->super.tls;
     ucc_tl_iface_t          *tl_iface;
     int                      i;
     ucc_status_t             status;
 
     attr->tls                = &cl_lib->super.tls.array;
-    cl_lib->tls_forced.count = 0;
-    cl_lib->tls_forced.names = NULL;
-    if (cl_lib->super.tls.mode == UCC_CONFIG_ALLOW_LIST_ALLOW) {
-        status = ucc_config_names_array_dup(&cl_lib->tls_forced,
+    if (cl_lib->super.tls.requested) {
+        status = ucc_config_names_array_dup(&cl_lib->super.tls_forced,
                                             &cl_lib->super.tls.array);
         if (UCC_OK != status) {
             return status;
         }
     }
-    attr->tls_forced             = &cl_lib->tls_forced;
+    attr->tls_forced             = &cl_lib->super.tls_forced;
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = 0;
     attr->super.flags            = 0;

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -24,6 +24,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *params,
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 {
     cl_info(&self->super, "finalizing lib object: %p", self);
+    ucc_config_names_array_free(&self->tls_forced);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
@@ -52,42 +53,42 @@ static inline ucc_status_t check_tl_lib_attr(const ucc_base_lib_t *lib,
 ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
                                        ucc_base_lib_attr_t  *base_attr)
 {
-    ucc_cl_lib_attr_t *attr   = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
-    ucc_cl_lib_t *     cl_lib = ucc_derived_of(lib, ucc_cl_lib_t);
-    ucc_config_names_array_t *tls = &cl_lib->tls;
-    ucc_tl_iface_t *          tl_iface;
-    int                       i;
-    ucc_status_t              status;
+    ucc_cl_lib_attr_t       *attr   = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
+    ucc_cl_basic_lib_t      *cl_lib = ucc_derived_of(lib, ucc_cl_basic_lib_t);
+    ucc_config_allow_list_t *tls    = &cl_lib->super.tls;
+    ucc_tl_iface_t          *tl_iface;
+    int                      i;
+    ucc_status_t             status;
 
-    attr->tls                    = &cl_lib->tls;
+    attr->tls                = &cl_lib->super.tls.array;
+    cl_lib->tls_forced.count = 0;
+    cl_lib->tls_forced.names = NULL;
+    if (cl_lib->super.tls.mode == UCC_CONFIG_ALLOW_LIST_ALLOW) {
+        status = ucc_config_names_array_dup(&cl_lib->tls_forced,
+                                            &cl_lib->super.tls.array);
+        if (UCC_OK != status) {
+            return status;
+        }
+    }
+    attr->tls_forced             = &cl_lib->tls_forced;
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = 0;
     attr->super.flags            = 0;
-    if (tls->count == 1 && !strcmp(tls->names[0], "all")) {
-        /* Check all available components, since CL_BASIC_TLS == "all" */
-        for (i = 0; i < ucc_global_config.tl_framework.n_components; i++) {
-            tl_iface = ucc_derived_of(
-                ucc_global_config.tl_framework.components[i], ucc_tl_iface_t);
-            ucc_assert(tl_iface);
-            if (UCC_OK != (status = check_tl_lib_attr(lib, tl_iface, attr))) {
-                return status;
-            }
+
+    ucc_assert(tls->array.count >= 1);
+    for (i = 0; i < tls->array.count; i++) {
+        /* Check TLs proveded in CL_BASIC_TLS. Not all of them could be
+           available, check for NULL. */
+        tl_iface = ucc_derived_of(
+            ucc_get_component(&ucc_global_config.tl_framework,
+                              tls->array.names[i]),
+            ucc_tl_iface_t);
+        if (!tl_iface) {
+            cl_warn(lib, "tl %s is not available", tls->array.names[i]);
+            continue;
         }
-    } else {
-        for (i = 0; i < tls->count; i++) {
-            /* Check TLs proveded in CL_BASIC_TLS. Not all of them could be
-               available, check for NULL. */
-            tl_iface = ucc_derived_of(
-                ucc_get_component(&ucc_global_config.tl_framework,
-                                  tls->names[i]),
-                ucc_tl_iface_t);
-            if (!tl_iface) {
-                cl_warn(lib, "tl %s is not available", tls->names[i]);
-                continue;
-            }
-            if (UCC_OK != (status = check_tl_lib_attr(lib, tl_iface, attr))) {
-                return status;
-            }
+        if (UCC_OK != (status = check_tl_lib_attr(lib, tl_iface, attr))) {
+            return status;
         }
     }
     return UCC_OK;

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -19,7 +19,7 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      "TLS to be used for NODE subgroup.\n"
      "NODE subgroup contains processes of a team located on the same node",
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NODE]),
-     UCC_CONFIG_TYPE_STRING_ARRAY},
+     UCC_CONFIG_TYPE_ALLOW_LIST},
 
     {"NODE_LEADERS_SBGP_TLS", "ucp",
      "TLS to be used for NODE_LEADERS subgroup.\n"
@@ -27,7 +27,7 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      "equal 0",
      ucc_offsetof(ucc_cl_hier_lib_config_t,
                   sbgp_tls[UCC_HIER_SBGP_NODE_LEADERS]),
-     UCC_CONFIG_TYPE_STRING_ARRAY},
+     UCC_CONFIG_TYPE_ALLOW_LIST},
 
     {"NET_SBGP_TLS", "ucp",
      "TLS to be used for NET subgroup.\n"
@@ -36,13 +36,13 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      "This subgroup only exists for teams with equal number of processes "
      "across the nodes",
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_NET]),
-     UCC_CONFIG_TYPE_STRING_ARRAY},
+     UCC_CONFIG_TYPE_ALLOW_LIST},
 
     {"FULL_SBGP_TLS", "ucp",
      "TLS to be used for FULL subgroup.\n"
      "FULL subgroup contains all processes of the team",
      ucc_offsetof(ucc_cl_hier_lib_config_t, sbgp_tls[UCC_HIER_SBGP_FULL]),
-     UCC_CONFIG_TYPE_STRING_ARRAY},
+     UCC_CONFIG_TYPE_ALLOW_LIST},
 
     {"ALLTOALLV_SPLIT_NODE_THRESH", "0",
      "Messages larger than that threshold will be sent via node sbgp tl",

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -47,7 +47,7 @@ typedef struct ucc_cl_hier_lib_config {
     ucc_cl_lib_config_t super;
     /* List of TLs corresponding to the sbgp team,
        which are selected based on the TL scores */
-    ucc_config_allow_list_t sbgp_tls[UCC_HIER_SBGP_LAST];
+    ucc_config_names_list_t sbgp_tls[UCC_HIER_SBGP_LAST];
     size_t                  a2av_node_thresh;
     uint32_t                allreduce_split_rail_n_frags;
     uint32_t                allreduce_split_rail_pipeline_depth;
@@ -66,8 +66,6 @@ typedef struct ucc_cl_hier_lib {
     ucc_cl_hier_lib_config_t cfg;
     ucc_config_allow_list_t  tls; /*< Intersection of UCC_CL_HIER_TLS
                                     vs sbgp_tls */
-    ucc_config_names_array_t tls_forced; /*< set of TLs that are
-                                           requested explicitly */
 } ucc_cl_hier_lib_t;
 UCC_CLASS_DECLARE(ucc_cl_hier_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -47,13 +47,13 @@ typedef struct ucc_cl_hier_lib_config {
     ucc_cl_lib_config_t super;
     /* List of TLs corresponding to the sbgp team,
        which are selected based on the TL scores */
-    ucc_config_names_array_t sbgp_tls[UCC_HIER_SBGP_LAST];
-    size_t                   a2av_node_thresh;
-    uint32_t                 allreduce_split_rail_n_frags;
-    uint32_t                 allreduce_split_rail_pipeline_depth;
-    int                      allreduce_split_rail_seq;
-    size_t                   allreduce_split_rail_frag_thresh;
-    size_t                   allreduce_split_rail_frag_size;
+    ucc_config_allow_list_t sbgp_tls[UCC_HIER_SBGP_LAST];
+    size_t                  a2av_node_thresh;
+    uint32_t                allreduce_split_rail_n_frags;
+    uint32_t                allreduce_split_rail_pipeline_depth;
+    int                     allreduce_split_rail_seq;
+    size_t                  allreduce_split_rail_frag_thresh;
+    size_t                  allreduce_split_rail_frag_size;
 
 } ucc_cl_hier_lib_config_t;
 
@@ -64,7 +64,8 @@ typedef struct ucc_cl_hier_context_config {
 typedef struct ucc_cl_hier_lib {
     ucc_cl_lib_t             super;
     ucc_cl_hier_lib_config_t cfg;
-    ucc_config_names_array_t tls; /*< Intersection of UCC_CL_HIER_TLS vs sbgp_tls */
+    ucc_config_allow_list_t  tls; /*< Intersection of UCC_CL_HIER_TLS vs sbgp_tls */
+    ucc_config_names_array_t tls_forced; /*< set of TLs that are requested explicitly */
 } ucc_cl_hier_lib_t;
 UCC_CLASS_DECLARE(ucc_cl_hier_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -64,8 +64,10 @@ typedef struct ucc_cl_hier_context_config {
 typedef struct ucc_cl_hier_lib {
     ucc_cl_lib_t             super;
     ucc_cl_hier_lib_config_t cfg;
-    ucc_config_allow_list_t  tls; /*< Intersection of UCC_CL_HIER_TLS vs sbgp_tls */
-    ucc_config_names_array_t tls_forced; /*< set of TLs that are requested explicitly */
+    ucc_config_allow_list_t  tls; /*< Intersection of UCC_CL_HIER_TLS
+                                    vs sbgp_tls */
+    ucc_config_names_array_t tls_forced; /*< set of TLs that are
+                                           requested explicitly */
 } ucc_cl_hier_lib_t;
 UCC_CLASS_DECLARE(ucc_cl_hier_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/cl/hier/cl_hier_context.c
+++ b/src/components/cl/hier/cl_hier_context.c
@@ -17,7 +17,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_context_t,
         ucc_derived_of(config, ucc_cl_context_config_t);
     ucc_cl_hier_lib_t        *lib = ucc_derived_of(cl_config->cl_lib,
                                                    ucc_cl_hier_lib_t);
-    ucc_config_names_array_t *tls = &lib->tls;
+    ucc_config_names_array_t *tls = &lib->tls.array;
     ucc_status_t              status;
     int                       i;
 

--- a/src/components/cl/hier/cl_hier_lib.c
+++ b/src/components/cl/hier/cl_hier_lib.c
@@ -18,45 +18,38 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_lib_t, const ucc_base_lib_params_t *params,
         ucc_derived_of(config, ucc_cl_hier_lib_config_t);
     ucc_config_names_array_t        requested_sbgp_tls;
     ucc_status_t                    status;
-    int                             i, all_tls_requested;
+    int                             i;
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_cl_lib_t, &ucc_cl_hier.super,
                               &cl_hier_config->super);
     memcpy(&self->cfg, cl_hier_config, sizeof(*cl_hier_config));
 
     requested_sbgp_tls.count = 0;
-    all_tls_requested   = 0;
+
     for (i = 0; i < UCC_HIER_SBGP_LAST; i++) {
-        status = ucc_config_names_array_dup(&self->cfg.sbgp_tls[i],
-                                            &cl_hier_config->sbgp_tls[i]);
+        status = ucc_config_allow_list_process(&cl_hier_config->sbgp_tls[i],
+                                               &self->super.tls.array,
+                                               &self->cfg.sbgp_tls[i]);
+
         if (UCC_OK != status) {
-            cl_error(&self->super, "failed to dup sbgp tls array");
+            cl_error(&self->super, "failed to process sbgp tls array");
             return status;
         }
-        if (!ucc_config_names_array_is_all(&cl_hier_config->sbgp_tls[i])) {
-            status = ucc_config_names_array_merge(&requested_sbgp_tls,
-                                                  &cl_hier_config->sbgp_tls[i]);
-            if (ucc_unlikely(UCC_OK != status)) {
-                cl_error(&self->super, "failed to merge tls config names arrays");
-                return status;
-            }
-        } else {
-            all_tls_requested = 1;
+        if (self->cfg.sbgp_tls[i].array.count == 0) {
+            cl_error(&self->super, "no TLs are available for sbgp");
+            return UCC_ERR_INVALID_PARAM;
+        }
+        status = ucc_config_names_array_merge(&requested_sbgp_tls,
+                                              &self->cfg.sbgp_tls[i].array);
+        if (ucc_unlikely(UCC_OK != status)) {
+            cl_error(&self->super, "failed to merge tls config names arrays");
+            return status;
         }
     }
+    ucc_assert(requested_sbgp_tls.count > 0);
+    self->tls.array.count = requested_sbgp_tls.count;
+    self->tls.array.names = requested_sbgp_tls.names;
 
-    if (requested_sbgp_tls.count == 0 || all_tls_requested) {
-        /* Some sbgp tls list contained "all". This means we should use
-           all possible TLs available to this CL: cl_hier_config->super.tls */
-        status = ucc_config_names_array_dup(&self->tls,
-                                            &cl_hier_config->super.tls);
-    } else {
-        status = ucc_config_names_array_dup(&self->tls,
-                                            &requested_sbgp_tls);
-    }
-    if (requested_sbgp_tls.count > 0) {
-        ucc_config_names_array_free(&requested_sbgp_tls);
-    }
     cl_info(&self->super, "initialized lib object: %p", self);
     return status;
 }
@@ -67,9 +60,10 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_hier_lib_t)
 
     cl_info(&self->super, "finalizing lib object: %p", self);
     for (i = 0; i < UCC_HIER_SBGP_LAST; i++) {
-        ucc_config_names_array_free(&self->cfg.sbgp_tls[i]);
+        ucc_config_names_array_free(&self->cfg.sbgp_tls[i].array);
     }
-    ucc_config_names_array_free(&self->tls);
+    ucc_config_names_array_free(&self->tls.array);
+    ucc_config_names_array_free(&self->tls_forced);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_hier_lib_t, ucc_cl_lib_t);
@@ -99,40 +93,42 @@ ucc_status_t ucc_cl_hier_get_lib_attr(const ucc_base_lib_t *lib,
 {
     ucc_cl_lib_attr_t *attr   = ucc_derived_of(base_attr, ucc_cl_lib_attr_t);
     ucc_cl_hier_lib_t *cl_lib = ucc_derived_of(lib, ucc_cl_hier_lib_t);
-    ucc_config_names_array_t *tls = &cl_lib->tls;
-    ucc_tl_iface_t           *tl_iface;
-    int                       i;
-    ucc_status_t              status;
+    ucc_config_allow_list_t *tls = &cl_lib->tls;
+    ucc_tl_iface_t          *tl_iface;
+    int                      i;
+    ucc_status_t             status;
 
-    attr->tls                    = &cl_lib->tls;
-    attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
-    attr->super.attr.coll_types  = UCC_CL_HIER_SUPPORTED_COLLS;
-    attr->super.flags            = 0;
-    if (tls->count == 1 && !strcmp(tls->names[0], "all")) {
-        /* Check all available components, since CL_HIER_TLS == "all" */
-        for (i = 0; i < ucc_global_config.tl_framework.n_components; i++) {
-            tl_iface = ucc_derived_of(
-                ucc_global_config.tl_framework.components[i], ucc_tl_iface_t);
-            ucc_assert(tl_iface);
-            if (UCC_OK != (status = check_tl_lib_attr(lib, tl_iface, attr))) {
+    attr->tls                = &cl_lib->tls.array;
+    cl_lib->tls_forced.count = 0;
+    cl_lib->tls_forced.names = NULL;
+    for (i = 0; i < UCC_HIER_SBGP_LAST; i++) {
+        if (cl_lib->cfg.sbgp_tls[i].mode == UCC_CONFIG_ALLOW_LIST_ALLOW) {
+            status = ucc_config_names_array_merge(&cl_lib->tls_forced,
+                                                  &cl_lib->cfg.sbgp_tls[i].array);
+            if (ucc_unlikely(UCC_OK != status)) {
                 return status;
             }
         }
-    } else {
-        for (i = 0; i < tls->count; i++) {
-            /* Check TLs proveded in CL_HIER_TLS. Not all of them could be
-               available, check for NULL. */
-            tl_iface = ucc_derived_of(
-                ucc_get_component(&ucc_global_config.tl_framework,
-                                  tls->names[i]),
-                ucc_tl_iface_t);
-            if (!tl_iface) {
-                cl_warn(lib, "tl %s is not available", tls->names[i]);
-                continue;
-            }
-            if (UCC_OK != (status = check_tl_lib_attr(lib, tl_iface, attr))) {
-                return status;
-            }
+    }
+    attr->tls_forced             = &cl_lib->tls_forced;
+    attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
+    attr->super.attr.coll_types  = UCC_CL_HIER_SUPPORTED_COLLS;
+    attr->super.flags            = 0;
+
+    ucc_assert(tls->array.count >= 1);
+    for (i = 0; i < tls->array.count; i++) {
+        /* Check TLs proveded in CL_HIER_TLS. Not all of them could be
+           available, check for NULL. */
+        tl_iface = ucc_derived_of(
+            ucc_get_component(&ucc_global_config.tl_framework,
+                              tls->array.names[i]),
+            ucc_tl_iface_t);
+        if (!tl_iface) {
+            cl_warn(lib, "tl %s is not available", tls->array.names[i]);
+            continue;
+        }
+        if (UCC_OK != (status = check_tl_lib_attr(lib, tl_iface, attr))) {
+            return status;
         }
     }
     return UCC_OK;

--- a/src/components/cl/hier/cl_hier_lib.c
+++ b/src/components/cl/hier/cl_hier_lib.c
@@ -27,7 +27,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_lib_t, const ucc_base_lib_params_t *params,
     requested_sbgp_tls.count = 0;
 
     for (i = 0; i < UCC_HIER_SBGP_LAST; i++) {
-        status = ucc_config_allow_list_process(&cl_hier_config->sbgp_tls[i],
+        status = ucc_config_allow_list_process(&cl_hier_config->sbgp_tls[i].list,
                                                &self->super.tls.array,
                                                &self->cfg.sbgp_tls[i]);
 
@@ -63,7 +63,6 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_hier_lib_t)
         ucc_config_names_array_free(&self->cfg.sbgp_tls[i].array);
     }
     ucc_config_names_array_free(&self->tls.array);
-    ucc_config_names_array_free(&self->tls_forced);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_hier_lib_t, ucc_cl_lib_t);
@@ -99,18 +98,16 @@ ucc_status_t ucc_cl_hier_get_lib_attr(const ucc_base_lib_t *lib,
     ucc_status_t             status;
 
     attr->tls                = &cl_lib->tls.array;
-    cl_lib->tls_forced.count = 0;
-    cl_lib->tls_forced.names = NULL;
     for (i = 0; i < UCC_HIER_SBGP_LAST; i++) {
-        if (cl_lib->cfg.sbgp_tls[i].mode == UCC_CONFIG_ALLOW_LIST_ALLOW) {
+        if (cl_lib->cfg.sbgp_tls[i].requested) {
             status = ucc_config_names_array_merge(
-                &cl_lib->tls_forced, &cl_lib->cfg.sbgp_tls[i].array);
+                &cl_lib->super.tls_forced, &cl_lib->cfg.sbgp_tls[i].array);
             if (ucc_unlikely(UCC_OK != status)) {
                 return status;
             }
         }
     }
-    attr->tls_forced             = &cl_lib->tls_forced;
+    attr->tls_forced             = &cl_lib->super.tls_forced;
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = UCC_CL_HIER_SUPPORTED_COLLS;
     attr->super.flags            = 0;

--- a/src/components/cl/hier/cl_hier_lib.c
+++ b/src/components/cl/hier/cl_hier_lib.c
@@ -103,8 +103,8 @@ ucc_status_t ucc_cl_hier_get_lib_attr(const ucc_base_lib_t *lib,
     cl_lib->tls_forced.names = NULL;
     for (i = 0; i < UCC_HIER_SBGP_LAST; i++) {
         if (cl_lib->cfg.sbgp_tls[i].mode == UCC_CONFIG_ALLOW_LIST_ALLOW) {
-            status = ucc_config_names_array_merge(&cl_lib->tls_forced,
-                                                  &cl_lib->cfg.sbgp_tls[i].array);
+            status = ucc_config_names_array_merge(
+                &cl_lib->tls_forced, &cl_lib->cfg.sbgp_tls[i].array);
             if (ucc_unlikely(UCC_OK != status)) {
                 return status;
             }
@@ -119,10 +119,10 @@ ucc_status_t ucc_cl_hier_get_lib_attr(const ucc_base_lib_t *lib,
     for (i = 0; i < tls->array.count; i++) {
         /* Check TLs proveded in CL_HIER_TLS. Not all of them could be
            available, check for NULL. */
-        tl_iface = ucc_derived_of(
-            ucc_get_component(&ucc_global_config.tl_framework,
-                              tls->array.names[i]),
-            ucc_tl_iface_t);
+        tl_iface =
+            ucc_derived_of(ucc_get_component(&ucc_global_config.tl_framework,
+                                             tls->array.names[i]),
+                           ucc_tl_iface_t);
         if (!tl_iface) {
             cl_warn(lib, "tl %s is not available", tls->array.names[i]);
             continue;

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -68,18 +68,13 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
                 continue;
             }
             hs->n_tls = 0;
-            tls       = &lib->cfg.sbgp_tls[i];
-            if (ucc_config_names_array_is_all(tls)) {
-                /* All possible TLs are requested for this SBGP.
-                   Loop through all available CL_HIER tls that are stored on lib.*/
-                tls = &lib->tls;
-            }
+            tls       = &lib->cfg.sbgp_tls[i].array;
             for (j = 0; j < tls->count; j++) {
                 status =
                     ucc_tl_context_get(ctx->super.super.ucc_context,
                                        tls->names[j], &hs->tl_ctxs[hs->n_tls]);
                 if (UCC_OK != status) {
-                    cl_warn(cl_context->lib,
+                    cl_debug(cl_context->lib,
                             "tl context %s is not available for sbgp %s",
                             tls->names[j], ucc_sbgp_str(hs->sbgp_type));
                 } else {

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -75,8 +75,8 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
                                        tls->names[j], &hs->tl_ctxs[hs->n_tls]);
                 if (UCC_OK != status) {
                     cl_debug(cl_context->lib,
-                            "tl context %s is not available for sbgp %s",
-                            tls->names[j], ucc_sbgp_str(hs->sbgp_type));
+                             "tl context %s is not available for sbgp %s",
+                             tls->names[j], ucc_sbgp_str(hs->sbgp_type));
                 } else {
                     hs->n_tls++;
                     n_sbgp_teams++;

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -14,14 +14,13 @@ static char * ucc_cl_tls_doc_str = "List of TLs used by a given CL component.\n"
 #define TLS_CONFIG_ENTRY 1
 ucc_config_field_t ucc_cl_lib_config_table[] = {
     [0] = {"", "", NULL, ucc_offsetof(ucc_cl_lib_config_t, super),
-     UCC_CONFIG_TYPE_TABLE(ucc_base_lib_config_table)},
+           UCC_CONFIG_TYPE_TABLE(ucc_base_lib_config_table)},
 
     [TLS_CONFIG_ENTRY] = {"TLS", "all", NULL,
                           ucc_offsetof(ucc_cl_lib_config_t, tls),
-     UCC_CONFIG_TYPE_ALLOW_LIST},
+                          UCC_CONFIG_TYPE_ALLOW_LIST},
 
-    {NULL}
-};
+    {NULL}};
 
 ucc_config_field_t ucc_cl_context_config_table[] = {
     [0] = {"", "", NULL, ucc_offsetof(ucc_cl_context_config_t, super),
@@ -49,15 +48,13 @@ UCC_CLASS_INIT_FUNC(ucc_cl_lib_t, ucc_cl_iface_t *cl_iface,
                      cl_iface->cl_lib_config.name,
                      sizeof(self->super.log_component.name));
 
-    status = ucc_config_allow_list_process(&cl_config->tls,
-                                           &ucc_global_config.tl_framework.names,
-                                           &self->tls);
+    status = ucc_config_allow_list_process(
+        &cl_config->tls, &ucc_global_config.tl_framework.names, &self->tls);
     if (status != UCC_OK) {
         return status;
     }
     if (self->tls.array.count == 0) {
-        ucc_error("no TLs are selected for %s",
-                  cl_iface->cl_lib_config.name);
+        ucc_error("no TLs are selected for %s", cl_iface->cl_lib_config.name);
         ucc_free(self->tls.array.names);
         return UCC_ERR_NOT_FOUND;
     }

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -58,12 +58,15 @@ UCC_CLASS_INIT_FUNC(ucc_cl_lib_t, ucc_cl_iface_t *cl_iface,
         ucc_free(self->tls.array.names);
         return UCC_ERR_NOT_FOUND;
     }
+    self->tls_forced.count = 0;
+    self->tls_forced.names = NULL;
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_lib_t)
 {
     ucc_config_names_array_free(&self->tls.array);
+    ucc_config_names_array_free(&self->tls_forced);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_lib_t, void);

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -91,8 +91,8 @@ UCC_CLASS_DECLARE(ucc_cl_team_t, ucc_cl_context_t *,
 
 typedef struct ucc_cl_lib_attr {
     ucc_base_lib_attr_t       super;
-    ucc_config_names_array_t  *tls;
-    ucc_config_names_array_t  *tls_forced;
+    ucc_config_names_array_t *tls;
+    ucc_config_names_array_t *tls_forced;
 } ucc_cl_lib_attr_t;
 
 #define UCC_CL_IFACE_DECLARE(_name, _NAME)                              \

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -73,7 +73,9 @@ typedef struct ucc_cl_iface {
 typedef struct ucc_cl_lib {
     ucc_base_lib_t           super;
     ucc_cl_iface_t          *iface;
-    ucc_config_allow_list_t  tls;
+    ucc_config_names_list_t  tls;
+    ucc_config_names_array_t tls_forced; /*< set of TLs that are
+                                           requested explicitly */
 } ucc_cl_lib_t;
 UCC_CLASS_DECLARE(ucc_cl_lib_t, ucc_cl_iface_t *, const ucc_cl_lib_config_t *);
 

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -39,7 +39,7 @@ typedef struct ucc_cl_team    ucc_cl_team_t;
 typedef struct ucc_cl_lib_config {
     ucc_base_lib_config_t    super;
     ucc_cl_iface_t          *iface;
-    ucc_config_names_array_t tls;
+    ucc_config_allow_list_t  tls;
 } ucc_cl_lib_config_t;
 extern ucc_config_field_t ucc_cl_lib_config_table[];
 
@@ -73,7 +73,7 @@ typedef struct ucc_cl_iface {
 typedef struct ucc_cl_lib {
     ucc_base_lib_t           super;
     ucc_cl_iface_t          *iface;
-    ucc_config_names_array_t tls;
+    ucc_config_allow_list_t  tls;
 } ucc_cl_lib_t;
 UCC_CLASS_DECLARE(ucc_cl_lib_t, ucc_cl_iface_t *, const ucc_cl_lib_config_t *);
 
@@ -91,7 +91,8 @@ UCC_CLASS_DECLARE(ucc_cl_team_t, ucc_cl_context_t *,
 
 typedef struct ucc_cl_lib_attr {
     ucc_base_lib_attr_t       super;
-    ucc_config_names_array_t *tls;
+    ucc_config_names_array_t  *tls;
+    ucc_config_names_array_t  *tls_forced;
 } ucc_cl_lib_attr_t;
 
 #define UCC_CL_IFACE_DECLARE(_name, _NAME)                              \

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -415,7 +415,7 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
     return UCC_OK;
 err:
     for (i = 0; i < ctx->n_tl_ctx; i++) {
-        tl_lib = lib->tl_libs[i];
+        tl_lib = ucc_derived_of(ctx->tl_ctx[i]->super.lib, ucc_tl_lib_t);
         tl_lib->iface->context.destroy(&ctx->tl_ctx[i]->super);
     }
     ucc_free(ctx->tl_ctx);

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -379,7 +379,7 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
             /* UCC_ERR_LAST means component was disabled via TUNE param:
                don't print warning. */
             if (UCC_ERR_LAST != status) {
-                if (ucc_tl_is_requested(lib, tl_lib->iface)) {
+                if (ucc_tl_is_required(lib, tl_lib->iface, 1)) {
                     ucc_error("failed to create tl context for %s",
                               tl_lib->iface->super.name);
                 } else {

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -213,16 +213,13 @@ error:
     return status;
 }
 
-static int ucc_tl_is_required(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface,
-                              int explicitly)
+static int ucc_tl_is_required(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface)
 {
-    ucc_config_names_array_t *tls;
-    int                       i;
+    int i;
 
     for (i = 0; i < lib->n_cl_libs_opened; i++) {
-        tls = lib->cl_attrs[i].tls;
-        if ((!explicitly && tls->count == 1 && !strcmp(tls->names[0], "all")) ||
-            ucc_config_names_search(tls, tl_iface->super.name) >= 0) {
+        if (ucc_config_names_search(lib->cl_attrs[i].tls,
+                                    tl_iface->super.name) >= 0) {
             return 1;
         }
     }
@@ -231,7 +228,16 @@ static int ucc_tl_is_required(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface,
 
 int ucc_tl_is_requested(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface)
 {
-    return ucc_tl_is_required(lib, tl_iface, 1);
+    int i;
+
+    for (i = 0; i < lib->n_cl_libs_opened; i++) {
+        if (ucc_config_names_search(lib->cl_attrs[i].tls_forced,
+                                    tl_iface->super.name) >= 0) {
+            return 1;
+        }
+    }
+    return 0;
+
 }
 
 static ucc_status_t ucc_tl_lib_init(const ucc_lib_params_t *user_params,
@@ -264,7 +270,7 @@ static ucc_status_t ucc_tl_lib_init(const ucc_lib_params_t *user_params,
            Failure to init a TL is not critical. Let CLs deal with it later during
            cl_context_create.
          */
-        if (ucc_tl_is_required(lib, tl_iface, 0)) {
+        if (ucc_tl_is_required(lib, tl_iface)) {
             status = ucc_tl_lib_config_read(tl_iface, lib->full_prefix,
                                             &tl_config);
             if (UCC_OK != status) {

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -213,25 +213,15 @@ error:
     return status;
 }
 
-static int ucc_tl_is_required(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface)
+int ucc_tl_is_required(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface,
+                       int forced)
 {
     int i;
 
     for (i = 0; i < lib->n_cl_libs_opened; i++) {
-        if (ucc_config_names_search(lib->cl_attrs[i].tls,
-                                    tl_iface->super.name) >= 0) {
-            return 1;
-        }
-    }
-    return 0;
-}
-
-int ucc_tl_is_requested(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface)
-{
-    int i;
-
-    for (i = 0; i < lib->n_cl_libs_opened; i++) {
-        if (ucc_config_names_search(lib->cl_attrs[i].tls_forced,
+        if (ucc_config_names_search(forced
+                                    ? lib->cl_attrs[i].tls_forced
+                                    : lib->cl_attrs[i].tls,
                                     tl_iface->super.name) >= 0) {
             return 1;
         }
@@ -269,7 +259,7 @@ static ucc_status_t ucc_tl_lib_init(const ucc_lib_params_t *user_params,
            Failure to init a TL is not critical. Let CLs deal with it later during
            cl_context_create.
          */
-        if (ucc_tl_is_required(lib, tl_iface)) {
+        if (ucc_tl_is_required(lib, tl_iface, 0)) {
             status = ucc_tl_lib_config_read(tl_iface, lib->full_prefix,
                                             &tl_config);
             if (UCC_OK != status) {

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -237,7 +237,6 @@ int ucc_tl_is_requested(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface)
         }
     }
     return 0;
-
 }
 
 static ucc_status_t ucc_tl_lib_init(const ucc_lib_params_t *user_params,

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -40,8 +40,6 @@ void ucc_get_version(unsigned *major_version, unsigned *minor_version,
 
 const char *ucc_get_version_string(void);
 
-/* Checks if a TL is explicitely requested by user via UCC_TLS
-   parameter */
-int ucc_tl_is_requested(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface);
-
+int ucc_tl_is_required(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface,
+                       int forced);
 #endif

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -179,9 +179,26 @@ ucc_status_t ucc_components_load(const char *framework_name,
            This has nearly 0 probability and must be resolved by
            the component developer via just a rename of a component. */
         ucc_error("all components of a framwork must have uniq name hash");
-        return UCC_ERR_INVALID_PARAM;
+        status = UCC_ERR_INVALID_PARAM;
+        goto err;
+    }
+
+    framework->names.names = ucc_malloc(sizeof(char *) * n_loaded,
+                                        "components_names");
+    if (!framework->names.names) {
+        ucc_error("failed to allocate %zd bytes for components names",
+                  sizeof(char *) * n_loaded);
+        status = UCC_ERR_NO_MEMORY;
+        goto err;
+    }
+    framework->names.count = n_loaded;
+    for (i = 0; i < n_loaded; i++) {
+        framework->names.names[i] = strdup(framework->components[i]->name);
     }
     return UCC_OK;
+err:
+    ucc_free(framework->components);
+    return status;
 }
 
 ucc_component_iface_t* ucc_get_component(ucc_component_framework_t *framework,

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -183,8 +183,8 @@ ucc_status_t ucc_components_load(const char *framework_name,
         goto err;
     }
 
-    framework->names.names = ucc_malloc(sizeof(char *) * n_loaded,
-                                        "components_names");
+    framework->names.names =
+        ucc_malloc(sizeof(char *) * n_loaded, "components_names");
     if (!framework->names.names) {
         ucc_error("failed to allocate %zd bytes for components names",
                   sizeof(char *) * n_loaded);

--- a/src/utils/ucc_component.h
+++ b/src/utils/ucc_component.h
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "ucc/api/ucc.h"
 #include "utils/ucc_compiler_def.h"
+#include "utils/ucc_parser.h"
 
 #define UCC_MAX_FRAMEWORK_NAME_LEN 64
 #define UCC_MAX_COMPONENT_NAME_LEN 64
@@ -21,9 +22,10 @@ typedef struct ucc_component_iface {
 } ucc_component_iface_t;
 
 typedef struct ucc_component_framework {
-    char                   *framework_name;
-    int                     n_components;
-    ucc_component_iface_t **components;
+    char                    *framework_name;
+    int                      n_components;
+    ucc_component_iface_t  **components;
+    ucc_config_names_array_t names;
 } ucc_component_framework_t;
 
 /* ucc_components_load searches for all available dynamic components 

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -24,9 +24,9 @@ ucc_status_t ucc_config_names_array_merge(ucc_config_names_array_t *dst,
         }
 
         if (n_new) {
-            dst->names = ucc_realloc(dst->names,
-                                     (dst->count + n_new) * sizeof(char *),
-                                     "ucc_config_names_array");
+            dst->names =
+                ucc_realloc(dst->names, (dst->count + n_new) * sizeof(char *),
+                            "ucc_config_names_array");
             if (ucc_unlikely(!dst->names)) {
                 return UCC_ERR_NO_MEMORY;
             }
@@ -80,9 +80,9 @@ void ucc_config_names_array_free(ucc_config_names_array_t *array)
     ucc_free(array->names);
 }
 
-
 int ucc_config_names_search(const ucc_config_names_array_t *config_names,
-                            const char *str) {
+                            const char *                    str)
+{
     unsigned i;
 
     for (i = 0; i < config_names->count; ++i) {
@@ -94,19 +94,18 @@ int ucc_config_names_search(const ucc_config_names_array_t *config_names,
     return -1;
 }
 
-ucc_status_t ucc_config_allow_list_process(const ucc_config_allow_list_t *list,
+ucc_status_t ucc_config_allow_list_process(const ucc_config_allow_list_t * list,
                                            const ucc_config_names_array_t *all,
-                                           ucc_config_allow_list_t *out)
+                                           ucc_config_allow_list_t *       out)
 {
-    ucc_status_t            status;
-    int                     i;
+    ucc_status_t status;
+    int          i;
 
     out->mode        = list->mode;
     out->array.names = NULL;
 
     if (out->mode == UCC_CONFIG_ALLOW_LIST_ALLOW) {
-        status = ucc_config_names_array_dup(&out->array,
-                                            &list->array);
+        status = ucc_config_names_array_dup(&out->array, &list->array);
         if (UCC_OK != status) {
             ucc_error("failed to dup config_names_array");
             return status;
@@ -116,7 +115,7 @@ ucc_status_t ucc_config_allow_list_process(const ucc_config_allow_list_t *list,
                    out->mode == UCC_CONFIG_ALLOW_LIST_ALLOW_ALL);
 
         out->array.count = 0;
-        out->array.names = ucc_malloc(sizeof(char*) * all->count, "names");
+        out->array.names = ucc_malloc(sizeof(char *) * all->count, "names");
         if (!out->array.names) {
             ucc_error("failed to allocate %zd bytes for names array",
                       sizeof(char *) * all->count);

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -10,40 +10,32 @@
 ucc_status_t ucc_config_names_array_merge(ucc_config_names_array_t *dst,
                                           const ucc_config_names_array_t *src)
 {
-    int i, j, n_new;
+    int i, n_new;
 
     n_new = 0;
     if (dst->count == 0) {
         return ucc_config_names_array_dup(dst, src);
     } else {
         for (i = 0; i < src->count; i++) {
-            for (j = 0; j < dst->count; j++) {
-                if (0 != strcmp(src->names[i], dst->names[j])) {
-                    break;
-                }
-            }
-            if (j < dst->count) {
+            if (ucc_config_names_search(dst, src->names[i]) < 0) {
                 /* found new entry in src which is not part of dst */
                 n_new++;
             }
         }
 
         if (n_new) {
-            dst->count += n_new;
-            dst->names = ucc_realloc(dst->names, dst->count * sizeof(char *),
+            dst->names = ucc_realloc(dst->names,
+                                     (dst->count + n_new) * sizeof(char *),
                                      "ucc_config_names_array");
             if (ucc_unlikely(!dst->names)) {
                 return UCC_ERR_NO_MEMORY;
             }
             for (i = 0; i < src->count; i++) {
-                for (j = 0; j < dst->count; j++) {
-                    if (0 != strcmp(src->names[i], dst->names[j])) {
-                        dst->names[dst->count - n_new] = strdup(src->names[i]);
-                        if (ucc_unlikely(!dst->names[dst->count - n_new])) {
-                            ucc_error("failed to dup config_names_array entry");
-                            return UCC_ERR_NO_MEMORY;
-                        }
-                        n_new--;
+                if (ucc_config_names_search(dst, src->names[i]) < 0) {
+                    dst->names[dst->count++] = strdup(src->names[i]);
+                    if (ucc_unlikely(!dst->names[dst->count - n_new])) {
+                        ucc_error("failed to dup config_names_array entry");
+                        return UCC_ERR_NO_MEMORY;
                     }
                 }
             }

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -22,6 +22,7 @@
 typedef ucs_config_field_t             ucc_config_field_t;
 typedef ucs_config_names_array_t       ucc_config_names_array_t;
 typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
+typedef ucs_config_allow_list_t        ucc_config_allow_list_t;
 
 #define UCC_CONFIG_TYPE_LOG_COMP        UCS_CONFIG_TYPE_LOG_COMP
 #define UCC_CONFIG_REGISTER_TABLE       UCS_CONFIG_REGISTER_TABLE
@@ -30,6 +31,7 @@ typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
 #define UCC_CONFIG_TYPE_INT             UCS_CONFIG_TYPE_INT
 #define UCC_CONFIG_TYPE_UINT            UCS_CONFIG_TYPE_UINT
 #define UCC_CONFIG_TYPE_STRING_ARRAY    UCS_CONFIG_TYPE_STRING_ARRAY
+#define UCC_CONFIG_TYPE_ALLOW_LIST      UCS_CONFIG_TYPE_ALLOW_LIST
 #define UCC_CONFIG_TYPE_ARRAY           UCS_CONFIG_TYPE_ARRAY
 #define UCC_CONFIG_TYPE_TABLE           UCS_CONFIG_TYPE_TABLE
 #define UCC_CONFIG_TYPE_ULUNITS         UCS_CONFIG_TYPE_ULUNITS
@@ -39,6 +41,9 @@ typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
 #define UCC_CONFIG_TYPE_BITMAP          UCS_CONFIG_TYPE_BITMAP
 #define UCC_CONFIG_TYPE_MEMUNITS        UCS_CONFIG_TYPE_MEMUNITS
 #define UCC_CONFIG_TYPE_BOOL            UCS_CONFIG_TYPE_BOOL
+#define UCC_CONFIG_ALLOW_LIST_NEGATE    UCS_CONFIG_ALLOW_LIST_NEGATE
+#define UCC_CONFIG_ALLOW_LIST_ALLOW_ALL UCS_CONFIG_ALLOW_LIST_ALLOW_ALL
+#define UCC_CONFIG_ALLOW_LIST_ALLOW     UCS_CONFIG_ALLOW_LIST_ALLOW
 
 static inline ucc_status_t
 ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,
@@ -119,7 +124,7 @@ ucc_status_t ucc_config_names_array_merge(ucc_config_names_array_t *dst,
 
 void ucc_config_names_array_free(ucc_config_names_array_t *array);
 
-int ucc_config_names_search(ucc_config_names_array_t *config_names,
+int ucc_config_names_search(const ucc_config_names_array_t *config_names,
                             const char *str);
 
 static inline
@@ -127,5 +132,9 @@ int ucc_config_names_array_is_all(const ucc_config_names_array_t *array)
 {
     return (array->count == 1) && (0 == strcmp(array->names[0], "all"));
 }
+
+ucc_status_t ucc_config_allow_list_process(const ucc_config_allow_list_t *list,
+                                           const ucc_config_names_array_t *all,
+                                           ucc_config_allow_list_t *out);
 
 #endif

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -125,7 +125,7 @@ ucc_status_t ucc_config_names_array_merge(ucc_config_names_array_t *dst,
 void ucc_config_names_array_free(ucc_config_names_array_t *array);
 
 int ucc_config_names_search(const ucc_config_names_array_t *config_names,
-                            const char *str);
+                            const char *                    str);
 
 static inline
 int ucc_config_names_array_is_all(const ucc_config_names_array_t *array)
@@ -133,8 +133,8 @@ int ucc_config_names_array_is_all(const ucc_config_names_array_t *array)
     return (array->count == 1) && (0 == strcmp(array->names[0], "all"));
 }
 
-ucc_status_t ucc_config_allow_list_process(const ucc_config_allow_list_t *list,
+ucc_status_t ucc_config_allow_list_process(const ucc_config_allow_list_t * list,
                                            const ucc_config_names_array_t *all,
-                                           ucc_config_allow_list_t *out);
+                                           ucc_config_allow_list_t *       out);
 
 #endif

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -45,6 +45,22 @@ typedef ucs_config_allow_list_t        ucc_config_allow_list_t;
 #define UCC_CONFIG_ALLOW_LIST_ALLOW_ALL UCS_CONFIG_ALLOW_LIST_ALLOW_ALL
 #define UCC_CONFIG_ALLOW_LIST_ALLOW     UCS_CONFIG_ALLOW_LIST_ALLOW
 
+/* Convenience structure used, for example, to represent TLS list.
+   "requested" field is set to 1 if the list of entries was
+   explicitly requested by user.
+
+   Union with allow_list is used in order to use this structure
+   directly as config_field. */
+typedef struct ucc_config_names_list {
+    union {
+        struct {
+            ucc_config_names_array_t array;
+            int                      requested;
+        };
+        ucc_config_allow_list_t list;
+    };
+} ucc_config_names_list_t;
+
 static inline ucc_status_t
 ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,
                             const char *env_prefix, const char *table_prefix,
@@ -135,6 +151,6 @@ int ucc_config_names_array_is_all(const ucc_config_names_array_t *array)
 
 ucc_status_t ucc_config_allow_list_process(const ucc_config_allow_list_t * list,
                                            const ucc_config_names_array_t *all,
-                                           ucc_config_allow_list_t *       out);
+                                           ucc_config_names_list_t *       out);
 
 #endif

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -13,6 +13,7 @@
 
 extern "C" {
 #include <core/ucc_global_opts.h>
+#include <schedule/ucc_schedule.h>
 }
 
 class test_obj_size : public ucc::test {
@@ -30,7 +31,7 @@ UCC_TEST_F(test_obj_size, size) {
     UCC_TEST_SKIP_R("Assert enabled");
 #else
 
-    EXPECTED_SIZE(ucc_global_config_t, 168);
+    EXPECTED_SIZE(ucc_coll_task_t, 448);
 
 #endif
 }


### PR DESCRIPTION
## What
Changes the way UCC_TLS (and UCC_CL_BASIC/HIER_TLS and UCC_CL_HIER_<SBGP_TYPE>_TLS) is handled. It used to be ucc_config_names_array_t. Now it will be ucc_config_allow_list_t. The difference is that the new type supports NEGATE option. Ie, now user can set UCC_TLS=^sharp, which means use everything except for specified value. This is not only convenience. 
Before we had to specify the full list, e.g. UCC_TLS=cuda,ucp. However, this would be considered a list of TLs explicitly requested by user; if some TL fails to init it will cause an error output from UCC. New way allows disabling TL w/o forcing others.

PR also fixes config_names_array_merge implementation and clarifies TLs specification in CL/HIER.

