### PR TITLE
CL/HIER: inplace alltoall fallback

### DIFF
--- a/src/components/cl/hier/alltoall/alltoall.c
+++ b/src/components/cl/hier/alltoall/alltoall.c
@@ -29,6 +29,11 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoall_init,
     ucc_rank_t              team_size;
     ucc_mc_buffer_header_t *h;
 
+    if (UCC_IS_INPLACE(coll_args->args)) {
+        cl_debug(team->context->lib, "inplace alltoall is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
     if (!SBGP_ENABLED(cl_team, NODE) || !SBGP_ENABLED(cl_team, FULL)) {
         cl_debug(team->context->lib, "alltoall requires NODE and FULL sbgps");
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/cl/hier/alltoallv/alltoallv.c
+++ b/src/components/cl/hier/alltoallv/alltoallv.c
@@ -116,6 +116,11 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoallv_init,
     ucc_sbgp_t             *sbgp;
     size_t                  elem_size;
 
+    if (UCC_IS_INPLACE(coll_args->args)) {
+        cl_debug(team->context->lib, "inplace alltoallv is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
     if (!SBGP_ENABLED(cl_team, NODE) || !SBGP_ENABLED(cl_team, FULL)) {
         cl_debug(team->context->lib, "alltoallv requires NODE and FULL sbgps");
         return UCC_ERR_NOT_SUPPORTED;


### PR DESCRIPTION
current alltoall(v) algorithms in CL/HIER do not support INPLACE alltoall (neither do algs in TLs). Fallback.

Fixes: https://redmine.mellanox.com/issues/3046532
