### PR TITLE
TL/CUDA: check cuda device in coll init

### DIFF
--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -39,7 +39,7 @@ static int                                 num_tests    = 1;
 static bool                                has_onesided = true;
 static bool                                verbose      = false;
 #if defined(HAVE_CUDA) || defined(HAVE_HIP)
-static test_set_gpu_device_t test_gpu_set_device = TEST_SET_DEV_NONE;
+extern test_set_gpu_device_t test_gpu_set_device;
 #endif
 
 static std::vector<std::string> str_split(const char *value, const char *delimiter)

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -397,6 +397,10 @@ void UccTestMpi::set_displ_vsizes(std::vector<ucc_test_vsize_flag_t> &_displs_vs
 }
 
 #if defined(HAVE_CUDA) || defined(HAVE_HIP)
+test_set_gpu_device_t test_gpu_set_device = TEST_SET_DEV_NONE;
+#endif
+
+#if defined(HAVE_CUDA) || defined(HAVE_HIP)
 void set_gpu_device(test_set_gpu_device_t set_device)
 {
     MPI_Comm local_comm;
@@ -623,6 +627,10 @@ typedef struct ucc_test_thread {
 static void *thread_start(void *arg)
 {
     ucc_test_thread_t *t = (ucc_test_thread_t *)arg;
+
+#if defined(HAVE_CUDA) || defined(HAVE_HIP)
+    set_gpu_device(test_gpu_set_device);
+#endif
     t->test->run_all_at_team(t->test->teams[t->id], t->rst);
     return 0;
 }


### PR DESCRIPTION
## What
Check GPU in collective_init matches device used to initialize team. Set GPU device in multithread test

## Why ?
Fixes segfault in multithread tests with TL CUDA
