### PR TITLE
CORE: add implementation for ucc_team_get_attr

### DIFF
--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -36,9 +36,23 @@ void ucc_copy_team_params(ucc_team_params_t *dst, const ucc_team_params_t *src)
 
 ucc_status_t ucc_team_get_attr(ucc_team_h team, ucc_team_attr_t *team_attr)
 {
-    ucc_error("ucc_team_get_attr() is not implemented");
+    uint64_t supported_fields =
+        UCC_TEAM_ATTR_FIELD_SIZE | UCC_TEAM_ATTR_FIELD_EP;
 
-    return UCC_ERR_NOT_IMPLEMENTED;
+    if (team_attr->mask & ~supported_fields) {
+        ucc_error("ucc_team_get_attr() is not implemented for specified field");
+        return UCC_ERR_NOT_IMPLEMENTED;
+    }
+
+    if (team_attr->mask & UCC_TEAM_ATTR_FIELD_SIZE) {
+        team_attr->size = team->size;
+    }
+
+    if (team_attr->mask & UCC_TEAM_ATTR_FIELD_EP) {
+        team_attr->ep = team->rank;
+    }
+
+    return UCC_OK;
 }
 
 static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,

--- a/test/gtest/core/test_team.cc
+++ b/test/gtest/core/test_team.cc
@@ -85,3 +85,28 @@ UCC_TEST_F(test_team, team_create_no_ep)
     UccTeam_h team = UccJob::getStaticJob()->create_team(
         UccJob::staticUccJobSize, false, false);
 }
+
+UCC_TEST_F(test_team, team_get_attr)
+{
+    UccJob *job   = UccJob::getStaticJob();
+    int job_size  = job->n_procs;
+    int n_teams   = 4; /* how many teams to create */
+    int test_rank = 1;
+    std::vector<UccTeam_h> teams;
+    std::vector<int> team_sizes;
+    for (int i = 0; i < n_teams; i++) {
+        int team_size = 2 + (rand() % (job_size - 2 + 1));
+        team_sizes.push_back(team_size);
+        teams.push_back(job->create_team(team_size));
+    }
+    for (int i = 0; i < n_teams; i++) {
+        ucc_team_h      team = teams[i].get()->procs[test_rank].team;
+        ucc_team_attr_t attr = {.mask = UCC_TEAM_ATTR_FIELD_SIZE |
+                                        UCC_TEAM_ATTR_FIELD_EP};
+        EXPECT_EQ(ucc_team_get_attr(team, &attr), UCC_OK);
+        EXPECT_EQ(attr.size, team_sizes[i]);
+        EXPECT_EQ(attr.ep, test_rank);
+    }
+    /* shuffle vector so that teams are destroyed in different order */
+    std::shuffle(teams.begin(), teams.end(), std::default_random_engine());
+}


### PR DESCRIPTION
## What
Add implementation for `ucc_team_get_attr()`

## Why ?
`ucc_team_get_size` and `ucc_team_get_my_ep` were removed in #555 

## How ?
Currently only `UCC_TEAM_ATTR_FIELD_SIZE` and `UCC_TEAM_ATTR_FIELD_EP` are supported.
