### PR TITLE
BUILD: exit on cuda compile error

### DIFF
--- a/cuda_lt.sh
+++ b/cuda_lt.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function replace_extension {
     __filename=$1


### PR DESCRIPTION
## What
stop compilation on nvcc build error

## Why ?
cuda_lt.sh is used to build device code, however any returned nvcc error (e.g. due to syntax error in code) ignored. In that case UCC build always finishes successfully although EC and MC CUDA were not built. 

## How ?
exit and return error if any cmd in cuda_lt.sh fails