### PR TITLE
CL/HIER: set contig buffer flag for a2a

### DIFF
--- a/src/coll_score/ucc_coll_score_map.c
+++ b/src/coll_score/ucc_coll_score_map.c
@@ -120,7 +120,8 @@ ucc_status_t ucc_coll_init(ucc_score_map_t      *map,
     while (&fb->list_elem != &r->fallback &&
            (status == UCC_ERR_NOT_SUPPORTED ||
             status == UCC_ERR_NOT_IMPLEMENTED)) {
-        ucc_debug("coll is not supported for %s, fallback %s",
+        ucc_debug("coll %s is not supported for %s, fallback %s",
+                  ucc_coll_type_str(bargs->args.coll_type),
                   team->context->lib->log_component.name,
                   fb->team->context->lib->log_component.name);
         team   = fb->team;

--- a/src/components/cl/hier/alltoall/alltoall.c
+++ b/src/components/cl/hier/alltoall/alltoall.c
@@ -41,7 +41,13 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoall_init,
 
     memcpy(&args, coll_args, sizeof(args));
     args.args.coll_type = UCC_COLL_TYPE_ALLTOALLV;
-    team_size           = UCC_CL_TEAM_SIZE(cl_team);
+    if (!(args.args.mask & UCC_COLL_ARGS_FIELD_FLAGS)) {
+        args.args.mask  = UCC_COLL_ARGS_FIELD_FLAGS;
+        args.args.flags = 0;
+    }
+    args.args.flags |= UCC_COLL_ARGS_FLAG_CONTIG_SRC_BUFFER |
+                       UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER;
+    team_size = UCC_CL_TEAM_SIZE(cl_team);
 
     status =
         ucc_mc_alloc(&h, sizeof(int) * team_size * 2, UCC_MEMORY_TYPE_HOST);


### PR DESCRIPTION
## What
Set contig src buffer and contig dst buffer flags in CL HIER alltoall.

## Why ?
In node split alltoall algorithm we know that both node and full subgroup tasks works with contig buffers, hence it's possible  to set contig flag to allow further optimizations in TL level. 
