### PR TITLE
TEST: fixes segv in test_mpi

### DIFF
--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -189,6 +189,7 @@ typedef struct ucc_test_team {
     {
 #ifdef HAVE_CUDA
         cuda_stream = nullptr;
+        cuda_ee     = nullptr;
 #endif
     };
 


### PR DESCRIPTION
## What
Initialize cuda_ec to nullptr, otherwise incorrect destroy happens
