### PR TITLE
TOOLS: fix peftest timer

### DIFF
--- a/tools/perf/ucc_pt_benchmark.h
+++ b/tools/perf/ucc_pt_benchmark.h
@@ -11,7 +11,6 @@
 #include "ucc_pt_coll.h"
 #include "ucc_pt_comm.h"
 #include <ucc/api/ucc.h>
-#include <chrono>
 
 class ucc_pt_benchmark {
     ucc_pt_benchmark_config config;
@@ -21,13 +20,13 @@ class ucc_pt_benchmark {
     ucc_status_t barrier();
     void print_header();
     void print_time(size_t count, ucc_coll_args_t args,
-                    std::chrono::nanoseconds time);
+                    double time);
 public:
     ucc_pt_benchmark(ucc_pt_benchmark_config cfg, ucc_pt_comm *communicator);
     ucc_status_t run_bench() noexcept;
     ucc_status_t run_single_test(ucc_coll_args_t args,
                                  int nwarmup, int niter,
-                                 std::chrono::nanoseconds &time) noexcept;
+                                 double &time) noexcept;
     ~ucc_pt_benchmark();
 };
 

--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -143,7 +143,7 @@ ucc_status_t ucc_pt_comm::barrier()
     return UCC_OK;
 }
 
-ucc_status_t ucc_pt_comm::allreduce(float* in, float* out, size_t size,
+ucc_status_t ucc_pt_comm::allreduce(double* in, double* out, size_t size,
                                     ucc_reduction_op_t op)
 {
     ucc_coll_args_t args;
@@ -154,11 +154,11 @@ ucc_status_t ucc_pt_comm::allreduce(float* in, float* out, size_t size,
     args.op                   = op;
     args.src.info.buffer      = in;
     args.src.info.count       = size;
-    args.src.info.datatype    = UCC_DT_FLOAT32;
+    args.src.info.datatype    = UCC_DT_FLOAT64;
     args.src.info.mem_type    = UCC_MEMORY_TYPE_HOST;
     args.dst.info.buffer      = out;
     args.dst.info.count       = size;
-    args.dst.info.datatype    = UCC_DT_FLOAT32;
+    args.dst.info.datatype    = UCC_DT_FLOAT64;
     args.dst.info.mem_type    = UCC_MEMORY_TYPE_HOST;
     ucc_collective_init(&args, &req, team);
     ucc_collective_post(req);

--- a/tools/perf/ucc_pt_comm.h
+++ b/tools/perf/ucc_pt_comm.h
@@ -28,7 +28,7 @@ public:
     ~ucc_pt_comm();
     ucc_status_t init();
     ucc_status_t barrier();
-    ucc_status_t allreduce(float* in, float *out, size_t size,
+    ucc_status_t allreduce(double* in, double *out, size_t size,
                            ucc_reduction_op_t op);
     ucc_status_t finalize();
 };


### PR DESCRIPTION
std::chrono adds ~0.5 usec of overhead which is a lot for low latency benchmarks and makes numbers inconsistent with other benchmarks (e.g. MPI osu ). Use gettimeofday based timer instead.

Same run with to timers:
1. Chrono:
```
           1           4        0.94        0.80        1.26
           2           8        1.04        0.86        1.44
           4          16        0.96        0.82        1.27
           8          32        1.03        0.86        1.40
          16          64        1.28        1.10        1.70
          32         128        1.52        1.30        2.04
          64         256        1.25        1.03        1.38
         128         512        1.36        1.09        1.48
         256        1024        1.52        1.13        1.66
         512        2048        2.01        1.33        2.19
        1024        4096        2.87        1.64        3.23
```

2. gettimeofday
```
           1           4        0.62        0.41        0.98
           2           8        0.52        0.36        0.88
           4          16        0.62        0.41        0.98
           8          32        0.52        0.36        0.89
          16          64        0.87        0.63        1.30
          32         128        1.03        0.83        1.62
          64         256        0.95        0.71        1.06
         128         512        1.01        0.75        1.12
         256        1024        1.20        0.81        1.33
         512        2048        1.62        0.96        1.82
        1024        4096        2.51        1.32        2.82
```
