### PR TITLE
Optimize scratch buffer allocation for pipelined algorithms

### DIFF
--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -134,10 +134,15 @@ typedef struct ucc_base_team_iface {
     ucc_get_coll_scores_fn_t get_scores;
 } ucc_base_team_iface_t;
 
+enum {
+    UCC_BASE_CARGS_MAX_FRAG_COUNT = UCC_BIT(0)
+};
+
 typedef struct ucc_base_coll_args {
     uint64_t         mask;
     ucc_coll_args_t  args;
     ucc_team_t      *team;
+    size_t           max_frag_count;
 } ucc_base_coll_args_t;
 
 typedef ucc_status_t (*ucc_base_coll_init_fn_t)(ucc_base_coll_args_t *coll_args,

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -249,11 +249,10 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
     size_t             count     = coll_args->args.dst.info.count;
     ucc_datatype_t     dt        = coll_args->args.dst.info.datatype;
     size_t             dt_size   = ucc_dt_size(dt);
-    size_t             data_size = count * dt_size;
     ucc_memory_type_t  mem_type  = coll_args->args.dst.info.mem_type;
     ucc_tl_ucp_task_t *task;
     ucc_status_t       status;
-    size_t             max_recv_size;
+    size_t             max_recv_size, data_size;
     ucc_kn_radix_t     step_radix;
 
     task                 = ucc_tl_ucp_init_task(coll_args, team);
@@ -268,6 +267,10 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_init_r(
     task->reduce_scatter_kn.scratch_mc_header = NULL;
 
     if (KN_NODE_EXTRA != task->reduce_scatter_kn.p.node_type) {
+        if (coll_args->mask & UCC_BASE_CARGS_MAX_FRAG_COUNT) {
+            count = coll_args->max_frag_count;
+        }
+        data_size = count * dt_size;
         step_radix =
             ucc_sra_kn_compute_step_radix(rank, size,
                                           &task->reduce_scatter_kn.p);

--- a/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
@@ -387,8 +387,12 @@ ucc_tl_ucp_reduce_scatterv_ring_init(ucc_base_coll_args_t *coll_args,
     s[1].map    = ucc_ep_map_create_reverse(UCC_TL_TEAM_SIZE(tl_team));
     s[1].myrank = ucc_ep_map_eval(s[1].map, UCC_TL_TEAM_RANK(tl_team));
 
-    max_segcount = ucc_coll_args_get_max_count(
-        &coll_args->args, coll_args->args.dst.info_v.counts, size);
+    if (coll_args->mask & UCC_BASE_CARGS_MAX_FRAG_COUNT) {
+        max_segcount = coll_args->max_frag_count;
+    } else {
+        max_segcount = ucc_coll_args_get_max_count(
+            &coll_args->args, coll_args->args.dst.info_v.counts, size);
+    }
     /* in flight we can have 2 sends from 2 differnt blocks and 1 recv:
        need 3 * max_segcount of scratch per set */
     count_per_set = (max_segcount + n_subsets - 1) / n_subsets;

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -18,8 +18,8 @@ extern "C" {
 class test_obj_size : public ucc::test {
 };
 
-#define EXPECTED_SIZE(_obj, _size) EXPECT_EQ((size_t)_size, sizeof(_obj))
-
 UCC_TEST_F(test_obj_size, size) {
-    EXPECTED_SIZE(ucc_coll_task_t, 472);
+    /* lets try to keep it within 8 cache lines
+       currently 480b */
+    EXPECT_LT(sizeof(ucc_coll_task_t), 64 * 8);
 }


### PR DESCRIPTION
## What
Improves scratch buffer usage in pipelined algs

## Why ?
Currently, the scratch buffer allocation for the allreduce (CL/HIER split rail, or TL/UCP SRA) is of the same size as the user buffer. For example, 128Mb allreduce will result in 128Mb scratch requirement. However, in the pipelined algorithm we only need the scratch as big as 1 frag.

## How ?
Extends base_args with the "max_frag_size" optional field. This way the collectives that support fragmentation can optimize their scratch allocation since they know the maximum size of fragment. (sra in tl/ucp has such support). 
CL/HIER split rail allreduce inplace case no longer needs to allocate scratch. It used to go:
RSV into scratch => Allreduce scratch->rbuf => Allgather inplace
now it is:
RSV inplace => Allreduce inplace => Allgather inplace