### PR TITLE
Move Common UCS Code from UCX into UCC

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,9 +48,13 @@ noinst_HEADERS =                      \
 	schedule/ucc_schedule_pipelined.h \
 	coll_score/ucc_coll_score.h       \
 	utils/arch/aarch64/cpu.h          \
+	utils/arch/aarch64/bitops.h       \
 	utils/arch/ppc64/cpu.h            \
+	utils/arch/ppc64/bitops.h         \
 	utils/arch/x86_64/cpu.h           \
+	utils/arch/x86_64/bitops.h        \
 	utils/arch/cpu.h                  \
+	utils/arch/bitops.h               \
 	utils/arch/cuda_def.h             \
 	utils/ucc_compiler_def.h          \
 	utils/ucc_log.h                   \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ endif
 SUBDIRS = . $(cl_dirs) $(mc_dirs) $(ec_dirs)
 
 include components/tl/makefile.am
+include utils/Makefile.am
 
 lib_LTLIBRARIES  = libucc.la
 noinst_LIBRARIES =
@@ -36,6 +37,7 @@ nobase_dist_libucc_la_HEADERS =	\
 	ucc/api/ucc_status.h
 
 noinst_HEADERS =                      \
+	$(utils_noinst_headers)           \
 	core/ucc_global_opts.h            \
 	core/ucc_lib.h                    \
 	core/ucc_context.h                \
@@ -47,35 +49,6 @@ noinst_HEADERS =                      \
 	schedule/ucc_schedule.h           \
 	schedule/ucc_schedule_pipelined.h \
 	coll_score/ucc_coll_score.h       \
-	utils/arch/aarch64/cpu.h          \
-	utils/arch/aarch64/bitops.h       \
-	utils/arch/ppc64/cpu.h            \
-	utils/arch/ppc64/bitops.h         \
-	utils/arch/x86_64/cpu.h           \
-	utils/arch/x86_64/bitops.h        \
-	utils/arch/cpu.h                  \
-	utils/arch/bitops.h               \
-	utils/arch/cuda_def.h             \
-	utils/ucc_compiler_def.h          \
-	utils/ucc_log.h                   \
-	utils/ucc_parser.h                \
-	utils/ucc_component.h             \
-	utils/ucc_datastruct.h            \
-	utils/ucc_math.h                  \
-	utils/ucc_coll_utils.h            \
-	utils/ucc_list.h                  \
-	utils/ucc_string.h                \
-	utils/ucc_queue.h                 \
-	utils/ucc_proc_info.h             \
-	utils/khash.h                     \
-	utils/ucc_spinlock.h              \
-	utils/ucc_mpool.h                 \
-	utils/ucc_rcache.h                \
-	utils/profile/ucc_profile.h       \
-	utils/profile/ucc_profile_on.h    \
-	utils/profile/ucc_profile_off.h   \
-	utils/ucc_time.h                  \
-	utils/ucc_sys.h                   \
 	components/base/ucc_base_iface.h  \
 	components/cl/ucc_cl.h            \
 	components/cl/ucc_cl_log.h        \
@@ -94,6 +67,7 @@ noinst_HEADERS =                      \
 	components/topo/ucc_sbgp.h
 
 libucc_la_SOURCES =                   \
+	$(utils_libucc_la_sources)        \
 	core/ucc_lib.c                    \
 	core/ucc_constructor.c            \
 	core/ucc_global_opts.c            \
@@ -111,18 +85,6 @@ libucc_la_SOURCES =                   \
 	schedule/ucc_schedule_pipelined.c \
 	coll_score/ucc_coll_score.c       \
 	coll_score/ucc_coll_score_map.c   \
-	utils/ucc_component.c             \
-	utils/ucc_status.c                \
-	utils/ucc_mpool.c                 \
-	utils/ucc_math.c                  \
-	utils/ucc_proc_info.c             \
-	utils/ucc_string.c                \
-	utils/ucc_coll_utils.c            \
-	utils/ucc_parser.c                \
-	utils/profile/ucc_profile.c       \
-	utils/ucc_sys.c                   \
-	utils/arch/x86_64/cpu.c           \
-	utils/arch/aarch64/cpu.c          \
 	components/base/ucc_base_iface.c  \
 	components/cl/ucc_cl.c            \
 	components/tl/ucc_tl.c            \

--- a/src/components/ec/cuda/ec_cuda_executor_interruptible.c
+++ b/src/components/ec/cuda/ec_cuda_executor_interruptible.c
@@ -6,7 +6,7 @@
 
 #include "ec_cuda_executor.h"
 #include "components/mc/ucc_mc.h"
-#include "utils/ucc_atomic.h"
+#include "utils/arch/atomic.h"
 
 ucc_status_t ucc_cuda_executor_interruptible_get_stream(cudaStream_t *stream)
 {

--- a/src/components/ec/rocm/ec_rocm_executor_interruptible.c
+++ b/src/components/ec/rocm/ec_rocm_executor_interruptible.c
@@ -7,7 +7,7 @@
 
 #include "ec_rocm_executor.h"
 #include "components/mc/ucc_mc.h"
-#include "utils/ucc_atomic.h"
+#include "utils/arch/atomic.h"
 
 ucc_status_t ucc_rocm_executor_interruptible_get_stream(hipStream_t *stream)
 {

--- a/src/ucc/api/ucc_status.h
+++ b/src/ucc/api/ucc_status.h
@@ -21,6 +21,13 @@ BEGIN_C_DECLS
 /**
  * @ingroup UCC_UTILS
  * @brief Status codes for the UCC operations
+ *
+ * @note In order to evaluate the necessary steps to recover from a certain
+ * error, all error codes which can be returned by the external API are grouped
+ * by the largest entity permanently effected by the error. Each group ranges
+ * between its UCc_ERR_FIRST_<name> and UCC_ERR_LAST_<name> enum values.
+ * For example, if a link fails it may be sufficient to destroy (and possibly
+ * replace) it, in contrast to an endpoint-level error.
  */
 
 typedef enum {
@@ -40,8 +47,55 @@ typedef enum {
     UCC_ERR_NO_MESSAGE                  =   -6, /*!< General purpose return code without specific error */
     UCC_ERR_NOT_FOUND                   =   -7,
     UCC_ERR_TIMED_OUT                   =   -8,
+    UCC_ERR_IO_ERROR                    =   -9,
+    UCC_ERR_UNREACHABLE                 =  -10,
+    UCC_ERR_INVALID_ADDR                =  -11,
+    UCC_ERR_MESSAGE_TRUNCATED           =  -12,
+    UCC_ERR_NO_PROGRESS                 =  -13,
+    UCC_ERR_BUFFER_TOO_SMALL            =  -14,
+    UCC_ERR_NO_ELEM                     =  -15,
+    UCC_ERR_SOME_CONNECTS_FAILED        =  -16,
+    UCC_ERR_NO_DEVICE                   =  -17,
+    UCC_ERR_BUSY                        =  -18,
+    UCC_ERR_CANCELED                    =  -19,
+    UCC_ERR_SHMEM_SEGMENT               =  -20,
+    UCC_ERR_ALREADY_EXISTS              =  -21,
+    UCC_ERR_OUT_OF_RANGE                =  -22,
+    UCC_ERR_EXCEEDS_LIMIT               =  -23,
+    UCC_ERR_UNSUPPORTED                 =  -24,
+    UCC_ERR_REJECTED                    =  -25,
+    UCC_ERR_NOT_CONNECTED               =  -26,
+    UCC_ERR_CONNECTION_RESET            =  -27,
+
+    UCC_ERR_FIRST_LINK_FAILURE          =  -40,
+    UCC_ERR_LAST_LINK_FAILURE           =  -59,
+    UCC_ERR_FIRST_ENDPOINT_FAILURE      =  -60,
+    UCC_ERR_ENDPOINT_TIMEOUT            =  -80,
+    UCC_ERR_LAST_ENDPOINT_FAILURE       =  -89,
+
     UCC_ERR_LAST                        = -100,
 } ucc_status_t;
+
+#define UCC_IS_ENDPOINT_ERROR(_code) \
+    (((_code) <= UCC_ERR_FIRST_ENDPOINT_FAILURE) && \
+     ((_code) >= UCC_ERR_LAST_ENDPOINT_FAILURE))
+/**
+ * @ingroup UCC_UTILS
+ * @brief Status pointer
+ *
+ * A pointer can represent one of these values:
+ * - NULL / UCS_OK
+ * - Error code pointer (UCS_ERR_xx)
+ * - Valid pointer
+ */
+typedef void *ucc_status_ptr_t;
+
+#define UCC_PTR_IS_ERR(_ptr)       (((uintptr_t)(_ptr)) >= ((uintptr_t)UCC_ERR_LAST))
+#define UCC_PTR_IS_PTR(_ptr)       (((uintptr_t)(_ptr) - 1) < ((uintptr_t)UCC_ERR_LAST - 1))
+#define UCC_PTR_RAW_STATUS(_ptr)   ((ucc_status_t)(intptr_t)(_ptr))
+#define UCC_PTR_STATUS(_ptr)       (UCC_PTR_IS_PTR(_ptr) ? UCS_INPROGRESS : UCC_PTR_RAW_STATUS(_ptr))
+#define UCC_STATUS_PTR(_status)    ((void*)(intptr_t)(_status))
+#define UCC_STATUS_IS_ERR(_status) ((_status) < 0)
 
 /**
  * @ingroup UCC_UTILS

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -1,0 +1,48 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2020-2022.  ALL RIGHTS RESERVED.
+#
+
+utils_noinst_headers =                     \
+	utils/arch/aarch64/cpu.h          \
+	utils/arch/aarch64/bitops.h       \
+	utils/arch/ppc64/cpu.h            \
+	utils/arch/ppc64/bitops.h         \
+	utils/arch/x86_64/cpu.h           \
+	utils/arch/x86_64/bitops.h        \
+	utils/arch/cpu.h                  \
+	utils/arch/bitops.h               \
+	utils/arch/cuda_def.h             \
+	utils/ucc_compiler_def.h          \
+	utils/ucc_log.h                   \
+	utils/ucc_parser.h                \
+	utils/ucc_component.h             \
+	utils/ucc_datastruct.h            \
+	utils/ucc_math.h                  \
+	utils/ucc_coll_utils.h            \
+	utils/ucc_list.h                  \
+	utils/ucc_string.h                \
+	utils/ucc_queue.h                 \
+	utils/ucc_proc_info.h             \
+	utils/khash.h                     \
+	utils/ucc_spinlock.h              \
+	utils/ucc_mpool.h                 \
+	utils/ucc_rcache.h                \
+	utils/profile/ucc_profile.h       \
+	utils/profile/ucc_profile_on.h    \
+	utils/profile/ucc_profile_off.h   \
+	utils/ucc_time.h                  \
+	utils/ucc_sys.h
+
+utils_libucc_la_sources =                 \
+	utils/ucc_component.c             \
+	utils/ucc_status.c                \
+	utils/ucc_mpool.c                 \
+	utils/ucc_math.c                  \
+	utils/ucc_proc_info.c             \
+	utils/ucc_string.c                \
+	utils/ucc_coll_utils.c            \
+	utils/ucc_parser.c                \
+	utils/profile/ucc_profile.c       \
+	utils/ucc_sys.c                   \
+	utils/arch/x86_64/cpu.c           \
+	utils/arch/aarch64/cpu.c

--- a/src/utils/arch/aarch64/bitops.h
+++ b/src/utils/arch/aarch64/bitops.h
@@ -1,0 +1,40 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCC_AARCH64_BITOPS_H_
+#define UCC_AARCH64_BITOPS_H_
+
+#include <ucc/sys/compiler_def.h>
+#include <sys/types.h>
+#include <stdint.h>
+
+
+static UCC_F_ALWAYS_INLINE unsigned __ucc_ilog2_u32(uint32_t n)
+{
+    int bit;
+    asm ("clz %w0, %w1" : "=r" (bit) : "r" (n));
+    return 31 - bit;
+}
+
+static UCC_F_ALWAYS_INLINE unsigned __ucc_ilog2_u64(uint64_t n)
+{
+    int64_t bit;
+    asm ("clz %0, %1" : "=r" (bit) : "r" (n));
+    return 63 - bit;
+}
+
+static UCC_F_ALWAYS_INLINE unsigned ucc_ffs32(uint32_t n)
+{
+    return __ucc_ilog2_u32(n & -n);
+}
+
+static UCC_F_ALWAYS_INLINE unsigned ucc_ffs64(uint64_t n)
+{
+    return __ucc_ilog2_u64(n & -n);
+}
+
+#endif

--- a/src/utils/arch/atomic.h
+++ b/src/utils/arch/atomic.h
@@ -1,0 +1,138 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCC_ARCH_ATOMIC_H
+#define UCC_ARCH_ATOMIC_H
+
+#include <stdint.h>
+
+#if defined(__x86_64__)
+#  include "x86_64/atomic.h"
+#elif defined(__powerpc64__)
+#  include "generic/atomic.h"
+#elif defined(__aarch64__)
+#  include "generic/atomic.h"
+#else
+#  error "Unsupported architecture"
+#endif
+
+#define UCC_DEFINE_ATOMIC_AND(_wordsize, _suffix) \
+    static inline void ucc_atomic_and##_wordsize(volatile uint##_wordsize##_t *ptr, \
+                                                 uint##_wordsize##_t value) { \
+        __sync_and_and_fetch(ptr, value); \
+    }
+
+#define UCC_DEFINE_ATOMIC_FAND(_wordsize, _suffix) \
+    static inline uint##_wordsize##_t ucc_atomic_fand##_wordsize(volatile uint##_wordsize##_t *ptr, \
+                                                                 uint##_wordsize##_t value) { \
+        return __sync_fetch_and_and(ptr, value); \
+    }
+
+#define UCC_DEFINE_ATOMIC_XOR(_wordsize, _suffix) \
+    static inline void ucc_atomic_xor##_wordsize(volatile uint##_wordsize##_t *ptr, \
+                                                 uint##_wordsize##_t value) { \
+        __sync_xor_and_fetch(ptr, value); \
+    }
+
+#define UCC_DEFINE_ATOMIC_FXOR(_wordsize, _suffix) \
+    static inline uint##_wordsize##_t ucc_atomic_fxor##_wordsize(volatile uint##_wordsize##_t *ptr, \
+                                                                 uint##_wordsize##_t value) { \
+        return __sync_fetch_and_xor(ptr, value); \
+    }
+
+#define UCC_DEFINE_ATOMIC_OR(_wordsize, _suffix) \
+    static inline void ucc_atomic_or##_wordsize(volatile uint##_wordsize##_t *ptr, \
+                                                uint##_wordsize##_t value) { \
+        __sync_or_and_fetch(ptr, value); \
+    }
+
+#define UCC_DEFINE_ATOMIC_FOR(_wordsize, _suffix) \
+    static inline uint##_wordsize##_t ucc_atomic_for##_wordsize(volatile uint##_wordsize##_t *ptr, \
+                                                                uint##_wordsize##_t value) { \
+        return __sync_fetch_and_or(ptr, value); \
+    }
+
+#define UCC_DEFINE_ATOMIC_SUB(wordsize, suffix) \
+    static inline void ucc_atomic_sub##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                uint##wordsize##_t value) { \
+        ucc_atomic_add##wordsize(ptr, (uint##wordsize##_t)-value); \
+    }
+
+#define UCC_DEFINE_ATOMIC_FSUB(wordsize, suffix) \
+    static inline uint##wordsize##_t ucc_atomic_fsub##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                               uint##wordsize##_t value) { \
+        return ucc_atomic_fadd##wordsize(ptr, (uint##wordsize##_t)-value); \
+    }
+
+/*
+ * Define atomic functions
+ */
+UCC_DEFINE_ATOMIC_ADD(8,  b);
+UCC_DEFINE_ATOMIC_ADD(16, w);
+UCC_DEFINE_ATOMIC_ADD(32, l);
+UCC_DEFINE_ATOMIC_ADD(64, q);
+
+UCC_DEFINE_ATOMIC_FADD(8,  b);
+UCC_DEFINE_ATOMIC_FADD(16, w);
+UCC_DEFINE_ATOMIC_FADD(32, l);
+UCC_DEFINE_ATOMIC_FADD(64, q);
+
+UCC_DEFINE_ATOMIC_SUB(8,  b);
+UCC_DEFINE_ATOMIC_SUB(16, w);
+UCC_DEFINE_ATOMIC_SUB(32, l);
+UCC_DEFINE_ATOMIC_SUB(64, q);
+
+UCC_DEFINE_ATOMIC_FSUB(8,  b);
+UCC_DEFINE_ATOMIC_FSUB(16, w);
+UCC_DEFINE_ATOMIC_FSUB(32, l);
+UCC_DEFINE_ATOMIC_FSUB(64, q);
+
+UCC_DEFINE_ATOMIC_AND(8,  b);
+UCC_DEFINE_ATOMIC_AND(16, w);
+UCC_DEFINE_ATOMIC_AND(32, l);
+UCC_DEFINE_ATOMIC_AND(64, q);
+
+UCC_DEFINE_ATOMIC_FAND(8,  b);
+UCC_DEFINE_ATOMIC_FAND(16, w);
+UCC_DEFINE_ATOMIC_FAND(32, l);
+UCC_DEFINE_ATOMIC_FAND(64, q);
+
+UCC_DEFINE_ATOMIC_OR(8,  b);
+UCC_DEFINE_ATOMIC_OR(16, w);
+UCC_DEFINE_ATOMIC_OR(32, l);
+UCC_DEFINE_ATOMIC_OR(64, q);
+
+UCC_DEFINE_ATOMIC_FOR(8,  b);
+UCC_DEFINE_ATOMIC_FOR(16, w);
+UCC_DEFINE_ATOMIC_FOR(32, l);
+UCC_DEFINE_ATOMIC_FOR(64, q);
+
+UCC_DEFINE_ATOMIC_XOR(8,  b);
+UCC_DEFINE_ATOMIC_XOR(16, w);
+UCC_DEFINE_ATOMIC_XOR(32, l);
+UCC_DEFINE_ATOMIC_XOR(64, q);
+
+UCC_DEFINE_ATOMIC_FXOR(8,  b);
+UCC_DEFINE_ATOMIC_FXOR(16, w);
+UCC_DEFINE_ATOMIC_FXOR(32, l);
+UCC_DEFINE_ATOMIC_FXOR(64, q);
+
+UCC_DEFINE_ATOMIC_SWAP(8,  b);
+UCC_DEFINE_ATOMIC_SWAP(16, w);
+UCC_DEFINE_ATOMIC_SWAP(32, l);
+UCC_DEFINE_ATOMIC_SWAP(64, q);
+
+UCC_DEFINE_ATOMIC_CSWAP(8,  b);
+UCC_DEFINE_ATOMIC_CSWAP(16, w);
+UCC_DEFINE_ATOMIC_CSWAP(32, l);
+UCC_DEFINE_ATOMIC_CSWAP(64, q);
+
+UCC_DEFINE_ATOMIC_BOOL_CSWAP(8,  b);
+UCC_DEFINE_ATOMIC_BOOL_CSWAP(16, w);
+UCC_DEFINE_ATOMIC_BOOL_CSWAP(32, l);
+UCC_DEFINE_ATOMIC_BOOL_CSWAP(64, q);
+
+#endif

--- a/src/utils/arch/bitops.h
+++ b/src/utils/arch/bitops.h
@@ -1,0 +1,202 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef ucc_ARCH_BITOPS_H
+#define ucc_ARCH_BITOPS_H
+
+#include <ucc/sys/compiler_def.h>
+#include <stdint.h>
+#include <string.h>
+
+BEGIN_C_DECLS
+
+#if defined(__x86_64__)
+#  include "x86_64/bitops.h"
+#elif defined(__powerpc64__)
+#  include "ppc64/bitops.h"
+#elif defined(__aarch64__)
+#  include "aarch64/bitops.h"
+#else
+#  error "Unsupported architecture"
+#endif
+
+
+#define ucc_ilog2(_n)                   \
+(                                       \
+    __builtin_constant_p(_n) ? (        \
+             (_n) < 1 ? 0 :             \
+             (_n) & (1ULL << 63) ? 63 : \
+             (_n) & (1ULL << 62) ? 62 : \
+             (_n) & (1ULL << 61) ? 61 : \
+             (_n) & (1ULL << 60) ? 60 : \
+             (_n) & (1ULL << 59) ? 59 : \
+             (_n) & (1ULL << 58) ? 58 : \
+             (_n) & (1ULL << 57) ? 57 : \
+             (_n) & (1ULL << 56) ? 56 : \
+             (_n) & (1ULL << 55) ? 55 : \
+             (_n) & (1ULL << 54) ? 54 : \
+             (_n) & (1ULL << 53) ? 53 : \
+             (_n) & (1ULL << 52) ? 52 : \
+             (_n) & (1ULL << 51) ? 51 : \
+             (_n) & (1ULL << 50) ? 50 : \
+             (_n) & (1ULL << 49) ? 49 : \
+             (_n) & (1ULL << 48) ? 48 : \
+             (_n) & (1ULL << 47) ? 47 : \
+             (_n) & (1ULL << 46) ? 46 : \
+             (_n) & (1ULL << 45) ? 45 : \
+             (_n) & (1ULL << 44) ? 44 : \
+             (_n) & (1ULL << 43) ? 43 : \
+             (_n) & (1ULL << 42) ? 42 : \
+             (_n) & (1ULL << 41) ? 41 : \
+             (_n) & (1ULL << 40) ? 40 : \
+             (_n) & (1ULL << 39) ? 39 : \
+             (_n) & (1ULL << 38) ? 38 : \
+             (_n) & (1ULL << 37) ? 37 : \
+             (_n) & (1ULL << 36) ? 36 : \
+             (_n) & (1ULL << 35) ? 35 : \
+             (_n) & (1ULL << 34) ? 34 : \
+             (_n) & (1ULL << 33) ? 33 : \
+             (_n) & (1ULL << 32) ? 32 : \
+             (_n) & (1ULL << 31) ? 31 : \
+             (_n) & (1ULL << 30) ? 30 : \
+             (_n) & (1ULL << 29) ? 29 : \
+             (_n) & (1ULL << 28) ? 28 : \
+             (_n) & (1ULL << 27) ? 27 : \
+             (_n) & (1ULL << 26) ? 26 : \
+             (_n) & (1ULL << 25) ? 25 : \
+             (_n) & (1ULL << 24) ? 24 : \
+             (_n) & (1ULL << 23) ? 23 : \
+             (_n) & (1ULL << 22) ? 22 : \
+             (_n) & (1ULL << 21) ? 21 : \
+             (_n) & (1ULL << 20) ? 20 : \
+             (_n) & (1ULL << 19) ? 19 : \
+             (_n) & (1ULL << 18) ? 18 : \
+             (_n) & (1ULL << 17) ? 17 : \
+             (_n) & (1ULL << 16) ? 16 : \
+             (_n) & (1ULL << 15) ? 15 : \
+             (_n) & (1ULL << 14) ? 14 : \
+             (_n) & (1ULL << 13) ? 13 : \
+             (_n) & (1ULL << 12) ? 12 : \
+             (_n) & (1ULL << 11) ? 11 : \
+             (_n) & (1ULL << 10) ? 10 : \
+             (_n) & (1ULL <<  9) ?  9 : \
+             (_n) & (1ULL <<  8) ?  8 : \
+             (_n) & (1ULL <<  7) ?  7 : \
+             (_n) & (1ULL <<  6) ?  6 : \
+             (_n) & (1ULL <<  5) ?  5 : \
+             (_n) & (1ULL <<  4) ?  4 : \
+             (_n) & (1ULL <<  3) ?  3 : \
+             (_n) & (1ULL <<  2) ?  2 : \
+             (_n) & (1ULL <<  1) ?  1 : \
+             (_n) & (1ULL <<  0) ?  0 : \
+             0                          \
+                                 ) :    \
+    (sizeof(_n) <= 4) ?                 \
+    __ucc_ilog2_u32((uint32_t)(_n)) :   \
+    __ucc_ilog2_u64((uint64_t)(_n))     \
+)
+
+#define ucc_ilog2_or0(_n) \
+    ( ((_n) == 0) ? 0 : ucc_ilog2(_n) )
+
+/* Returns the number of 1-bits in x */
+#define ucc_popcount(_n) \
+    ((sizeof(_n) <= 4) ? __builtin_popcount((uint32_t)(_n)) : \
+                         __builtin_popcountl(_n))
+
+/* On some arch ffs64(0) returns 0, on other -1, let's unify this */
+#define ucc_ffs64_safe(_val) ((_val) ? ucc_ffs64(_val) : 64)
+
+/* Returns the number of trailing 0-bits in x, starting at the least
+ * significant bit position.  If x is 0, the result is undefined.
+ */
+#define ucc_count_trailing_zero_bits(_n) \
+    ((sizeof(_n) <= 4) ? __builtin_ctz((uint32_t)(_n)) : __builtin_ctzl(_n))
+
+/* Returns the number of leading 0-bits in _n.
+ * If _n is 0, the result is undefined
+ */
+#define ucc_count_leading_zero_bits(_n) \
+    ((sizeof(_n) <= 4) ? __builtin_clz((uint32_t)(_n)) : __builtin_clzl(_n))
+
+/* Returns the number of 1-bits by _idx mask */
+#define ucc_bitmap2idx(_map, _idx) \
+    ucc_popcount((_map) & (ucc_MASK(_idx)))
+
+
+/**
+ * Count how many bits at the end of the buffer are equal to zero.
+ *
+ * @param [in] ptr         Pointer to the buffer.
+ * @param [in] bit_length  Total Buffer length (in bits).
+ *
+ * @return The number of trailing zero bits.
+ */
+static inline unsigned
+ucc_count_ptr_trailing_zero_bits(const void *ptr, uint64_t bit_length)
+{
+    uint64_t idx = bit_length;
+    uint8_t tmp  = 0;
+
+    if (idx == 0) {
+        return 0;
+    }
+
+    /* Start from the end of the given buffer, with fractions of a bytes */
+    if ((idx % 8) != 0) {
+        tmp  = *(uint8_t*)ucc_PTR_BYTE_OFFSET(ptr, idx / 8);
+        tmp &= ~ucc_MASK(8 - (idx % 8));
+        if (idx < 8) {
+            tmp |= ucc_BIT(idx % 8);
+        }
+        if ((idx < 8) || (tmp != 0)) {
+            return __builtin_ctz(tmp | (((uint32_t)-1) << 8));
+        }
+    }
+
+    /* from now on - offsets are in bytes */
+    idx = (idx / 8) - 1;
+    while (((tmp = *(uint8_t*)ucc_PTR_BYTE_OFFSET(ptr, idx)) == 0) &&
+           (idx > 0)) {
+        idx--;
+    }
+
+    return bit_length - ((idx + 1) * 8) +
+           __builtin_ctz(tmp | (((uint32_t)-1) << 8));
+}
+
+/**
+ * Check if two buffers are equal (for the given amount of bits).
+ *
+ * @param [in] ptr1        Pointer to the first buffer.
+ * @param [in] ptr2        Pointer to the second buffer.
+ * @param [in] bit_length  Buffer length (in bits).
+ *
+ * @return Whether the buffers are equal.
+ */
+static inline int
+ucc_bitwise_is_equal(const void *ptr1, const void *ptr2, uint64_t bit_length)
+{
+    size_t length          = bit_length / 8;
+    unsigned remainder_val = bit_length % 8;
+
+    if (memcmp(ptr1, ptr2, length) != 0) {
+        return 0;
+    }
+
+    if (remainder_val == 0) {
+        return 1;
+    }
+
+    /* Compare up to 7 last bits */
+    return ((*((uint8_t*)ptr1 + length) & ~ucc_MASK(8 - remainder_val)) ==
+            (*((uint8_t*)ptr2 + length) & ~ucc_MASK(8 - remainder_val)));
+}
+
+END_C_DECLS
+
+#endif

--- a/src/utils/arch/generic/atomic.h
+++ b/src/utils/arch/generic/atomic.h
@@ -1,0 +1,47 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCC_GENERIC_ATOMIC_H_
+#define UCC_GENERIC_ATOMIC_H_
+
+
+#define UCC_DEFINE_ATOMIC_ADD(wordsize, suffix) \
+    static inline void ucc_atomic_add##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                uint##wordsize##_t value) { \
+        __sync_add_and_fetch(ptr, value); \
+    }
+
+#define UCC_DEFINE_ATOMIC_FADD(wordsize, suffix) \
+    static inline uint##wordsize##_t ucc_atomic_fadd##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                               uint##wordsize##_t value) { \
+        return __sync_fetch_and_add(ptr, value); \
+    }
+
+#define UCC_DEFINE_ATOMIC_SWAP(wordsize, suffix) \
+    static inline uint##wordsize##_t ucc_atomic_swap##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                               uint##wordsize##_t value) { \
+        uint##wordsize##_t old; \
+        do { \
+           old = *ptr; \
+        } while(old != __sync_val_compare_and_swap(ptr, old, value)); \
+        return old; \
+    }
+
+#define UCC_DEFINE_ATOMIC_CSWAP(wordsize, suffix) \
+    static inline uint##wordsize##_t ucc_atomic_cswap##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                                uint##wordsize##_t compare, \
+                                                                uint##wordsize##_t swap) { \
+        return __sync_val_compare_and_swap(ptr, compare, swap); \
+    }
+
+#define UCC_DEFINE_ATOMIC_BOOL_CSWAP(wordsize, suffix) \
+    static inline uint##wordsize##_t ucc_atomic_bool_cswap##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                                     uint##wordsize##_t compare, \
+                                                                     uint##wordsize##_t swap) { \
+        return __sync_bool_compare_and_swap(ptr, compare, swap); \
+    }
+
+#endif

--- a/src/utils/arch/ppc64/bitops.h
+++ b/src/utils/arch/ppc64/bitops.h
@@ -1,0 +1,38 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCC_PPC64_BITOPS_H_
+#define UCC_PPC64_BITOPS_H_
+
+#include <ucc/sys/compiler_def.h>
+#include <stdint.h>
+
+
+static UCC_F_ALWAYS_INLINE unsigned __ucc_ilog2_u32(uint32_t n)
+{
+    int bit;
+    asm ("cntlzw %0,%1" : "=r" (bit) : "r" (n));
+    return 31 - bit;
+}
+
+static UCC_F_ALWAYS_INLINE unsigned __ucc_ilog2_u64(uint64_t n)
+{
+    int bit;
+    asm ("cntlzd %0,%1" : "=r" (bit) : "r" (n));
+    return 63 - bit;
+}
+
+static UCC_F_ALWAYS_INLINE unsigned ucc_ffs32(uint32_t n)
+{
+    return __ucc_ilog2_u32(n & -n);
+}
+
+static UCC_F_ALWAYS_INLINE unsigned ucc_ffs64(uint64_t n)
+{
+    return __ucc_ilog2_u64(n & -n);
+}
+
+#endif

--- a/src/utils/arch/x86_64/atomic.h
+++ b/src/utils/arch/x86_64/atomic.h
@@ -1,0 +1,60 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCC_X86_64_ATOMIC_H_
+#define UCC_X86_64_ATOMIC_H_
+
+
+#define UCC_DEFINE_ATOMIC_ADD(wordsize, suffix) \
+    static inline void ucc_atomic_add##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                uint##wordsize##_t value) { \
+        asm volatile ( \
+              "lock add" #suffix " %1, %0" \
+              : "+m"(*ptr) \
+              : "ir" (value)); \
+    }
+
+#define UCC_DEFINE_ATOMIC_FADD(wordsize, suffix) \
+    static inline uint##wordsize##_t ucc_atomic_fadd##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                               uint##wordsize##_t value) { \
+        asm volatile ( \
+              "lock xadd" #suffix " %0, %1" \
+              : "+r" (value), "+m" (*ptr) \
+              : : "memory"); \
+        return value; \
+    }
+
+#define UCC_DEFINE_ATOMIC_SWAP(wordsize, suffix) \
+    static inline uint##wordsize##_t ucc_atomic_swap##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                               uint##wordsize##_t value) { \
+        asm volatile ( \
+              "lock xchg" #suffix " %0, %1" \
+              : "+r" (value), "+m" (*ptr) \
+              : : "memory", "cc"); \
+        return value; \
+    }
+
+#define UCC_DEFINE_ATOMIC_CSWAP(wordsize, suffix) \
+    static inline uint##wordsize##_t ucc_atomic_cswap##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                                uint##wordsize##_t compare, \
+                                                                uint##wordsize##_t swap) { \
+        unsigned long prev; \
+        asm volatile ( \
+              "lock cmpxchg" # suffix " %1, %2" \
+              : "=a" (prev) \
+              : "r"(swap), "m"(*ptr), "0" (compare) \
+              : "memory"); \
+        return prev; \
+    }
+
+#define UCC_DEFINE_ATOMIC_BOOL_CSWAP(wordsize, suffix) \
+    static inline uint##wordsize##_t ucc_atomic_bool_cswap##wordsize(volatile uint##wordsize##_t *ptr, \
+                                                                     uint##wordsize##_t compare, \
+                                                                     uint##wordsize##_t swap) { \
+        return ucc_atomic_cswap##wordsize(ptr, compare, swap) == compare; \
+    }
+
+#endif

--- a/src/utils/arch/x86_64/bitops.h
+++ b/src/utils/arch/x86_64/bitops.h
@@ -1,0 +1,50 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCC_X86_64_BITOPS_H_
+#define UCC_X86_64_BITOPS_H_
+
+#include <ucc/sys/compiler_def.h>
+#include <stdint.h>
+
+
+static UCC_F_ALWAYS_INLINE unsigned ucc_ffs32(uint32_t n)
+{
+    uint32_t result;
+    asm("bsfl %1,%0"
+        : "=r" (result)
+        : "r" (n));
+    return result;
+}
+
+static UCC_F_ALWAYS_INLINE unsigned ucc_ffs64(uint64_t n)
+{
+    uint64_t result;
+    asm("bsfq %1,%0"
+        : "=r" (result)
+        : "r" (n));
+    return result;
+}
+
+static UCC_F_ALWAYS_INLINE unsigned __ucc_ilog2_u32(uint32_t n)
+{
+    uint32_t result;
+    asm("bsrl %1,%0"
+        : "=r" (result)
+        : "r" (n));
+    return result;
+}
+
+static UCC_F_ALWAYS_INLINE unsigned __ucc_ilog2_u64(uint64_t n)
+{
+    uint64_t result;
+    asm("bsrq %1,%0"
+        : "=r" (result)
+        : "r" (n));
+    return result;
+}
+
+#endif

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -1,5 +1,9 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+ * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+ * Copyright (C) Arm, Ltd. 2021. ALL RIGHTS RESERVED.
+ * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
  * See file LICENSE for terms.
  */
 
@@ -11,11 +15,210 @@
 #include <ucs/type/status.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/preprocessor.h>
-#include <ucs/sys/compiler_def.h>
 #include <ucs/debug/log_def.h>
 #if ENABLE_DEBUG == 1
 #include <assert.h>
 #endif
+
+/* Note: Place "@file <file name>.h" after BEGIN_C_DECS
+ * to avoid bugs in a documentation */
+#ifdef __cplusplus
+# define BEGIN_C_DECLS  extern "C" {
+# define END_C_DECLS    }
+#else
+# define BEGIN_C_DECLS
+# define END_C_DECLS
+#endif
+
+/*
+ * Assertions which are checked in compile-time
+ *
+ * Usage: UCC_STATIC_ASSERT(condition)
+ */
+#define UCC_STATIC_ASSERT(_cond) \
+     switch(0) {case 0:case (_cond):;}
+
+/* Maximal allocation size for on-stack buffers */
+#define UCC_ALLOCA_MAX_SIZE  1200
+
+/* Aliasing structure */
+#define UCC_S_MAY_ALIAS __attribute__((may_alias))
+
+/* A function without side effects */
+#define UCC_F_PURE   __attribute__((pure))
+
+/* A function which does not return */
+#define UCC_F_NORETURN __attribute__((noreturn))
+
+/* Packed structure */
+#define UCC_S_PACKED             __attribute__((packed))
+
+/* Avoid inlining the function */
+#define UCC_F_NOINLINE __attribute__ ((noinline))
+
+/* Shared library constructor and destructor */
+#define UCC_F_CTOR __attribute__((constructor))
+#define UCC_F_DTOR __attribute__((destructor))
+
+/* Silence "defined but not used" error for static function */
+#define UCC_F_MAYBE_UNUSED __attribute__((used))
+
+/* Non-null return */
+#define UCC_F_NON_NULL __attribute__((nonnull))
+
+/* Always inline the function */
+#ifdef __GNUC__
+#define UCC_F_ALWAYS_INLINE      inline __attribute__ ((always_inline))
+#else
+#define UCC_F_ALWAYS_INLINE      inline
+#endif
+
+/* Silence "uninitialized variable" for stupid compilers (gcc 4.1)
+ * which can't optimize properly.
+ */
+#if (((__GNUC__ == 4) && (__GNUC_MINOR__ == 1)) || !defined(__OPTIMIZE__))
+#  define UCC_V_INITIALIZED(_v)  (_v = (ucc_typeof(_v))0)
+#else
+#  define UCC_V_INITIALIZED(_v)  ((void)0)
+#endif
+
+/* The i-th bit */
+#define UCC_BIT(i)               (1ul << (i))
+
+/* Mask of bits 0..i-1 */
+#define UCC_MASK(i)              (UCC_BIT(i) - 1)
+
+/*
+ * Enable compiler checks for printf-like formatting.
+ *
+ * @param fmtargN number of formatting argument
+ * @param vargN   number of variadic argument
+ */
+#define UCC_F_PRINTF(fmtargN, vargN) __attribute__((format(printf, fmtargN, vargN)))
+
+/* Unused variable */
+#define UCC_V_UNUSED __attribute__((unused))
+
+/* Aligned variable */
+#define UCC_V_ALIGNED(_align) __attribute__((aligned(_align)))
+
+/* Used for labels */
+#define UCC_EMPTY_STATEMENT {}
+
+/* Helper macro for address arithmetic in bytes */
+#define UCC_PTR_BYTE_OFFSET(_ptr, _offset) \
+    ((void *)((intptr_t)(_ptr) + (intptr_t)(_offset)))
+
+/* Helper macro to calculate an address with offset equal to size of _type */
+#define UCC_PTR_TYPE_OFFSET(_ptr, _type) \
+    ((void *)((ucc_typeof(_type) *)(_ptr) + 1))
+
+/* Helper macro to calculate ptr difference (_end - _start) */
+#define UCC_PTR_BYTE_DIFF(_start, _end) \
+    ((ptrdiff_t)((uintptr_t)(_end) - (uintptr_t)(_start)))
+
+
+/**
+ * Size of statically-declared array
+ */
+#define ucc_static_array_size(_array) \
+    (sizeof(_array) / sizeof((_array)[0]))
+
+
+/**
+ * @return Offset of _member in _type. _type is a structure type.
+ */
+#define ucc_offsetof(_type, _member) \
+    ((unsigned long)&( ((_type*)0)->_member ))
+
+
+/**
+ * Get a pointer to a struct containing a member.
+ *
+ * @param _ptr     Pointer to the member.
+ * @param _type    Container type.
+ * @param _member  Element member inside the container.
+
+ * @return Address of the container structure.
+ */
+#define ucc_container_of(_ptr, _type, _member) \
+    ( (_type*)( (char*)(void*)(_ptr) - ucc_offsetof(_type, _member) )  )
+
+
+/**
+ * Get the type of a structure or variable.
+ *
+ * @param _type  Return the type of this argument.
+ *
+ * @return The type of the given argument.
+ */
+#define ucc_typeof(_type) \
+    __typeof__(_type)
+
+
+/**
+ * @return Address of a derived structure. It must have a "super" member at offset 0.
+ * NOTE: we use the built-in offsetof here because we can't use ucc_offsetof() in
+ *       a constant expression.
+ */
+#define ucc_derived_of(_ptr, _type) \
+    ({\
+        UCC_STATIC_ASSERT(offsetof(_type, super) == 0) \
+        ucc_container_of(_ptr, _type, super); \
+    })
+
+/**
+ * @param _type   Structure type.
+ * @param _field  Field of structure.
+ *
+ * @return Size of _field in _type.
+ */
+#define ucc_field_sizeof(_type, _field) \
+    sizeof(((_type*)0)->_field)
+
+/**
+ * @param _type   Structure type.
+ * @param _field  Field of structure.
+ *
+ * @return Type of _field in _type.
+ */
+#define ucc_field_type(_type, _field) \
+    ucc_typeof(((_type*)0)->_field)
+
+/**
+ * Prevent compiler from reordering instructions
+ */
+#define ucc_compiler_fence()       asm volatile(""::: "memory")
+
+/**
+ * Prefetch cache line
+ */
+#define ucc_prefetch(p)            __builtin_prefetch(p)
+
+/* Branch prediction */
+#define ucc_likely(x)              __builtin_expect(x, 1)
+#define ucc_unlikely(x)            __builtin_expect(x, 0)
+
+/* Check if an expression is a compile-time constant */
+#define ucc_is_constant(expr)      __builtin_constant_p(expr)
+
+/*
+ * Define code which runs at global constructor phase
+ */
+#define UCC_STATIC_INIT \
+    static void UCC_F_CTOR UCC_PP_APPEND_UNIQUE_ID(ucc_initializer_ctor)()
+
+/*
+ * Define code which runs at global destructor phase
+ */
+#define UCC_STATIC_CLEANUP \
+    static void UCC_F_DTOR UCC_PP_APPEND_UNIQUE_ID(ucc_initializer_dtor)()
+
+/*
+ * Check if the two types are the same
+ */
+#define ucs_same_type(_type1, _type2) \
+    __builtin_types_compatible_p(_type1, _type2)
 
 #define ucc_offsetof      ucs_offsetof
 #define ucc_container_of  ucs_container_of
@@ -60,6 +263,7 @@ typedef int                        ucc_score_t;
         }                                                                      \
     } while (0)
 
+/* TODO - Delete when ucs_status_t is deleted */
 static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
 {
     switch (status) {

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -12,7 +12,7 @@
 
 #include "config.h"
 #include "ucc/api/ucc_status.h"
-#include <ucs/type/status.h>
+#include <ucs/type/status.h> /* Delete when last use of ucs_status_t is gone */
 #include <ucs/sys/string.h>
 #include <ucs/sys/preprocessor.h>
 #include <ucs/debug/log_def.h>
@@ -220,13 +220,8 @@
 #define ucs_same_type(_type1, _type2) \
     __builtin_types_compatible_p(_type1, _type2)
 
-#define ucc_offsetof      ucs_offsetof
-#define ucc_container_of  ucs_container_of
-#define ucc_derived_of    ucs_derived_of
-#define ucc_strncpy_safe  ucs_strncpy_safe
+#define ucc_strncpy_safe  ucs_strncpy_safe /* TODO - Remove this when converted */
 #define ucc_snprintf_safe snprintf
-#define ucc_likely        ucs_likely
-#define ucc_unlikely      ucs_unlikely
 
 /**
  * Prevent compiler from reordering instructions
@@ -271,12 +266,56 @@ static inline ucc_status_t ucs_status_to_ucc_status(ucs_status_t status)
         return UCC_OK;
     case UCS_INPROGRESS:
         return UCC_INPROGRESS;
-    case UCS_ERR_NO_MEMORY:
-        return UCC_ERR_NO_MEMORY;
+    case UCS_ERR_NOT_IMPLEMENTED:
+        return UCC_ERR_NOT_IMPLEMENTED;
     case UCS_ERR_INVALID_PARAM:
         return UCC_ERR_INVALID_PARAM;
+    case UCS_ERR_NO_MEMORY:
+        return UCC_ERR_NO_MEMORY;
     case UCS_ERR_NO_RESOURCE:
         return UCC_ERR_NO_RESOURCE;
+    case UCS_ERR_NO_MESSAGE:
+        return UCC_ERR_NO_MESSAGE;
+    case UCS_ERR_TIMED_OUT:
+        return UCC_ERR_TIMED_OUT;
+    case UCS_ERR_IO_ERROR:
+        return UCC_ERR_IO_ERROR;
+    case UCS_ERR_UNREACHABLE:
+        return UCC_ERR_UNREACHABLE;
+    case UCS_ERR_INVALID_ADDR:
+        return UCC_ERR_INVALID_ADDR;
+    case UCS_ERR_MESSAGE_TRUNCATED:
+        return UCC_ERR_MESSAGE_TRUNCATED;
+    case UCS_ERR_NO_PROGRESS:
+        return UCC_ERR_NO_PROGRESS;
+    case UCS_ERR_BUFFER_TOO_SMALL:
+        return UCC_ERR_BUFFER_TOO_SMALL;
+    case UCS_ERR_NO_ELEM:
+        return UCC_ERR_NO_ELEM;
+    case UCS_ERR_SOME_CONNECTS_FAILED:
+        return UCC_ERR_SOME_CONNECTS_FAILED;
+    case UCS_ERR_NO_DEVICE:
+        return UCC_ERR_NO_DEVICE;
+    case UCS_ERR_BUSY:
+        return UCC_ERR_BUSY;
+    case UCS_ERR_CANCELED:
+        return UCC_ERR_CANCELED;
+    case UCS_ERR_SHMEM_SEGMENT:
+        return UCC_ERR_SHMEM_SEGMENT;
+    case UCS_ERR_ALREADY_EXISTS:
+        return UCC_ERR_ALREADY_EXISTS;
+    case UCS_ERR_OUT_OF_RANGE:
+        return UCC_ERR_OUT_OF_RANGE;
+    case UCS_ERR_EXCEEDS_LIMIT:
+        return UCC_ERR_EXCEEDS_LIMIT;
+    case UCS_ERR_UNSUPPORTED:
+        return UCC_ERR_UNSUPPORTED;
+    case UCS_ERR_REJECTED:
+        return UCC_ERR_REJECTED;
+    case UCS_ERR_NOT_CONNECTED:
+        return UCC_ERR_NOT_CONNECTED;
+    case UCS_ERR_CONNECTION_RESET:
+        return UCC_ERR_CONNECTION_RESET;
     default:
         break;
     }
@@ -290,12 +329,56 @@ static inline ucs_status_t ucc_status_to_ucs_status(ucc_status_t status)
         return UCS_OK;
     case UCC_INPROGRESS:
         return UCS_INPROGRESS;
-    case UCC_ERR_NO_MEMORY:
-        return UCS_ERR_NO_MEMORY;
+    case UCC_ERR_NOT_IMPLEMENTED:
+        return UCS_ERR_NOT_IMPLEMENTED;
     case UCC_ERR_INVALID_PARAM:
         return UCS_ERR_INVALID_PARAM;
+    case UCC_ERR_NO_MEMORY:
+        return UCS_ERR_NO_MEMORY;
     case UCC_ERR_NO_RESOURCE:
         return UCS_ERR_NO_RESOURCE;
+    case UCC_ERR_NO_MESSAGE:
+        return UCS_ERR_NO_MESSAGE;
+    case UCC_ERR_TIMED_OUT:
+        return UCS_ERR_TIMED_OUT;
+    case UCC_ERR_IO_ERROR:
+        return UCS_ERR_IO_ERROR;
+    case UCC_ERR_UNREACHABLE:
+        return UCS_ERR_UNREACHABLE;
+    case UCC_ERR_INVALID_ADDR:
+        return UCS_ERR_INVALID_ADDR;
+    case UCC_ERR_MESSAGE_TRUNCATED:
+        return UCS_ERR_MESSAGE_TRUNCATED;
+    case UCC_ERR_NO_PROGRESS:
+        return UCS_ERR_NO_PROGRESS;
+    case UCC_ERR_BUFFER_TOO_SMALL:
+        return UCS_ERR_BUFFER_TOO_SMALL;
+    case UCC_ERR_NO_ELEM:
+        return UCS_ERR_NO_ELEM;
+    case UCC_ERR_SOME_CONNECTS_FAILED:
+        return UCS_ERR_SOME_CONNECTS_FAILED;
+    case UCC_ERR_NO_DEVICE:
+        return UCS_ERR_NO_DEVICE;
+    case UCC_ERR_BUSY:
+        return UCS_ERR_BUSY;
+    case UCC_ERR_CANCELED:
+        return UCS_ERR_CANCELED;
+    case UCC_ERR_SHMEM_SEGMENT:
+        return UCS_ERR_SHMEM_SEGMENT;
+    case UCC_ERR_ALREADY_EXISTS:
+        return UCS_ERR_ALREADY_EXISTS;
+    case UCC_ERR_OUT_OF_RANGE:
+        return UCS_ERR_OUT_OF_RANGE;
+    case UCC_ERR_EXCEEDS_LIMIT:
+        return UCS_ERR_EXCEEDS_LIMIT;
+    case UCC_ERR_UNSUPPORTED:
+        return UCS_ERR_UNSUPPORTED;
+    case UCC_ERR_REJECTED:
+        return UCS_ERR_REJECTED;
+    case UCC_ERR_NOT_CONNECTED:
+        return UCS_ERR_NOT_CONNECTED;
+    case UCC_ERR_CONNECTION_RESET:
+        return UCS_ERR_CONNECTION_RESET;
     default:
         break;
     }

--- a/src/utils/ucc_lock_free_queue.h
+++ b/src/utils/ucc_lock_free_queue.h
@@ -7,7 +7,7 @@
 #define UCC_LOCKFREE_QUEUE_H_
 
 #include "utils/ucc_spinlock.h"
-#include "utils/ucc_atomic.h"
+#include "utils/arch/atomic.h"
 #include "utils/ucc_list.h"
 #include <string.h>
 

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -15,7 +15,6 @@
 
 #include <ucs/config/parser.h>
 #include <ucs/sys/preprocessor.h>
-#include <ucs/sys/compiler_def.h>
 #include <ucs/config/types.h>
 #include <ucs/config/parser.h>
 #include <ucs/config/ini.h>

--- a/test/gtest/utils/test_lock_free_queue.cc
+++ b/test/gtest/utils/test_lock_free_queue.cc
@@ -6,7 +6,7 @@
 
 extern "C" {
 #include "utils/ucc_lock_free_queue.h"
-#include "utils/ucc_atomic.h"
+#include "utils/arch/atomic.h"
 #include "utils/ucc_malloc.h"
 #include <pthread.h>
 #include <stdio.h>


### PR DESCRIPTION
## What
Moves the UCS code that's used by all TLs from the UCX repository into the UCC repository. At the end of the conversion, when not compiling with something that requires UCX otherwise (e.g., UCP TL), UCC will not link against `libucx.so`/`libucs.so`/`libucm.so`.

## Why ?
See the [thread](https://elist.ornl.gov/mailman/private/ucx-group/2022-July/001933.html) for all of the background, but the top reasons are:

1.  The UCS/UCM code was not written with the intention of being used outside of the UCX library. The API is not necessarily stable or backward/forward compatible. UCC has been bitten in the past by changes inside UCX that caused breakages on the UCC side.
1.  Meta doesn't want production teams to have to maintain (or be familiar with) libraries that we're not using. Currently, we have to bring in knowledge of UCX in order to build UCC (even if we turn off the UCP TL). Obviously, if we're using the UCP TL, we need UCX, but that's not expected to be the common case.
1.  Even if we just use the UCS/UCM code inside UCX, we still have to know the UCX codebase well enough to know what parts are relevant and what parts are not.

## How ?
This PR will bring over the code that is used by both UCC (outside of TLs that require UCX anyway) and UCX itself. Primarily, this means that everything aside from rcache will be brought over from UCX to UCC.

Most of the code will go into the [src/utils](https://github.com/openucx/ucc/tree/master/src/utils) directory, but there is a little bleeding outside of that directory when necessary.