### PR TITLE
TEST: fix verbose option

### DIFF
--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -348,6 +348,7 @@ void ProcessArgs(int argc, char** argv)
                                 {"iter", required_argument, nullptr, 'i'},
                                 {"thread-multiple", no_argument, nullptr, 'T'},
                                 {"num_tests", required_argument, nullptr, 'N'},
+                                {"verbose", no_argument, nullptr, 'v'},
 #ifdef HAVE_CUDA
                                 {"set_device", required_argument, nullptr, 'S'},
 #endif


### PR DESCRIPTION
## What
Fix parsing long option "--verbose" in ucc_test_mpi 
