### PR TITLE
TOOLS: perf: fix build

### DIFF
--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -32,4 +32,4 @@ LD=$(MPICXX)
 ucc_perftest_CPPFLAGS = $(BASE_CPPFLAGS)
 ucc_perftest_CXXFLAGS = -std=gnu++11 $(BASE_CXXFLAGS)
 ucc_perftest_LDFLAGS = -Wl,--rpath-link=${UCS_LIBDIR}
-ucc_perftest_LDADD = $(UCC_TOP_BUILDDIR)/src/libucc.la
+ucc_perftest_LDADD = $(UCC_TOP_BUILDDIR)/src/libucc.la -ldl


### PR DESCRIPTION
## What
Fixes build of ucc_perftest due to "/usr/bin/ld: ucc_perftest-ucc_pt_cuda.o: undefined reference to symbol 'dlsym@@GLIBC_2.2.5'"

