### PR TITLE
CL/BASIC: fix score_map cleanup

### DIFF
--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -26,6 +26,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_team_t, ucc_base_context_t *cl_context,
         goto err;
     }
     self->n_tl_teams = 0;
+    self->score_map  = NULL;
     status           = ucc_team_multiple_req_alloc(&self->team_create_req,
                                                    ctx->n_tl_ctxs);
     if (UCC_OK != status) {
@@ -93,7 +94,9 @@ ucc_status_t ucc_cl_basic_team_destroy(ucc_base_team_t *cl_team)
         }
     }
     ucc_team_multiple_req_free(team->team_create_req);
-    ucc_coll_score_free_map(team->score_map);
+    if (team->score_map) {
+        ucc_coll_score_free_map(team->score_map);
+    }
     ucc_free(team->tl_teams);
     UCC_CLASS_DELETE_FUNC_NAME(ucc_cl_basic_team_t)(cl_team);
     return status;
@@ -106,6 +109,7 @@ ucc_status_t ucc_cl_basic_team_create_test(ucc_base_team_t *cl_team)
     ucc_status_t            status;
     int                     i;
     ucc_coll_score_t       *score, *score_next, *score_merge;
+
     status = ucc_tl_team_create_multiple(team->team_create_req);
     if (status == UCC_OK) {
         for (i = 0; i < ctx->n_tl_ctxs; i++) {


### PR DESCRIPTION
## What
Fixes potential segv in cl/basic team destroy when score_map_free is called on non-init value.

## Why ?
If CL/BASIC fails to init any team (e.g. when team_size == 1 and TL/SELF is not available, maybe UCC_TLS=ucp is set), then segv happens in cl_basic_team_destroy. 
