### PR TITLE
TL/NCCL: allgatherv send dtype check fix

### DIFF
--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -412,7 +412,7 @@ ucc_status_t ucc_tl_nccl_allgatherv_init(ucc_tl_nccl_task_t *task)
         tl_error(UCC_TASK_LIB(task), "inplace allgatherv is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info_v.datatype) ||
+    if ((!UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).src.info.datatype) ||
         !UCC_DT_IS_PREDEFINED((TASK_ARGS(task)).dst.info_v.datatype))) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -174,9 +174,9 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
         status = ucc_tl_nccl_scatterv_init(task);
         break;
     default:
-        tl_error(UCC_TASK_LIB(task),
-                 "collective %d is not supported by nccl tl",
-                 coll_args->args.coll_type);
+        tl_debug(UCC_TASK_LIB(task),
+                 "collective %s is not supported by nccl tl",
+                 ucc_coll_type_str(coll_args->args.coll_type));
         status = UCC_ERR_NOT_SUPPORTED;
     }
     if (ucc_unlikely(status != UCC_OK)) {


### PR DESCRIPTION
## What
Fixes src dtype check in TL/NCCL: should be taken from src.info instead of info_v.
Also decreases log level of "unsupported coll" message to debug. This case is not fatal error: we can still fallback to other TLs. If no other TLs avail the error will be thrown by the CORE. 

