### PR TITLE
TL/RCCL and TL/NCCL: move event_destroy call

### DIFF
--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -119,6 +119,9 @@ ucc_tl_nccl_task_t * ucc_tl_nccl_init_task(ucc_base_coll_args_t *coll_args,
 void ucc_tl_nccl_free_task(ucc_tl_nccl_task_t *task)
 {
     UCC_TL_NCCL_PROFILE_REQUEST_FREE(task);
+    if (task->completed) {
+        ucc_ec_destroy_event(task->completed, UCC_EE_CUDA_STREAM);
+    }
     ucc_mpool_put(task);
 }
 
@@ -156,9 +159,6 @@ ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
     ucc_status_t       status = UCC_OK ;
 
     tl_info(UCC_TASK_LIB(task), "finalizing coll task %p", task);
-    if (task->completed) {
-        ucc_ec_destroy_event(task->completed, UCC_EE_CUDA_STREAM);
-    }
     ucc_tl_nccl_free_task(task);
     return status;
 }

--- a/src/components/tl/rccl/tl_rccl_coll.c
+++ b/src/components/tl/rccl/tl_rccl_coll.c
@@ -112,6 +112,9 @@ ucc_tl_rccl_task_t * ucc_tl_rccl_init_task(ucc_base_coll_args_t *coll_args,
 void ucc_tl_rccl_free_task(ucc_tl_rccl_task_t *task)
 {
     UCC_TL_RCCL_PROFILE_REQUEST_FREE(task);
+    if (task->completed) {
+        ucc_ec_destroy_event(task->completed, UCC_EE_ROCM_STREAM);
+    }
     ucc_mpool_put(task);
 }
 
@@ -150,9 +153,6 @@ ucc_status_t ucc_tl_rccl_coll_finalize(ucc_coll_task_t *coll_task)
     ucc_status_t       status = UCC_OK ;
 
     tl_info(UCC_TASK_LIB(task), "finalizing coll task %p", task);
-    if (task->completed) {
-        ucc_ec_destroy_event(task->completed, UCC_EE_ROCM_STREAM);
-    }
     ucc_tl_rccl_free_task(task);
     return status;
 }


### PR DESCRIPTION
## What
move the invocation of event_destroy() from the coll_finalize() function to the free_task() function .

## Why ?
Running ucc_test_mpi generated warning about event objects not being returned to the mpool. This commit fixes the problem by making sure that the events are correctly managed even if a test is skipped due to an unsupported datatype.