### PR TITLE
CORE: reorganize pre-defined ucc name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,7 @@ AC_SUBST([localmoduledir], ['$(abs_top_builddir)/modules']) # local directory fo
 AC_SUBST([objdir],         [${objdir}])                     # libtool objects dir, usually .libs
 AC_SUBST([shrext],         [${shrext_cmds}])                # libtool shared library extension
 AC_DEFINE_UNQUOTED([UCC_MODULE_SUBDIR], ["${modulesubdir}"], [UCC module sub-directory])
+AC_DEFINE_UNQUOTED([UCC_LIB_SO_NAME], ["libucc.so"], [Default name of UCC shared object])
 
 #
 # Additional m4 files

--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,12 @@ AC_SUBST([localmoduledir], ['$(abs_top_builddir)/modules']) # local directory fo
 AC_SUBST([objdir],         [${objdir}])                     # libtool objects dir, usually .libs
 AC_SUBST([shrext],         [${shrext_cmds}])                # libtool shared library extension
 AC_DEFINE_UNQUOTED([UCC_MODULE_SUBDIR], ["${modulesubdir}"], [UCC module sub-directory])
-AC_DEFINE_UNQUOTED([UCC_LIB_SO_NAME], ["libucc.so"], [Default name of UCC shared object])
+#
+# customized name of UCC soname for library search at runtime
+#
+test "${UCC_SONAME+set}" = set || UCC_SONAME="libucc.so"
+AC_ARG_VAR(UCC_SONAME, [Customized UCC soname for library search at runtime (default is libucc.so)])
+AC_DEFINE_UNQUOTED([UCC_LIB_SO_NAME], ["$UCC_SONAME"], [UCC soname for library search at runtime])
 
 #
 # Additional m4 files

--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -14,9 +14,8 @@
 #include <link.h>
 #include <dlfcn.h>
 
-#define UCC_LIB_SO_NAME "libucc.so"
-#define UCC_COMPONENT_LIBDIR "ucc"
-#define UCC_COMPONENT_LIBDIR_LEN strlen("ucc")
+#define UCC_COMPONENT_LIBDIR     UCC_MODULE_SUBDIR
+#define UCC_COMPONENT_LIBDIR_LEN strlen(UCC_MODULE_SUBDIR)
 
 static int callback(struct dl_phdr_info *info, size_t size, void *data)
 {


### PR DESCRIPTION
## What
Move definition of UCC component path and library name to `config.h`

## Why ?
In the case of using customized UCC component path and library name, those changes need to be made in `src/core/ucc_constructor.c` and can not be upstreamed. This PR moves pre-defined UCC component path and library name to `config.h`, which is not tracked and can be easily customized without disturbing the upstream process.

## How ?
- `UCC_COMPONENT_LIBDIR` is always the same as `UCC_MODULE_SUBDIR`
- move `UCC_LIB_SO_NAME` to configure.ac (will generate `config.h` which is not tracked and can be easily changed) 
- minor: code formatting of `src/core/ucc_constructor.c`
