### PR TITLE
TL/RCCL: fix configure logic

### DIFF
--- a/config/m4/rccl.m4
+++ b/config/m4/rccl.m4
@@ -21,7 +21,7 @@ AS_IF([test "x$rccl_checked" != "xyes"],[
         AS_IF([test ! -z "$with_rccl" -a "x$with_rccl" != "xyes" -a "x$with_rccl" != "xguess"],
         [
             AS_IF([test ! -d $with_rccl],
-                  [AC_MSG_ERROR([Provided "--with-rccl=${with_rccl}" location does not exist])], [])])
+                  [AC_MSG_ERROR([Provided "--with-rccl=${with_rccl}" location does not exist])])
             check_rccl_dir="$with_rccl"
             check_rccl_libdir="$with_rccl/lib"
             CPPFLAGS="-I$with_rccl/include $save_CPPFLAGS"
@@ -59,7 +59,7 @@ AS_IF([test "x$rccl_checked" != "xyes"],[
                     [
 			rccl_happy="no"
                     ])
-                ]),
+                ])
             ])
         ],
         [
@@ -100,4 +100,4 @@ AS_IF([test "x$rccl_checked" != "xyes"],[
     ])
 
     rccl_checked=yes
-])
+])])


### PR DESCRIPTION
## What
allow to explicitly disable tl/rccl 

## Why ?
If rccl is installed as part of the rocm software package, the configure script picks it up (correctly) even if the user did not explicitly request it. However, if not desired, the  ```--with-rccl=no``` option did not work correctly due to a minor mistake in the configure script.