### PR TITLE
BUILD: return error for not implemented functions

### DIFF
--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -206,7 +206,7 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
         switch(coll_mem_type) {
         case UCC_MEMORY_TYPE_CUDA:
             coll_ee_type = UCC_EE_CUDA_STREAM;
-            break; 
+            break;
         case UCC_MEMORY_TYPE_ROCM:
             coll_ee_type = UCC_EE_ROCM_STREAM;
             break;
@@ -286,6 +286,15 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_post, (request),
         }
     }
     return task->post(task);
+}
+
+UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init_and_post,
+                      (coll_args, request, team), ucc_coll_args_t *coll_args,
+                      ucc_coll_req_h *request, ucc_team_h team)
+{
+    ucc_error("ucc_collective_init_and_post() is not implemented");
+
+    return UCC_ERR_NOT_IMPLEMENTED;
 }
 
 UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_finalize, (request),

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -34,6 +34,13 @@ void ucc_copy_team_params(ucc_team_params_t *dst, const ucc_team_params_t *src)
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_TEAM_PARAM_FIELD_EP_MAP, ep_map);
 }
 
+ucc_status_t ucc_team_get_attr(ucc_team_h team, ucc_team_attr_t *team_attr)
+{
+    ucc_error("ucc_team_get_attr() is not implemented");
+
+    return UCC_ERR_NOT_IMPLEMENTED;
+}
+
 static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
                                                 ucc_team_t *team)
 {

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1191,7 +1191,9 @@ enum ucc_team_attr_field {
     UCC_TEAM_ATTR_FIELD_EP                     = UCC_BIT(2),
     UCC_TEAM_ATTR_FIELD_EP_RANGE               = UCC_BIT(3),
     UCC_TEAM_ATTR_FIELD_SYNC_TYPE              = UCC_BIT(4),
-    UCC_TEAM_ATTR_FIELD_MEM_PARAMS             = UCC_BIT(5)
+    UCC_TEAM_ATTR_FIELD_MEM_PARAMS             = UCC_BIT(5),
+    UCC_TEAM_ATTR_FIELD_SIZE                   = UCC_BIT(6),
+    UCC_TEAM_ATTR_FIELD_EPS                    = UCC_BIT(7)
 };
 
 /**
@@ -1479,6 +1481,8 @@ typedef struct ucc_team_attr {
     ucc_ep_range_type_t    ep_range;
     ucc_coll_sync_type_t   sync_type;
     ucc_mem_map_params_t   mem_params;
+    uint32_t               size;
+    uint64_t              *eps;
 } ucc_team_attr_t;
 
 
@@ -1622,73 +1626,6 @@ ucc_status_t ucc_team_get_attr(ucc_team_h team,
 ucc_status_t ucc_team_create_from_parent(uint64_t my_ep, uint32_t included,
                                          ucc_team_h parent_team,
                                          ucc_team_h *new_team);
-
-/**
- *  @ingroup UCC_TEAM
- *
- *  @brief The routine returns the size of the team.
- *
- *  @param [in]   team      Team handle
- *  @param [out]  size      The size of team as number of endpoints
- *
- *  @parblock
- *
- *  @b Description
- *
- *  @ref ucc_team_get_size routine queries the size of the team. It reflects the
- *  number of unique endpoints in the team.
- *
- *  @endparblock
- *
- *  @return Error code as defined by @ref ucc_status_t
- */
-ucc_status_t ucc_team_get_size(ucc_team_h team, uint32_t *size);
-
-
-/**
- *  @ingroup UCC_TEAM
- *
- *  @brief The routine returns the endpoint of the calling participant.
- *
- *  @param [out]  ep          Endpoint of the participant calling the routine
- *  @param [in]   team        Team handle
- *
- *  @parblock
- *
- *  @b Description
- *
- *  @ref ucc_team_get_my_ep routine queries and returns the endpoint of the
- *  participant invoking the interface.
- *
- *  @endparblock
- *
- *  @return Error code as defined by @ref ucc_status_t
- */
-ucc_status_t ucc_team_get_my_ep(ucc_team_h team, uint64_t *ep);
-
-/**
- *  @ingroup UCC_TEAM
- *
- *  @brief The routine queries all endpoints associated with the team handle.
- *
- *  @param [out]     ep          List of endpoints
- *  @param [out]     num_eps     Number of endpoints
- *  @param [in]      team        Team handle
- *
- *  @parblock
- *
- *  @b Description
- *
- *  @ref ucc_team_get_all_eps routine queries and returns all endpoints of all
- *  participants in the team.
- *
- *  @endparblock
- *
- *  @return Error code as defined by @ref ucc_status_t
- */
-ucc_status_t ucc_team_get_all_eps(ucc_team_h team, uint64_t **ep,
-                                  uint64_t *num_eps);
-
 
 /*
  * *************************************************************


### PR DESCRIPTION
## What
Print error if not implemented UCC API function is called.

## Why ?
Following functions are not currently implemented. Linker will throw undefined reference error if somebody tries to use them.

ucc_team_get_attr
ucc_team_get_size
ucc_team_get_my_ep
ucc_team_get_all_eps
ucc_collective_init_and_post

For discussion: can we remove ucc_team_get_size and ucc_team_get_my_ep? Maybe it's better to return team size and ep using  ucc_team_get_attr?