### PR TITLE
TOOLS: assign comm.mt default value

### DIFF
--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -18,6 +18,7 @@ ucc_pt_config::ucc_pt_config() {
     bench.n_warmup_large = 20;
     bench.large_thresh   = 64 * 1024;
     bench.full_print     = false;
+    comm.mt              = bench.mt;
 }
 
 const std::map<std::string, ucc_reduction_op_t> ucc_pt_op_map = {


### PR DESCRIPTION
## What
Assign comm.mt default value

## Why ?
Beforehand, was throwing error unless user specified mt 
