### PR TITLE
UTIL: mpool init fix

### DIFF
--- a/src/utils/ucc_mpool.c
+++ b/src/utils/ucc_mpool.c
@@ -44,6 +44,9 @@ ucc_status_t ucc_mpool_init(ucc_mpool_t *mp, size_t priv_size, size_t elem_size,
                             const char *name)
 {
     ucs_mpool_ops_t *ucs_ops = ucc_calloc(1, sizeof(*ucs_ops), "mpool_ops");
+#if UCS_HAVE_MPOOL_PARAMS
+    ucs_mpool_params_t params;
+#endif
 
     if (!ucs_ops) {
         ucc_error("failed to allocate %zd bytes for mpool ucs ops",
@@ -63,19 +66,19 @@ ucc_status_t ucc_mpool_init(ucc_mpool_t *mp, size_t priv_size, size_t elem_size,
         ucs_ops->obj_cleanup = ucc_mpool_obj_cleanup_wrapper;
     }
 #if UCS_HAVE_MPOOL_PARAMS
-    ucs_mpool_params_t params = {
-        .priv_size       = priv_size,
-        .elem_size       = elem_size,
-        .align_offset    = align_offset,
-        .alignment       = alignment,
-        .malloc_safe     = 0,
-        .elems_per_chunk = elems_per_chunk,
-        .max_chunk_size  = elems_per_chunk * elem_size,
-        .max_elems       = max_elems,
-        .grow_factor     = 1.0,
-        .ops             = ucs_ops,
-        .name            = name
-    };
+    ucs_mpool_params_reset(&params);
+    params.priv_size       = priv_size;
+    params.elem_size       = elem_size;
+    params.align_offset    = align_offset;
+    params.alignment       = alignment;
+    params.malloc_safe     = 0;
+    params.elems_per_chunk = elems_per_chunk;
+    params.max_chunk_size  = SIZE_MAX;
+    params.max_elems       = max_elems;
+    params.grow_factor     = 1.0;
+    params.ops             = ucs_ops;
+    params.name            = name;
+
     return ucs_status_to_ucc_status(ucs_mpool_init(&params, &mp->super));
 #else
     return ucs_status_to_ucc_status(


### PR DESCRIPTION
## What
Fixes data corruption with the new mpool interface.
For small elem_sizes (e.g. in mc/cuda elem size is sizeof(ucc_mc_cuda_mpool_header_t) = 16b) setting max_chunk_size = elems_per_chunk * elem_size just seems correct. But elem_size is aligned up internally in UCS. this makes elem_size  > max_chunk_size which is not correctly handled in UCS. Setting grow_factor = 1 and max_chunk_size = SIZE_MAX fixes it and makes behaviour similar to legacy api.


