### PR TITLE
EC/CUDA: fixes uninit build fix

### DIFF
--- a/src/components/ec/cuda/ec_cuda_executor_interruptible.c
+++ b/src/components/ec/cuda/ec_cuda_executor_interruptible.c
@@ -48,8 +48,8 @@ ucc_cuda_executor_interruptible_task_post(ucc_ee_executor_t *executor,
                                          const ucc_ee_executor_task_args_t *task_args,
                                          ucc_ee_executor_task_t **task)
 {
+    cudaStream_t stream = NULL;
     ucc_ec_cuda_executor_interruptible_task_t *ee_task;
-    cudaStream_t stream;
     ucc_status_t status;
 
     status = ucc_cuda_executor_interruptible_get_stream(&stream);


### PR DESCRIPTION
## What
On some systems 
```
root@hpc-kernel-03:/tmp/val/ucc/src/components/ec/cuda# cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.5 LTS"
root@hpc-kernel-03:/tmp/val/ucc/src/components/ec/cuda# gcc --version
gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
the build of ec/cuda fails with the output

```
libtool: link: ar cru .libs/libucc_ec_cuda_kernels.a '.libs/ec_cuda_wait_kernel.o' '.libs/ec_cuda_executor.o'
ar: `u' modifier ignored since `D' is the default (see `U')
libtool: link: ranlib .libs/libucc_ec_cuda_kernels.a
libtool: link: ( cd ".libs" && rm -f "libucc_ec_cuda_kernels.la" && ln -s "../libucc_ec_cuda_kernels.la" "libucc_ec_cuda_kernels.la" )
make[1]: Leaving directory '/tmp/val/ucc/src/components/ec/cuda/kernel'
make[1]: Entering directory '/tmp/val/ucc/src/components/ec/cuda'
  CC       libucc_ec_cuda_la-ec_cuda.lo
  CC       libucc_ec_cuda_la-ec_cuda_executor.lo
  CC       libucc_ec_cuda_la-ec_cuda_executor_interruptible.lo
Makefile:644: recipe for target 'libucc_ec_cuda_la-ec_cuda_executor_interruptible.lo' failed
make[1]: *** [libucc_ec_cuda_la-ec_cuda_executor_interruptible.lo] Error 1
```

Running compile line manually:
```
root@hpc-kernel-03:/tmp/val/ucc/src/components/ec/cuda# gcc -DHAVE_CONFIG_H -I. -I../../../.. -DCPU_FLAGS= -I/tmp/val/ucc/src -I/tmp/val/ucc -I/tmp/val/ucc/src -I/hpc/local/benchmarks/daily/next/2022-06-06/hpcx-gcc-redhat7/ucx/include/ -Wall -Werror -funwind-tables -Wno-missing-field-initializers -Wno-unused-parameter -Wno-long-long -Wno-endif-labels -Wno-sign-compare -Wno-multichar -Wno-deprecated-declarations -Winvalid-pch -Wno-pointer-sign -Werror-implicit-function-declaration -Wnested-externs -Wshadow -O3 -g -DNDEBUG -D__HIP_PLATFORM_AMD__ -std=gnu11 -MT libucc_ec_cuda_la-ec_cuda_executor_interruptible.lo -MD -MP -MF .deps/libucc_ec_cuda_la-ec_cuda_executor_interruptible.Tpo -c ec_cuda_executor_interruptible.c -o libucc_ec_cuda_la-ec_cuda_executor_interruptible.o
ec_cuda_executor_interruptible.c: In function 'ucc_cuda_executor_interruptible_task_post':
ec_cuda_executor_interruptible.c:128:12: error: 'stream' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     status = ucc_ec_cuda_event_post(stream, ee_task->event);
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

## How ?
Just initialize stream to NULL.

not clear why autoconf/make on that systems adds " >/dev/null 2>&1" to the end of gcc compile line and this way hides the error message.