### PR TITLE
CORE: remove COMPONENT_PATH param

### DIFF
--- a/src/core/ucc_constructor.c
+++ b/src/core/ucc_constructor.c
@@ -8,65 +8,16 @@
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_component.h"
 #include "utils/ucc_log.h"
+#include "utils/ucc_sys.h"
 #include "utils/ucc_string.h"
 #include "utils/ucc_proc_info.h"
 #include "utils/profile/ucc_profile.h"
-#include <link.h>
-#include <dlfcn.h>
-
-#define UCC_LIB_SO_NAME "libucc.so"
-#define UCC_COMPONENT_LIBDIR "ucc"
-#define UCC_COMPONENT_LIBDIR_LEN strlen("ucc")
-
-static int callback(struct dl_phdr_info *info, size_t size, void *data)
-{
-    char  *str;
-    char  *component_path;
-    char  *install_path;
-    size_t len;
-    int    pos;
-    if ((data != NULL) || (size == 0)) {
-        return -1;
-    }
-    if (NULL != (str = strstr(info->dlpi_name, UCC_LIB_SO_NAME))) {
-        pos            = (int)(str - info->dlpi_name);
-        len            = pos + UCC_COMPONENT_LIBDIR_LEN + 1;
-
-        install_path = (char *)ucc_malloc(len, "install_path");
-        if (!install_path) {
-            ucc_error("failed to allocate %zd bytes for install_path", len);
-            return -1;
-        }
-        ucc_strncpy_safe(install_path, info->dlpi_name, pos - 3);
-        ucc_global_config.install_path = install_path;
-        component_path = (char *)ucc_malloc(len, "component_path");
-        if (!component_path) {
-            ucc_free(install_path);
-            ucc_error("failed to allocate %zd bytes for component_path", len);
-            return -1;
-        }
-        /* copying up to pos+1 due to ucs_strncpy_safe implementation specifics:
-           it'll always write '\0' to the end position of the dest string. */
-        ucc_strncpy_safe(component_path, info->dlpi_name, pos + 1);
-        len                -= (pos + 1);
-        component_path[pos] = '\0';
-        strncat(component_path, UCC_COMPONENT_LIBDIR, len);
-        ucc_global_config.component_path =
-            ucc_global_config.component_path_default = component_path;
-    }
-    return 0;
-}
-
-static void get_default_lib_path()
-{
-    dl_iterate_phdr(callback, NULL);
-}
 
 static ucc_status_t ucc_check_config_file(void)
 {
     ucc_global_config_t *cfg                = &ucc_global_config;
     ucc_status_t         status             = UCC_OK;
-    const char *         default_share_name = "share/ucc.conf";
+    const char *         default_share_name = "/share/ucc.conf";
     const char *         default_home_name  = "/ucc.conf";
     const char *         home;
     char *               filename;
@@ -111,28 +62,51 @@ static ucc_status_t ucc_check_config_file(void)
     return status;
 }
 
+static ucc_status_t init_lib_paths(void)
+{
+    const char  *so_path = ucc_sys_get_lib_path();
+    ucc_status_t status;
+    char        *lib_path;
+
+    if (!so_path) {
+        return UCC_ERR_NOT_FOUND;
+    }
+    lib_path = ucc_sys_dirname(so_path);
+    if (!lib_path) {
+        return UCC_ERR_NOT_FOUND;
+    }
+
+    ucc_global_config.install_path = ucc_sys_dirname(lib_path);
+    if (!ucc_global_config.install_path) {
+        status = UCC_ERR_NO_MEMORY;
+        goto out;
+    }
+    status = ucc_str_concat(lib_path, "/ucc",
+                            &ucc_global_config.component_path);
+out:
+    free(lib_path);
+    return  status;
+}
+
 ucc_status_t ucc_constructor(void)
 {
     ucc_global_config_t *cfg = &ucc_global_config;
     ucc_status_t         status;
 
     if (!cfg->initialized) {
-        cfg->initialized            = 1;
-        cfg->component_path_default = NULL;
-
+        cfg->initialized = 1;
         status = ucc_config_parser_fill_opts(
             &ucc_global_config, ucc_global_config_table, "UCC_", NULL, 1);
         if (UCC_OK != status) {
             ucc_error("failed to parse global options");
             return status;
         }
-        if (strlen(cfg->component_path) == 0) {
-            get_default_lib_path();
+
+        if (UCC_OK != (status = init_lib_paths())) {
+            ucc_error("failed to init ucc components path");
+            return status;
         }
-        if (!cfg->component_path) {
-            ucc_error("failed to get ucc components path");
-            return UCC_ERR_NOT_FOUND;
-        }
+
         status = ucc_check_config_file();
         if (UCC_OK != status && UCC_ERR_NOT_FOUND != status) {
             /* bail only in case of real error */
@@ -207,5 +181,7 @@ __attribute__((destructor)) static void ucc_destructor(void)
         if (ucc_global_config.file_cfg) {
             ucc_release_file_config(ucc_global_config.file_cfg);
         }
+        free(ucc_global_config.component_path);
+        free(ucc_global_config.install_path);
     }
 }

--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -12,7 +12,8 @@ UCC_LIST_HEAD(ucc_config_global_list);
 
 ucc_global_config_t ucc_global_config = {
     .log_component    = {UCC_LOG_LEVEL_WARN, "UCC"},
-    .component_path   = "",
+    .component_path   = NULL,
+    .install_path     = NULL,
     .initialized      = 0,
     .profile_mode     = 0,
     .profile_file     = "",
@@ -27,9 +28,6 @@ ucc_config_field_t ucc_global_config_table[] = {
      "poll.",
      ucc_offsetof(ucc_global_config_t, log_component),
      UCC_CONFIG_TYPE_LOG_COMP},
-
-    {"COMPONENT_PATH", "", "Specifies dynamic components location",
-     ucc_offsetof(ucc_global_config_t, component_path), UCC_CONFIG_TYPE_STRING},
 
     {"PROFILE_MODE", "",
      "Profile collection modes. If none is specified, profiling is disabled.\n"

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -22,7 +22,6 @@ typedef struct ucc_global_config {
 
     /* Coll component libraries path */
     char *component_path;
-    char *component_path_default;
     char *install_path;
     int   initialized;
     /* Profiling mode */

--- a/src/utils/ucc_sys.h
+++ b/src/utils/ucc_sys.h
@@ -17,6 +17,9 @@ ucc_status_t ucc_sysv_alloc(size_t *size, void **addr, int *shm_id);
 
 ucc_status_t ucc_sysv_free(void *addr);
 
+const char* ucc_sys_get_lib_path();
+char *ucc_sys_dirname(const char* path);
+
 size_t ucc_get_page_size();
 
 #endif


### PR DESCRIPTION
## What
Removes UCC_COMPONENT_PATH parameter

## Why ?
Nobody ever used it. We always search components based on .so path. the logic is significantly simplified. No "libucc.so" pattern is required.

