### PR TITLE
CORE: option to disable cfg file

### DIFF
--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -72,7 +72,12 @@ static ucc_status_t ucc_check_config_file(void)
     char *               filename;
 
     /* First check the UCC_CONFIG_FILE - most precedence */
-    if (strlen(cfg->cfg_filename) > 0) {
+    if (strlen(cfg->cfg_filename) == 0) {
+        /* file configuration disabled */
+        return UCC_OK;
+    }
+    if (0 != strcasecmp(cfg->cfg_filename, "auto")) {
+        /* Actual file path is provided */
         status = ucc_parse_file_config(cfg->cfg_filename,
                                        &ucc_global_config.file_cfg);
         if (UCC_ERR_NOT_FOUND == status) {
@@ -82,6 +87,7 @@ static ucc_status_t ucc_check_config_file(void)
         return status;
     }
 
+    /* CONFIG_FILE is set to AUTO. Search HOME and install/share */
     if (NULL != (home = getenv("HOME"))) {
         if (UCC_OK != (status = ucc_str_concat(home ,default_home_name,
                                                &filename))) {

--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -49,7 +49,11 @@ ucc_config_field_t ucc_global_config_table[] = {
      ucc_offsetof(ucc_global_config_t, profile_log_size),
      UCC_CONFIG_TYPE_MEMUNITS},
 
-    {"CONFIG_FILE", "", "Location of configuration file",
+    {"CONFIG_FILE", "auto",
+     "Location of configuration file.\n"
+     "auto - config file is searched in $HOME/ucc.conf first, then, if not "
+     "found, in <ucc_install_path>/share/ucc.conf.\n"
+     "empty string \"\" - disable use of config file",
      ucc_offsetof(ucc_global_config_t, cfg_filename), UCC_CONFIG_TYPE_STRING},
 
     {NULL}};


### PR DESCRIPTION
## What
Adds option to disable config files usage

## Why ?
If config file is installed into default path (HOME/ucc.conf) or ucc_install/share/ucc.conf then it will be used and user has no option to not use it (only put another empty file and point UCC_CONFIG_FILE to it, which is not convenient).

## How ?
Now, default value for UCC_CONFIG_FILE is "auto" which means search in default paths. "n", "no", "0", "" means - don't use cfg file.
