### PR TITLE
(tl_mlx5_5) CORE: ctx service team flag

### DIFF
--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -41,8 +41,9 @@ typedef struct ucc_base_ctx_config {
 } ucc_base_ctx_config_t;
 
 enum {
-    UCC_BASE_LIB_FLAG_TEAM_ID_REQUIRED      = UCC_BIT(1),
-    UCC_BASE_LIB_FLAG_SERVICE_TEAM_REQUIRED = UCC_BIT(2)
+    UCC_BASE_LIB_FLAG_TEAM_ID_REQUIRED          = UCC_BIT(1),
+    UCC_BASE_LIB_FLAG_SERVICE_TEAM_REQUIRED     = UCC_BIT(2),
+    UCC_BASE_LIB_FLAG_CTX_SERVICE_TEAM_REQUIRED = UCC_BIT(3)
 };
 
 typedef struct ucc_base_lib_attr_t {

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -361,7 +361,11 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
     ucc_base_context_t *b_ctx;
     int                 i, num_tls;
     ucc_status_t        status;
+    ucc_base_lib_attr_t attr;
+    int                 ctx_service_team;
 
+    ctx_service_team = ctx_config->internal_oob &&
+        b_params.params.mask & UCC_CONTEXT_PARAM_FIELD_OOB;
     num_tls = ctx_config->n_tl_cfg;
     ctx->tl_ctx = (ucc_tl_context_t **)ucc_malloc(
         sizeof(ucc_tl_context_t *) * num_tls, "tl_ctx_array");
@@ -373,6 +377,17 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
     ctx->n_tl_ctx = 0;
     for (i = 0; i < num_tls; i++) {
         tl_lib = ctx_config->tl_cfgs[i]->tl_lib;
+        status = tl_lib->iface->lib.get_attr(&tl_lib->super, &attr);
+        if (UCC_OK != status) {
+            ucc_error("failed to query tl lib %s attr", tl_lib->iface->super.name);
+            return status;
+        }
+        if ((attr.flags & UCC_BASE_LIB_FLAG_CTX_SERVICE_TEAM_REQUIRED) &&
+            (!ctx_service_team)) {
+            ucc_debug("can not create tl/%s context because context service team "
+                      "is not available for it", tl_lib->iface->super.name);
+            continue;
+        }
         status = tl_lib->iface->context.create(
             &b_params, &ctx_config->tl_cfgs[i]->super.super, &b_ctx);
         if (UCC_OK != status) {


### PR DESCRIPTION
## What
Adds UCC_BASE_LIB_FLAG_CTX_SERVICE_TEAM_REQUIRED to the tl_context attribute flags. This flag allows a TL to indicate that it requires a service_team during tl context creation.

## Why ?
TL/MLX5 needs to establish shared_pd during tl context creation. For that it requires OOB exchange over "node" subgroup. It is done using service team that needs to be available at ctx creation. If it is not available tl/mlx5 context should be skipped.

