### PR TITLE
TOOLS: perftest: remove cuda dep

### DIFF
--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -13,6 +13,7 @@ ucc_perftest_SOURCES =            \
 	ucc_perftest.cc               \
 	ucc_pt_config.cc              \
 	ucc_pt_comm.cc                \
+	ucc_pt_cuda.cc                \
 	ucc_pt_benchmark.cc           \
 	ucc_pt_bootstrap_mpi.cc       \
 	ucc_pt_coll.cc                \
@@ -32,9 +33,3 @@ ucc_perftest_CPPFLAGS = $(BASE_CPPFLAGS)
 ucc_perftest_CXXFLAGS = -std=gnu++11 $(BASE_CXXFLAGS)
 ucc_perftest_LDFLAGS = -Wl,--rpath-link=${UCS_LIBDIR}
 ucc_perftest_LDADD = $(UCC_TOP_BUILDDIR)/src/libucc.la
-
-if HAVE_CUDA
-ucc_perftest_CPPFLAGS += $(CUDA_CPPFLAGS)
-ucc_perftest_LDFLAGS += $(CUDA_LDFLAGS)
-ucc_perftest_LDADD += $(CUDA_LIBS)
-endif

--- a/tools/perf/ucc_perftest.cc
+++ b/tools/perf/ucc_perftest.cc
@@ -2,6 +2,7 @@
 #include "ucc_pt_comm.h"
 #include "ucc_pt_config.h"
 #include "ucc_pt_coll.h"
+#include "ucc_pt_cuda.h"
 #include "ucc_pt_benchmark.h"
 
 int main(int argc, char *argv[])
@@ -12,6 +13,7 @@ int main(int argc, char *argv[])
     ucc_status_t st;
 
     pt_config.process_args(argc, argv);
+    ucc_pt_cuda_init();
     try {
         comm = new ucc_pt_comm(pt_config.comm);
     } catch(std::exception &e) {

--- a/tools/perf/ucc_perftest.h
+++ b/tools/perf/ucc_perftest.h
@@ -31,17 +31,3 @@ extern "C" {
             goto _label;                                                       \
         }                                                                      \
     } while (0)
-
-#ifdef HAVE_CUDA
-#include <cuda_runtime_api.h>
-#define CUDA_CHECK_GOTO(_call, _label, _status)                                \
-    do {                                                                       \
-        _status = (_call);                                                     \
-        if (cudaSuccess != _status) {                                          \
-            std::cerr << "UCC perftest error: " << cudaGetErrorString(_status) \
-                      << " in " << STR(_call) << "\n";                         \
-            goto _label;                                                       \
-        }                                                                      \
-    } while (0)
-
-#endif

--- a/tools/perf/ucc_pt_cuda.cc
+++ b/tools/perf/ucc_pt_cuda.cc
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_pt_cuda.h"
+#include <iostream>
+#include <dlfcn.h>
+#include <stdlib.h>
+
+ucc_pt_cuda_iface_t ucc_pt_cuda_iface = {
+    .available = 0,
+};
+
+#define LOAD_CUDA_SYM(_sym, _pt_sym) ({                                    \
+            void *h = dlsym(handle, _sym);                                 \
+            if ((error = dlerror()) != NULL)  {                            \
+                return;                                                    \
+            }                                                              \
+            ucc_pt_cuda_iface. _pt_sym =                                   \
+                reinterpret_cast<decltype(ucc_pt_cuda_iface. _pt_sym)>(h); \
+        })
+
+void ucc_pt_cuda_init(void)
+{
+    char *error;
+    void *handle;
+
+    handle = dlopen ("libcudart.so", RTLD_LAZY);
+    if (!handle) {
+        return;
+    }
+    LOAD_CUDA_SYM("cudaGetDeviceCount", getDeviceCount);
+    LOAD_CUDA_SYM("cudaSetDevice", setDevice);
+    LOAD_CUDA_SYM("cudaGetErrorString", getErrorString);
+    ucc_pt_cuda_iface.available = 1;
+}

--- a/tools/perf/ucc_pt_cuda.h
+++ b/tools/perf/ucc_pt_cuda.h
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_PT_CUDA_H
+#define UCC_PT_CUDA_H
+#include <iostream>
+
+typedef struct ucc_pt_cuda_iface {
+    int available;
+    int (*getDeviceCount)(int* count);
+    int (*setDevice)(int device);
+    char* (*getErrorString)(int err);
+} ucc_pt_cuda_iface_t;
+
+extern ucc_pt_cuda_iface_t ucc_pt_cuda_iface;
+void ucc_pt_cuda_init(void);
+
+#define cudaSuccess 0
+
+#define STR(x) #x
+#define CUDA_CHECK(_call)                                       \
+    do {                                                        \
+        int _status = (_call);                                  \
+        if (cudaSuccess != _status) {                           \
+            std::cerr << "UCC perftest error: " <<              \
+                ucc_pt_cuda_iface.getErrorString(_status)       \
+                      << " in " << STR(_call) << "\n";          \
+            return _status;                                     \
+        }                                                       \
+    } while (0)
+
+static inline int ucc_pt_cudaGetDeviceCount(int *count)
+{
+    if (!ucc_pt_cuda_iface.available) {
+        return 1;
+    }
+    CUDA_CHECK(ucc_pt_cuda_iface.getDeviceCount(count));
+    return 0;
+}
+
+static inline int ucc_pt_cudaSetDevice(int device)
+{
+    if (!ucc_pt_cuda_iface.available) {
+        return 1;
+    }
+    CUDA_CHECK(ucc_pt_cuda_iface.setDevice(device));
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## What
Removes explicit link dependency of ucc_perftest on libcudart. Required cuda functions are loaded in runtime via dlopen.

## Why ?
ucc_perftest binary will be distributed as part of binary package and should work on systems with and w/o cuda.


