### PR TITLE
TEST/MPI: don't call comm_split from set_gpu_dev

### DIFF
--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -5,6 +5,7 @@
 
 int test_rand_seed = -1;
 static size_t test_max_size = TEST_UCC_RANK_BUF_SIZE_MAX;
+ucc_test_mpi_data_t ucc_test_mpi_data;
 
 static std::vector<ucc_coll_type_t> colls = {
     UCC_COLL_TYPE_BARRIER,        UCC_COLL_TYPE_BCAST,
@@ -508,6 +509,7 @@ int main(int argc, char *argv[])
         goto mpi_exit;
     }
 
+    init_test_mpi_data();
 #if defined(HAVE_CUDA) || defined(HAVE_HIP)
     set_gpu_device(test_gpu_set_device);
 #endif
@@ -599,4 +601,15 @@ test_exit:
 mpi_exit:
     MPI_Finalize();
     return failed;
+}
+
+int init_test_mpi_data(void)
+{
+    MPI_Comm local_comm;
+
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
+                        &local_comm);
+    MPI_Comm_rank(local_comm, &ucc_test_mpi_data.local_node_rank);
+    MPI_Comm_free(&local_comm);
+    return 0;
 }

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -407,18 +407,14 @@ test_set_gpu_device_t test_gpu_set_device = TEST_SET_DEV_NONE;
 #if defined(HAVE_CUDA) || defined(HAVE_HIP)
 void set_gpu_device(test_set_gpu_device_t set_device)
 {
-    MPI_Comm local_comm;
+    int local_rank = ucc_test_mpi_data.local_node_rank;
     int gpu_dev_count;
-    int local_rank;
     int device_id;
 
     if (set_device == TEST_SET_DEV_NONE) {
         return;
     }
 
-    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
-                        &local_comm);
-    MPI_Comm_rank(local_comm, &local_rank);
 #if defined(HAVE_CUDA)
     CUDA_CHECK(cudaGetDeviceCount(&gpu_dev_count));
 #elif defined(HAVE_HIP)

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -168,6 +168,13 @@ static inline const char* team_str(ucc_test_mpi_team_t t) {
     return NULL;
 }
 
+typedef struct ucc_test_mpi_data {
+    int local_node_rank;
+} ucc_test_mpi_data_t;
+extern ucc_test_mpi_data_t ucc_test_mpi_data;
+
+int init_test_mpi_data(void);
+
 #if defined(HAVE_CUDA) || defined(HAVE_HIP)
 void set_gpu_device(test_set_gpu_device_t set_device);
 #endif


### PR DESCRIPTION
## What
Fixes hangs in multi-threaded test run 

## Why ?
Each thread calls set_gpu_device which used to call MPI_Comm_split to figure out local node rank. This comm split is not allowed to be called concurrently by multiple threads (by MPI spec). 

## How ?
Pre-compute node_local_rank once 