### PR TITLE
EC/ROCM: add support for using rocm memory from tl/upc

### DIFF
--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -120,8 +120,14 @@ AS_IF([test "x$with_rocm" != "xno"],
     LDFLAGS="$SAVE_LDFLAGS"
     LIBS="$SAVE_LIBS"
 
+
+    AS_IF([test "x$hip_happy" = "xyes"],
+          [AC_PATH_PROG([HIPCC], [hipcc], [notfound], [$PATH:$with_rocm/bin])])
+         AS_IF([test "$HIPCC" = "notfound"], [hip_happy="no"])
+
     AS_IF([test "x$hip_happy" = "xyes"],
           [AC_DEFINE([HAVE_HIP], 1, [Enable HIP support])
+           AC_SUBST([HIPCC])
            AC_SUBST([HIP_CPPFLAGS])
            AC_SUBST([HIP_CXXFLAGS])
            AC_SUBST([HIP_LDFLAGS])

--- a/configure.ac
+++ b/configure.ac
@@ -215,8 +215,10 @@ AC_CONFIG_FILES([
                  src/components/ec/cuda/Makefile
                  src/components/ec/cuda/kernel/Makefile
                  src/components/mc/rocm/Makefile
+                 src/components/mc/rocm/kernel/Makefile
                  src/components/ec/rocm/Makefile
-		 test/mpi/Makefile
+                 src/components/ec/rocm/kernel/Makefile
+                 test/mpi/Makefile
                  test/gtest/Makefile
                  tools/info/Makefile
                  tools/perf/Makefile

--- a/src/components/ec/rocm/Makefile.am
+++ b/src/components/ec/rocm/Makefile.am
@@ -4,10 +4,15 @@
 #
 
 if HAVE_ROCM
+SUBDIRS = kernel
 
-sources =    \
-	ec_rocm.h \
-	ec_rocm.c
+sources =                                \
+	ec_rocm.h                        \
+	ec_rocm.c                        \
+	ec_rocm_executor.h               \
+	ec_rocm_executor.c               \
+	ec_rocm_executor_interruptible.c \
+	ec_rocm_executor_persistent.c
 
 module_LTLIBRARIES         = libucc_ec_rocm.la
 libucc_ec_rocm_la_SOURCES  = $(sources)
@@ -15,7 +20,8 @@ libucc_ec_rocm_la_CPPFLAGS = $(AM_CPPFLAGS) $(HIP_CPPFLAGS) $(ROCM_CPPFLAGS) $(B
 libucc_ec_rocm_la_CFLAGS   = $(BASE_CFLAGS)
 libucc_ec_rocm_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(HIP_LDFLAGS) $(ROCM_LDFLAGS)
 libucc_ec_rocm_la_LIBADD   = $(HIP_LIBS) $(ROCM_LIBS)          \
-                             $(UCC_TOP_BUILDDIR)/src/libucc.la
+			     kernel/libucc_ec_rocm_kernels.la  \
+			     $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 include $(top_srcdir)/config/module.am
 endif

--- a/src/components/ec/rocm/ec_rocm.c
+++ b/src/components/ec/rocm/ec_rocm.c
@@ -6,6 +6,7 @@
  */
 
 #include "ec_rocm.h"
+#include "ec_rocm_executor.h"
 #include "utils/ucc_malloc.h"
 #include "utils/arch/cpu.h"
 #include <hip/hip_runtime.h>
@@ -49,8 +50,84 @@ static ucc_config_field_t ucc_ec_rocm_config_table[] = {
      ucc_offsetof(ucc_ec_rocm_config_t, stream_blocking_wait),
      UCC_CONFIG_TYPE_UINT},
 
+    {"EXEC_NUM_WORKERS", "1",
+     "Number of thread blocks to use for rocm executor",
+     ucc_offsetof(ucc_ec_rocm_config_t, exec_num_workers),
+     UCC_CONFIG_TYPE_ULUNITS},
+
+    {"EXEC_NUM_THREADS", "512",
+     "Number of thread per block to use for rocm executor",
+     ucc_offsetof(ucc_ec_rocm_config_t, exec_num_threads),
+     UCC_CONFIG_TYPE_ULUNITS},
+
+    {"EXEC_MAX_TASKS", "128",
+     "Maximum number of outstanding tasks per executor",
+     ucc_offsetof(ucc_ec_rocm_config_t, exec_max_tasks),
+     UCC_CONFIG_TYPE_ULUNITS},
+
+    {"EXEC_NUM_STREAMS", "16",
+     "Number of streams used by interruptible executor",
+     ucc_offsetof(ucc_ec_rocm_config_t, exec_num_streams),
+     UCC_CONFIG_TYPE_ULUNITS},
+
     {NULL}
+
 };
+
+static ucc_status_t ucc_ec_rocm_ee_executor_mpool_chunk_malloc(ucc_mpool_t *mp,
+                                                               size_t *size_p,
+                                                               void ** chunk_p)
+{
+    return ROCM_FUNC(hipHostMalloc((void**)chunk_p, *size_p,
+                                   hipHostMallocMapped));
+}
+
+static void ucc_ec_rocm_ee_executor_mpool_chunk_free(ucc_mpool_t *mp,
+                                                     void *chunk)
+{
+    ROCM_FUNC(hipHostFree(chunk));
+}
+
+static void ucc_ec_rocm_executor_chunk_init(ucc_mpool_t *mp, void *obj,
+                                            void *chunk)
+{
+    ucc_ec_rocm_executor_t *eee       = (ucc_ec_rocm_executor_t*) obj;
+    int                     max_tasks = EC_ROCM_CONFIG->exec_max_tasks;
+
+    ROCM_FUNC(hipHostGetDevicePointer(
+                  (void**)(&eee->dev_state), (void *)&eee->state, 0));
+    ROCM_FUNC(hipHostGetDevicePointer(
+                  (void**)(&eee->dev_pidx), (void *)&eee->pidx, 0));
+    ROCM_FUNC(hipMalloc((void**)&eee->dev_cidx, sizeof(*eee->dev_cidx)));
+    ROCM_FUNC(hipHostMalloc((void**)&eee->tasks,
+                             max_tasks * sizeof(ucc_ee_executor_task_t),
+                             hipHostMallocMapped));
+    ROCM_FUNC(hipHostGetDevicePointer(
+                  (void**)(&eee->dev_tasks), (void *)eee->tasks, 0));
+    if (ucc_ec_rocm.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spinlock_init(&eee->tasks_lock, 0);
+    }
+}
+
+static void ucc_ec_rocm_executor_chunk_cleanup(ucc_mpool_t *mp, void *obj)
+{
+    ucc_ec_rocm_executor_t *eee = (ucc_ec_rocm_executor_t*) obj;
+
+    ROCM_FUNC(hipFree((void*)eee->dev_cidx));
+    ROCM_FUNC(hipHostFree((void*)eee->tasks));
+    if (ucc_ec_rocm.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spinlock_destroy(&eee->tasks_lock);
+    }
+}
+
+
+static ucc_mpool_ops_t ucc_ec_rocm_ee_executor_mpool_ops = {
+    .chunk_alloc   = ucc_ec_rocm_ee_executor_mpool_chunk_malloc,
+    .chunk_release = ucc_ec_rocm_ee_executor_mpool_chunk_free,
+    .obj_init      = ucc_ec_rocm_executor_chunk_init,
+    .obj_cleanup   = ucc_ec_rocm_executor_chunk_cleanup,
+};
+
 
 static ucc_status_t ucc_ec_rocm_stream_req_mpool_chunk_malloc(ucc_mpool_t *mp,
                                                               size_t *size_p,
@@ -104,6 +181,8 @@ static void ucc_ec_rocm_event_cleanup(ucc_mpool_t *mp, void *obj)
     }
 }
 
+
+
 static ucc_mpool_ops_t ucc_ec_rocm_event_mpool_ops = {
     .chunk_alloc   = ucc_mpool_hugetlb_malloc,
     .chunk_release = ucc_mpool_hugetlb_free,
@@ -111,22 +190,41 @@ static ucc_mpool_ops_t ucc_ec_rocm_event_mpool_ops = {
     .obj_cleanup   = ucc_ec_rocm_event_cleanup,
 };
 
-static ucc_status_t ucc_ec_rocm_post_kernel_stream_task(uint32_t *status,
+ucc_status_t ucc_ec_rocm_post_kernel_stream_task(uint32_t *status,
                                                  int blocking_wait,
-                                                 hipStream_t stream)
+                                                 hipStream_t stream);
+
+static ucc_status_t ucc_ec_rocm_post_driver_stream_task(uint32_t *status,
+                                                        int blocking_wait,
+                                                        hipStream_t stream)
 {
-    return UCC_ERR_NOT_IMPLEMENTED;
+    hipDeviceptr_t status_ptr  = (hipDeviceptr_t)status;
+
+    if (blocking_wait) {
+        ROCM_FUNC(hipStreamWriteValue32(stream, status_ptr,
+                                        UCC_EC_ROCM_TASK_STARTED, 0));
+        ROCM_FUNC(hipStreamWaitValue32(stream, status_ptr,
+                                       UCC_EC_ROCM_TASK_COMPLETED,
+                                       hipStreamWaitValueEq, 0xFFFFFFFF));
+    }
+    ROCM_FUNC(hipStreamWriteValue32(stream, status_ptr,
+                                    UCC_EC_ROCM_TASK_COMPLETED_ACK, 0));
+    return UCC_OK;
 }
 
 static ucc_status_t ucc_ec_rocm_init(const ucc_ec_params_t *ec_params)
 {
     ucc_ec_rocm_config_t *cfg = EC_ROCM_CONFIG;
-    ucc_status_t status;
-    int device, num_devices;
-    hipError_t rocm_st;
+    ucc_status_t          status;
+    int                   device, num_devices;
+    int                   attr=0;
+    hipError_t            rocm_st;
+    hipDevice_t           hip_dev;
+    const char           *hip_err_st_str;
 
-    ucc_ec_rocm.stream             = NULL;
-    ucc_ec_rocm.stream_initialized = 0;
+    ucc_ec_rocm.stream                   = NULL;
+    ucc_ec_rocm.stream_initialized       = 0;
+    ucc_ec_rocm.exec_streams_initialized = 0;
     ucc_strncpy_safe(ucc_ec_rocm.super.config->log_component.name,
                      ucc_ec_rocm.super.super.name,
                      sizeof(ucc_ec_rocm.super.config->log_component.name));
@@ -139,6 +237,13 @@ static ucc_status_t ucc_ec_rocm_init(const ucc_ec_params_t *ec_params)
     ROCMCHECK(hipGetDevice(&device));
 
     /*create event pool */
+    ucc_ec_rocm.exec_streams = ucc_calloc(cfg->exec_num_streams,
+                                          sizeof(hipStream_t),
+                                          "ec rocm streams");
+    if (!ucc_ec_rocm.exec_streams) {
+        ec_error(&ucc_ec_rocm.super, "failed to allocate streams array");
+        return UCC_ERR_NO_MEMORY;
+    }
     status = ucc_mpool_init(&ucc_ec_rocm.events, 0, sizeof(ucc_ec_rocm_event_t),
                             0, UCC_CACHE_LINE_SIZE, 16, UINT_MAX,
                             &ucc_ec_rocm_event_mpool_ops, UCC_THREAD_MULTIPLE,
@@ -158,15 +263,49 @@ static ucc_status_t ucc_ec_rocm_init(const ucc_ec_params_t *ec_params)
         return status;
     }
 
+    status = ucc_mpool_init(
+        &ucc_ec_rocm.executors, 0, sizeof(ucc_ec_rocm_executor_t), 0,
+        UCC_CACHE_LINE_SIZE, 16, UINT_MAX, &ucc_ec_rocm_ee_executor_mpool_ops,
+        UCC_THREAD_MULTIPLE, "EE executor Objects");
+    if (status != UCC_OK) {
+        ec_error(&ucc_ec_rocm.super, "failed to create executors pool");
+        return status;
+    }
+
+    status = ucc_mpool_init(
+        &ucc_ec_rocm.executor_interruptible_tasks, 0,
+        sizeof(ucc_ec_rocm_executor_interruptible_task_t), 0, UCC_CACHE_LINE_SIZE,
+        16, UINT_MAX, NULL, UCC_THREAD_MULTIPLE,
+        "interruptible executor tasks");
+    
     if (cfg->strm_task_mode == UCC_EC_ROCM_TASK_KERNEL) {
         ucc_ec_rocm.strm_task_mode = UCC_EC_ROCM_TASK_KERNEL;
         ucc_ec_rocm.post_strm_task = ucc_ec_rocm_post_kernel_stream_task;
     } else {
-        if (cfg->strm_task_mode == UCC_EC_ROCM_TASK_AUTO) {
-            ucc_ec_rocm.strm_task_mode = UCC_EC_ROCM_TASK_KERNEL;
-            ucc_ec_rocm.post_strm_task = ucc_ec_rocm_post_kernel_stream_task;
+        ucc_ec_rocm.strm_task_mode = UCC_EC_ROCM_TASK_MEM_OPS;
+        ucc_ec_rocm.post_strm_task = ucc_ec_rocm_post_driver_stream_task;
+
+        rocm_st = hipCtxGetDevice(&hip_dev);
+        if (rocm_st != hipSuccess){
+            hip_err_st_str = hipGetErrorString(rocm_st);
+            ec_debug(&ucc_ec_rocm.super, "hipCtxGetDevice() failed: %s",
+                     hip_err_st_str);
+            attr = 0;
         } else {
-            ec_error(&ucc_ec_rocm.super, "ROCM MEM OPS are not supported");
+            ROCM_FUNC(hipDeviceGetAttribute(&attr,
+		      hipDeviceAttributeCanUseStreamWaitValue,
+                      hip_dev));
+        }
+        if (cfg->strm_task_mode == UCC_EC_ROCM_TASK_AUTO) {
+            if (attr == 0) {
+                ec_info(&ucc_ec_rocm.super,
+                        "ROCm MEM OPS are not supported or disabled");
+                ucc_ec_rocm.strm_task_mode = UCC_EC_ROCM_TASK_KERNEL;
+                ucc_ec_rocm.post_strm_task = ucc_ec_rocm_post_kernel_stream_task;
+            }
+        } else if (attr == 0) {
+            ec_error(&ucc_ec_rocm.super,
+                     "ROCm MEM OPS are not supported or disabled");
             return UCC_ERR_NOT_SUPPORTED;
         }
     }
@@ -186,10 +325,10 @@ static ucc_status_t ucc_ec_rocm_get_attr(ucc_ec_attr_t *ec_attr)
 
 ucc_status_t ucc_ec_rocm_task_post(void *ee_stream, void **ee_req)
 {
-    ucc_ec_rocm_config_t *cfg = EC_ROCM_CONFIG;
+    ucc_ec_rocm_config_t         *cfg = EC_ROCM_CONFIG;
     ucc_ec_rocm_stream_request_t *req;
-    ucc_ec_rocm_event_t *rocm_event;
-    ucc_status_t status;
+    ucc_ec_rocm_event_t          *rocm_event;
+    ucc_status_t                  status = UCC_OK;
 
     UCC_EC_ROCM_INIT_STREAM();
     req = ucc_mpool_get(&ucc_ec_rocm.strm_reqs);
@@ -272,7 +411,7 @@ ucc_status_t ucc_ec_rocm_task_end(void *ee_req)
     return UCC_OK;
 }
 
-ucc_status_t ucc_ec_rocm_create_event(void **event)
+ucc_status_t ucc_ec_rocm_event_create(void **event)
 {
     ucc_ec_rocm_event_t *rocm_event;
 
@@ -285,7 +424,7 @@ ucc_status_t ucc_ec_rocm_create_event(void **event)
     return UCC_OK;
 }
 
-ucc_status_t ucc_ec_rocm_destroy_event(void *event)
+ucc_status_t ucc_ec_rocm_event_destroy(void *event)
 {
     ucc_ec_rocm_event_t *rocm_event = event;
 
@@ -317,11 +456,23 @@ ucc_status_t ucc_ec_rocm_event_test(void *event)
 
 static ucc_status_t ucc_ec_rocm_finalize()
 {
+    int i;
+
     if (ucc_ec_rocm.stream != NULL) {
         ROCMCHECK(hipStreamDestroy(ucc_ec_rocm.stream));
         ucc_ec_rocm.stream = NULL;
     }
-    ucc_spinlock_destroy(&ucc_ec_rocm.init_spinlock);
+    if (ucc_ec_rocm.exec_streams_initialized) {
+        for (i = 0; i < EC_ROCM_CONFIG->exec_num_streams; i++) {
+            ROCM_FUNC(hipStreamDestroy(ucc_ec_rocm.exec_streams[i]));
+        }
+        ucc_ec_rocm.exec_streams_initialized = 0;
+    }
+
+    ucc_mpool_cleanup(&ucc_ec_rocm.events, 1);
+    ucc_mpool_cleanup(&ucc_ec_rocm.strm_reqs, 1);
+    ucc_mpool_cleanup(&ucc_ec_rocm.executors, 1);
+    ucc_free(ucc_ec_rocm.exec_streams);
     return UCC_OK;
 }
 
@@ -339,13 +490,21 @@ ucc_ec_rocm_t ucc_ec_rocm = {
             .table  = ucc_ec_rocm_config_table,
             .size   = sizeof(ucc_ec_rocm_config_t),
         },
-    .super.ops.task_post     = ucc_ec_rocm_task_post,
-    .super.ops.task_query    = ucc_ec_rocm_task_query,
-    .super.ops.task_end      = ucc_ec_rocm_task_end,
-    .super.ops.create_event  = ucc_ec_rocm_create_event,
-    .super.ops.destroy_event = ucc_ec_rocm_destroy_event,
-    .super.ops.event_post    = ucc_ec_rocm_event_post,
-    .super.ops.event_test    = ucc_ec_rocm_event_test,
+    .super.ops.task_post              = ucc_ec_rocm_task_post,
+    .super.ops.task_query             = ucc_ec_rocm_task_query,
+    .super.ops.task_end               = ucc_ec_rocm_task_end,
+    .super.ops.create_event           = ucc_ec_rocm_event_create,
+    .super.ops.destroy_event          = ucc_ec_rocm_event_destroy,
+    .super.ops.event_post             = ucc_ec_rocm_event_post,
+    .super.ops.event_test             = ucc_ec_rocm_event_test,
+    .super.executor_ops.init          = ucc_rocm_executor_init,
+    .super.executor_ops.start         = ucc_rocm_executor_start,
+    .super.executor_ops.status        = ucc_rocm_executor_status,
+    .super.executor_ops.stop          = ucc_rocm_executor_stop,
+    .super.executor_ops.task_post     = ucc_rocm_executor_task_post,
+    .super.executor_ops.task_test     = ucc_rocm_executor_task_test,
+    .super.executor_ops.task_finalize = ucc_rocm_executor_task_finalize,
+    .super.executor_ops.finalize      = ucc_rocm_executor_finalize,
 };
 
 UCC_CONFIG_REGISTER_TABLE_ENTRY(&ucc_ec_rocm.super.config_table,

--- a/src/components/ec/rocm/ec_rocm.h
+++ b/src/components/ec/rocm/ec_rocm.h
@@ -12,6 +12,7 @@
 #include "components/ec/ucc_ec_log.h"
 #include "utils/ucc_mpool.h"
 #include "utils/arch/rocm_def.h"
+#include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 
 typedef enum ucc_ec_rocm_strm_task_mode {
@@ -33,6 +34,20 @@ typedef enum ucc_ec_task_status {
     UCC_EC_ROCM_TASK_STARTED,
     UCC_EC_ROCM_TASK_COMPLETED_ACK
 } ucc_ec_task_status_t;
+
+typedef enum ucc_ec_rocm_executor_state {
+    UCC_EC_ROCM_EXECUTOR_INITIALIZED,
+    UCC_EC_ROCM_EXECUTOR_POSTED,
+    UCC_EC_ROCM_EXECUTOR_STARTED,
+    UCC_EC_ROCM_EXECUTOR_SHUTDOWN,
+    UCC_EC_ROCM_EXECUTOR_SHUTDOWN_ACK
+} ucc_ec_rocm_executor_state_t;
+
+typedef enum ucc_ec_rocm_executor_mode {
+    UCC_EC_ROCM_EXECUTOR_MODE_PERSISTENT,
+    UCC_EC_ROCM_EXECUTOR_MODE_INTERRUPTIBLE
+} ucc_ec_rocm_executor_mode_t;
+
 
 static inline ucc_status_t hip_error_to_ucc_status(hipError_t hip_err)
 {
@@ -56,14 +71,22 @@ typedef struct ucc_ec_rocm_config {
     ucc_ec_rocm_strm_task_mode_t   strm_task_mode;
     ucc_ec_rocm_task_stream_type_t task_strm_type;
     int                            stream_blocking_wait;
+    unsigned long                  exec_num_workers;
+    unsigned long                  exec_num_threads;
+    unsigned long                  exec_max_tasks;
+    unsigned long                  exec_num_streams;
 } ucc_ec_rocm_config_t;
 
 typedef struct ucc_ec_rocm {
     ucc_ec_base_t                  super;
     int                            stream_initialized;
     hipStream_t                    stream;
+    int                            exec_streams_initialized;
+    hipStream_t                   *exec_streams;
     ucc_mpool_t                    events;
     ucc_mpool_t                    strm_reqs;
+    ucc_mpool_t                    executors;
+    ucc_mpool_t                    executor_interruptible_tasks;
     ucc_thread_mode_t              thread_mode;
     ucc_ec_rocm_strm_task_mode_t   strm_task_mode;
     ucc_ec_rocm_task_stream_type_t task_strm_type;
@@ -80,6 +103,41 @@ typedef struct ucc_ec_rocm_stream_request {
     uint32_t           *dev_status;
     hipStream_t         stream;
 } ucc_ec_rocm_stream_request_t;
+
+typedef struct ucc_ec_rocm_executor_interruptible_task {
+    ucc_ee_executor_task_t  super;
+    void                   *event;
+} ucc_ec_rocm_executor_interruptible_task_t;
+
+typedef struct ucc_ec_rocm_executor_task_ops {
+    ucc_status_t (*task_post)(ucc_ee_executor_t *executor,
+                              const ucc_ee_executor_task_args_t *task_args,
+                              ucc_ee_executor_task_t **task);
+    ucc_status_t (*task_test)(const ucc_ee_executor_task_t *task);
+    ucc_status_t (*task_finalize)(ucc_ee_executor_task_t *task);
+} ucc_ec_rocm_executor_task_ops_t;
+
+typedef struct ucc_ec_rocm_executor {
+    ucc_ee_executor_t                super;
+    ucc_ec_rocm_executor_mode_t      mode;
+    ucc_ec_rocm_executor_task_ops_t  ops;
+    ucc_spinlock_t                   tasks_lock;
+    ucc_ec_rocm_executor_state_t     state;
+    int                              pidx;
+    ucc_ee_executor_task_t          *tasks;
+    ucc_ec_rocm_executor_state_t    *dev_state;
+    ucc_ee_executor_task_t          *dev_tasks;
+    int                             *dev_pidx;
+    int                             *dev_cidx;
+} ucc_ec_rocm_executor_t;
+
+ucc_status_t ucc_ec_rocm_event_create(void **event);
+
+ucc_status_t ucc_ec_rocm_event_destroy(void *event);
+
+ucc_status_t ucc_ec_rocm_event_post(void *ee_context, void *event);
+
+ucc_status_t ucc_ec_rocm_event_test(void *event);
 
 extern ucc_ec_rocm_t ucc_ec_rocm;
 

--- a/src/components/ec/rocm/ec_rocm_executor.c
+++ b/src/components/ec/rocm/ec_rocm_executor.c
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ec_rocm_executor.h"
+
+ucc_status_t ucc_rocm_executor_persistent_start(ucc_ee_executor_t *executor,
+                                                void *ee_context);
+
+ucc_status_t ucc_rocm_executor_persistent_stop(ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_rocm_executor_interruptible_start(ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_rocm_executor_interruptible_stop(ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_rocm_executor_init(const ucc_ee_executor_params_t *params,
+                                    ucc_ee_executor_t **executor)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_mpool_get(&ucc_ec_rocm.executors);
+
+    if (ucc_unlikely(!eee)) {
+        ec_error(&ucc_ec_rocm.super, "failed to allocate executor");
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    ec_debug(&ucc_ec_rocm.super, "executor init, eee: %p", eee);
+    eee->super.ee_type = params->ee_type;
+    eee->state         = UCC_EC_ROCM_EXECUTOR_INITIALIZED;
+
+    *executor = &eee->super;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_rocm_executor_status(const ucc_ee_executor_t *executor)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_rocm_executor_t);
+
+    switch (eee->state) {
+    case UCC_EC_ROCM_EXECUTOR_INITIALIZED:
+        return UCC_OPERATION_INITIALIZED;
+    case UCC_EC_ROCM_EXECUTOR_POSTED:
+        return UCC_INPROGRESS;
+    case UCC_EC_ROCM_EXECUTOR_STARTED:
+        return UCC_OK;
+    default:
+/* executor has been destroyed */
+        return UCC_ERR_NO_RESOURCE;
+    }
+}
+
+ucc_status_t ucc_rocm_executor_finalize(ucc_ee_executor_t *executor)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_rocm_executor_t);
+
+    ec_debug(&ucc_ec_rocm.super, "executor free, eee: %p", eee);
+    ucc_assert(eee->state == UCC_EC_ROCM_EXECUTOR_INITIALIZED);
+    ucc_mpool_put(eee);
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_rocm_executor_task_post(ucc_ee_executor_t *executor,
+                                         const ucc_ee_executor_task_args_t *task_args,
+                                         ucc_ee_executor_task_t **task)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_rocm_executor_t);
+    return eee->ops.task_post(executor, task_args, task);
+}
+
+
+ucc_status_t ucc_rocm_executor_task_test(const ucc_ee_executor_task_t *task)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(task->eee,
+                                                 ucc_ec_rocm_executor_t);
+    return eee->ops.task_test(task);
+}
+
+ucc_status_t ucc_rocm_executor_task_finalize(ucc_ee_executor_task_t *task)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(task->eee,
+                                                 ucc_ec_rocm_executor_t);
+    return eee->ops.task_finalize(task);
+}
+
+ucc_status_t ucc_rocm_executor_start(ucc_ee_executor_t *executor,
+                                     void *ee_context)
+{
+    if (!ee_context) {
+        return ucc_rocm_executor_interruptible_start(executor);
+    } else {
+        return ucc_rocm_executor_persistent_start(executor, ee_context);
+    }
+}
+
+ucc_status_t ucc_rocm_executor_stop(ucc_ee_executor_t *executor)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_rocm_executor_t);
+    if (eee->mode == UCC_EC_ROCM_EXECUTOR_MODE_INTERRUPTIBLE) {
+        return ucc_rocm_executor_interruptible_stop(executor);
+    } else {
+        return ucc_rocm_executor_persistent_stop(executor);
+    }
+}

--- a/src/components/ec/rocm/ec_rocm_executor.h
+++ b/src/components/ec/rocm/ec_rocm_executor.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_EC_ROCM_EXECUTOR_H_
+#define UCC_EC_ROCM_EXECUTOR_H_
+
+#include "ec_rocm.h"
+
+ucc_status_t ucc_rocm_executor_init(const ucc_ee_executor_params_t *params,
+                                    ucc_ee_executor_t **executor);
+
+ucc_status_t ucc_rocm_executor_status(const ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_rocm_executor_finalize(ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_rocm_executor_start(ucc_ee_executor_t *executor,
+                                     void *ee_context);
+
+ucc_status_t ucc_rocm_executor_stop(ucc_ee_executor_t *executor);
+
+ucc_status_t ucc_rocm_executor_task_post(ucc_ee_executor_t *executor,
+                                         const ucc_ee_executor_task_args_t *task_args,
+                                         ucc_ee_executor_task_t **task);
+
+ucc_status_t ucc_rocm_executor_task_test(const ucc_ee_executor_task_t *task);
+
+ucc_status_t ucc_rocm_executor_task_finalize(ucc_ee_executor_task_t *task);
+
+/* implemented in ec_rocm_executor.cu */
+ucc_status_t ucc_ec_rocm_persistent_kernel_start(ucc_ec_rocm_executor_t *eee);
+
+#endif

--- a/src/components/ec/rocm/ec_rocm_executor_interruptible.c
+++ b/src/components/ec/rocm/ec_rocm_executor_interruptible.c
@@ -1,0 +1,188 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ec_rocm_executor.h"
+#include "components/mc/ucc_mc.h"
+#include "utils/ucc_atomic.h"
+
+ucc_status_t ucc_rocm_executor_interruptible_get_stream(hipStream_t *stream)
+{
+    static uint32_t last_used   = 0;
+    int             num_streams = EC_ROCM_CONFIG->exec_num_streams;
+    ucc_status_t    st;
+    int             i, j;
+    uint32_t        id;
+
+    if (ucc_unlikely(!ucc_ec_rocm.exec_streams_initialized)) {
+        ucc_spin_lock(&ucc_ec_rocm.init_spinlock);
+        if (ucc_ec_rocm.exec_streams_initialized) {
+            goto unlock;
+        }
+
+        for(i = 0; i < num_streams; i++) {
+            st = ROCM_FUNC(hipStreamCreateWithFlags(&ucc_ec_rocm.exec_streams[i],
+                                                     hipStreamNonBlocking));
+            if (st != UCC_OK) {
+                for (j = 0; j < i; j++) {
+                    ROCM_FUNC(hipStreamDestroy(ucc_ec_rocm.exec_streams[j]));
+                }
+                ucc_spin_unlock(&ucc_ec_rocm.init_spinlock);
+                return st;
+            }
+        }
+        ucc_ec_rocm.exec_streams_initialized = 1;
+unlock:
+        ucc_spin_unlock(&ucc_ec_rocm.init_spinlock);
+    }
+
+    id = ucc_atomic_fadd32(&last_used, 1);
+    *stream = ucc_ec_rocm.exec_streams[id % num_streams];
+    return UCC_OK;
+}
+
+ucc_status_t
+ucc_rocm_executor_interruptible_task_post(ucc_ee_executor_t *executor,
+                                         const ucc_ee_executor_task_args_t *task_args,
+                                         ucc_ee_executor_task_t **task)
+{
+    ucc_ec_rocm_executor_interruptible_task_t *ee_task;
+    hipStream_t stream;
+    ucc_status_t status;
+
+    status = ucc_rocm_executor_interruptible_get_stream(&stream);
+    if (ucc_unlikely(status != UCC_OK)) {
+        return status;
+    }
+
+    ee_task = ucc_mpool_get(&ucc_ec_rocm.executor_interruptible_tasks);
+    if (ucc_unlikely(!ee_task)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    status  = ucc_ec_rocm_event_create(&ee_task->event);
+    if (ucc_unlikely(status != UCC_OK)) {
+        ucc_mpool_put(ee_task);
+        return status;
+    }
+
+    ee_task->super.status = UCC_INPROGRESS;
+    ee_task->super.eee    = executor;
+    memcpy(&ee_task->super.args, task_args, sizeof(ucc_ee_executor_task_args_t));
+    switch (task_args->task_type) {
+    case UCC_EE_EXECUTOR_TASK_TYPE_COPY:
+        status = ROCM_FUNC(hipMemcpyAsync(task_args->bufs[0],
+                                          task_args->bufs[1],
+                                          task_args->count, hipMemcpyDefault,
+                                          stream));
+        if (ucc_unlikely(status != UCC_OK)) {
+            ec_error(&ucc_ec_rocm.super, "failed to start memcpy op");
+            goto free_task;
+        }
+
+        break;
+    case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE:
+        /* temp workaround to avoid code duplication*/
+        status = ucc_mc_reduce(task_args->bufs[1], task_args->bufs[2],
+                               task_args->bufs[0], task_args->count,
+                               task_args->dt, task_args->op,
+                               UCC_MEMORY_TYPE_ROCM);
+        if (ucc_unlikely(status != UCC_OK)) {
+            ec_error(&ucc_ec_rocm.super, "failed to start reduce op");
+            goto free_task;
+        }
+
+        break;
+    case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI:
+        status = ucc_mc_reduce_multi(task_args->bufs[1], task_args->bufs[2],
+                                     task_args->bufs[0], task_args->size,
+                                     task_args->count, task_args->stride,
+                                     task_args->dt, task_args->op,
+                                     UCC_MEMORY_TYPE_ROCM);
+        if (ucc_unlikely(status != UCC_OK)) {
+            ec_error(&ucc_ec_rocm.super, "failed to start reduce multi op");
+            goto free_task;
+        }
+        break;
+    case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI_ALPHA:
+        status = ucc_mc_reduce_multi_alpha(task_args->bufs[1],
+                                           task_args->bufs[2],
+                                           task_args->bufs[0],
+                                           task_args->size, task_args->count,
+                                           task_args->stride, task_args->dt,
+                                           task_args->op, UCC_OP_PROD,
+                                           task_args->alpha,
+                                           UCC_MEMORY_TYPE_ROCM);
+        if (ucc_unlikely(status != UCC_OK)) {
+            ec_error(&ucc_ec_rocm.super, "failed to start reduce multi alpha op");
+            goto free_task;
+        }
+        break;
+    default:
+        ec_error(&ucc_ec_rocm.super, "executor operation is not supported task_type %d", task_args->task_type);
+        status = UCC_ERR_INVALID_PARAM;
+        goto free_task;
+    }
+
+    status = ucc_ec_rocm_event_post(stream, ee_task->event);
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto free_task;
+    }
+
+    *task = &ee_task->super;
+    return UCC_OK;
+
+free_task:
+    ucc_ec_rocm_event_destroy(ee_task->event);
+    ucc_mpool_put(ee_task);
+    return status;
+}
+
+ucc_status_t
+ucc_rocm_executor_interruptible_task_test(const ucc_ee_executor_task_t *task)
+{
+    ucc_ec_rocm_executor_interruptible_task_t *ee_task =
+        ucc_derived_of(task, ucc_ec_rocm_executor_interruptible_task_t);
+
+    ee_task->super.status = ucc_ec_rocm_event_test(ee_task->event);
+    return ee_task->super.status;
+}
+
+ucc_status_t
+ucc_rocm_executor_interruptible_task_finalize(ucc_ee_executor_task_t *task)
+{
+    ucc_ec_rocm_executor_interruptible_task_t *ee_task =
+        ucc_derived_of(task, ucc_ec_rocm_executor_interruptible_task_t);
+    ucc_status_t status;
+
+    status = ucc_ec_rocm_event_destroy(ee_task->event);
+    ucc_mpool_put(task);
+    return status;
+}
+
+ucc_status_t ucc_rocm_executor_interruptible_start(ucc_ee_executor_t *executor)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_rocm_executor_t);
+
+    eee->mode  = UCC_EC_ROCM_EXECUTOR_MODE_INTERRUPTIBLE;
+    eee->state = UCC_EC_ROCM_EXECUTOR_STARTED;
+
+    eee->ops.task_post     = ucc_rocm_executor_interruptible_task_post;
+    eee->ops.task_test     = ucc_rocm_executor_interruptible_task_test;
+    eee->ops.task_finalize = ucc_rocm_executor_interruptible_task_finalize;
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_rocm_executor_interruptible_stop(ucc_ee_executor_t *executor)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_rocm_executor_t);
+
+    eee->state = UCC_EC_ROCM_EXECUTOR_INITIALIZED;
+    return UCC_OK;
+}

--- a/src/components/ec/rocm/ec_rocm_executor_persistent.c
+++ b/src/components/ec/rocm/ec_rocm_executor_persistent.c
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ec_rocm_executor.h"
+#include "utils/arch/cpu.h"
+
+ucc_status_t
+ucc_rocm_executor_persistent_task_post(ucc_ee_executor_t *executor,
+                                       const ucc_ee_executor_task_args_t *task_args,
+                                       ucc_ee_executor_task_t **task)
+{
+    ucc_ec_rocm_executor_t *eee       = ucc_derived_of(executor,
+                                                       ucc_ec_rocm_executor_t);
+    int                     max_tasks = EC_ROCM_CONFIG->exec_max_tasks;
+    ucc_ee_executor_task_t *ee_task;
+
+    if (task_args->task_type == UCC_EE_EXECUTOR_TASK_TYPE_REDUCE) {
+        if (task_args->op != UCC_OP_SUM) {
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+        if ((task_args->dt != UCC_DT_FLOAT32) &&
+            (task_args->dt != UCC_DT_FLOAT64) &&
+            (task_args->dt != UCC_DT_INT32)) {
+            return UCC_ERR_NOT_SUPPORTED;
+        }
+    }
+    if (ucc_ec_rocm.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spin_lock(&eee->tasks_lock);
+    }
+    ee_task         = &(eee->tasks[eee->pidx % max_tasks]);
+    ee_task->eee    = executor;
+    ee_task->status = UCC_OPERATION_INITIALIZED;
+    memcpy(&ee_task->args, task_args, sizeof(ucc_ee_executor_task_args_t));
+    ucc_memory_cpu_store_fence();
+    eee->pidx += 1;
+    if (ucc_ec_rocm.thread_mode == UCC_THREAD_MULTIPLE) {
+        ucc_spin_unlock(&eee->tasks_lock);
+    }
+    ec_debug(&ucc_ec_rocm.super, "executor task post, eee: %p", eee);
+
+    *task = ee_task;
+    return UCC_OK;
+}
+
+
+ucc_status_t
+ucc_rocm_executor_persistent_task_test(const ucc_ee_executor_task_t *task)
+{
+    ROCMCHECK(hipGetLastError());
+    return task->status;
+}
+
+ucc_status_t
+ucc_rocm_executor_persistent_task_finalize(ucc_ee_executor_task_t *task)
+{
+    return UCC_OK;
+}
+
+ucc_status_t ucc_rocm_executor_persistent_start(ucc_ee_executor_t *executor,
+                                                void *ee_context)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_rocm_executor_t);
+    ucc_status_t status;
+
+    ucc_assert(eee->state == UCC_EC_ROCM_EXECUTOR_INITIALIZED);
+    ec_debug(&ucc_ec_rocm.super, "executor start, eee: %p", eee);
+    eee->super.ee_context = ee_context;
+    eee->state            = UCC_EC_ROCM_EXECUTOR_POSTED;
+    eee->pidx             = 0;
+    eee->mode             = UCC_EC_ROCM_EXECUTOR_MODE_PERSISTENT;
+
+    status = ucc_ec_rocm_persistent_kernel_start(eee);
+    if (status != UCC_OK) {
+        ec_error(&ucc_ec_rocm.super, "failed to launch executor kernel");
+        return status;
+    }
+
+    eee->ops.task_post     = ucc_rocm_executor_persistent_task_post;
+    eee->ops.task_test     = ucc_rocm_executor_persistent_task_test;
+    eee->ops.task_finalize = ucc_rocm_executor_persistent_task_finalize;
+    return UCC_OK;
+}
+
+ucc_status_t ucc_rocm_executor_persistent_stop(ucc_ee_executor_t *executor)
+{
+    ucc_ec_rocm_executor_t *eee = ucc_derived_of(executor,
+                                                 ucc_ec_rocm_executor_t);
+    volatile ucc_ec_rocm_executor_state_t *st = &eee->state;
+
+    ec_debug(&ucc_ec_rocm.super, "executor stop, eee: %p", eee);
+    /* can be safely ended only if it's in STARTED or COMPLETED_ACK state */
+    ucc_assert((*st != UCC_EC_ROCM_EXECUTOR_POSTED) &&
+               (*st != UCC_EC_ROCM_EXECUTOR_SHUTDOWN));
+    *st = UCC_EC_ROCM_EXECUTOR_SHUTDOWN;
+    eee->pidx = -1;
+    while(*st != UCC_EC_ROCM_EXECUTOR_SHUTDOWN_ACK) { }
+    eee->super.ee_context = NULL;
+    eee->state = UCC_EC_ROCM_EXECUTOR_INITIALIZED;
+
+    return UCC_OK;
+}

--- a/src/components/ec/rocm/kernel/Makefile.am
+++ b/src/components/ec/rocm/kernel/Makefile.am
@@ -1,0 +1,31 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+#
+
+HIPCCFLAGS =                                     \
+    ${AM_CPPFLAGS}                               \
+    ${UCS_CPPFLAGS}                              \
+    ${HIP_CPPFLAGS}                              \
+    ${ROCM_CPPFLAGS}                             \
+    -I${UCC_TOP_BUILDDIR}                        \
+    -I${UCC_TOP_SRCDIR}                          \
+    -I${UCC_TOP_SRCDIR}/src                      \
+    -I${UCC_TOP_BUILDDIR}/src                    \
+    -I${UCC_TOP_SRCDIR}/src/components/ec/rocm
+
+
+LINK = $(LIBTOOL) --mode=link $(CC) -o $@
+
+.cu.o:
+	$(HIPCC) -c $< -o $@  $(HIPCCFLAGS) 
+
+.cu.lo:
+	/bin/bash $(top_srcdir)/cuda_lt.sh "$(LIBTOOL)" $@ $(HIPCC) -c  $< $(HIPCCFLAGS) 
+
+comp_noinst = libucc_ec_rocm_kernels.la
+
+libucc_ec_rocm_kernels_la_SOURCES  = ec_rocm_wait_kernel.cu  \
+                                     ec_rocm_executor_kernel.cu
+libucc_ec_rocm_kernels_la_CPPFLAGS =
+
+noinst_LTLIBRARIES = $(comp_noinst)

--- a/src/components/ec/rocm/kernel/ec_rocm_executor_kernel.cu
+++ b/src/components/ec/rocm/kernel/ec_rocm_executor_kernel.cu
@@ -1,0 +1,265 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ec_rocm.h"
+#include "utils/ucc_math.h"
+#include <inttypes.h>
+
+#define align_pow2(_n, _p) ((_n) & ((_p) - 1))
+
+__global__ void executor_start(ucc_ec_rocm_executor_state_t *state,
+                               int *cidx)
+{
+    *cidx  = 0;
+    *state = UCC_EC_ROCM_EXECUTOR_STARTED;
+}
+
+__global__ void executor_shutdown_ack(ucc_ec_rocm_executor_state_t *state)
+{
+    *state = UCC_EC_ROCM_EXECUTOR_SHUTDOWN_ACK;
+}
+
+template <typename T>
+__device__ void executor_copy(T* __restrict__ d, T* __restrict__ s,
+                              size_t count)
+{
+    size_t start = threadIdx.x;
+    const size_t step  = blockDim.x;
+
+    for (size_t i = start; i < count; i+=step) {
+        d[i] = s[i];
+    }
+}
+
+template <typename T>
+__device__ void executor_copy_aligned(T* __restrict__ d, T* __restrict__ s,
+                                      size_t count)
+{
+    size_t idx = threadIdx.x;
+    const size_t step  = blockDim.x;
+    const int n = count / sizeof(T);
+    const int num_iter = n / step + ((idx < n % step) ? 1 : 0);
+    char1 *s1 = (char1*)s;
+    char1 *d1 = (char1*)d;
+
+#pragma unroll 4
+    for(int i = 0; i < num_iter; i++) {
+        d[i * step + idx] = s[i * step + idx];
+    }
+
+    if (idx < count % sizeof(T)) {
+        d1[count - idx - 1] = s1[count - idx - 1];
+    }
+}
+
+__device__ inline void add_float4(float4 &d, const float4 &x, const float4 &y)
+{
+    d.x = x.x + y.x;
+    d.y = x.y + y.y;
+    d.z = x.z + y.z;
+    d.w = x.w + y.w;
+}
+
+__device__ void executor_reduce_float(const float *s1, const float *s2,
+                                      float *d, size_t count)
+{
+    const float4 *s14      = (const float4*)s1;
+    const float4 *s24      = (const float4*)s2;
+    float4       *d4       = (float4*)d;
+    const size_t  idx      = threadIdx.x;
+    const size_t  step     = blockDim.x;
+    const int     n        = count / 4;
+    const int     num_iter = n / step + ((idx < n % step) ? 1 : 0);
+
+    for(int i = 0; i < num_iter; i++) {
+        add_float4(d4[i * step + idx], s14[i * step + idx],
+                   s24[i * step + idx]);
+    }
+    if (idx < count % 4) {
+        d[count - idx - 1] = s1[count - idx - 1] + s2[count - idx - 1];
+    }
+}
+
+template <typename T>
+__device__ void executor_reduce(const T* __restrict__ s1,
+                                const T* __restrict__ s2,
+                                T* __restrict__ d, size_t count)
+{
+    const size_t step  = blockDim.x;
+    const size_t start = threadIdx.x;
+
+    for (size_t i = start; i < count; i+=step) {
+        d[i] = s1[i] + s2[i];
+    }
+}
+
+template <typename T>
+__device__ void executor_reduce_multi(const T* __restrict__ s1,
+                                      const T* __restrict__ s2,
+                                      T* __restrict__ d, size_t count,
+                                      size_t size, size_t stride)
+{
+    const size_t step  = blockDim.x;
+    const size_t start = threadIdx.x;
+    const size_t ld    = stride / sizeof(T);
+
+    for (size_t i = start; i < count; i+=step) {
+        d[i] = s1[i] + s2[i];
+        for (size_t j = 1; j < size; j++) {
+            d[i] = d[i] + s2[i + j*ld];
+        }
+    }
+}
+
+__global__ void executor_kernel(volatile ucc_ec_rocm_executor_t *eee,
+                                int q_size)
+{
+    const uint32_t  worker_id   = blockIdx.x;
+    const uint32_t  num_workers = gridDim.x;
+    bool            is_master   = (threadIdx.x == 0) ? true: false;
+    int cidx_local, pidx_local;
+    volatile int *pidx, *cidx;
+    ucc_ee_executor_task_t *tasks;
+    __shared__ ucc_ee_executor_task_args_t args;
+    __shared__ bool worker_done;
+
+    if (is_master) {
+        cidx_local = worker_id;
+        pidx       = eee->dev_pidx;
+        cidx       = eee->dev_cidx;
+        tasks      = eee->dev_tasks;
+    }
+
+    worker_done = false;
+    __syncthreads();
+    while (1) {
+        if (is_master) {
+            while ((*cidx % num_workers) != worker_id);
+            do {
+                pidx_local = *pidx;
+            } while (*cidx == pidx_local);
+            (*cidx)++;
+            worker_done = (pidx_local == -1);
+            if (!worker_done) {
+                args = tasks[cidx_local].args;
+            }
+        }
+        __syncthreads();
+        if (worker_done) {
+            return;
+        }
+        switch (args.task_type) {
+            bool aligned;
+            case UCC_EE_EXECUTOR_TASK_TYPE_COPY:
+                aligned = !(align_pow2((intptr_t)args.bufs[0], 16) ||
+                            align_pow2((intptr_t)args.bufs[1], 16));
+                if (aligned) {
+                    executor_copy_aligned<uint4>((uint4*)args.bufs[0],
+                                                 (uint4*)args.bufs[1],
+                                                 args.count);
+
+                } else {
+                    executor_copy((char*)args.bufs[0],
+                                  (char*)args.bufs[1],
+                                   args.count);
+                }
+                break;
+            case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE:
+                aligned = !(align_pow2((intptr_t)args.bufs[0], 16) ||
+                            align_pow2((intptr_t)args.bufs[1], 16) ||
+                            align_pow2((intptr_t)args.bufs[2], 16));
+                switch (args.dt)
+                {
+                case UCC_DT_FLOAT32:
+                    if (aligned) {
+                        executor_reduce_float((float*)args.bufs[1],
+                                              (float*)args.bufs[2],
+                                              (float*)args.bufs[0],
+                                              args.count);
+                    } else {
+                        executor_reduce<float>((float*)args.bufs[1],
+                                               (float*)args.bufs[2],
+                                               (float*)args.bufs[0],
+                                               args.count);
+                    }
+                    break;
+                case UCC_DT_FLOAT64:
+                    executor_reduce<double>((double*)args.bufs[1],
+                                            (double*)args.bufs[2],
+                                            (double*)args.bufs[0],
+                                             args.count);
+                    break;
+                case UCC_DT_INT32:
+                    executor_reduce<int32_t>((int32_t*)args.bufs[1],
+                                             (int32_t*)args.bufs[2],
+                                             (int32_t*)args.bufs[0],
+                                              args.count);
+                    break;
+
+                default:
+                    break;
+                }
+                break;
+            case UCC_EE_EXECUTOR_TASK_TYPE_REDUCE_MULTI:
+                switch(args.dt) {
+                case UCC_DT_FLOAT32:
+                    executor_reduce_multi<float>((float*)args.bufs[1],
+                                                 (float*)args.bufs[2],
+                                                 (float*)args.bufs[0],
+                                                 args.count, args.size,
+                                                 args.stride);
+                    break;
+                case UCC_DT_FLOAT64:
+                    executor_reduce_multi<double>((double*)args.bufs[1],
+                                                  (double*)args.bufs[2],
+                                                  (double*)args.bufs[0],
+                                                  args.count, args.size,
+                                                  args.stride);
+                    break;
+                case UCC_DT_INT32:
+                    executor_reduce_multi<int32_t>((int32_t*)args.bufs[1],
+                                                   (int32_t*)args.bufs[2],
+                                                   (int32_t*)args.bufs[0],
+                                                   args.count, args.size,
+                                                   args.stride);
+                    break;
+                }
+                break;
+            default: break;
+        }
+        __syncthreads();
+        __threadfence_system();
+        if (is_master) {
+            tasks[cidx_local].status = UCC_OK;
+            cidx_local = (cidx_local + num_workers) %q_size;
+        }
+    }
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ucc_status_t ucc_ec_rocm_persistent_kernel_start(ucc_ec_rocm_executor_t *eee)
+{
+    hipStream_t stream  = (hipStream_t)eee->super.ee_context;
+    int          nb     = EC_ROCM_CONFIG->exec_num_workers;
+    int          nt     = EC_ROCM_CONFIG->exec_num_threads;
+    int          q_size = EC_ROCM_CONFIG->exec_max_tasks;
+
+    executor_start<<<1, 1, 0, stream>>>(eee->dev_state, eee->dev_cidx);
+    executor_kernel<<<nb, nt, 0, stream>>>(eee, q_size);
+    executor_shutdown_ack<<<1, 1, 0, stream>>>(eee->dev_state);
+    ROCMCHECK(hipGetLastError());
+
+    return UCC_OK;
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/components/ec/rocm/kernel/ec_rocm_wait_kernel.cu
+++ b/src/components/ec/rocm/kernel/ec_rocm_wait_kernel.cu
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ec_rocm.h"
+
+__global__ void wait_kernel(volatile uint32_t *status) {
+    ucc_status_t st;
+    *status = UCC_EC_ROCM_TASK_STARTED;
+    do {
+        st = (ucc_status_t)*status;
+    } while(st != UCC_EC_ROCM_TASK_COMPLETED);
+    *status = UCC_EC_ROCM_TASK_COMPLETED_ACK;
+    return;
+}
+
+__global__ void wait_kernel_nb(volatile uint32_t *status) {
+    *status = UCC_EC_ROCM_TASK_COMPLETED_ACK;
+    return;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ucc_status_t ucc_ec_rocm_post_kernel_stream_task(uint32_t *status,
+                                                 int blocking_wait,
+                                                 hipStream_t stream)
+{
+    if (blocking_wait) {
+        wait_kernel<<<1, 1, 0, stream>>>(status);
+    } else {
+        wait_kernel_nb<<<1, 1, 0, stream>>>(status);
+    }
+    ROCMCHECK(hipGetLastError());
+    return UCC_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/components/mc/rocm/Makefile.am
+++ b/src/components/mc/rocm/Makefile.am
@@ -4,6 +4,7 @@
 #
 
 if HAVE_ROCM
+SUBDIRS = kernel
 
 sources =    \
     mc_rocm.h \
@@ -15,7 +16,8 @@ libucc_mc_rocm_la_CPPFLAGS = $(AM_CPPFLAGS) $(HIP_CPPFLAGS) $(ROCM_CPPFLAGS) $(B
 libucc_mc_rocm_la_CFLAGS   = $(BASE_CFLAGS)
 libucc_mc_rocm_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(HIP_LDFLAGS) $(ROCM_LDFLAGS)
 libucc_mc_rocm_la_LIBADD   = $(HIP_LIBS) $(ROCM_LIBS) \
-                             $(UCC_TOP_BUILDDIR)/src/libucc.la
+                             $(UCC_TOP_BUILDDIR)/src/libucc.la \
+			     kernel/libucc_mc_rocm_kernels.la
 
 include $(top_srcdir)/config/module.am
 endif

--- a/src/components/mc/rocm/kernel/Makefile.am
+++ b/src/components/mc/rocm/kernel/Makefile.am
@@ -1,0 +1,31 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+
+HIPCCFLAGS =                                     \
+    ${AM_CPPFLAGS}                               \
+    ${UCS_CPPFLAGS}                              \
+    ${HIP_CPPFLAGS}                              \
+    ${ROCM_CPPFLAGS}                             \
+    -I${UCC_TOP_BUILDDIR}                        \
+    -I${UCC_TOP_SRCDIR}                          \
+    -I${UCC_TOP_SRCDIR}/src                      \
+    -I${UCC_TOP_BUILDDIR}/src                    \
+    -I${UCC_TOP_SRCDIR}/src/components/mc/rocm
+
+LINK = $(LIBTOOL) --mode=link $(CC) -o $@
+
+.cu.o:
+	$(HIPCC) -c $< -o $@  $(HIPCCFLAGS) 
+
+.cu.lo:
+	/bin/bash $(top_srcdir)/cuda_lt.sh "$(LIBTOOL)" $@ $(HIPCC) -c  $< $(HIPCCFLAGS)
+
+comp_noinst = libucc_mc_rocm_kernels.la
+
+libucc_mc_rocm_kernels_la_SOURCES  = mc_rocm_reduce.cu              \
+                                     mc_rocm_reduce_multi.cu        \
+                                     mc_rocm_reduce_multi_alpha.cu
+libucc_mc_rocm_kernels_la_CPPFLAGS =
+
+noinst_LTLIBRARIES = $(comp_noinst)

--- a/src/components/mc/rocm/kernel/mc_rocm_reduce.cu
+++ b/src/components/mc/rocm/kernel/mc_rocm_reduce.cu
@@ -1,0 +1,192 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "mc_rocm.h"
+#include "utils/ucc_math.h"
+
+#include "mc_rocm_reduce_ops.h"
+
+#define ROCM_REDUCE_WITH_OP(NAME, OP)                                          \
+template <typename T>                                                          \
+__global__ void UCC_REDUCE_ROCM_ ## NAME (const T *s1, const T *s2, T *d,      \
+                                          size_t count)                        \
+{                                                                              \
+        size_t start = blockIdx.x * blockDim.x + threadIdx.x;                  \
+        size_t step  = blockDim.x * gridDim.x;                                 \
+        for (size_t i = start; i < count; i+=step) {                           \
+            d[i] = OP(s1[i], s2[i]);                                           \
+        }                                                                      \
+}                                                                              \
+
+#define ROCM_REDUCE_WITH_OP_SPECIALIZED(NAME, OP, TYPE)                        \
+template <>                                                                    \
+__global__ void UCC_REDUCE_ROCM_ ## NAME (const TYPE *s1, const TYPE *s2,      \
+                                          TYPE *d, size_t count)               \
+{                                                                              \
+        size_t start = blockIdx.x * blockDim.x + threadIdx.x;                  \
+        size_t step  = blockDim.x * gridDim.x;                                 \
+        for (size_t i = start; i < count; i+=step) {                           \
+            d[i] = OP(s1[i], s2[i]);                                           \
+        }                                                                      \
+}                                                                              \
+
+ROCM_REDUCE_WITH_OP(MAX,  DO_OP_MAX)
+ROCM_REDUCE_WITH_OP(MIN,  DO_OP_MIN)
+ROCM_REDUCE_WITH_OP(SUM,  DO_OP_SUM)
+ROCM_REDUCE_WITH_OP(PROD, DO_OP_PROD)
+ROCM_REDUCE_WITH_OP(LAND, DO_OP_LAND)
+ROCM_REDUCE_WITH_OP(BAND, DO_OP_BAND)
+ROCM_REDUCE_WITH_OP(LOR,  DO_OP_LOR)
+ROCM_REDUCE_WITH_OP(BOR,  DO_OP_BOR)
+ROCM_REDUCE_WITH_OP(LXOR, DO_OP_LXOR)
+ROCM_REDUCE_WITH_OP(BXOR, DO_OP_BXOR)
+
+ROCM_REDUCE_WITH_OP_SPECIALIZED(MAX, DO_OP_MAX_HALF, __half)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(MIN, DO_OP_MIN_HALF, __half)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(SUM, DO_OP_SUM_HALF, __half)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(PROD, DO_OP_PROD_HALF, __half)
+
+ROCM_REDUCE_WITH_OP_SPECIALIZED(MAX, DO_OP_MAX_BFLOAT16, hip_bfloat16)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(MIN, DO_OP_MIN_BFLOAT16, hip_bfloat16)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(SUM, DO_OP_SUM_BFLOAT16, hip_bfloat16)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(PROD, DO_OP_PROD_BFLOAT16, hip_bfloat16)
+
+#define LAUNCH_KERNEL(NAME, type, src1, src2, dest, count, s, b, t)            \
+    do {                                                                       \
+        UCC_REDUCE_ROCM_ ## NAME<type> <<<b, t, 0, s>>>(src1, src2,            \
+                                                        dest, count);          \
+    } while(0)
+
+
+#define DT_REDUCE_INT(type, op, src1_p, src2_p, dest_p, count, s, b, t) do {   \
+        const type *sbuf1 = (type *)src1_p;                                    \
+        const type *sbuf2= (type *)src2_p;                                     \
+        type *dest = (type *)dest_p;                                           \
+        switch(op) {                                                           \
+        case UCC_OP_MAX:                                                       \
+            LAUNCH_KERNEL(MAX, type, sbuf1, sbuf2, dest, count, s, b, t);      \
+            break;                                                             \
+        case UCC_OP_MIN:                                                       \
+            LAUNCH_KERNEL(MIN, type, sbuf1, sbuf2, dest, count, s, b, t);      \
+            break;                                                             \
+        case UCC_OP_SUM:                                                       \
+            LAUNCH_KERNEL(SUM, type, sbuf1, sbuf2, dest, count, s, b, t);      \
+            break;                                                             \
+        case UCC_OP_PROD:                                                      \
+            LAUNCH_KERNEL(PROD, type, sbuf1, sbuf2, dest, count, s, b, t);     \
+            break;                                                             \
+        case UCC_OP_LAND:                                                      \
+            LAUNCH_KERNEL(LAND, type, sbuf1, sbuf2, dest, count, s, b, t);     \
+            break;                                                             \
+        case UCC_OP_BAND:                                                      \
+            LAUNCH_KERNEL(BAND, type, sbuf1, sbuf2, dest, count, s, b, t);     \
+            break;                                                             \
+        case UCC_OP_LOR:                                                       \
+            LAUNCH_KERNEL(LOR, type, sbuf1, sbuf2, dest, count, s, b, t);      \
+            break;                                                             \
+        case UCC_OP_BOR:                                                       \
+            LAUNCH_KERNEL(BOR, type, sbuf1, sbuf2, dest, count, s, b, t);      \
+            break;                                                             \
+        case UCC_OP_LXOR:                                                      \
+            LAUNCH_KERNEL(LXOR, type, sbuf1, sbuf2, dest, count, s, b, t);     \
+            break;                                                             \
+        case UCC_OP_BXOR:                                                      \
+            LAUNCH_KERNEL(BXOR, type, sbuf1, sbuf2, dest, count, s, b, t);     \
+            break;                                                             \
+        default:                                                               \
+            mc_error(&ucc_mc_rocm.super, "int dtype does not support "         \
+                     "requested reduce op: %s", ucc_reduction_op_str(op));     \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
+    } while(0)
+
+#define DT_REDUCE_FLOAT(type, op, src1_p, src2_p, dest_p, count, s, b, t)      \
+    do {                                                                       \
+        const type *sbuf1 = (const type *)src1_p;                              \
+        const type *sbuf2 = (const type *)src2_p;                              \
+        type       *dest  = (type *)dest_p;                                    \
+        switch (op) {                                                          \
+        case UCC_OP_MAX:                                                       \
+            LAUNCH_KERNEL(MAX, type, sbuf1, sbuf2, dest, count, s, b, t);      \
+            break;                                                             \
+        case UCC_OP_MIN:                                                       \
+            LAUNCH_KERNEL(MIN, type, sbuf1, sbuf2, dest, count, s, b, t);      \
+            break;                                                             \
+        case UCC_OP_SUM:                                                       \
+        case UCC_OP_AVG:                                                       \
+            LAUNCH_KERNEL(SUM, type, sbuf1, sbuf2, dest, count, s, b, t);      \
+            break;                                                             \
+        case UCC_OP_PROD:                                                      \
+            LAUNCH_KERNEL(PROD, type, sbuf1, sbuf2, dest, count, s, b, t);     \
+            break;                                                             \
+        default:                                                               \
+            mc_error(&ucc_mc_rocm.super,                                       \
+                     "float dtype does not support "                           \
+                     "requested reduce op: %s",                                \
+                     ucc_reduction_op_str(op));                                \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
+    } while (0)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ucc_status_t ucc_mc_rocm_reduce(const void *src1, const void *src2, void *dst,
+                                size_t count, ucc_datatype_t dt,
+                                ucc_reduction_op_t op)
+{
+    int           th     = MC_ROCM_CONFIG->reduce_num_threads;
+    unsigned long bk     = (count + th - 1)/th;
+    hipStream_t  stream;
+
+    UCC_MC_ROCM_INIT_STREAM();
+    stream = ucc_mc_rocm.stream;
+    if (MC_ROCM_CONFIG->reduce_num_blocks != UCC_ULUNITS_AUTO) {
+        bk = ucc_min(bk, MC_ROCM_CONFIG->reduce_num_blocks);
+    }
+    switch (dt)
+    {
+        case UCC_DT_INT16:
+            DT_REDUCE_INT(int16_t, op, src1, src2, dst, count, stream, bk, th);
+            break;
+        case UCC_DT_INT32:
+            DT_REDUCE_INT(int32_t, op, src1, src2, dst, count, stream, bk, th);
+            break;
+        case UCC_DT_INT64:
+            DT_REDUCE_INT(int64_t, op, src1, src2, dst, count, stream, bk, th);
+            break;
+        case UCC_DT_FLOAT16:
+            ucc_assert(2 == sizeof(__half));
+            DT_REDUCE_FLOAT(__half, op, src1, src2, dst, count, stream, bk, th);
+            break;
+        case UCC_DT_FLOAT32:
+            ucc_assert(4 == sizeof(float));
+            DT_REDUCE_FLOAT(float, op, src1, src2, dst, count, stream, bk, th);
+            break;
+        case UCC_DT_FLOAT64:
+            ucc_assert(8 == sizeof(double));
+            DT_REDUCE_FLOAT(double, op, src1, src2, dst, count, stream, bk, th);
+            break;
+        case UCC_DT_BFLOAT16:
+            ucc_assert(2 == sizeof(hip_bfloat16));
+            DT_REDUCE_FLOAT(hip_bfloat16, op, src1, src2, dst, count, stream,
+                            bk, th);
+            break;
+        default:
+            mc_error(&ucc_mc_rocm.super, "unsupported reduction type (%s)",
+                     ucc_datatype_str(dt));
+            return UCC_ERR_NOT_SUPPORTED;
+    }
+    ROCMCHECK(hipGetLastError());
+    ROCMCHECK(hipStreamSynchronize(stream));
+    return UCC_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/components/mc/rocm/kernel/mc_rocm_reduce_multi.cu
+++ b/src/components/mc/rocm/kernel/mc_rocm_reduce_multi.cu
@@ -1,0 +1,228 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "mc_rocm.h"
+#include "utils/ucc_math.h"
+
+#include "mc_rocm_reduce_ops.h"
+
+#define ROCM_REDUCE_WITH_OP(NAME, OP)                                          \
+template <typename T>                                                          \
+__global__ void UCC_REDUCE_ROCM_ ## NAME (const T *s1, const T *s2, T *d,      \
+                                          size_t size, size_t count,           \
+                                          size_t ld)                           \
+{                                                                              \
+        size_t start = blockIdx.x * blockDim.x + threadIdx.x;                  \
+        size_t step  = blockDim.x * gridDim.x;                                 \
+        for (size_t i = start; i < count; i+=step) {                           \
+            d[i] = OP(s1[i], s2[i]);                                           \
+            for (size_t j = 1; j < size; j++) {                                \
+                d[i] = OP(d[i], s2[i + j * ld]);                               \
+            }                                                                  \
+        }                                                                      \
+}
+
+#define ROCM_REDUCE_WITH_OP_SPECIALIZED(NAME, OP, TYPE)                        \
+template <>                                                                    \
+__global__ void UCC_REDUCE_ROCM_ ## NAME (const TYPE *s1, const TYPE *s2,      \
+                                          TYPE *d, size_t size, size_t count,  \
+                                          size_t ld)                           \
+{                                                                              \
+        size_t start = blockIdx.x * blockDim.x + threadIdx.x;                  \
+        size_t step  = blockDim.x * gridDim.x;                                 \
+        for (size_t i = start; i < count; i+=step) {                           \
+            d[i] = OP(s1[i], s2[i]);                                           \
+            for (size_t j = 1; j < size; j++) {                                \
+                d[i] = OP(d[i], s2[i + j * ld]);                               \
+            }                                                                  \
+        }                                                                      \
+}
+
+ROCM_REDUCE_WITH_OP(MAX,  DO_OP_MAX)
+ROCM_REDUCE_WITH_OP(MIN,  DO_OP_MIN)
+ROCM_REDUCE_WITH_OP(SUM,  DO_OP_SUM)
+ROCM_REDUCE_WITH_OP(PROD, DO_OP_PROD)
+ROCM_REDUCE_WITH_OP(LAND, DO_OP_LAND)
+ROCM_REDUCE_WITH_OP(BAND, DO_OP_BAND)
+ROCM_REDUCE_WITH_OP(LOR,  DO_OP_LOR)
+ROCM_REDUCE_WITH_OP(BOR,  DO_OP_BOR)
+ROCM_REDUCE_WITH_OP(LXOR, DO_OP_LXOR)
+ROCM_REDUCE_WITH_OP(BXOR, DO_OP_BXOR)
+
+ROCM_REDUCE_WITH_OP_SPECIALIZED(MAX, DO_OP_MAX_HALF, __half)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(MIN, DO_OP_MIN_HALF, __half)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(SUM, DO_OP_SUM_HALF, __half)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(PROD, DO_OP_PROD_HALF, __half)
+
+ROCM_REDUCE_WITH_OP_SPECIALIZED(MAX, DO_OP_MAX_BFLOAT16, hip_bfloat16)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(MIN, DO_OP_MIN_BFLOAT16, hip_bfloat16)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(SUM, DO_OP_SUM_BFLOAT16, hip_bfloat16)
+ROCM_REDUCE_WITH_OP_SPECIALIZED(PROD, DO_OP_PROD_BFLOAT16, hip_bfloat16)
+
+#define LAUNCH_KERNEL(NAME, type, src1, src2, dest, size, count, ld, s, b, t)  \
+    do {                                                                       \
+        UCC_REDUCE_ROCM_ ## NAME<type> <<<b, t, 0, s>>>(src1, src2, dest,      \
+                                                        size, count, ld);      \
+    } while(0)
+
+#define DT_REDUCE_INT(type, op, src1_p, src2_p, dest_p, size, count, ld, s, b, \
+                      t)                                                       \
+    do {                                                                       \
+        const type *sbuf1 = (type *)src1_p;                                    \
+        const type *sbuf2 = (type *)src2_p;                                    \
+        type *      dest  = (type *)dest_p;                                    \
+        switch (op) {                                                          \
+        case UCC_OP_MAX:                                                       \
+            LAUNCH_KERNEL(MAX, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_MIN:                                                       \
+            LAUNCH_KERNEL(MIN, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_SUM:                                                       \
+            LAUNCH_KERNEL(SUM, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_PROD:                                                      \
+            LAUNCH_KERNEL(PROD, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_LAND:                                                      \
+            LAUNCH_KERNEL(LAND, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_BAND:                                                      \
+            LAUNCH_KERNEL(BAND, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_LOR:                                                       \
+            LAUNCH_KERNEL(LOR, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_BOR:                                                       \
+            LAUNCH_KERNEL(BOR, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_LXOR:                                                      \
+            LAUNCH_KERNEL(LXOR, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_BXOR:                                                      \
+            LAUNCH_KERNEL(BXOR, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        default:                                                               \
+            mc_error(&ucc_mc_rocm.super,                                       \
+                     "int dtype does not support "                             \
+                     "requested reduce op: %s",                                \
+                     ucc_reduction_op_str(op));                                \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
+    } while (0)
+
+#define DT_REDUCE_FLOAT(type, op, src1_p, src2_p, dest_p, size, count, ld, s,  \
+                        b, t)                                                  \
+    do {                                                                       \
+        const type *sbuf1 = (const type *)src1_p;                              \
+        const type *sbuf2 = (const type *)src2_p;                              \
+        type *      dest  = (type *)dest_p;                                    \
+        switch (op) {                                                          \
+        case UCC_OP_MAX:                                                       \
+            LAUNCH_KERNEL(MAX, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_MIN:                                                       \
+            LAUNCH_KERNEL(MIN, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_SUM:                                                       \
+        case UCC_OP_AVG:                                                       \
+            LAUNCH_KERNEL(SUM, type, sbuf1, sbuf2, dest, size, count, ld, s,   \
+                          b, t);                                               \
+            break;                                                             \
+        case UCC_OP_PROD:                                                      \
+            LAUNCH_KERNEL(PROD, type, sbuf1, sbuf2, dest, size, count, ld, s,  \
+                          b, t);                                               \
+            break;                                                             \
+        default:                                                               \
+            mc_error(&ucc_mc_rocm.super,                                       \
+                     "float dtype does not support "                           \
+                     "requested reduce op: %s",                                \
+                     ucc_reduction_op_str(op));                                \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
+    } while (0)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <unistd.h>
+ucc_status_t ucc_mc_rocm_reduce_multi(const void *src1, const void *src2,
+                                      void *dst, size_t n_vectors,
+                                      size_t count, size_t stride,
+                                      ucc_datatype_t dt,
+                                      ucc_reduction_op_t op)
+{
+    size_t        ld     = stride / ucc_dt_size(dt);
+    int           th     = MC_ROCM_CONFIG->reduce_num_threads;
+    unsigned long bk     = (count + th - 1)/th;
+    hipStream_t  stream;
+
+    UCC_MC_ROCM_INIT_STREAM();
+    stream = ucc_mc_rocm.stream;
+    if (MC_ROCM_CONFIG->reduce_num_blocks != UCC_ULUNITS_AUTO) {
+        bk = ucc_min(bk, MC_ROCM_CONFIG->reduce_num_blocks);
+    }
+    switch (dt)
+    {
+        case UCC_DT_INT16:
+            DT_REDUCE_INT(int16_t, op, src1, src2, dst, n_vectors, count, ld,
+                          stream, bk, th);
+            break;
+        case UCC_DT_INT32:
+            DT_REDUCE_INT(int32_t, op, src1, src2, dst, n_vectors, count, ld,
+                          stream, bk, th);
+            break;
+        case UCC_DT_INT64:
+            DT_REDUCE_INT(int64_t, op, src1, src2, dst, n_vectors, count, ld,
+                          stream, bk, th);
+            break;
+        case UCC_DT_FLOAT16:
+            ucc_assert(2 == sizeof(__half));
+            DT_REDUCE_FLOAT(__half, op, src1, src2, dst, n_vectors, count, ld,
+                            stream, bk, th);
+            break;
+        case UCC_DT_FLOAT32:
+            ucc_assert(4 == sizeof(float));
+            DT_REDUCE_FLOAT(float, op, src1, src2, dst, n_vectors, count, ld,
+                            stream, bk, th);
+            break;
+        case UCC_DT_FLOAT64:
+            ucc_assert(8 == sizeof(double));
+            DT_REDUCE_FLOAT(double, op, src1, src2, dst, n_vectors, count, ld,
+                            stream, bk, th);
+            break;
+        case UCC_DT_BFLOAT16:
+            ucc_assert(2 == sizeof(hip_bfloat16));
+            DT_REDUCE_FLOAT(hip_bfloat16, op, src1, src2, dst, n_vectors,
+                            count, ld, stream, bk, th);
+            break;
+        default:
+            mc_error(&ucc_mc_rocm.super, "unsupported reduction type (%s)",
+                     ucc_datatype_str(dt));
+            return UCC_ERR_NOT_SUPPORTED;
+    }
+    ROCMCHECK(hipGetLastError());
+    ROCMCHECK(hipStreamSynchronize(stream));
+    return UCC_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/components/mc/rocm/kernel/mc_rocm_reduce_multi_alpha.cu
+++ b/src/components/mc/rocm/kernel/mc_rocm_reduce_multi_alpha.cu
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2020-2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "mc_rocm.h"
+#include "utils/ucc_math.h"
+
+#include "mc_rocm_reduce_ops.h"
+
+#define ROCM_REDUCE_ALPHA_WITH_OP(NAME, REDUCE_OP, VECTOR_OP)                  \
+    template <typename T>                                                      \
+    __global__ void UCC_REDUCE_ALPHA_ROCM_##NAME(                              \
+        const T *s1, const T *s2, T *d, size_t size, size_t count, size_t ld,  \
+        const T alpha)                                                         \
+    {                                                                          \
+        size_t start = blockIdx.x * blockDim.x + threadIdx.x;                  \
+        size_t step  = blockDim.x * gridDim.x;                                 \
+        for (size_t i = start; i < count; i += step) {                         \
+            d[i] = REDUCE_OP(s1[i], s2[i]);                                    \
+            for (size_t j = 1; j < size; j++) {                                \
+                d[i] = REDUCE_OP(d[i], s2[i + j * ld]);                        \
+            }                                                                  \
+            d[i] = VECTOR_OP(d[i], alpha);                                     \
+        }                                                                      \
+    }
+
+#define ROCM_REDUCE_ALPHA_WITH_OP_SPECIALIZED(NAME, REDUCE_OP, TYPE,           \
+                                              VECTOR_OP)                       \
+    template <>                                                                \
+    __global__ void UCC_REDUCE_ALPHA_ROCM_##NAME(                              \
+        const TYPE *s1, const TYPE *s2, TYPE *d, size_t size, size_t count,    \
+        size_t ld, const TYPE alpha)                                           \
+    {                                                                          \
+        size_t start = blockIdx.x * blockDim.x + threadIdx.x;                  \
+        size_t step  = blockDim.x * gridDim.x;                                 \
+        for (size_t i = start; i < count; i += step) {                         \
+            d[i] = REDUCE_OP(s1[i], s2[i]);                                    \
+            for (size_t j = 1; j < size; j++) {                                \
+                d[i] = REDUCE_OP(d[i], s2[i + j * ld]);                        \
+            }                                                                  \
+            d[i] = VECTOR_OP(d[i], alpha);                                     \
+        }                                                                      \
+    }
+
+ROCM_REDUCE_ALPHA_WITH_OP(SUM_WITH_PROD, DO_OP_SUM, DO_OP_PROD)
+
+ROCM_REDUCE_ALPHA_WITH_OP_SPECIALIZED(SUM_WITH_PROD, DO_OP_SUM_HALF, __half,
+                                      DO_OP_PROD_HALF)
+
+ROCM_REDUCE_ALPHA_WITH_OP_SPECIALIZED(SUM_WITH_PROD, DO_OP_SUM_BFLOAT16,
+                                      hip_bfloat16, DO_OP_PROD_BFLOAT16)
+
+#define LAUNCH_KERNEL(NAME, type, src1, src2, dest, size, count, ld, alpha, s, \
+                      b, t)                                                    \
+    do {                                                                       \
+        UCC_REDUCE_ALPHA_ROCM_##NAME<type>                                     \
+            <<<b, t, 0, s>>>(src1, src2, dest, size, count, ld, alpha);        \
+    } while (0)
+
+#define DT_REDUCE_FLOAT(type, reduce_op, src1_p, src2_p, dest_p, size, count,  \
+                        ld, alpha, vector_op, s, b, t)                         \
+    do {                                                                       \
+        const type *sbuf1 = (const type *)src1_p;                              \
+        const type *sbuf2 = (const type *)src2_p;                              \
+        type *      dest  = (type *)dest_p;                                    \
+        switch (vector_op) {                                                   \
+        case UCC_OP_PROD:                                                      \
+            switch (reduce_op) {                                               \
+            case UCC_OP_AVG:                                                   \
+                LAUNCH_KERNEL(SUM_WITH_PROD, type, sbuf1, sbuf2, dest, size,   \
+                              count, ld, alpha, s, b, t);                      \
+                break;                                                         \
+            default:                                                           \
+                mc_error(&ucc_mc_rocm.super,                                   \
+                         "float dtype does not support "                       \
+                         "requested reduce op: %s",                            \
+                         ucc_reduction_op_str(reduce_op));                     \
+                return UCC_ERR_NOT_SUPPORTED;                                  \
+            }                                                                  \
+            break;                                                             \
+        default:                                                               \
+            mc_error(&ucc_mc_rocm.super,                                       \
+                     "float dtype does not support "                           \
+                     "requested vector op: %s",                                \
+                     ucc_reduction_op_str(vector_op));                         \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
+    } while (0)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ucc_status_t
+ucc_mc_rocm_reduce_multi_alpha(const void *src1, const void *src2, void *dst,
+                               size_t n_vectors, size_t count, size_t stride,
+                               ucc_datatype_t dt, ucc_reduction_op_t reduce_op,
+                               ucc_reduction_op_t vector_op, double alpha)
+{
+    size_t ld = stride / ucc_dt_size(dt);
+    int    th = MC_ROCM_CONFIG->reduce_num_threads;
+    unsigned long bk = (count + th - 1) / th;
+    hipStream_t stream;
+
+    UCC_MC_ROCM_INIT_STREAM();
+    stream = ucc_mc_rocm.stream;
+    if (MC_ROCM_CONFIG->reduce_num_blocks != UCC_ULUNITS_AUTO) {
+        bk = ucc_min(bk, MC_ROCM_CONFIG->reduce_num_blocks);
+    }
+    switch (dt) {
+    case UCC_DT_FLOAT16:
+        ucc_assert(2 == sizeof(__half));
+        DT_REDUCE_FLOAT(__half, reduce_op, src1, src2, dst, n_vectors, count,
+                        ld, __float2half((float)alpha), vector_op, stream, bk, th);
+        break;
+    case UCC_DT_FLOAT32:
+        ucc_assert(4 == sizeof(float));
+        DT_REDUCE_FLOAT(float, reduce_op, src1, src2, dst, n_vectors, count, ld,
+                        (float)alpha, vector_op, stream, bk, th);
+        break;
+    case UCC_DT_FLOAT64:
+        ucc_assert(8 == sizeof(double));
+        DT_REDUCE_FLOAT(double, reduce_op, src1, src2, dst, n_vectors, count,
+                        ld, alpha, vector_op, stream, bk, th);
+        break;
+    case UCC_DT_BFLOAT16:
+        DT_REDUCE_FLOAT(hip_bfloat16, reduce_op, src1, src2, dst, n_vectors,
+                        count, ld, hip_bfloat16((float)alpha), vector_op, stream, bk, th);
+        break;
+    default:
+        mc_error(&ucc_mc_rocm.super, "unsupported reduction type (%s)",
+                 ucc_datatype_str(dt));
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    ROCMCHECK(hipGetLastError());
+    ROCMCHECK(hipStreamSynchronize(stream));
+    return UCC_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/components/mc/rocm/kernel/mc_rocm_reduce_ops.h
+++ b/src/components/mc/rocm/kernel/mc_rocm_reduce_ops.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_MC_ROCM_REDUCE_OPS_H_
+#define UCC_MC_ROCM_REDUCE_OPS_H_
+
+#include <hip_fp16.h>
+#include <hip_bfloat16.h>
+
+#define DO_OP_MAX_HALF(_v1, _v2) ((__half2float(_v1) > __half2float(_v2)) ? _v1 : _v2)
+#define DO_OP_MIN_HALF(_v1, _v2) ((__half2float(_v1) < __half2float(_v2)) ? _v1 : _v2)
+#define DO_OP_SUM_HALF(_v1, _v2) (__float2half(__half2float(_v1) + __half2float(_v2)))
+#define DO_OP_PROD_HALF(_v1, _v2) (__float2half(__half2float(_v1) * __half2float(_v2)))
+
+#define DO_OP_MAX_BFLOAT16(_v1, _v2)					\
+    ((static_cast<float>(_v1) > static_cast<float>(_v2)) ? _v1 : _v2)
+#define DO_OP_MIN_BFLOAT16(_v1, _v2)					\
+    ((static_cast<float>(_v1) < static_cast<float>(_v2)) ? _v1 : _v2)
+#define DO_OP_SUM_BFLOAT16(_v1, _v2)					\
+    (hip_bfloat16(static_cast<float>(_v1) + static_cast<float>(_v2)))
+#define DO_OP_PROD_BFLOAT16(_v1, _v2)					\
+    (hip_bfloat16(static_cast<float>(_v1) * static_cast<float>(_v2)))
+
+#endif

--- a/src/components/mc/rocm/mc_rocm.c
+++ b/src/components/mc/rocm/mc_rocm.c
@@ -347,6 +347,9 @@ ucc_mc_rocm_t ucc_mc_rocm = {
     .super.ops.mem_alloc          = ucc_mc_rocm_mem_pool_alloc_with_init,
     .super.ops.mem_free           = ucc_mc_rocm_mem_pool_free,
     .super.ops.memcpy             = ucc_mc_rocm_memcpy,
+    .super.ops.reduce             = ucc_mc_rocm_reduce,
+    .super.ops.reduce_multi       = ucc_mc_rocm_reduce_multi,
+    .super.ops.reduce_multi_alpha = ucc_mc_rocm_reduce_multi_alpha,
     .super.config_table =
         {
             .name   = "ROCM memory component",

--- a/src/components/mc/rocm/mc_rocm.h
+++ b/src/components/mc/rocm/mc_rocm.h
@@ -52,6 +52,30 @@ typedef struct ucc_mc_rocm {
 } ucc_mc_rocm_t;
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ucc_status_t ucc_mc_rocm_reduce(const void *src1, const void *src2,
+                                void *dst, size_t count, ucc_datatype_t dt,
+                                ucc_reduction_op_t op);
+
+ucc_status_t ucc_mc_rocm_reduce_multi(const void *src1, const void *src2,
+                                      void *dst, size_t n_vectors,
+                                      size_t count, size_t stride,
+                                      ucc_datatype_t dt,
+                                      ucc_reduction_op_t op);
+
+ucc_status_t
+ucc_mc_rocm_reduce_multi_alpha(const void *src1, const void *src2, void *dst,
+                               size_t n_vectors, size_t count, size_t stride,
+                               ucc_datatype_t dt, ucc_reduction_op_t reduce_op,
+                               ucc_reduction_op_t vector_op, double alpha);
+
+#ifdef __cplusplus
+}    
+#endif
+    
 extern ucc_mc_rocm_t ucc_mc_rocm;
 
 #define MC_ROCM_CONFIG                                                         \

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -206,8 +206,11 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
         switch(coll_mem_type) {
         case UCC_MEMORY_TYPE_CUDA:
             coll_ee_type = UCC_EE_CUDA_STREAM;
+            break; 
+        case UCC_MEMORY_TYPE_ROCM:
+            coll_ee_type = UCC_EE_ROCM_STREAM;
             break;
-        case UCC_MEMORY_TYPE_HOST:
+       case UCC_MEMORY_TYPE_HOST:
             coll_ee_type = UCC_EE_CPU_THREAD;
             break;
         default:


### PR DESCRIPTION

## What
Add support for using TL/UCP for ROCm memory

## Why ?
This commit allows among other things to use the Open MPI /ucc component for buffer located on ROCm devices.

## How ?

