### PR TITLE
TL/RCCL: fix configure logic and allgatherv score

### DIFF
--- a/config/m4/rccl.m4
+++ b/config/m4/rccl.m4
@@ -38,7 +38,7 @@ AS_IF([test "x$rccl_checked" != "xyes"],[
         [
             CPPFLAGS="$HIP_CPPFLAGS $CPPFLAGS"
             LDFLAGS="$ROCM_LDFLAGS $LDFLAGS"
-            AC_CHECK_HEADER([rccl.h],
+            AC_CHECK_HEADER([rccl/rccl.h],
             [
                 AC_CHECK_LIB([rccl], [ncclCommInitRank],
                 [
@@ -49,7 +49,17 @@ AS_IF([test "x$rccl_checked" != "xyes"],[
                 ])
             ],
             [
-                rccl_happy="no"
+                AC_CHECK_HEADER([rccl.h],
+                [
+                    AC_CHECK_LIB([rccl], [ncclCommInitRank],
+ 	    	    [
+			rccl_happy="yes"
+		        rccl_old_headers="-DRCCL_OLD_HEADERS"
+                    ],
+                    [
+			rccl_happy="no"
+                    ])
+                ]),
             ])
         ],
         [
@@ -61,7 +71,7 @@ AS_IF([test "x$rccl_checked" != "xyes"],[
             AS_IF([test "x$check_rccl_dir" != "x"],
             [
                 AC_MSG_RESULT([RCCL dir: $check_rccl_dir])
-                AC_SUBST(RCCL_CPPFLAGS, "-I$check_rccl_dir/include/")
+                AC_SUBST(RCCL_CPPFLAGS, "-I$check_rccl_dir/include/ $rccl_old_headers")
             ])
 
             AS_IF([test "x$check_rccl_libdir" != "x"],

--- a/src/components/tl/rccl/allgatherv/allgatherv.h
+++ b/src/components/tl/rccl/allgatherv/allgatherv.h
@@ -18,7 +18,7 @@ enum {
 };
 
 #define UCC_TL_RCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR                          \
-    "allgatherv:0-16k:@0#allgatherv:16k-1M:@1#allgatherv:1M-inf:@2"
+    "allgatherv:rocm:0-16k:@0#allgatherv:rocm:16k-1M:@1#allgatherv:rocm:1M-inf:@2"
 
 extern ucc_base_coll_alg_info_t
              ucc_tl_rccl_allgatherv_algs[UCC_TL_RCCL_ALLGATHERV_ALG_LAST + 1];

--- a/src/components/tl/rccl/tl_rccl.h
+++ b/src/components/tl/rccl/tl_rccl.h
@@ -16,7 +16,12 @@
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
+
+#ifdef RCCL_OLD_HEADERS
+#include <rccl.h>
+#else
 #include <rccl/rccl.h>
+#endif
 
 #ifndef UCC_TL_RCCL_DEFAULT_SCORE
 #define UCC_TL_RCCL_DEFAULT_SCORE 20


### PR DESCRIPTION
Two minor fixes to the TL/RCCL component

## What
 - update the RCCL configure logic to recognize also old header file location
   used before ROCm 5.0
- Previous version incorrectly specified score for all mem types with
  allgatherv in TL/RCCL. It breaks host memory allgatherv because it was directed to
  RCCL TL which does not handle such pattern. This patch fixes it by adding
  the rocm mem type in UCC_TL_RCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR

## Why ?
bug fixes

