### PR TITLE
UTIL: cfg parser respect inherited vars

### DIFF
--- a/test/gtest/utils/test_cfg_file.cc
+++ b/test/gtest/utils/test_cfg_file.cc
@@ -106,3 +106,13 @@ UCC_TEST_F(test_cfg_file, env_preference) {
     EXPECT_EQ(123, cfg.bar);
     EXPECT_EQ(1,  cfg.boo);
 }
+
+UCC_TEST_F(test_cfg_file, env_preference_inherited) {
+    std::string filename = test_dir + "ucc_test.conf";
+
+    setenv("GTEST_UCC_FOO", "123", 1);
+    EXPECT_EQ(UCC_OK, ucc_parse_file_config(filename.c_str(), &file_cfg));
+    init_cfg();
+    unsetenv("GTEST_UCC_FOO");
+    EXPECT_EQ(123, cfg.super.foo);
+}


### PR DESCRIPTION
## What
Fixes config file parsing with respect to inherited variables

## Why ?
When the variable in the config table is inherited from another parent table (e.g., TLS var in CLs is defined in parent ucc_cl_base_config), and user sets the top variable in the env it gets overwritten by the file configuration.
For example,
if there is cfg file with entry:
UCC_CL_BASIC_TLS=^sharp

and user runs app with: UCC_TLS=ucp , then the value of CL_BASIC_TLS would still be "^sharp", i.e. all except sharp - not what user expects (which is "ucp" only).

## How ?
When applying value from cfg file database need to check if there is a parent variable setting in the environment and then skip it in that case.
