### PR TITLE
TL/CUDA: fix zero size rs and ag

### DIFF
--- a/src/components/tl/cuda/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv_ring.c
@@ -243,6 +243,12 @@ ucc_status_t ucc_tl_cuda_allgatherv_ring_start(ucc_coll_task_t *coll_task)
     for (i = 1; i < tsize; i++) {
         send_size = ucc_max(send_size, task->allgatherv_ring.get_count(task, i));
     }
+
+    if (send_size == 0) {
+        task->super.status = UCC_OK;
+        return ucc_task_complete(&task->super);
+    }
+
     send_size = ucc_dt_size(task->allgatherv_ring.dt) * send_size;
     frag_size = ucc_min(ssize/2, send_size);
 

--- a/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_ring.c
@@ -220,6 +220,12 @@ ucc_status_t ucc_tl_cuda_reduce_scatterv_ring_start(ucc_coll_task_t *coll_task)
         send_size = ucc_max(send_size,
                             task->reduce_scatterv_ring.get_count(task, i));
     }
+
+    if (send_size == 0) {
+        task->super.status = UCC_OK;
+        return ucc_task_complete(&task->super);
+    }
+
     frag_size = ucc_min(ssize / ucc_dt_size(dt) / 2, send_size);
 
     task->reduce_scatterv_ring.num_frags = ucc_div_round_up(send_size, frag_size);


### PR DESCRIPTION
## What
Fixes integer divide by zero exception in TL CUDA reduce scatter and allgather when count is 0
