### PR TITLE
TL/SHARP: use internal oob

### DIFF
--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -74,7 +74,7 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
 
     ucc_assert(tls->array.count >= 1);
     for (i = 0; i < tls->array.count; i++) {
-        /* Check TLs proveded in CL_BASIC_TLS. Not all of them could be
+        /* Check TLs provided in CL_BASIC_TLS. Not all of them could be
            available, check for NULL. */
         tl_iface =
             ucc_derived_of(ucc_get_component(&ucc_global_config.tl_framework,

--- a/src/components/tl/sharp/tl_sharp.c
+++ b/src/components/tl/sharp/tl_sharp.c
@@ -17,6 +17,11 @@ static ucc_config_field_t ucc_tl_sharp_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_sharp_lib_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)},
 
+    {"USE_INTERNAL_OOB", "n",
+     "Use service team to create sharp context",
+     ucc_offsetof(ucc_tl_sharp_lib_config_t, use_internal_oob),
+     UCC_CONFIG_TYPE_BOOL},
+
     {NULL}};
 
 static ucc_config_field_t ucc_tl_sharp_context_config_table[] = {
@@ -47,6 +52,7 @@ static ucc_config_field_t ucc_tl_sharp_context_config_table[] = {
      "Seed for random sharp job ID. (0 - use default).",
      ucc_offsetof(ucc_tl_sharp_context_config_t, rand_seed),
      UCC_CONFIG_TYPE_UINT},
+
     {NULL}};
 
 UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_sharp_lib_t, ucc_base_lib_t,
@@ -75,3 +81,10 @@ ucc_status_t ucc_tl_sharp_coll_init(ucc_base_coll_args_t *coll_args,
 ucc_status_t ucc_tl_sharp_team_get_scores(ucc_base_team_t   *tl_team,
                                           ucc_coll_score_t **score_p);
 UCC_TL_IFACE_DECLARE(sharp, SHARP);
+
+ucc_status_t ucc_tl_sharp_context_create_epilog(ucc_base_context_t *context);
+
+__attribute__((constructor)) static void tl_sharp_iface_init(void)
+{
+    ucc_tl_sharp.super.context.create_epilog = ucc_tl_sharp_context_create_epilog;
+}

--- a/src/components/tl/sharp/tl_sharp.h
+++ b/src/components/tl/sharp/tl_sharp.h
@@ -39,6 +39,7 @@ extern ucc_tl_sharp_iface_t ucc_tl_sharp;
 
 typedef struct ucc_tl_sharp_lib_config {
     ucc_tl_lib_config_t super;
+    int                 use_internal_oob;
 } ucc_tl_sharp_lib_config_t;
 
 typedef struct ucc_tl_sharp_context_config {
@@ -52,7 +53,8 @@ typedef struct ucc_tl_sharp_context_config {
 } ucc_tl_sharp_context_config_t;
 
 typedef struct ucc_tl_sharp_lib {
-    ucc_tl_lib_t super;
+    ucc_tl_lib_t              super;
+    ucc_tl_sharp_lib_config_t cfg;
 } ucc_tl_sharp_lib_t;
 UCC_CLASS_DECLARE(ucc_tl_sharp_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);
@@ -73,6 +75,7 @@ typedef struct ucc_tl_sharp_rcache_region {
 
 typedef struct ucc_tl_sharp_context {
     ucc_tl_context_t              super;
+    ucc_thread_mode_t             tm;
     struct sharp_coll_context    *sharp_context;
     ucc_tl_sharp_context_config_t cfg;
     ucc_mpool_t                   req_mp;

--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -126,6 +126,123 @@ static int ucc_tl_sharp_oob_bcast(void *arg, void *buf, int size, int root)
     return status;
 }
 
+static int ucc_tl_sharp_service_barrier(void *arg)
+{
+    ucc_tl_sharp_oob_ctx_t *oob_ctx = (ucc_tl_sharp_oob_ctx_t*)arg;
+    ucc_tl_sharp_context_t *ctx     = (ucc_tl_sharp_context_t*)oob_ctx->ctx;
+    ucc_tl_team_t          *steam   = ctx->super.super.ucc_context->service_team;
+    ucc_subset_t subset;
+    ucc_coll_task_t *req;
+    ucc_status_t status;
+    char sbuf, *rbuf;
+
+
+    subset.map.type   = UCC_EP_MAP_FULL;
+    subset.map.ep_num = oob_ctx->oob->n_oob_eps;
+    subset.myrank     = oob_ctx->oob->oob_ep;
+
+    rbuf = ucc_malloc(sizeof(char) * subset.map.ep_num, "tmp_barrier");
+    if (!rbuf) {
+        tl_error(ctx->super.super.lib,
+                 "failed to allocate %zd bytes for tmp barrier array",
+                 sizeof(char) * subset.map.ep_num);
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    status = UCC_TL_TEAM_IFACE(steam)->scoll.allgather(&steam->super, &sbuf,
+                                                       rbuf, sizeof(char),
+                                                       subset, &req);
+    if (status != UCC_OK) {
+        tl_error(ctx->super.super.lib, "tl sharp gather failed\n");
+        return status;
+    }
+
+    do {
+        ucc_context_progress(ctx->super.super.ucc_context);
+        status = ucc_collective_test(&req->super);
+    } while (status == UCC_INPROGRESS);
+    ucc_collective_finalize(&req->super);
+
+    ucc_free(rbuf);
+
+    return status;
+}
+
+static int ucc_tl_sharp_service_gather(void *arg, int root, void *sbuf,
+                                       void *rbuf, int size)
+{
+    ucc_tl_sharp_oob_ctx_t *oob_ctx  = (ucc_tl_sharp_oob_ctx_t*)arg;
+    ucc_tl_sharp_context_t *ctx      = (ucc_tl_sharp_context_t*)oob_ctx->ctx;
+    ucc_tl_team_t          *steam    = ctx->super.super.ucc_context->service_team;
+    size_t                  msg_size = (size_t)size;
+    ucc_coll_task_t *req;
+    ucc_status_t status;
+    ucc_subset_t subset;
+
+    subset.map.type   = UCC_EP_MAP_FULL;
+    subset.map.ep_num = oob_ctx->oob->n_oob_eps;
+    subset.myrank     = oob_ctx->oob->oob_ep;
+
+    if (subset.myrank != root) {
+        rbuf = ucc_malloc(msg_size * subset.map.ep_num, "tmp_gather");
+        if (!rbuf) {
+            tl_error(ctx->super.super.lib,
+                     "failed to allocate %zd bytes for tmp barrier array",
+                     msg_size * subset.map.ep_num);
+            return UCC_ERR_NO_MEMORY;
+        }
+    }
+
+    status = UCC_TL_TEAM_IFACE(steam)->scoll.allgather(&steam->super, sbuf,
+                                                       rbuf, msg_size,
+                                                       subset, &req);
+    if (status != UCC_OK) {
+        tl_error(ctx->super.super.lib, "tl sharp gather failed\n");
+        return status;
+    }
+
+    do {
+        ucc_context_progress(ctx->super.super.ucc_context);
+        status = ucc_collective_test(&req->super);
+    } while (status == UCC_INPROGRESS);
+    ucc_collective_finalize(&req->super);
+
+    if (subset.myrank != root) {
+        ucc_free(rbuf);
+    }
+
+    return status;
+}
+
+static int ucc_tl_sharp_service_bcast(void *arg, void *buf, int size, int root)
+{
+    ucc_tl_sharp_oob_ctx_t *oob_ctx = (ucc_tl_sharp_oob_ctx_t*)arg;
+    ucc_tl_sharp_context_t *ctx     = (ucc_tl_sharp_context_t*)oob_ctx->ctx;
+    ucc_tl_team_t          *steam   = ctx->super.super.ucc_context->service_team;
+    ucc_coll_task_t *req;
+    ucc_status_t status;
+    ucc_subset_t subset;
+
+    subset.map.type   = UCC_EP_MAP_FULL;
+    subset.map.ep_num = oob_ctx->oob->n_oob_eps;
+    subset.myrank     = oob_ctx->oob->oob_ep;
+
+    status = UCC_TL_TEAM_IFACE(steam)->scoll.bcast(&steam->super, buf, size,
+                                                   root, subset, &req);
+    if (status != UCC_OK) {
+        tl_error(ctx->super.super.lib, "tl sharp bcast failed\n");
+        return status;
+    }
+
+    do {
+        ucc_context_progress(ctx->super.super.ucc_context);
+        status = ucc_collective_test(&req->super);
+    } while (status == UCC_INPROGRESS);
+
+    ucc_collective_finalize(&req->super);
+    return status;
+}
+
 static ucs_status_t
 ucc_tl_sharp_rcache_mem_reg_cb(void *context, ucc_rcache_t *rcache,
                                void *arg, ucc_rcache_region_t *rregion,
@@ -189,13 +306,66 @@ static ucc_rcache_ops_t ucc_tl_sharp_rcache_ops = {
     .dump_region = ucc_tl_sharp_rcache_dump_region_cb
 };
 
+ucc_status_t ucc_tl_sharp_context_init(ucc_tl_sharp_context_t *sharp_ctx)
+{
+    struct sharp_coll_init_spec  init_spec = {0};
+    ucc_tl_sharp_lib_t          *lib       = ucc_derived_of(sharp_ctx->super.super.lib,
+                                                            ucc_tl_sharp_lib_t);
+    ucc_status_t status;
+
+    init_spec.progress_func                  = NULL;
+    init_spec.world_rank                     = UCC_TL_CTX_OOB(sharp_ctx).oob_ep;
+    init_spec.world_local_rank               = 0;
+    init_spec.world_size                     = UCC_TL_CTX_OOB(sharp_ctx).n_oob_eps;
+    init_spec.group_channel_idx              = 0;
+    init_spec.group_channel_idx              = 0;
+    init_spec.oob_ctx                        = &sharp_ctx->oob_ctx;
+    init_spec.config                         = sharp_coll_default_config;
+    init_spec.config.user_progress_num_polls = sharp_ctx->cfg.uprogress_num_polls;
+    init_spec.config.ib_dev_list             = sharp_ctx->cfg.dev_list;
+    init_spec.job_id                         = ((getpid() ^ pthread_self())
+                                                ^ rand_r(&sharp_ctx->cfg.rand_seed));
+    init_spec.enable_thread_support          =
+                    (sharp_ctx->tm == UCC_THREAD_MULTIPLE) ? 1 : 0;
+
+    if (lib->cfg.use_internal_oob) {
+        tl_info(sharp_ctx->super.super.lib, "using internal oob");
+        init_spec.oob_colls.barrier = ucc_tl_sharp_service_barrier;
+        init_spec.oob_colls.bcast   = ucc_tl_sharp_service_bcast;
+        init_spec.oob_colls.gather  = ucc_tl_sharp_service_gather;
+    } else {
+        tl_info(sharp_ctx->super.super.lib, "using user provided oob");
+        init_spec.oob_colls.barrier = ucc_tl_sharp_oob_barrier;
+        init_spec.oob_colls.bcast   = ucc_tl_sharp_oob_bcast;
+        init_spec.oob_colls.gather  = ucc_tl_sharp_oob_gather;
+    }
+
+    //TODO: replace with unique context ID?
+    status = init_spec.oob_colls.bcast((void *)&sharp_ctx->oob_ctx,
+                                        &init_spec.job_id,
+                                        sizeof(uint64_t), 0);
+    if (status != UCC_OK) {
+        tl_error(sharp_ctx->super.super.lib, "failed to broadcast SHARP job_id");
+        return status;
+    }
+
+    int ret = sharp_coll_init(&init_spec, &sharp_ctx->sharp_context);
+    if (ret < 0 ) {
+        tl_debug(sharp_ctx->super.super.lib, "Failed to initialize SHARP "
+                 "collectives:%s(%d) job ID:%" PRIu64"\n",
+                 sharp_coll_strerror(ret), ret, init_spec.job_id);
+        return UCC_ERR_NO_RESOURCE;
+    }
+
+    return UCC_OK;
+}
+
 UCC_CLASS_INIT_FUNC(ucc_tl_sharp_context_t,
                     const ucc_base_context_params_t *params,
                     const ucc_base_config_t *config)
 {
     ucc_tl_sharp_context_config_t *tl_sharp_config =
         ucc_derived_of(config, ucc_tl_sharp_context_config_t);
-    struct sharp_coll_init_spec    init_spec = {0};
     ucc_status_t                   status;
     ucc_rcache_params_t            rcache_params;
     struct timeval                 tval;
@@ -215,39 +385,11 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_context_t,
         self->cfg.rand_seed = (int) tval.tv_usec;
     }
 
-    self->rcache       = NULL;
-    self->oob_ctx.ctx  = self;
-    self->oob_ctx.oob  = &UCC_TL_CTX_OOB(self);
-
-    init_spec.progress_func                  = NULL;
-    init_spec.world_rank                     = UCC_TL_CTX_OOB(self).oob_ep;
-    init_spec.world_local_rank               = 0;
-    init_spec.world_size                     = UCC_TL_CTX_OOB(self).n_oob_eps;
-    init_spec.enable_thread_support          =
-                    (params->thread_mode == UCC_THREAD_MULTIPLE) ? 1 : 0;
-    init_spec.group_channel_idx              = 0;
-    init_spec.oob_colls.barrier              = ucc_tl_sharp_oob_barrier;
-    init_spec.oob_colls.bcast                = ucc_tl_sharp_oob_bcast;
-    init_spec.oob_colls.gather               = ucc_tl_sharp_oob_gather;
-    init_spec.oob_ctx                        = &self->oob_ctx;
-    init_spec.config                         = sharp_coll_default_config;
-    init_spec.config.user_progress_num_polls = self->cfg.uprogress_num_polls;
-    init_spec.config.ib_dev_list             = self->cfg.dev_list;
-    init_spec.job_id                         = ((getpid() ^ pthread_self())
-                                                ^ rand_r(&self->cfg.rand_seed));
-
-    //TODO: replace with unique context ID?
-    ucc_tl_sharp_oob_bcast((void *)&self->oob_ctx,  &init_spec.job_id,
-                           sizeof(uint64_t), 0);
-
-    int ret = sharp_coll_init(&init_spec, &self->sharp_context);
-    if (ret < 0 ) {
-        tl_debug(self->super.super.lib, "Failed to initialize SHARP "
-                 "collectives:%s(%d) job ID:%" PRIu64"\n",
-                 sharp_coll_strerror(ret), ret, init_spec.job_id);
-        status = UCC_ERR_NO_RESOURCE;
-        goto err;
-    }
+    self->sharp_context = NULL;
+    self->rcache        = NULL;
+    self->oob_ctx.ctx   = self;
+    self->oob_ctx.oob   = &UCC_TL_CTX_OOB(self);
+    self->tm            = params->thread_mode;
 
     status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_sharp_task_t), 0,
                             UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
@@ -260,47 +402,55 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_context_t,
         goto err;
     }
 
-   if (UCC_OK != ucc_context_progress_register(
-                      params->context,
-                      (ucc_context_progress_fn_t)sharp_coll_progress,
-                      self->sharp_context)) {
-        tl_error(self->super.super.lib, "failed to register progress function");
-        status = UCC_ERR_NO_MESSAGE;
-        goto err_clean_mpool;
-   }
+    if (self->cfg.use_rcache) {
+        rcache_params.alignment          = 64;
+        rcache_params.ucm_event_priority = 1000;
+        rcache_params.max_regions        = ULONG_MAX;
+        rcache_params.max_size           = SIZE_MAX;
+        rcache_params.region_struct_size = sizeof(ucc_tl_sharp_rcache_region_t);
+        rcache_params.max_alignment      = getpagesize();
+        rcache_params.ucm_events         = UCM_EVENT_VM_UNMAPPED |
+                                            UCM_EVENT_MEM_TYPE_FREE;
+        rcache_params.context            = self;
+        rcache_params.ops                = &ucc_tl_sharp_rcache_ops;
+        rcache_params.flags              = 0;
 
-   if (self->cfg.use_rcache) {
-       rcache_params.alignment          = 64;
-       rcache_params.ucm_event_priority = 1000;
-       rcache_params.max_regions        = ULONG_MAX;
-       rcache_params.max_size           = SIZE_MAX;
-       rcache_params.region_struct_size = sizeof(ucc_tl_sharp_rcache_region_t);
-       rcache_params.max_alignment      = getpagesize();
-       rcache_params.ucm_events         = UCM_EVENT_VM_UNMAPPED |
-                                          UCM_EVENT_MEM_TYPE_FREE;
-       rcache_params.context            = self;
-       rcache_params.ops                = &ucc_tl_sharp_rcache_ops;
-       rcache_params.flags              = 0;
-
-       status = ucc_rcache_create(&rcache_params, "SHARP", &self->rcache);
-       if (status != UCC_OK) {
-           tl_error(self->super.super.lib, "failed to create rcache");
-           status = UCC_ERR_NO_RESOURCE;
-           goto err_clean_progress;
-       }
+        status = ucc_rcache_create(&rcache_params, "SHARP", &self->rcache);
+        if (status != UCC_OK) {
+            tl_error(self->super.super.lib, "failed to create rcache");
+            status = UCC_ERR_NO_RESOURCE;
+            goto err_clean_mpool;
+        }
    }
 
    tl_info(self->super.super.lib, "initialized tl context: %p", self);
    return UCC_OK;
 
-err_clean_progress:
-    ucc_context_progress_deregister(
-        params->context, (ucc_context_progress_fn_t)sharp_coll_progress,
-        self->sharp_context);
 err_clean_mpool:
     ucc_mpool_cleanup(&self->req_mp, 0);
 err:
     return status;
+}
+
+ucc_status_t ucc_tl_sharp_context_create_epilog(ucc_base_context_t *context)
+{
+    ucc_tl_sharp_context_t *ctx = ucc_derived_of(context, ucc_tl_sharp_context_t);
+    ucc_status_t status;
+
+    status = ucc_tl_sharp_context_init(ctx);
+    if (status != UCC_OK) {
+        return status;
+    }
+
+    status = ucc_context_progress_register(
+        context->ucc_context, (ucc_context_progress_fn_t)sharp_coll_progress,
+        ctx->sharp_context);
+    if (status != UCC_OK) {
+        tl_error(context->lib, "failed to register progress function");
+        return status;
+    }
+
+    return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_sharp_context_t)
@@ -310,11 +460,12 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_sharp_context_t)
     if (self->rcache != NULL) {
         ucc_rcache_destroy(self->rcache);
     }
-
     ucc_context_progress_deregister(
         self->super.super.ucc_context,
         (ucc_context_progress_fn_t)sharp_coll_progress, self->sharp_context);
-    sharp_coll_finalize(self->sharp_context);
+    if (self->sharp_context) {
+        sharp_coll_finalize(self->sharp_context);
+    }
     ucc_mpool_cleanup(&self->req_mp, 1);
 }
 

--- a/src/components/tl/sharp/tl_sharp_lib.c
+++ b/src/components/tl/sharp/tl_sharp_lib.c
@@ -11,10 +11,14 @@
 UCC_CLASS_INIT_FUNC(ucc_tl_sharp_lib_t, const ucc_base_lib_params_t *params,
                     const ucc_base_config_t *config)
 {
-    const ucc_tl_lib_config_t *tl_config =
-                            ucc_derived_of(config, ucc_tl_lib_config_t);
+    // const ucc_tl_lib_config_t *tl_config =
+    //                         ucc_derived_of(config, ucc_tl_lib_config_t);
+    const ucc_tl_sharp_lib_config_t *tl_sharp_config =
+                            ucc_derived_of(config, ucc_tl_sharp_lib_config_t);
 
-    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_sharp.super, tl_config);
+    UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_sharp.super,
+                              &tl_sharp_config->super);
+    memcpy(&self->cfg, tl_sharp_config, sizeof(*tl_sharp_config));
     tl_info(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
@@ -29,9 +33,15 @@ UCC_CLASS_DEFINE(ucc_tl_sharp_lib_t, ucc_tl_lib_t);
 ucc_status_t ucc_tl_sharp_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
                                        ucc_base_lib_attr_t *base_attr)
 {
-    ucc_tl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
+    ucc_tl_sharp_lib_t *sharp_lib = ucc_derived_of(lib, ucc_tl_sharp_lib_t);
+    ucc_tl_lib_attr_t  *attr      = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
 
-    attr->super.flags            = 0;
+    attr->super.flags = 0;
+    if (lib != NULL) {
+        if (sharp_lib->cfg.use_internal_oob) {
+            attr->super.flags |= UCC_BASE_LIB_FLAG_CTX_SERVICE_TEAM_REQUIRED;
+        }
+    }
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = UCC_TL_SHARP_SUPPORTED_COLLS;
     return UCC_OK;

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -861,19 +861,19 @@ ucc_status_t ucc_context_progress_register(ucc_context_t *ctx,
     return UCC_OK;
 }
 
-void ucc_context_progress_deregister(ucc_context_t *ctx,
-                                     ucc_context_progress_fn_t fn,
-                                     void *progress_arg)
+ucc_status_t ucc_context_progress_deregister(ucc_context_t *ctx,
+                                             ucc_context_progress_fn_t fn,
+                                             void *progress_arg)
 {
     ucc_context_progress_entry_t *entry, *tmp;
     ucc_list_for_each_safe(entry, tmp, &ctx->progress_list, list_elem) {
         if (entry->fn == fn && entry->arg == progress_arg) {
             ucc_list_del(&entry->list_elem);
             ucc_free(entry);
-            return;
+            return UCC_OK;
         }
     }
-    ucc_assert(0);
+    return UCC_ERR_NOT_FOUND;
 }
 
 ucc_status_t ucc_context_progress(ucc_context_h context)

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -94,7 +94,7 @@ ucc_status_t ucc_context_progress_register(ucc_context_t *ctx,
                                            ucc_context_progress_fn_t fn,
                                            void *progress_arg);
 
-void         ucc_context_progress_deregister(ucc_context_t *ctx,
+ucc_status_t ucc_context_progress_deregister(ucc_context_t *ctx,
                                              ucc_context_progress_fn_t fn,
                                              void *progress_arg);
 /* Performs address exchange between the processes group defined by OOB.

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -40,7 +40,7 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
     ucc_status_t status;
 
     if (context->service_team && team->size > 1) {
-        /* User internal service team for OOB, skip OOB if team size is 1 */
+        /* Use internal service team for OOB, skip OOB if team size is 1 */
         ucc_subset_t subset = {.myrank     = team->rank,
                                .map.ep_num = team->size,
                                .map.type   = UCC_EP_MAP_FULL};
@@ -48,6 +48,7 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
         if (UCC_OK != status) {
             return status;
         }
+        team->bp.params.mask |= UCC_TEAM_PARAM_FIELD_OOB;
     }
 
     team->cl_teams = ucc_malloc(sizeof(ucc_cl_team_t *) * context->n_cl_ctx);


### PR DESCRIPTION
## What
Add support for internal OOB  in TL SHARP

## Why ?
Internal OOB has native support for broadcast, no need to allocate temp buffer and use allgather to emulate broadcast as it's done for SHARP OOB now.
Need to set UCC_TL_SHARP_USE_INTERNAL_OOB=1 to enable internal OOB in TL SHARP.

