### PR TITLE
TEST/MPI: use dedicated comm per ucc team

### DIFF
--- a/test/mpi/mpi_util.cc
+++ b/test/mpi/mpi_util.cc
@@ -40,17 +40,23 @@ static MPI_Comm create_reverse_comm()
 
 MPI_Comm create_mpi_comm(ucc_test_mpi_team_t t)
 {
+    MPI_Comm comm = MPI_COMM_NULL;
+
     switch(t) {
     case TEAM_WORLD:
-        return MPI_COMM_WORLD;
+        MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+        break;
     case TEAM_REVERSE:
-        return create_reverse_comm();
+        comm = create_reverse_comm();
+        break;
     case TEAM_SPLIT_HALF:
-        return create_half_comm();
+        comm = create_half_comm();
+        break;
     case TEAM_SPLIT_ODD_EVEN:
-        return create_odd_even_comm();
+        comm = create_odd_even_comm();
+        break;
     default:
         break;
     }
-    return MPI_COMM_NULL;
+    return comm;
 }

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -230,8 +230,10 @@ void UccTestMpi::create_team(ucc_test_mpi_team_t t, bool is_onesided)
     ucc_team_h team;
     MPI_Comm comm = create_mpi_comm(t);
     if (is_onesided) {
-        team = create_ucc_team(comm, true);
-        onesided_teams.push_back(ucc_test_team_t(t, comm, team, onesided_ctx));
+        MPI_Comm comm_dup;
+        MPI_Comm_dup(comm, &comm_dup);
+        team = create_ucc_team(comm_dup, true);
+        onesided_teams.push_back(ucc_test_team_t(t, comm_dup, team, onesided_ctx));
     } else {
         team = create_ucc_team(comm);
         teams.push_back(ucc_test_team_t(t, comm, team, ctx));


### PR DESCRIPTION
## What
Create separate MPI comm for each UCC team created in test/mpi.

## Why ?
MPI comms are used concurrently during ucc_test_mpi if '-T' (multithreaded) is provided. MPI_COMM_WORLD is used for oob progress as well. This causes a race and results in "truncated message" error that has been observed lately in Jenkins.
