### PR TITLE
CORE: config file support

### DIFF
--- a/src/components/base/ucc_base_iface.c
+++ b/src/components/base/ucc_base_iface.c
@@ -58,5 +58,6 @@ ucc_status_t ucc_base_config_read(const char *full_prefix,
     } else {
         *config = cfg;
     }
+
     return status;
 }

--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -17,10 +17,9 @@ ucc_global_config_t ucc_global_config = {
     .profile_mode     = 0,
     .profile_file     = "",
     .profile_log_size = 0,
-};
+    .file_cfg         = 0};
 
-ucc_config_field_t ucc_global_config_table[] =
-{
+ucc_config_field_t ucc_global_config_table[] = {
     {"LOG_LEVEL", "warn",
      "UCC logging level. Messages with a level higher or equal to the selected "
      "will be printed.\n"
@@ -33,24 +32,27 @@ ucc_config_field_t ucc_global_config_table[] =
      ucc_offsetof(ucc_global_config_t, component_path), UCC_CONFIG_TYPE_STRING},
 
     {"PROFILE_MODE", "",
-    "Profile collection modes. If none is specified, profiling is disabled.\n"
-    " - log   - Record all timestamps.\n"
-    " - accum - Accumulate measurements per location.\n",
-    ucc_offsetof(ucc_global_config_t, profile_mode),
-    UCC_CONFIG_TYPE_BITMAP(ucs_profile_mode_names)},
+     "Profile collection modes. If none is specified, profiling is disabled.\n"
+     " - log   - Record all timestamps.\n"
+     " - accum - Accumulate measurements per location.\n",
+     ucc_offsetof(ucc_global_config_t, profile_mode),
+     UCC_CONFIG_TYPE_BITMAP(ucs_profile_mode_names)},
 
     {"PROFILE_FILE", "ucc_%h_%p.prof",
-    "File name to dump profiling data to.\n"
-    "Substitutions: %h: host, %p: pid, %c: cpu, %t: time, %u: user, %e: exe.\n",
-    ucc_offsetof(ucc_global_config_t, profile_file), UCC_CONFIG_TYPE_STRING},
+     "File name to dump profiling data to.\n"
+     "Substitutions: %h: host, %p: pid, %c: cpu, %t: time, %u: user, %e: "
+     "exe.\n",
+     ucc_offsetof(ucc_global_config_t, profile_file), UCC_CONFIG_TYPE_STRING},
 
     {"PROFILE_LOG_SIZE", "4m",
-    "Maximal size of profiling log. New records will replace old records.",
-    ucc_offsetof(ucc_global_config_t, profile_log_size),
-    UCC_CONFIG_TYPE_MEMUNITS},
+     "Maximal size of profiling log. New records will replace old records.",
+     ucc_offsetof(ucc_global_config_t, profile_log_size),
+     UCC_CONFIG_TYPE_MEMUNITS},
 
-    {NULL}
-};
+    {"CONFIG_FILE", "", "Location of configuration file",
+     ucc_offsetof(ucc_global_config_t, cfg_filename), UCC_CONFIG_TYPE_STRING},
+
+    {NULL}};
 
 UCC_CONFIG_REGISTER_TABLE(ucc_global_config_table, "UCC global", NULL,
                           ucc_global_config, &ucc_config_global_list)

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -23,15 +23,18 @@ typedef struct ucc_global_config {
     /* Coll component libraries path */
     char *component_path;
     char *component_path_default;
+    char *install_path;
     int   initialized;
     /* Profiling mode */
     unsigned                   profile_mode;
 
     /* Profiling output file name */
-    char                       *profile_file;
+    char *profile_file;
 
     /* Limit for profiling log size */
     size_t                     profile_log_size;
+    char *                     cfg_filename;
+    ucc_file_config_t *        file_cfg;
 } ucc_global_config_t;
 
 extern ucc_global_config_t ucc_global_config;

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -9,6 +9,7 @@
 #include "ucc_lib.h"
 #include "utils/ucc_log.h"
 #include "utils/ucc_malloc.h"
+#include "utils/ucc_parser.h"
 #include "utils/ucc_math.h"
 #include "components/cl/ucc_cl.h"
 #include "components/tl/ucc_tl.h"
@@ -332,6 +333,7 @@ ucc_status_t ucc_init_version(unsigned api_major_version,
         status = UCC_ERR_NO_MEMORY;
         goto error;
     }
+
     /* Initialize ucc lib handle using requirements from the user
        provided via params/config and available CLs in the
        CL component framework.
@@ -362,6 +364,10 @@ ucc_status_t ucc_lib_config_read(const char *env_prefix, const char *filename,
     ucc_status_t      status;
     size_t            full_prefix_len;
     const char       *base_prefix = "UCC_";
+
+    if (UCC_OK != (status = ucc_constructor())) {
+        return status;
+    }
 
     if (filename != NULL) {
         ucc_error("read from file is not implemented");

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -6,6 +6,7 @@
 #include "ucc_parser.h"
 #include "ucc_malloc.h"
 #include "ucc_log.h"
+#include "khash.h"
 
 ucc_status_t ucc_config_names_array_merge(ucc_config_names_array_t *dst,
                                           const ucc_config_names_array_t *src)
@@ -131,4 +132,230 @@ ucc_status_t ucc_config_allow_list_process(const ucc_config_allow_list_t * list,
         ucc_assert(0);
     }
     return status;
+}
+
+KHASH_MAP_INIT_STR(ucc_cfg_file, char *);
+
+typedef struct ucc_file_config {
+    khash_t(ucc_cfg_file) vars;
+} ucc_file_config_t;
+
+static int ucc_file_parse_handler(void *arg, const char *section,
+                                  const char *name, const char *value)
+{
+    ucc_file_config_t *cfg      = arg;
+    khash_t(ucc_cfg_file) *vars = &cfg->vars;
+    khiter_t iter;
+    int      result;
+
+    if (NULL != getenv(name)) {
+        /* variabel is set in env, skip it.
+           Env gets precedence over file */
+        ;
+        return 1;
+    }
+    if (strlen(name) < 4 || NULL == strstr(name, "UCC_")) {
+        ucc_warn("incorrect parameter name %s "
+                 "(param name should start with UCC_ or <PREFIX>_UCC_)",
+                 name);
+        return 0;
+    }
+
+    iter = kh_get(ucc_cfg_file, vars, name);
+    if (iter != kh_end(vars)) {
+        ucc_warn("found duplicate '%s' in config file", name);
+        return 0;
+    } else {
+        iter = kh_put(ucc_cfg_file, vars, strdup(name), &result);
+        if (result == UCS_KH_PUT_FAILED) {
+            ucc_error("inserting '%s' to config map failed", name);
+            return 0;
+        }
+    }
+    kh_val(vars, iter) = strdup(value);
+    return 1;
+}
+
+ucc_status_t ucc_parse_file_config(const char *        filename,
+                                   ucc_file_config_t **cfg_p)
+{
+    ucc_file_config_t *cfg;
+    int                ret;
+    ucc_status_t       status;
+
+    cfg = ucc_calloc(1, sizeof(*cfg), "file_cfg");
+    if (!cfg) {
+        ucc_error("failed to allocate %zd bytes for file config", sizeof(*cfg));
+        return UCC_ERR_NO_MEMORY;
+    }
+    ret = ini_parse(filename, ucc_file_parse_handler, cfg);
+    if (-1 == ret) {
+        /* according to ucs/ini.h -1 means error in
+           file open */
+        status = UCC_ERR_NOT_FOUND;
+        goto out;
+    } else if (ret) {
+        ucc_error("failed to parse config file %s", filename);
+        status = UCC_ERR_INVALID_PARAM;
+        goto out;
+    }
+
+    *cfg_p = cfg;
+    return UCC_OK;
+out:
+    ucc_free(cfg);
+    return status;
+}
+
+void ucc_release_file_config(ucc_file_config_t *cfg)
+{
+    const char *key;
+    char *      value;
+
+    kh_foreach(&cfg->vars, key, value, {
+        ucc_free((void *)key);
+        ucc_free(value);
+    }) kh_destroy_inplace(ucc_cfg_file, &cfg->vars);
+    ucc_free(cfg);
+}
+
+static const char *ucc_file_config_get(ucc_file_config_t *cfg,
+                                       const char *       var_name)
+{
+    khiter_t iter;
+    khash_t(ucc_cfg_file) *vars = &cfg->vars;
+
+    iter = kh_get(ucc_cfg_file, vars, var_name);
+    if (iter == kh_end(vars)) {
+        /* variable not found in prefix hash*/
+        return NULL;
+    }
+    return kh_val(vars, iter);
+}
+
+static ucc_status_t ucc_apply_file_cfg_value(void *              opts,
+                                             ucc_config_field_t *fields,
+                                             const char *        base_prefix,
+                                             const char *component_prefix,
+                                             const char *name)
+{
+    char        var[512];
+    size_t      left = sizeof(var);
+    const char *base_prefix_var;
+    const char *cfg_value;
+
+    ucc_strncpy_safe(var, base_prefix, left);
+    left -= strlen(base_prefix);
+    strncat(var, component_prefix, left);
+    left -= strlen(component_prefix);
+    strncat(var, name, left);
+
+    base_prefix_var = strstr(var, "UCC_");
+    cfg_value =
+        ucc_file_config_get(ucc_global_config.file_cfg, base_prefix_var);
+    if (cfg_value) {
+        return ucc_config_parser_set_value(opts, fields, name, cfg_value);
+    };
+
+    if (base_prefix_var != var) {
+        cfg_value = ucc_file_config_get(ucc_global_config.file_cfg, var);
+        if (cfg_value) {
+            return ucc_config_parser_set_value(opts, fields, name, cfg_value);
+        }
+    }
+
+    return UCC_ERR_NOT_FOUND;
+}
+
+static ucc_status_t ucc_apply_file_cfg(void *opts, ucc_config_field_t *fields,
+                                       const char *env_prefix,
+                                       const char *component_prefix)
+{
+    ucc_status_t status = UCC_OK;
+
+    while (fields->name != NULL) {
+        if (strlen(fields->name) == 0) {
+            status = ucc_apply_file_cfg(
+                opts, (ucc_config_field_t *)fields->parser.arg, env_prefix,
+                component_prefix);
+            if (UCC_OK != status) {
+                return status;
+            }
+            fields++;
+            continue;
+        }
+        status = ucc_apply_file_cfg_value(
+            opts, fields, env_prefix, component_prefix ? component_prefix : "",
+            fields->name);
+        if (status == UCC_ERR_NOT_FOUND && component_prefix) {
+            status = ucc_apply_file_cfg_value(opts, fields, env_prefix, "",
+                                              fields->name);
+        }
+        if (status != UCC_OK && status != UCC_ERR_NOT_FOUND) {
+            return status;
+        }
+
+        fields++;
+    }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,
+                                         const char *env_prefix,
+                                         const char *table_prefix,
+                                         int         ignore_errors)
+{
+    ucs_status_t ucs_status;
+    ucc_status_t status;
+
+    ucs_status = ucs_config_parser_fill_opts(opts, fields, env_prefix,
+                                             table_prefix, ignore_errors);
+    status     = ucs_status_to_ucc_status(ucs_status);
+
+    if (UCC_OK == status && ucc_global_config.file_cfg) {
+        status = ucc_apply_file_cfg(opts, fields, env_prefix, table_prefix);
+    }
+
+    return status;
+}
+
+void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
+                                      ucc_config_print_flags_t flags,
+                                      ucc_list_link_t *        config_list)
+{
+    const ucc_config_global_list_entry_t *entry;
+    ucs_config_print_flags_t              ucs_flags;
+    ucc_status_t                          status;
+    char                                  title[64];
+    void *                                opts;
+
+    ucs_flags = ucc_print_flags_to_ucs_print_flags(flags);
+    ucc_list_for_each(entry, config_list, list)
+    {
+        if ((entry->table == NULL) || (entry->table[0].name == NULL)) {
+            /* don't print title for an empty configuration table */
+            continue;
+        }
+
+        opts = ucc_malloc(entry->size, "tmp_opts");
+        if (opts == NULL) {
+            ucc_error("could not allocate configuration of size %zu",
+                      entry->size);
+            continue;
+        }
+
+        status = ucc_config_parser_fill_opts(opts, entry->table, prefix,
+                                             entry->prefix, 0);
+        if (status != UCC_OK) {
+            ucc_free(opts);
+            continue;
+        }
+
+        snprintf(title, sizeof(title), "%s configuration", entry->name);
+        ucs_config_parser_print_opts(stream, title, opts, entry->table,
+                                     entry->prefix, prefix, ucs_flags);
+
+        ucs_config_parser_release_opts(opts, entry->table);
+        ucc_free(opts);
+    }
 }

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -18,11 +18,14 @@
 #include <ucs/sys/compiler_def.h>
 #include <ucs/config/types.h>
 #include <ucs/config/parser.h>
+#include <ucs/config/ini.h>
 
 typedef ucs_config_field_t             ucc_config_field_t;
 typedef ucs_config_names_array_t       ucc_config_names_array_t;
 typedef ucs_config_global_list_entry_t ucc_config_global_list_entry_t;
 typedef ucs_config_allow_list_t        ucc_config_allow_list_t;
+
+typedef struct ucc_file_config ucc_file_config_t;
 
 #define UCC_CONFIG_TYPE_LOG_COMP        UCS_CONFIG_TYPE_LOG_COMP
 #define UCC_CONFIG_REGISTER_TABLE       UCS_CONFIG_REGISTER_TABLE
@@ -61,15 +64,10 @@ typedef struct ucc_config_names_list {
     };
 } ucc_config_names_list_t;
 
-static inline ucc_status_t
-ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,
-                            const char *env_prefix, const char *table_prefix,
-                            int ignore_errors)
-{
-    ucs_status_t status = ucs_config_parser_fill_opts(
-        opts, fields, env_prefix, table_prefix, ignore_errors);
-    return ucs_status_to_ucc_status(status);
-}
+ucc_status_t ucc_config_parser_fill_opts(void *opts, ucc_config_field_t *fields,
+                                         const char *env_prefix,
+                                         const char *table_prefix,
+                                         int         ignore_errors);
 
 static inline void
 ucc_config_parser_release_opts(void *opts, ucc_config_field_t *fields)
@@ -121,16 +119,9 @@ static inline void ucc_config_parser_print_opts(FILE *stream, const char *title,
                                  prefix, ucs_flags);
 }
 
-static inline void
-ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
-                                 ucc_config_print_flags_t flags,
-                                 ucc_list_link_t *config_list)
-{
-    ucs_config_print_flags_t ucs_flags;
-
-    ucs_flags = ucc_print_flags_to_ucs_print_flags(flags);
-    ucs_config_parser_print_all_opts(stream, prefix, ucs_flags, config_list);
-}
+void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
+                                      ucc_config_print_flags_t flags,
+                                      ucc_list_link_t *        config_list);
 
 ucc_status_t ucc_config_names_array_dup(ucc_config_names_array_t *dst,
                                         const ucc_config_names_array_t *src);
@@ -152,5 +143,9 @@ int ucc_config_names_array_is_all(const ucc_config_names_array_t *array)
 ucc_status_t ucc_config_allow_list_process(const ucc_config_allow_list_t * list,
                                            const ucc_config_names_array_t *all,
                                            ucc_config_names_list_t *       out);
+
+ucc_status_t ucc_parse_file_config(const char *        filename,
+                                   ucc_file_config_t **cfg);
+void         ucc_release_file_config(ucc_file_config_t *cfg);
 
 #endif

--- a/src/utils/ucc_string.c
+++ b/src/utils/ucc_string.c
@@ -111,3 +111,22 @@ const char* ucc_strstr_last(const char* string, const char* pattern)
     }
     return found;
 }
+
+ucc_status_t ucc_str_concat(const char *str1, const char *str2,
+                            char **out)
+{
+    size_t len;
+    char  *rst;
+
+    len = strlen(str1) + strlen(str2) + 1;
+    rst = ucc_malloc(len, "str_concat");
+    if (!rst) {
+        ucc_error("failed to allocate %zd bytes for concatenated string", len);
+        return UCC_ERR_NO_MEMORY;
+    }
+    ucc_strncpy_safe(rst, str1, len);
+    len -= strlen(str1);
+    strncat(rst, str2, len);
+    *out = rst;
+    return UCC_OK;
+}

--- a/src/utils/ucc_string.h
+++ b/src/utils/ucc_string.h
@@ -8,6 +8,8 @@
 #include "config.h"
 #include "ucc/api/ucc_status.h"
 
+#define      ucc_memunits_range_str ucs_memunits_range_str
+
 char**       ucc_str_split(const char *str, const char *delim);
 
 unsigned     ucc_str_split_count(char **split);
@@ -20,6 +22,9 @@ ucc_status_t ucc_str_to_memunits(const char *buf, void *dest);
 
 /* Finds last occurence of pattern in string */
 const char*  ucc_strstr_last(const char* string, const char* pattern);
-#define      ucc_memunits_range_str ucs_memunits_range_str
 
+/* Concatenates 2 strings. The space allocated for "out" must be
+   released with ucc_free. */
+ucc_status_t ucc_str_concat(const char *str1, const char *str2,
+                            char **out);
 #endif

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -61,7 +61,8 @@ gtest_LDFLAGS = $(GTEST_LDFLAGS) -pthread -no-install -Wl,-dynamic-list-data \
 gtest_CFLAGS   = $(BASE_CFLAGS) $(AM_CPPFLAGS)
 gtest_CXXFLAGS = -std=gnu++11 \
 	$(BASE_CXXFLAGS) $(GTEST_CXXFLAGS) \
-	-DGTEST_UCM_HOOK_LIB_DIR="\"${abs_builddir}/ucm/test_dlopen/.libs\""
+	-DGTEST_UCM_HOOK_LIB_DIR="\"${abs_builddir}/ucm/test_dlopen/.libs\"" \
+	-DGTEST_UCC_TOP_SRCDIR="\"${UCC_TOP_SRCDIR}\""
 
 gtest_SOURCES =                     \
 	common/gtest-all.cc             \
@@ -95,6 +96,7 @@ gtest_SOURCES =                     \
 	utils/test_ep_map.cc            \
 	utils/test_lock_free_queue.cc   \
 	utils/test_math.cc              \
+	utils/test_cfg_file.cc          \
 	coll_score/test_score.cc        \
 	coll_score/test_score_str.cc    \
 	coll_score/test_score_update.cc

--- a/test/gtest/utils/test_cfg_file.cc
+++ b/test/gtest/utils/test_cfg_file.cc
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+extern "C" {
+#include "utils/ucc_parser.h"
+#include "core/ucc_global_opts.h"
+}
+#include <common/test.h>
+
+typedef struct ucc_gtest_config_base {
+    int foo;
+} ucc_gtest_config_base_t;
+
+typedef struct ucc_gtest_config {
+    ucc_gtest_config_base_t super;
+    int                     bar;
+    int                     boo;
+} ucc_gtest_config_t;
+
+
+static ucc_config_field_t ucc_gtest_config_table_base[] = {
+    {"FOO", "1", "gtest base config variable",
+     ucc_offsetof(ucc_gtest_config_base_t, foo),
+     UCC_CONFIG_TYPE_INT},
+
+    {NULL}
+};
+
+static ucc_config_field_t ucc_gtest_config_table[] = {
+    {"", "", NULL, ucc_offsetof(ucc_gtest_config_t, super),
+     UCC_CONFIG_TYPE_TABLE(ucc_gtest_config_table_base)},
+
+    {"BAR", "1", "gtest config variable",
+     ucc_offsetof(ucc_gtest_config_t, bar),
+     UCC_CONFIG_TYPE_INT},
+
+    {"BOO", "1", "gtest config variable",
+     ucc_offsetof(ucc_gtest_config_t, boo),
+     UCC_CONFIG_TYPE_INT},
+
+    {NULL}
+};
+
+class test_cfg_file : public ucc::test {
+public:
+    ucc_file_config_t  *file_cfg;
+    ucc_gtest_config_t  cfg;
+    std::string         test_dir;
+    test_cfg_file() {
+        file_cfg = NULL;
+        test_dir = std::string(GTEST_UCC_TOP_SRCDIR) +
+            "/test/gtest/utils/";
+    }
+    ~test_cfg_file() {
+        if (file_cfg) {
+            ucc_release_file_config(file_cfg);
+        }
+        ucc_config_parser_release_opts(&cfg, ucc_gtest_config_table);
+    }
+    void init_cfg() {
+        ucc_status_t status;
+        std::swap(ucc_global_config.file_cfg, file_cfg);
+        status = ucc_config_parser_fill_opts(&cfg, ucc_gtest_config_table,
+                                             "GTEST_UCC_", "CFG_", 1);
+        std::swap(ucc_global_config.file_cfg, file_cfg);
+        EXPECT_EQ(UCC_OK, status);
+    };
+};
+
+UCC_TEST_F(test_cfg_file, parse_existing) {
+    std::string filename = test_dir + "ucc_test.conf";
+
+    EXPECT_EQ(UCC_OK, ucc_parse_file_config(filename.c_str(), &file_cfg));
+}
+
+UCC_TEST_F(test_cfg_file, parse_non_existing) {
+    std::string filename = test_dir + "ucc_test_nonexisting.conf";
+
+    EXPECT_EQ(UCC_ERR_NOT_FOUND, ucc_parse_file_config(filename.c_str(),
+                                                       &file_cfg));
+}
+
+/* Checks options are applied from cfg file */
+UCC_TEST_F(test_cfg_file, opts_applied) {
+    std::string filename = test_dir + "ucc_test.conf";
+
+    EXPECT_EQ(UCC_OK, ucc_parse_file_config(filename.c_str(), &file_cfg));
+    init_cfg();
+    EXPECT_EQ(10, cfg.super.foo);
+    EXPECT_EQ(20, cfg.bar);
+    EXPECT_EQ(1,  cfg.boo);
+}
+
+/* Checks that options set via env var have preference
+   over cfg file */
+UCC_TEST_F(test_cfg_file, env_preference) {
+    std::string filename = test_dir + "ucc_test.conf";
+
+    setenv("GTEST_UCC_CFG_BAR", "123", 1);
+    EXPECT_EQ(UCC_OK, ucc_parse_file_config(filename.c_str(), &file_cfg));
+    init_cfg();
+    unsetenv("GTEST_UCC_CFG_BAR");
+    EXPECT_EQ(10, cfg.super.foo);
+    /* Expected value is 123 from env rather than 20 from file */
+    EXPECT_EQ(123, cfg.bar);
+    EXPECT_EQ(1,  cfg.boo);
+}

--- a/test/gtest/utils/test_string.cc
+++ b/test/gtest/utils/test_string.cc
@@ -4,6 +4,7 @@
  */
 extern "C" {
 #include "utils/ucc_string.h"
+#include "utils/ucc_malloc.h"
 }
 #include <common/test.h>
 #include <string>
@@ -78,4 +79,25 @@ UCC_TEST_F(test_string, find_last)
 
     s = ucc_strstr_last(str2, "/tmp");
     EXPECT_EQ(str2, s);
+}
+
+UCC_TEST_F(test_string, concat)
+{
+    char *rst;
+
+    EXPECT_EQ(UCC_OK, ucc_str_concat("aaa", "bbb", &rst));
+    EXPECT_EQ("aaabbb", std::string(rst));
+    ucc_free(rst);
+
+    EXPECT_EQ(UCC_OK, ucc_str_concat("aaabbbccc", "d", &rst));
+    EXPECT_EQ("aaabbbcccd", std::string(rst));
+    ucc_free(rst);
+
+    EXPECT_EQ(UCC_OK, ucc_str_concat("aaa", "", &rst));
+    EXPECT_EQ("aaa", std::string(rst));
+    ucc_free(rst);
+
+    EXPECT_EQ(UCC_OK, ucc_str_concat("", "aaa", &rst));
+    EXPECT_EQ("aaa", std::string(rst));
+    ucc_free(rst);
 }

--- a/test/gtest/utils/ucc_test.conf
+++ b/test/gtest/utils/ucc_test.conf
@@ -1,0 +1,8 @@
+# Some random comment
+
+UCC_FOO = 10 ## Tests setting global variable
+
+GTEST_UCC_CFG_BAR = 20 ;; test setting var with ENV_PREFIX = GTEST
+
+#variable with undefined ENV_PREFIX - will be ignored
+GGGTEST_UCC_BOO = 30


### PR DESCRIPTION
## What
Adds support for configuration files with UCC parameters

## Why ?
Allows distribution of UCC with pre-built configuration

## How ?
configuration file can contain any UCC variables in the format var = value (";" symbol in the begging of the file comments out the setting). Configuration file is searched by the library once during ucc_constructor call: firstly the env variable UCC_CONFIG_FILE is checked (it has highest precedence); if not found the default file "ucc.conf" is checked in the $HOME; if not found the default file "ucc.conf" is checked in the <ucc_install_dir>/share/ucc.conf.

Example config file:
UCC_TL_UCP_LOG_LEVEL=info
UCC_TLS=ucp
MPI_UCC_TL_UCP_KN_RADIX=3 ;; MPI_ prefix means that the var only affects UCC lib objects with "MPI" env prefix

NOTES:
why "filename" arguments from ucc_lib_confi_read and ucc_context_config_read are not used ?
main problem is user experience: it is not clear for user which variable belongs to "lib" and which to "context", ie user will need to maintain 2 different files and understand which variable to put into each file.
Having 1 global file makes it much more usable imho. 

another reason: ec/mc configrations (e.g. mpool settings). these components are singletons (ie initialized only once, and they are global objects for all ucc_lib objects in the memory space of a process), and their configurations must be global, so can't be read from lib/context specific "files". 

If required we can extend the support for those "filename" args in lib/context_config_read but they will only be applied for some set of variables. I would postpone that until explicitly requested by anyone.
