### PR TITLE
CORE: fix memory leak

### DIFF
--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -29,7 +29,7 @@ ucc_config_field_t ucc_global_config_table[] = {
      UCC_CONFIG_TYPE_LOG_COMP},
 
     {"COMPONENT_PATH", "", "Specifies dynamic components location",
-     ucc_offsetof(ucc_global_config_t, component_path), UCC_CONFIG_TYPE_STRING},
+     ucc_offsetof(ucc_global_config_t, component_path_customized), UCC_CONFIG_TYPE_STRING},
 
     {"PROFILE_MODE", "",
      "Profile collection modes. If none is specified, profiling is disabled.\n"

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -22,7 +22,7 @@ typedef struct ucc_global_config {
 
     /* Coll component libraries path */
     char *component_path;
-    char *component_path_default;
+    char *component_path_customized;
     char *install_path;
     int   initialized;
     /* Profiling mode */


### PR DESCRIPTION
## What
fix memory leak

## Why ?
`ucc_global_config.component_path` initially gets allocated implicitly by ucs (as in a config opt table), but it gets changed when loading libraries at runtime later, and we lost the pointer. Hence, a memory leak.

## How ?
~~reallocate `ucc_global_config.component_path` if we happen to reassign the pointer.~~ (see below disucssion)
