### PR TITLE
TL/CUDA: alltoall dst buf registration

### DIFF
--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -31,9 +31,10 @@ size_t ucc_tl_cuda_alltoall_get_offset(const ucc_tl_cuda_task_t *task,
 
 ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
 {
-    ucc_coll_args_t *args = &TASK_ARGS(task);
-    ucc_status_t     status;
-    size_t           data_len;
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_coll_args_t    *args = &TASK_ARGS(task);
+    ucc_status_t        status;
+    size_t              data_len;
 
     task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
 
@@ -56,10 +57,13 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;
     }
-    status = ucc_tl_cuda_mem_info_get(args->dst.info.buffer, data_len,
-                                      &task->alltoallv_ce.mem_info_dst);
-    if (ucc_unlikely(status != UCC_OK)) {
-        goto exit_err;
+
+    if (team->topo->proxy_needed) {
+        status = ucc_tl_cuda_mem_info_get(args->dst.info.buffer, data_len,
+                                          &task->alltoallv_ce.mem_info_dst);
+        if (ucc_unlikely(status != UCC_OK)) {
+            goto exit_err;
+        }
     }
 
     task->super.post           = ucc_tl_cuda_alltoallv_ce_start;

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -82,7 +82,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_setup_test(ucc_tl_cuda_task_t *task)
     volatile ucc_tl_cuda_sync_t *peer_sync, *sync;
     ucc_tl_cuda_cache_t         *cache;
     ucc_status_t                 status;
-    ucc_rank_t                   i;
+    ucc_rank_t                   i, dst;
     ucc_ee_h                     ee     = task->super.ee;
     cudaStream_t                 stream = (ee) ? (cudaStream_t)ee->ee_context : team->stream;
 
@@ -104,6 +104,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_setup_test(ucc_tl_cuda_task_t *task)
             status = UCC_ERR_NO_MESSAGE;
             goto exit_err;
         }
+
         status = ucc_tl_cuda_map_memhandle(
             peer_sync->mem_info_src.ptr, peer_sync->mem_info_src.length,
             peer_sync->mem_info_src.handle,
@@ -112,18 +113,31 @@ ucc_status_t ucc_tl_cuda_alltoallv_setup_test(ucc_tl_cuda_task_t *task)
             ucc_error("ucc_cuda_ipc_map_memhandle failed");
             return UCC_ERR_INVALID_PARAM;
         }
-        status = ucc_tl_cuda_map_memhandle(
-            peer_sync->mem_info_dst.ptr, peer_sync->mem_info_dst.length,
-            peer_sync->mem_info_dst.handle,
-            &task->alltoallv_ce.peer_map_addr_dst[i], cache);
-        if (UCC_OK != status) {
-            ucc_error("ucc_cuda_ipc_map_memhandle failed");
-            return UCC_ERR_INVALID_PARAM;
-        }
+
         CUDA_CHECK_GOTO(
             cudaStreamWaitEvent(stream, sync->data[i].ipc_event_remote, 0),
             exit_err, status);
     }
+
+    for (i = 0; i < team->topo->num_proxies; i++) {
+        dst = team->topo->proxies[i].dst;
+        peer_sync = TASK_SYNC(task, dst);
+        cache     = ucc_tl_cuda_get_cache(team, dst);
+        if (ucc_unlikely(!cache)) {
+            status = UCC_ERR_NO_MESSAGE;
+            goto exit_err;
+        }
+
+        status = ucc_tl_cuda_map_memhandle(
+            peer_sync->mem_info_dst.ptr, peer_sync->mem_info_dst.length,
+            peer_sync->mem_info_dst.handle,
+            &task->alltoallv_ce.peer_map_addr_dst[dst], cache);
+        if (UCC_OK != status) {
+            ucc_error("ucc_cuda_ipc_map_memhandle failed");
+            return UCC_ERR_INVALID_PARAM;
+        }
+    }
+
     return UCC_OK;
 
 exit_err:
@@ -189,40 +203,36 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
     }
 
     for (i = 0; i < team->topo->num_proxies; i++) {
-        if (team->topo->proxies[i].proxy == rank) {
-            psrc      = team->topo->proxies[i].src;
-            pdst      = team->topo->proxies[i].dst;
-            peer_sync = TASK_SYNC(task, psrc);
-            data_size = task->alltoallv_ce.get_size(
-                task, peer_sync->alltoallv_ce.sbytes, pdst);
-            if (data_size == 0) {
-                continue;
-            }
-            data_displ = task->alltoallv_ce.get_offset(
-                task, peer_sync->alltoallv_ce.sdispl_bytes, pdst);
-            src        = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_src[psrc],
-                                    peer_sync->mem_info_src.offset);
-            src        = PTR_OFFSET(src, data_displ);
-            peer_sync  = TASK_SYNC(task, pdst);
-            dst        = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_dst[pdst],
-                                    peer_sync->mem_info_dst.offset);
-            data_displ = task->alltoallv_ce.get_offset(
-                task, peer_sync->alltoallv_ce.rdispl_bytes, psrc);
-
-            dst                 = PTR_OFFSET(dst, data_displ);
-            exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
-            exec_args.copy.dst  = dst;
-            exec_args.copy.src  = src;
-            exec_args.copy.len  = data_size;
-
-            exec_task =
-                &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
-            status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
-            if (ucc_unlikely(status != UCC_OK)) {
-                goto exit;
-            }
-            task->alltoallv_ce.num_posted++;
+        psrc      = team->topo->proxies[i].src;
+        pdst      = team->topo->proxies[i].dst;
+        peer_sync = TASK_SYNC(task, psrc);
+        data_size = task->alltoallv_ce.get_size(
+            task, peer_sync->alltoallv_ce.sbytes, pdst);
+        if (data_size == 0) {
+            continue;
         }
+        data_displ = task->alltoallv_ce.get_offset(
+            task, peer_sync->alltoallv_ce.sdispl_bytes, pdst);
+        src        = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_src[psrc],
+                                peer_sync->mem_info_src.offset);
+        src        = PTR_OFFSET(src, data_displ);
+        peer_sync  = TASK_SYNC(task, pdst);
+        dst        = PTR_OFFSET(task->alltoallv_ce.peer_map_addr_dst[pdst],
+                                peer_sync->mem_info_dst.offset);
+        data_displ = task->alltoallv_ce.get_offset(
+            task, peer_sync->alltoallv_ce.rdispl_bytes, psrc);
+        dst                 = PTR_OFFSET(dst, data_displ);
+        exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
+        exec_args.copy.dst  = dst;
+        exec_args.copy.src  = src;
+        exec_args.copy.len  = data_size;
+        exec_task =
+            &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
+        status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
+        if (ucc_unlikely(status != UCC_OK)) {
+            goto exit;
+        }
+        task->alltoallv_ce.num_posted++;
     }
 exit:
     return status;
@@ -386,13 +396,16 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
     if (ucc_unlikely(status != UCC_OK)) {
         goto exit_err;
     }
-    data_len = ucc_dt_size(args->dst.info_v.datatype) *
-               ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
-                                             UCC_TL_TEAM_SIZE(team));
-    status = ucc_tl_cuda_mem_info_get(args->dst.info_v.buffer, data_len,
-                                      &task->alltoallv_ce.mem_info_dst);
-    if (ucc_unlikely(status != UCC_OK)) {
-        goto exit_err;
+
+    if (team->topo->proxy_needed) {
+        data_len = ucc_dt_size(args->dst.info_v.datatype) *
+                ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
+                                              UCC_TL_TEAM_SIZE(team));
+        status = ucc_tl_cuda_mem_info_get(args->dst.info_v.buffer, data_len,
+                                          &task->alltoallv_ce.mem_info_dst);
+        if (ucc_unlikely(status != UCC_OK)) {
+            goto exit_err;
+        }
     }
 
     task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -254,7 +254,7 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
     }
 
     if (UCC_TL_TEAM_LIB(team)->log_component.log_level >= UCC_LOG_LEVEL_DEBUG) {
-        ucc_tl_cuda_team_topo_print(&team->super, team->topo);
+        ucc_tl_cuda_team_topo_print_proxies(&team->super, team->topo);
         ucc_tl_cuda_team_topo_print_rings(&team->super, team->topo);
     }
 

--- a/src/components/tl/cuda/tl_cuda_team_topo.h
+++ b/src/components/tl/cuda/tl_cuda_team_topo.h
@@ -11,22 +11,23 @@
 #include "tl_cuda_topo.h"
 
 typedef struct ucc_tl_cuda_proxy {
-    ucc_rank_t src;
-    ucc_rank_t dst;
-    ucc_rank_t proxy;
+    ucc_rank_t src;   /* source rank */
+    ucc_rank_t dst;   /* destination rank */
+    ucc_rank_t proxy; /* proxy rank */
 } ucc_tl_cuda_proxy_t;
 
 typedef struct ucc_tl_cuda_ring {
-    ucc_rank_t *ring;
-    ucc_rank_t *iring;
+    ucc_rank_t *ring;  /* list of ranks forming ring */
+    ucc_rank_t *iring; /* inverse of ring */
 } ucc_tl_cuda_ring_t;
 
 typedef struct ucc_tl_cuda_team_topo {
-    int                     *matrix;
-    int                      num_proxies;
-    ucc_tl_cuda_proxy_t     *proxies;
-    int                      num_rings;
-    ucc_tl_cuda_ring_t      *rings;
+    int                     *matrix;       /* nvlink adjacency matrix */
+    int                      proxy_needed; /* is proxy needed for current rank */
+    int                      num_proxies;  /* number of entries in proxies list */
+    ucc_tl_cuda_proxy_t     *proxies;      /* list of pairs where current rank is proxy */
+    int                      num_rings;    /* number of entries in rings list */
+    ucc_tl_cuda_ring_t      *rings;        /* list of rings for ring algorithms */
 } ucc_tl_cuda_team_topo_t;
 
 ucc_status_t ucc_tl_cuda_team_topo_create(const ucc_tl_team_t *team,
@@ -34,8 +35,8 @@ ucc_status_t ucc_tl_cuda_team_topo_create(const ucc_tl_team_t *team,
 
 ucc_status_t ucc_tl_cuda_team_topo_destroy(ucc_tl_cuda_team_topo_t *team_topo);
 
-void ucc_tl_cuda_team_topo_print(const ucc_tl_team_t *team,
-                                 const ucc_tl_cuda_team_topo_t *cuda_topo);
+void ucc_tl_cuda_team_topo_print_proxies(const ucc_tl_team_t *team,
+                                         const ucc_tl_cuda_team_topo_t *topo);
 
 void ucc_tl_cuda_team_topo_print_rings(const ucc_tl_team_t *tl_team,
                                        const ucc_tl_cuda_team_topo_t *topo);


### PR DESCRIPTION
## What
Reworked TL/CUDA proxy storage. Each rank keeps list of ranks where this rank is proxy.

## Why ?
In TL/CUDA alltoall/alltoallv:
* No need to go over list of proxy ranks to post copy
* Destination buffer registered only if required
