### PR TITLE
(tl_mlx5_4) UTIL: rcache_get_arg

### DIFF
--- a/src/components/tl/sharp/tl_sharp_coll.c
+++ b/src/components/tl/sharp/tl_sharp_coll.c
@@ -92,7 +92,8 @@ ucc_tl_sharp_mem_register(ucc_tl_sharp_context_t *ctx, void *addr,
     }
 
     if (ctx->rcache) {
-        status = ucc_rcache_get(ctx->rcache, (void *)addr, length, &rregion);
+        status = ucc_rcache_get(ctx->rcache, (void *)addr, length, NULL,
+                                &rregion);
         if (status != UCC_OK) {
             tl_error(ctx->super.super.lib, "ucc_rcache_get failed");
             return UCC_ERR_INVALID_PARAM;

--- a/src/utils/ucc_rcache.h
+++ b/src/utils/ucc_rcache.h
@@ -29,13 +29,16 @@ ucc_rcache_create(const ucc_rcache_params_t *params,
                                         params, name, NULL, rcache_p));
 }
 
+/* [arg] parameter allows passing additional information from mem_reg callabck.
+   For example, it can be used to indicate whether the entry was found in the
+   cache or new registration happened. */
 static inline ucc_status_t
 ucc_rcache_get(ucc_rcache_t *rcache, void *address, size_t length,
-               ucc_rcache_region_t **region_p)
+               void *arg, ucc_rcache_region_t **region_p)
 {
     return ucs_status_to_ucc_status(ucs_rcache_get(
                                        rcache, address, length,
-                                       PROT_READ | PROT_WRITE, NULL, region_p));
+                                       PROT_READ | PROT_WRITE, arg, region_p));
 }
 
 #endif


### PR DESCRIPTION
## What
Extended version of ucc_rcache_get that supports in/out "args" parameter. 

## Why ?
Used in tl/mlx5 to indicate if rache entry was modified (i.e., if actual memory dereg/reg happened). In this case tl/mlx5 needs to update umr mkeys.
