### PR TITLE
TOOLS: add ec ops to perftest

### DIFF
--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +30,10 @@ ucc_perftest_SOURCES =            \
 	ucc_pt_coll_reduce.cc         \
 	ucc_pt_coll_reduce_scatter.cc \
 	ucc_pt_coll_scatter.cc        \
-	ucc_pt_coll_scatterv.cc
+	ucc_pt_coll_scatterv.cc       \
+	ucc_pt_op_memcpy.cc           \
+	ucc_pt_op_reduce.cc           \
+	ucc_pt_op_reduce_strided.cc
 
 CXX=$(MPICXX)
 LD=$(MPICXX)

--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -3,54 +3,65 @@
 #include "components/mc/ucc_mc.h"
 #include "ucc_perftest.h"
 #include "utils/ucc_coll_utils.h"
+#include "core/ucc_ee.h"
 
 ucc_pt_benchmark::ucc_pt_benchmark(ucc_pt_benchmark_config cfg,
                                    ucc_pt_comm *communicator):
     config(cfg),
     comm(communicator)
 {
-    switch (cfg.coll_type) {
-    case UCC_COLL_TYPE_ALLGATHER:
+    switch (cfg.op_type) {
+    case UCC_PT_OP_TYPE_ALLGATHER:
         coll = new ucc_pt_coll_allgather(cfg.dt, cfg.mt, cfg.inplace, comm);
         break;
-    case UCC_COLL_TYPE_ALLGATHERV:
+    case UCC_PT_OP_TYPE_ALLGATHERV:
         coll = new ucc_pt_coll_allgatherv(cfg.dt, cfg.mt, cfg.inplace, comm);
         break;
-    case UCC_COLL_TYPE_ALLREDUCE:
+    case UCC_PT_OP_TYPE_ALLREDUCE:
         coll = new ucc_pt_coll_allreduce(cfg.dt, cfg.mt, cfg.op, cfg.inplace,
                                          comm);
         break;
-    case UCC_COLL_TYPE_ALLTOALL:
+    case UCC_PT_OP_TYPE_ALLTOALL:
         coll = new ucc_pt_coll_alltoall(cfg.dt, cfg.mt, cfg.inplace, comm);
         break;
-    case UCC_COLL_TYPE_ALLTOALLV:
+    case UCC_PT_OP_TYPE_ALLTOALLV:
         coll = new ucc_pt_coll_alltoallv(cfg.dt, cfg.mt, cfg.inplace, comm);
         break;
-    case UCC_COLL_TYPE_BARRIER:
+    case UCC_PT_OP_TYPE_BARRIER:
         coll = new ucc_pt_coll_barrier(comm);
         break;
-    case UCC_COLL_TYPE_BCAST:
+    case UCC_PT_OP_TYPE_BCAST:
         coll = new ucc_pt_coll_bcast(cfg.dt, cfg.mt, comm);
         break;
-    case UCC_COLL_TYPE_REDUCE:
+    case UCC_PT_OP_TYPE_REDUCE:
         coll = new ucc_pt_coll_reduce(cfg.dt, cfg.mt, cfg.op, cfg.inplace,
                                       comm);
         break;
-    case UCC_COLL_TYPE_REDUCE_SCATTER:
+    case UCC_PT_OP_TYPE_REDUCE_SCATTER:
         coll = new ucc_pt_coll_reduce_scatter(cfg.dt, cfg.mt, cfg.op,
                                               cfg.inplace, comm);
         break;
-    case UCC_COLL_TYPE_GATHER:
+    case UCC_PT_OP_TYPE_GATHER:
         coll = new ucc_pt_coll_gather(cfg.dt, cfg.mt, cfg.inplace, comm);
         break;
-    case UCC_COLL_TYPE_GATHERV:
+    case UCC_PT_OP_TYPE_GATHERV:
         coll = new ucc_pt_coll_gatherv(cfg.dt, cfg.mt, cfg.inplace, comm);
         break;
-    case UCC_COLL_TYPE_SCATTER:
+    case UCC_PT_OP_TYPE_SCATTER:
         coll = new ucc_pt_coll_scatter(cfg.dt, cfg.mt, cfg.inplace, comm);
         break;
-    case UCC_COLL_TYPE_SCATTERV:
+    case UCC_PT_OP_TYPE_SCATTERV:
         coll = new ucc_pt_coll_scatterv(cfg.dt, cfg.mt, cfg.inplace, comm);
+        break;
+    case UCC_PT_OP_TYPE_MEMCPY:
+        coll = new ucc_pt_op_memcpy(cfg.dt, cfg.mt, comm);
+        break;
+    case UCC_PT_OP_TYPE_REDUCEDT:
+        coll = new ucc_pt_op_reduce(cfg.dt, cfg.mt, cfg.op, cfg.n_bufs, comm);
+        break;
+    case UCC_PT_OP_TYPE_REDUCEDT_STRIDED:
+        coll = new ucc_pt_op_reduce_strided(cfg.dt, cfg.mt, cfg.op, cfg.n_bufs,
+                                            comm);
         break;
     default:
         throw std::runtime_error("not supported collective");
@@ -61,9 +72,9 @@ ucc_status_t ucc_pt_benchmark::run_bench() noexcept
 {
     size_t min_count = coll->has_range() ? config.min_count : 1;
     size_t max_count = coll->has_range() ? config.max_count : 1;
-    ucc_status_t    st;
-    ucc_coll_args_t args;
-    double          time;
+    ucc_status_t       st;
+    ucc_pt_test_args_t args;
+    double             time;
 
     print_header();
     for (size_t cnt = min_count; cnt <= max_count; cnt *= 2) {
@@ -74,15 +85,22 @@ ucc_status_t ucc_pt_benchmark::run_bench() noexcept
             iter = config.n_iter_large;
             warmup = config.n_warmup_large;
         }
-        UCCCHECK_GOTO(coll->init_coll_args(cnt, args), exit_err, st);
-        UCCCHECK_GOTO(run_single_test(args, warmup, iter, time), free_coll, st);
+        UCCCHECK_GOTO(coll->init_args(cnt, args), exit_err, st);
+        if ((uint64_t)config.op_type < (uint64_t)UCC_COLL_TYPE_LAST) {
+            UCCCHECK_GOTO(run_single_coll_test(args.coll_args, warmup, iter, time),
+                          free_coll, st);
+        } else {
+            UCCCHECK_GOTO(run_single_executor_test(args.executor_args,
+                                                   warmup, iter, time),
+                          free_coll, st);
+        }
         print_time(cnt, args, time);
-        coll->free_coll_args(args);
+        coll->free_args(args);
     }
 
     return UCC_OK;
 free_coll:
-    coll->free_coll_args(args);
+    coll->free_args(args);
 exit_err:
     return st;
 }
@@ -95,10 +113,10 @@ static inline double get_time_us(void)
     return t.tv_sec * 1e6 + t.tv_usec;
 }
 
-ucc_status_t ucc_pt_benchmark::run_single_test(ucc_coll_args_t args,
-                                               int nwarmup, int niter,
-                                               double &time)
-                                               noexcept
+ucc_status_t ucc_pt_benchmark::run_single_coll_test(ucc_coll_args_t args,
+                                                    int nwarmup, int niter,
+                                                    double &time)
+                                                    noexcept
 {
     const bool    triggered = config.triggered;
     ucc_team_h    team      = comm->get_team();
@@ -162,13 +180,69 @@ exit_err:
     return st;
 }
 
+ucc_status_t
+ucc_pt_benchmark::run_single_executor_test(ucc_ee_executor_task_args_t args,
+                                           int nwarmup, int niter,
+                                           double &time) noexcept
+{
+    const bool              triggered = config.triggered;
+    ucc_ee_executor_t      *executor  = comm->get_executor();
+    ucc_status_t            st        = UCC_OK;
+    ucc_ee_h                ee;
+    ucc_ee_executor_task_t *task;
+
+    time = 0;
+    if (triggered) {
+        try {
+            ee = comm->get_ee();
+        } catch(std::exception &e) {
+            std::cerr << e.what() << std::endl;
+            return UCC_ERR_NO_MESSAGE;
+        }
+        UCCCHECK_GOTO(ucc_ee_executor_start(executor, ee->ee_context),
+                      exit_err, st);
+    } else {
+        UCCCHECK_GOTO(ucc_ee_executor_start(executor, nullptr), exit_err, st);
+    }
+
+    for (int i = 0; i < nwarmup + niter; i++) {
+        double s = get_time_us();
+
+        UCCCHECK_GOTO(ucc_ee_executor_task_post(executor, &args, &task),
+                      stop_exec, st);
+        st = ucc_ee_executor_task_test(task);
+        while (st > 0) {
+            st = ucc_ee_executor_task_test(task);
+        }
+        ucc_ee_executor_task_finalize(task);
+        double f = get_time_us();
+        if (st != UCC_OK) {
+            goto exit_err;
+        }
+        if (i >= nwarmup) {
+            time += f - s;
+        }
+    }
+
+    UCCCHECK_GOTO(ucc_ee_executor_stop(executor), exit_err, st);
+    if (niter != 0) {
+        time /= niter;
+    }
+    return UCC_OK;
+
+stop_exec:
+    ucc_ee_executor_stop(executor);
+exit_err:
+    return st;
+}
+
 void ucc_pt_benchmark::print_header()
 {
     if (comm->get_rank() == 0) {
         std::ios iostate(nullptr);
         iostate.copyfmt(std::cout);
         std::cout << std::left << std::setw(24)
-                  << "Collective: " << ucc_coll_type_str(config.coll_type)
+                  << "Collective: " << ucc_pt_op_type_str(config.op_type)
                   << std::endl;
         std::cout << std::left << std::setw(24)
                   << "Memory type: " << ucc_memory_type_names[config.mt]
@@ -221,7 +295,7 @@ void ucc_pt_benchmark::print_header()
     }
 }
 
-void ucc_pt_benchmark::print_time(size_t count, ucc_coll_args_t args,
+void ucc_pt_benchmark::print_time(size_t count, ucc_pt_test_args_t args,
                                   double time)
 {
     double time_us = time;
@@ -254,8 +328,8 @@ void ucc_pt_benchmark::print_time(size_t count, ucc_coll_args_t args,
                           << std::setw(12) << "N/A"
                           << std::setw(12) << "N/A";
             } else {
-                if (config.coll_type == UCC_COLL_TYPE_GATHER ||
-                    config.coll_type == UCC_COLL_TYPE_SCATTER) {
+                if (config.op_type == UCC_PT_OP_TYPE_GATHER ||
+                    config.op_type == UCC_PT_OP_TYPE_SCATTER) {
                     std::cout << std::setw(12) << "N/A"
                               << std::setw(12) << "N/A"
                               << std::setw(12) << coll->get_bw(time_max, gsize,

--- a/tools/perf/ucc_pt_benchmark.h
+++ b/tools/perf/ucc_pt_benchmark.h
@@ -19,14 +19,16 @@ class ucc_pt_benchmark {
 
     ucc_status_t barrier();
     void print_header();
-    void print_time(size_t count, ucc_coll_args_t args,
-                    double time);
+    void print_time(size_t count, ucc_pt_test_args_t args, double time);
 public:
     ucc_pt_benchmark(ucc_pt_benchmark_config cfg, ucc_pt_comm *communicator);
     ucc_status_t run_bench() noexcept;
-    ucc_status_t run_single_test(ucc_coll_args_t args,
-                                 int nwarmup, int niter,
-                                 double &time) noexcept;
+    ucc_status_t run_single_coll_test(ucc_coll_args_t args,
+                                      int nwarmup, int niter,
+                                      double &time) noexcept;
+    ucc_status_t run_single_executor_test(ucc_ee_executor_task_args_t args,
+                                          int nwarmup, int niter,
+                                          double &time) noexcept;
     ~ucc_pt_benchmark();
 };
 

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -10,8 +10,14 @@
 #include "ucc_pt_comm.h"
 #include <ucc/api/ucc.h>
 extern "C" {
+#include <components/ec/ucc_ec.h>
 #include <components/mc/ucc_mc.h>
 }
+
+typedef union {
+    ucc_coll_args_t             coll_args;
+    ucc_ee_executor_task_args_t executor_args;
+} ucc_pt_test_args_t;
 
 class ucc_pt_coll {
 protected:
@@ -21,6 +27,7 @@ protected:
     bool has_bw_;
     ucc_pt_comm *comm;
     ucc_coll_args_t coll_args;
+    ucc_ee_executor_task_args_t executor_args;
     ucc_mc_buffer_header_t *dst_header;
     ucc_mc_buffer_header_t *src_header;
 public:
@@ -28,10 +35,10 @@ public:
     {
         comm = communicator;
     }
-    virtual ucc_status_t init_coll_args(size_t count,
-                                        ucc_coll_args_t &args) = 0;
-    virtual void free_coll_args(ucc_coll_args_t &args) = 0;
-    virtual float get_bw(float time_ms, int grsize, ucc_coll_args_t args)
+    virtual ucc_status_t init_args(size_t count,
+                                   ucc_pt_test_args_t &args) = 0;
+    virtual void free_args(ucc_pt_test_args_t &args) = 0;
+    virtual float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args)
     {
         return 0.0;
     }
@@ -46,17 +53,17 @@ class ucc_pt_coll_allgather: public ucc_pt_coll {
 public:
     ucc_pt_coll_allgather(ucc_datatype_t dt, ucc_memory_type mt,
                           bool is_inplace, ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
-    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
 };
 
 class ucc_pt_coll_allgatherv: public ucc_pt_coll {
 public:
     ucc_pt_coll_allgatherv(ucc_datatype_t dt, ucc_memory_type mt,
                            bool is_inplace, ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
 };
 
 class ucc_pt_coll_allreduce: public ucc_pt_coll {
@@ -64,42 +71,42 @@ public:
     ucc_pt_coll_allreduce(ucc_datatype_t dt, ucc_memory_type mt,
                           ucc_reduction_op_t op, bool is_inplace,
                           ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
-    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
 };
 
 class ucc_pt_coll_alltoall: public ucc_pt_coll {
 public:
     ucc_pt_coll_alltoall(ucc_datatype_t dt, ucc_memory_type mt,
                          bool is_inplace, ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
-    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
 };
 
 class ucc_pt_coll_alltoallv: public ucc_pt_coll {
 public:
     ucc_pt_coll_alltoallv(ucc_datatype_t dt, ucc_memory_type mt,
                           bool is_inplace, ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
 };
 
 class ucc_pt_coll_barrier: public ucc_pt_coll {
 public:
     ucc_pt_coll_barrier(ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
 };
 
 class ucc_pt_coll_bcast: public ucc_pt_coll {
 public:
     ucc_pt_coll_bcast(ucc_datatype_t dt, ucc_memory_type mt,
                       ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
-    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
 };
 
 class ucc_pt_coll_reduce: public ucc_pt_coll {
@@ -107,9 +114,9 @@ public:
     ucc_pt_coll_reduce(ucc_datatype_t dt, ucc_memory_type mt,
                        ucc_reduction_op_t op, bool is_inplace,
                        ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
-    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
 };
 
 class ucc_pt_coll_reduce_scatter: public ucc_pt_coll {
@@ -117,43 +124,82 @@ public:
     ucc_pt_coll_reduce_scatter(ucc_datatype_t dt, ucc_memory_type mt,
                                ucc_reduction_op_t op, bool is_inplace,
                                ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
-    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
 };
 
 class ucc_pt_coll_gather: public ucc_pt_coll {
 public:
     ucc_pt_coll_gather(ucc_datatype_t dt, ucc_memory_type mt,
-                          bool is_inplace, ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
-    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
+                       bool is_inplace, ucc_pt_comm *communicator);
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
 };
 
 class ucc_pt_coll_gatherv: public ucc_pt_coll {
 public:
     ucc_pt_coll_gatherv(ucc_datatype_t dt, ucc_memory_type mt,
-                           bool is_inplace, ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
+                        bool is_inplace, ucc_pt_comm *communicator);
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
 };
 
 class ucc_pt_coll_scatter: public ucc_pt_coll {
 public:
     ucc_pt_coll_scatter(ucc_datatype_t dt, ucc_memory_type mt,
-                         bool is_inplace, ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
-    float get_bw(float time_ms, int grsize, ucc_coll_args_t args) override;
+                        bool is_inplace, ucc_pt_comm *communicator);
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
 };
 
 class ucc_pt_coll_scatterv: public ucc_pt_coll {
 public:
     ucc_pt_coll_scatterv(ucc_datatype_t dt, ucc_memory_type mt,
-                           bool is_inplace, ucc_pt_comm *communicator);
-    ucc_status_t init_coll_args(size_t count, ucc_coll_args_t &args) override;
-    void free_coll_args(ucc_coll_args_t &args) override;
+                         bool is_inplace, ucc_pt_comm *communicator);
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+};
+
+class ucc_pt_op_memcpy: public ucc_pt_coll {
+    ucc_memory_type_t mem_type;
+    ucc_datatype_t    data_type;
+public:
+    ucc_pt_op_memcpy(ucc_datatype_t dt, ucc_memory_type mt,
+                     ucc_pt_comm *communicator);
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
+};
+
+class ucc_pt_op_reduce: public ucc_pt_coll {
+    ucc_memory_type_t  mem_type;
+    ucc_datatype_t     data_type;
+    ucc_reduction_op_t reduce_op;
+    int                num_bufs;
+public:
+    ucc_pt_op_reduce(ucc_datatype_t dt, ucc_memory_type mt,
+                     ucc_reduction_op_t op, int nbufs,
+                     ucc_pt_comm *communicator);
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
+};
+
+class ucc_pt_op_reduce_strided: public ucc_pt_coll {
+    ucc_memory_type_t  mem_type;
+    ucc_datatype_t     data_type;
+    ucc_reduction_op_t reduce_op;
+    int                num_bufs;
+public:
+    ucc_pt_op_reduce_strided(ucc_datatype_t dt, ucc_memory_type mt,
+                             ucc_reduction_op_t op, int nbufs,
+                             ucc_pt_comm *communicator);
+    ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
+    void free_args(ucc_pt_test_args_t &args) override;
+    float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
 };
 
 #endif

--- a/tools/perf/ucc_pt_coll_allgather.cc
+++ b/tools/perf/ucc_pt_coll_allgather.cc
@@ -26,13 +26,14 @@ ucc_pt_coll_allgather::ucc_pt_coll_allgather(ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_allgather::init_coll_args(size_t single_rank_count,
-                                                   ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_allgather::init_args(size_t single_rank_count,
+                                              ucc_pt_test_args_t &test_args)
 {
-    size_t dt_size  = ucc_dt_size(coll_args.src.info.datatype);
-    size_t size_src = single_rank_count * dt_size;
-    size_t size_dst = comm->get_size() * single_rank_count * dt_size;
-    ucc_status_t st;
+    ucc_coll_args_t &args     = test_args.coll_args;
+    size_t           dt_size  = ucc_dt_size(coll_args.src.info.datatype);
+    size_t           size_src = single_rank_count * dt_size;
+    size_t           size_dst = comm->get_size() * single_rank_count * dt_size;
+    ucc_status_t     st;
 
     args = coll_args;
     args.dst.info.count = single_rank_count * comm->get_size();
@@ -54,16 +55,20 @@ exit:
 }
 
 float ucc_pt_coll_allgather::get_bw(float time_ms, int grsize,
-                                    ucc_coll_args_t args)
+                                    ucc_pt_test_args_t test_args)
 {
-    float N = grsize;
-    float S = args.dst.info.count * ucc_dt_size(args.dst.info.datatype);
+    ucc_coll_args_t &args = test_args.coll_args;
+    float           N     = grsize;
+    float           S     = args.dst.info.count *
+                            ucc_dt_size(args.dst.info.datatype);
 
     return (S / time_ms) * ((N - 1) / N) / 1000.0;
 }
 
-void ucc_pt_coll_allgather::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_allgather::free_args(ucc_pt_test_args_t &test_args)
 {
+    ucc_coll_args_t &args = test_args.coll_args;
+
     if (!UCC_IS_INPLACE(args)) {
         ucc_mc_free(src_header);
     }

--- a/tools/perf/ucc_pt_coll_allgatherv.cc
+++ b/tools/perf/ucc_pt_coll_allgatherv.cc
@@ -25,13 +25,14 @@ ucc_pt_coll_allgatherv::ucc_pt_coll_allgatherv(ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_allgatherv::init_coll_args(size_t count,
-                                                  ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_allgatherv::init_args(size_t count,
+                                               ucc_pt_test_args_t &test_args)
 {
-    int comm_size   = comm->get_size();
-	size_t dt_size  = ucc_dt_size(coll_args.src.info.datatype);
-    size_t size_src = count * dt_size;
-    size_t size_dst = comm_size * count * dt_size;
+    ucc_coll_args_t &args      = test_args.coll_args;
+    int              comm_size = comm->get_size();
+	size_t           dt_size   = ucc_dt_size(coll_args.src.info.datatype);
+    size_t           size_src  = count * dt_size;
+    size_t           size_dst  = comm_size * count * dt_size;
     ucc_status_t st;
 
     args = coll_args;
@@ -64,8 +65,10 @@ exit:
     return st;
 }
 
-void ucc_pt_coll_allgatherv::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_allgatherv::free_args(ucc_pt_test_args_t &test_args)
 {
+    ucc_coll_args_t &args = test_args.coll_args;
+
     if (!UCC_IS_INPLACE(args)) {
         ucc_mc_free(src_header);
     }

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -27,12 +27,13 @@ ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
     coll_args.dst.info.mem_type = mt;
 }
 
-ucc_status_t ucc_pt_coll_allreduce::init_coll_args(size_t count,
-                                                   ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_allreduce::init_args(size_t count,
+                                              ucc_pt_test_args_t &test_args)
 {
-    size_t       dt_size = ucc_dt_size(coll_args.src.info.datatype);
-    size_t       size    = count * dt_size;
-    ucc_status_t st      = UCC_OK;
+    ucc_coll_args_t &args    = test_args.coll_args;
+    size_t           dt_size = ucc_dt_size(coll_args.src.info.datatype);
+    size_t           size    = count * dt_size;
+    ucc_status_t     st      = UCC_OK;
 
     args = coll_args;
     args.src.info.count = count;
@@ -52,8 +53,10 @@ exit:
     return st;
 }
 
-void ucc_pt_coll_allreduce::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_allreduce::free_args(ucc_pt_test_args_t &test_args)
 {
+    ucc_coll_args_t &args = test_args.coll_args;
+
     if (!UCC_IS_INPLACE(args)) {
         ucc_mc_free(src_header);
     }
@@ -61,10 +64,12 @@ void ucc_pt_coll_allreduce::free_coll_args(ucc_coll_args_t &args)
 }
 
 float ucc_pt_coll_allreduce::get_bw(float time_ms, int grsize,
-                                    ucc_coll_args_t args)
+                                    ucc_pt_test_args_t test_args)
 {
-    float N = grsize;
-    float S = args.src.info.count * ucc_dt_size(args.src.info.datatype);
+    ucc_coll_args_t &args = test_args.coll_args;
+    float            N    = grsize;
+    float            S    = args.src.info.count *
+                            ucc_dt_size(args.src.info.datatype);
 
     return (S / time_ms) * (2 * (N - 1) / N) / 1000.0;
 }

--- a/tools/perf/ucc_pt_coll_alltoall.cc
+++ b/tools/perf/ucc_pt_coll_alltoall.cc
@@ -25,13 +25,14 @@ ucc_pt_coll_alltoall::ucc_pt_coll_alltoall(ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_alltoall::init_coll_args(size_t single_rank_count,
-                                                  ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_alltoall::init_args(size_t single_rank_count,
+                                             ucc_pt_test_args_t &test_args)
 {
-    int          comm_size = comm->get_size();
-    size_t       dt_size   = ucc_dt_size(coll_args.src.info.datatype);
-    size_t       size      = comm_size * single_rank_count * dt_size;
-    ucc_status_t st        = UCC_OK;
+    ucc_coll_args_t &args      = test_args.coll_args;
+    int              comm_size = comm->get_size();
+    size_t           dt_size   = ucc_dt_size(coll_args.src.info.datatype);
+    size_t           size      = comm_size * single_rank_count * dt_size;
+    ucc_status_t     st        = UCC_OK;
 
     args = coll_args;
     args.dst.info.count = single_rank_count * comm_size;
@@ -51,8 +52,10 @@ exit:
     return st;
 }
 
-void ucc_pt_coll_alltoall::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_alltoall::free_args(ucc_pt_test_args_t &test_args)
 {
+    ucc_coll_args_t &args = test_args.coll_args;
+
     if (!UCC_IS_INPLACE(args)) {
         ucc_mc_free(src_header);
     }
@@ -60,10 +63,12 @@ void ucc_pt_coll_alltoall::free_coll_args(ucc_coll_args_t &args)
 }
 
 float ucc_pt_coll_alltoall::get_bw(float time_ms, int grsize,
-                                   ucc_coll_args_t args)
+                                   ucc_pt_test_args_t test_args)
 {
-    float N = grsize;
-    float S = args.src.info.count * ucc_dt_size(args.src.info.datatype);
+    ucc_coll_args_t &args = test_args.coll_args;
+    float            N    = grsize;
+    float            S    = args.src.info.count *
+                            ucc_dt_size(args.src.info.datatype);
 
     return (S / time_ms) * ((N - 1) / N) / 1000.0;
 }

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -26,13 +26,14 @@ ucc_pt_coll_alltoallv::ucc_pt_coll_alltoallv(ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_alltoallv::init_coll_args(size_t count,
-                                                   ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_alltoallv::init_args(size_t count,
+                                              ucc_pt_test_args_t &test_args)
 {
-    int          comm_size = comm->get_size();
-    size_t       dt_size   = ucc_dt_size(coll_args.src.info_v.datatype);
-    size_t       size      = comm_size * count * dt_size;
-    ucc_status_t st        = UCC_OK;
+    ucc_coll_args_t &args      = test_args.coll_args;
+    int              comm_size = comm->get_size();
+    size_t           dt_size   = ucc_dt_size(coll_args.src.info_v.datatype);
+    size_t           size      = comm_size * count * dt_size;
+    ucc_status_t     st        = UCC_OK;
 
     args = coll_args;
     args.src.info_v.counts = (ucc_count_t *) ucc_malloc(comm_size * sizeof(uint32_t), "counts buf");
@@ -72,8 +73,10 @@ exit:
     return st;
 }
 
-void ucc_pt_coll_alltoallv::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_alltoallv::free_args(ucc_pt_test_args_t &test_args)
 {
+    ucc_coll_args_t &args = test_args.coll_args;
+
     if (!UCC_IS_INPLACE(args)) {
         ucc_mc_free(src_header);
     }

--- a/tools/perf/ucc_pt_coll_barrier.cc
+++ b/tools/perf/ucc_pt_coll_barrier.cc
@@ -16,14 +16,16 @@ ucc_pt_coll_barrier::ucc_pt_coll_barrier(ucc_pt_comm *communicator) :
     coll_args.coll_type = UCC_COLL_TYPE_BARRIER;
 }
 
-ucc_status_t ucc_pt_coll_barrier::init_coll_args(size_t count,
-                                                 ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_barrier::init_args(size_t count,
+                                            ucc_pt_test_args_t &test_args)
 {
+    ucc_coll_args_t &args = test_args.coll_args;
+
     args = coll_args;
     return UCC_OK;
 }
 
-void ucc_pt_coll_barrier::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_barrier::free_args(ucc_pt_test_args_t &test_args)
 {
     return;
 }

--- a/tools/perf/ucc_pt_coll_bcast.cc
+++ b/tools/perf/ucc_pt_coll_bcast.cc
@@ -19,12 +19,13 @@ ucc_pt_coll_bcast::ucc_pt_coll_bcast(ucc_datatype_t dt, ucc_memory_type mt,
     coll_args.src.info.mem_type = mt;
 }
 
-ucc_status_t ucc_pt_coll_bcast::init_coll_args(size_t count,
-                                                   ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_bcast::init_args(size_t count,
+                                          ucc_pt_test_args_t &test_args)
 {
-    size_t dt_size = ucc_dt_size(coll_args.src.info.datatype);
-    size_t size    = count * dt_size;
-    ucc_status_t st;
+    ucc_coll_args_t &args     = test_args.coll_args;
+    size_t           dt_size  = ucc_dt_size(coll_args.src.info.datatype);
+    size_t           size     = count * dt_size;
+    ucc_status_t     st;
 
     args = coll_args;
     args.src.info.count = count;
@@ -35,14 +36,17 @@ exit:
     return st;
 }
 
-void ucc_pt_coll_bcast::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_bcast::free_args(ucc_pt_test_args_t &test_args)
 {
     ucc_mc_free(src_header);
 }
 
-float ucc_pt_coll_bcast::get_bw(float time_ms, int grsize, ucc_coll_args_t args)
+float ucc_pt_coll_bcast::get_bw(float time_ms, int grsize,
+                                ucc_pt_test_args_t test_args)
 {
-    float S = args.src.info.count * ucc_dt_size(args.src.info.datatype);
+    ucc_coll_args_t &args = test_args.coll_args;
+    float            S    = args.src.info.count *
+                            ucc_dt_size(args.src.info.datatype);
 
     return S / time_ms / 1000.0;
 }

--- a/tools/perf/ucc_pt_coll_gather.cc
+++ b/tools/perf/ucc_pt_coll_gather.cc
@@ -26,12 +26,13 @@ ucc_pt_coll_gather::ucc_pt_coll_gather(ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_gather::init_coll_args(size_t single_rank_count,
-                                                   ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_gather::init_args(size_t single_rank_count,
+                                           ucc_pt_test_args_t &test_args)
 {
-    size_t dt_size  = ucc_dt_size(coll_args.src.info.datatype);
-    size_t size_src = single_rank_count * dt_size;
-    size_t size_dst = comm->get_size() * single_rank_count * dt_size;
+    ucc_coll_args_t &args     = test_args.coll_args;
+    size_t           dt_size  = ucc_dt_size(coll_args.src.info.datatype);
+    size_t           size_src = single_rank_count * dt_size;
+    size_t           size_dst = comm->get_size() * single_rank_count * dt_size;
     ucc_status_t st_src, st_dst;
     bool is_root;
 
@@ -62,17 +63,21 @@ exit:
 }
 
 float ucc_pt_coll_gather::get_bw(float time_ms, int grsize,
-                                    ucc_coll_args_t args)
+                                 ucc_pt_test_args_t test_args)
 {
-    float S = args.src.info.count * ucc_dt_size(args.src.info.datatype);
-    float N = grsize - 1;
+    ucc_coll_args_t &args = test_args.coll_args;
+    float            N    = grsize - 1;
+    float            S    = args.src.info.count *
+                            ucc_dt_size(args.src.info.datatype);
 
     return (S * N) / time_ms / 1000.0;
 }
 
-void ucc_pt_coll_gather::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_gather::free_args(ucc_pt_test_args_t &test_args)
 {
-    bool is_root = (comm->get_rank() == args.root);
+    ucc_coll_args_t &args    = test_args.coll_args;
+    bool             is_root = (comm->get_rank() == args.root);
+
     if (!is_root || !UCC_IS_INPLACE(args)) {
         ucc_mc_free(src_header);
     }

--- a/tools/perf/ucc_pt_coll_gatherv.cc
+++ b/tools/perf/ucc_pt_coll_gatherv.cc
@@ -26,15 +26,16 @@ ucc_pt_coll_gatherv::ucc_pt_coll_gatherv(ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_gatherv::init_coll_args(size_t count,
-                                                   ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_gatherv::init_args(size_t count,
+                                            ucc_pt_test_args_t &test_args)
 {
-    int comm_size   = comm->get_size();
-    size_t dt_size  = ucc_dt_size(coll_args.src.info.datatype);
-    size_t size_src = count * dt_size;
-    size_t size_dst = comm_size * count * dt_size;
+    ucc_coll_args_t &args      = test_args.coll_args;
+    int              comm_size = comm->get_size();
+    size_t           dt_size   = ucc_dt_size(coll_args.src.info.datatype);
+    size_t           size_src  = count * dt_size;
+    size_t           size_dst  = comm_size * count * dt_size;
     ucc_status_t st;
-    bool is_root;
+    bool         is_root;
 
     args    = coll_args;
     is_root = (comm->get_rank() == args.root);
@@ -79,9 +80,11 @@ exit:
     return st;
 }
 
-void ucc_pt_coll_gatherv::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_gatherv::free_args(ucc_pt_test_args_t &test_args)
 {
-    bool is_root = (comm->get_rank() == args.root);
+    ucc_coll_args_t &args    = test_args.coll_args;
+    bool             is_root = (comm->get_rank() == args.root);
+
     if (!is_root || !UCC_IS_INPLACE(args)) {
         ucc_mc_free(src_header);
     }

--- a/tools/perf/ucc_pt_coll_reduce.cc
+++ b/tools/perf/ucc_pt_coll_reduce.cc
@@ -28,11 +28,12 @@ ucc_pt_coll_reduce::ucc_pt_coll_reduce(ucc_datatype_t dt, ucc_memory_type mt,
     coll_args.dst.info.mem_type = mt;
 }
 
-ucc_status_t ucc_pt_coll_reduce::init_coll_args(size_t count,
-                                                   ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_reduce::init_args(size_t count,
+                                           ucc_pt_test_args_t &test_args)
 {
-    size_t dt_size = ucc_dt_size(coll_args.src.info.datatype);
-    size_t size    = count * dt_size;
+    ucc_coll_args_t &args    = test_args.coll_args;
+    size_t           dt_size = ucc_dt_size(coll_args.src.info.datatype);
+    size_t           size    = count * dt_size;
     ucc_status_t st_src, st_dst;
 
     args = coll_args;
@@ -59,9 +60,11 @@ exit:
     return st_dst;
 }
 
-void ucc_pt_coll_reduce::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_reduce::free_args(ucc_pt_test_args_t &test_args)
 {
-    bool is_root = (comm->get_rank() == args.root);
+    ucc_coll_args_t &args    = test_args.coll_args;
+    bool             is_root = (comm->get_rank() == args.root);
+
     if (!is_root || !UCC_IS_INPLACE(args)) {
         ucc_mc_free(src_header);
     }
@@ -71,9 +74,11 @@ void ucc_pt_coll_reduce::free_coll_args(ucc_coll_args_t &args)
 }
 
 float ucc_pt_coll_reduce::get_bw(float time_ms, int grsize,
-                                    ucc_coll_args_t args)
+                                 ucc_pt_test_args_t test_args)
 {
-    float S = args.src.info.count * ucc_dt_size(args.src.info.datatype);
+    ucc_coll_args_t &args = test_args.coll_args;
+    float            S    = args.src.info.count *
+                            ucc_dt_size(args.src.info.datatype);
 
     return S / time_ms / 1000.0;
 }

--- a/tools/perf/ucc_pt_coll_reduce_scatter.cc
+++ b/tools/perf/ucc_pt_coll_reduce_scatter.cc
@@ -28,9 +28,10 @@ ucc_pt_coll_reduce_scatter::ucc_pt_coll_reduce_scatter(ucc_datatype_t dt,
     coll_args.dst.info.mem_type = mt;
 }
 
-ucc_status_t ucc_pt_coll_reduce_scatter::init_coll_args(size_t count,
-                                                        ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_reduce_scatter::init_args(size_t count,
+                                                   ucc_pt_test_args_t &test_args)
 {
+    ucc_coll_args_t &args = test_args.coll_args;
     size_t size;
     ucc_status_t st;
 
@@ -62,7 +63,7 @@ exit:
     return st;
 }
 
-void ucc_pt_coll_reduce_scatter::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_reduce_scatter::free_args(ucc_pt_test_args_t &test_args)
 {
     if (dst_header) {
         ucc_mc_free(dst_header);
@@ -75,12 +76,13 @@ void ucc_pt_coll_reduce_scatter::free_coll_args(ucc_coll_args_t &args)
 }
 
 float ucc_pt_coll_reduce_scatter::get_bw(float time_ms, int grsize,
-                                         ucc_coll_args_t args)
+                                         ucc_pt_test_args_t test_args)
 {
-    float N      = grsize;
-    size_t count = UCC_IS_INPLACE(args) ? args.dst.info.count :
-                                          args.src.info.count;
-    float S      = count * ucc_dt_size(args.dst.info.datatype);
+    ucc_coll_args_t &args  = test_args.coll_args;
+    float            N     = grsize;
+    size_t           count = UCC_IS_INPLACE(args) ? args.dst.info.count :
+                                                   args.src.info.count;
+    float S                = count * ucc_dt_size(args.dst.info.datatype);
 
     return (S / time_ms) * ((N - 1) / N) / 1000.0;
 }

--- a/tools/perf/ucc_pt_coll_scatter.cc
+++ b/tools/perf/ucc_pt_coll_scatter.cc
@@ -26,13 +26,14 @@ ucc_pt_coll_scatter::ucc_pt_coll_scatter(ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_scatter::init_coll_args(size_t single_rank_count,
-                                                   ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_scatter::init_args(size_t single_rank_count,
+                                            ucc_pt_test_args_t &test_args)
 {
-    size_t dt_size  = ucc_dt_size(coll_args.dst.info.datatype);
-    size_t size_dst = single_rank_count * dt_size;
-    size_t size_src = comm->get_size() * single_rank_count * dt_size;
-    ucc_status_t st_src = UCC_OK, st_dst = UCC_OK;
+    ucc_coll_args_t &args     = test_args.coll_args;
+    size_t           dt_size  = ucc_dt_size(coll_args.dst.info.datatype);
+    size_t           size_dst = single_rank_count * dt_size;
+    size_t           size_src = comm->get_size() * single_rank_count * dt_size;
+    ucc_status_t     st_src = UCC_OK, st_dst = UCC_OK;
     bool is_root;
 
     args                = coll_args;
@@ -61,17 +62,20 @@ exit:
 }
 
 float ucc_pt_coll_scatter::get_bw(float time_ms, int grsize,
-                                    ucc_coll_args_t args)
+                                  ucc_pt_test_args_t test_args)
 {
-    float S = args.dst.info.count * ucc_dt_size(args.dst.info.datatype);
-    float N = grsize - 1;
+    ucc_coll_args_t &args = test_args.coll_args;
+    float            S    = args.dst.info.count * ucc_dt_size(args.dst.info.datatype);
+    float            N    = grsize - 1;
 
     return (S * N) / time_ms / 1000.0;
 }
 
-void ucc_pt_coll_scatter::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_scatter::free_args(ucc_pt_test_args_t &test_args)
 {
-    bool is_root = (comm->get_rank() == args.root);
+    ucc_coll_args_t &args    = test_args.coll_args;
+    bool             is_root = (comm->get_rank() == args.root);
+
     if (!is_root || !UCC_IS_INPLACE(args)) {
         ucc_mc_free(dst_header);
     }

--- a/tools/perf/ucc_pt_coll_scatterv.cc
+++ b/tools/perf/ucc_pt_coll_scatterv.cc
@@ -26,13 +26,14 @@ ucc_pt_coll_scatterv::ucc_pt_coll_scatterv(ucc_datatype_t dt,
     }
 }
 
-ucc_status_t ucc_pt_coll_scatterv::init_coll_args(size_t count,
-                                                   ucc_coll_args_t &args)
+ucc_status_t ucc_pt_coll_scatterv::init_args(size_t count,
+                                             ucc_pt_test_args_t &test_args)
 {
-    int comm_size   = comm->get_size();
-    size_t dt_size  = ucc_dt_size(coll_args.dst.info.datatype);
-    size_t size_dst = count * dt_size;
-    size_t size_src = comm_size * count * dt_size;
+    ucc_coll_args_t &args      = test_args.coll_args;
+    int              comm_size = comm->get_size();
+    size_t           dt_size   = ucc_dt_size(coll_args.dst.info.datatype);
+    size_t           size_dst  = count * dt_size;
+    size_t           size_src  = comm_size * count * dt_size;
     ucc_status_t st;
     bool is_root;
 
@@ -79,9 +80,11 @@ exit:
     return st;
 }
 
-void ucc_pt_coll_scatterv::free_coll_args(ucc_coll_args_t &args)
+void ucc_pt_coll_scatterv::free_args(ucc_pt_test_args_t &test_args)
 {
-    bool is_root = (comm->get_rank() == args.root);
+    ucc_coll_args_t &args    = test_args.coll_args;
+    bool             is_root = (comm->get_rank() == args.root);
+
     if (!is_root || !UCC_IS_INPLACE(args)) {
         ucc_mc_free(dst_header);
     }

--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -9,6 +9,7 @@ extern "C" {
 #include "utils/ucc_coll_utils.h"
 #include "components/mc/ucc_mc.h"
 }
+
 ucc_pt_comm::ucc_pt_comm(ucc_pt_comm_config config)
 {
     cfg = config;
@@ -25,12 +26,12 @@ void ucc_pt_comm::set_gpu_device()
     int dev_count = 0;
 
     if (ucc_pt_cudaGetDeviceCount(&dev_count) == 0 && dev_count != 0) {
-	ucc_pt_cudaSetDevice(bootstrap->get_local_rank() % dev_count);
-	return;
+        ucc_pt_cudaSetDevice(bootstrap->get_local_rank() % dev_count);
+        return;
     }
 
     if (ucc_pt_rocmGetDeviceCount(&dev_count) == 0 && dev_count != 0) {
-	ucc_pt_rocmSetDevice(bootstrap->get_local_rank() % dev_count);
+        ucc_pt_rocmSetDevice(bootstrap->get_local_rank() % dev_count);
     }
 
     return;
@@ -76,6 +77,31 @@ ucc_ee_h ucc_pt_comm::get_ee()
     return ee;
 }
 
+ucc_ee_executor_t* ucc_pt_comm::get_executor()
+{
+    ucc_ee_executor_params_t executor_params;
+    ucc_status_t             status;
+
+    if (!executor) {
+        executor_params.mask = UCC_EE_EXECUTOR_PARAM_FIELD_TYPE;
+        if (cfg.mt ==  UCC_MEMORY_TYPE_HOST) {
+            executor_params.ee_type = UCC_EE_CPU_THREAD;
+        } else if (cfg.mt == UCC_MEMORY_TYPE_CUDA) {
+            executor_params.ee_type = UCC_EE_CUDA_STREAM;
+        } else if (cfg.mt == UCC_MEMORY_TYPE_ROCM) {
+            executor_params.ee_type = UCC_EE_ROCM_STREAM;
+        } else {
+            std::cerr << "executor is not supported for given memory type";
+            throw std::runtime_error("not supported");
+        }
+        status = ucc_ee_executor_init(&executor_params, &executor);
+        if (status != UCC_OK) {
+            throw std::runtime_error("failed to init executor");
+        }
+    }
+    return executor;
+}
+
 ucc_team_h ucc_pt_comm::get_team()
 {
     return team;
@@ -96,7 +122,10 @@ ucc_status_t ucc_pt_comm::init()
     ucc_status_t st;
     std::string cfg_mod;
 
-    ee = nullptr;
+    ee       = nullptr;
+    executor = nullptr;
+    stream   = nullptr;
+
     if (cfg.mt != UCC_MEMORY_TYPE_HOST) {
         set_gpu_device();
     }
@@ -170,6 +199,14 @@ ucc_status_t ucc_pt_comm::finalize()
         } else {
             std::cerr << "execution engine is not supported for given memory type";
             throw std::runtime_error("not supported");
+        }
+    }
+
+    if (executor) {
+        status = ucc_ee_executor_finalize(executor);
+        if (status != UCC_OK) {
+            std::cerr << "ucc executor finalize error: "
+                      << ucc_status_string(status);
         }
     }
 

--- a/tools/perf/ucc_pt_comm.h
+++ b/tools/perf/ucc_pt_comm.h
@@ -11,6 +11,9 @@
 #include "ucc_pt_config.h"
 #include "ucc_pt_bootstrap.h"
 #include "ucc_pt_bootstrap_mpi.h"
+extern "C" {
+#include "components/ec/ucc_ec.h"
+}
 
 class ucc_pt_comm {
     ucc_pt_comm_config cfg;
@@ -19,12 +22,14 @@ class ucc_pt_comm {
     ucc_team_h team;
     void *stream;
     ucc_ee_h ee;
+    ucc_ee_executor_t *executor;
     ucc_pt_bootstrap *bootstrap;
     void set_gpu_device();
 public:
     ucc_pt_comm(ucc_pt_comm_config config);
     int get_rank();
     int get_size();
+    ucc_ee_executor_t* get_executor();
     ucc_ee_h get_ee();
     ucc_team_h get_team();
     ucc_context_h get_context();

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <getopt.h>
 #include <ucc/api/ucc.h>
+#include "utils/ucc_log.h"
 
 enum ucc_pt_bootstrap_type_t {
     UCC_PT_BOOTSTRAP_MPI,
@@ -27,8 +28,49 @@ struct ucc_pt_comm_config {
     ucc_memory_type_t mt;
 };
 
+typedef enum {
+    UCC_PT_OP_TYPE_ALLGATHER       = UCC_COLL_TYPE_ALLGATHER,
+    UCC_PT_OP_TYPE_ALLGATHERV      = UCC_COLL_TYPE_ALLGATHERV,
+    UCC_PT_OP_TYPE_ALLREDUCE       = UCC_COLL_TYPE_ALLREDUCE,
+    UCC_PT_OP_TYPE_ALLTOALL        = UCC_COLL_TYPE_ALLTOALL,
+    UCC_PT_OP_TYPE_ALLTOALLV       = UCC_COLL_TYPE_ALLTOALLV,
+    UCC_PT_OP_TYPE_BARRIER         = UCC_COLL_TYPE_BARRIER,
+    UCC_PT_OP_TYPE_BCAST           = UCC_COLL_TYPE_BCAST,
+    UCC_PT_OP_TYPE_FANIN           = UCC_COLL_TYPE_FANIN,
+    UCC_PT_OP_TYPE_FANOUT          = UCC_COLL_TYPE_FANOUT,
+    UCC_PT_OP_TYPE_GATHER          = UCC_COLL_TYPE_GATHER,
+    UCC_PT_OP_TYPE_GATHERV         = UCC_COLL_TYPE_GATHERV,
+    UCC_PT_OP_TYPE_REDUCE          = UCC_COLL_TYPE_REDUCE,
+    UCC_PT_OP_TYPE_REDUCE_SCATTER  = UCC_COLL_TYPE_REDUCE_SCATTER,
+    UCC_PT_OP_TYPE_REDUCE_SCATTERV = UCC_COLL_TYPE_REDUCE_SCATTERV,
+    UCC_PT_OP_TYPE_SCATTER         = UCC_COLL_TYPE_SCATTER,
+    UCC_PT_OP_TYPE_SCATTERV        = UCC_COLL_TYPE_SCATTERV,
+    UCC_PT_OP_TYPE_MEMCPY          = UCC_COLL_TYPE_LAST + 1,
+    UCC_PT_OP_TYPE_REDUCEDT,
+    UCC_PT_OP_TYPE_REDUCEDT_STRIDED,
+    UCC_PT_OP_TYPE_LAST
+} ucc_pt_op_type_t;
+
+static inline const char* ucc_pt_op_type_str(ucc_pt_op_type_t op)
+{
+    if ((uint64_t)op < (uint64_t)UCC_COLL_TYPE_LAST) {
+        return ucc_coll_type_str((ucc_coll_type_t)op);
+    }
+    switch(op) {
+    case UCC_PT_OP_TYPE_MEMCPY:
+        return "Memcpy";
+    case UCC_PT_OP_TYPE_REDUCEDT:
+        return "Reduce DT";
+    case UCC_PT_OP_TYPE_REDUCEDT_STRIDED:
+        return "Reduce DT strided";
+    default:
+        break;
+    }
+    return NULL;
+}
+
 struct ucc_pt_benchmark_config {
-    ucc_coll_type_t    coll_type;
+    ucc_pt_op_type_t   op_type;
     size_t             min_count;
     size_t             max_count;
     ucc_datatype_t     dt;
@@ -41,6 +83,7 @@ struct ucc_pt_benchmark_config {
     int                n_warmup_small;
     int                n_iter_large;
     int                n_warmup_large;
+    int                n_bufs;
     bool               full_print;
 };
 

--- a/tools/perf/ucc_pt_op_memcpy.cc
+++ b/tools/perf/ucc_pt_op_memcpy.cc
@@ -1,0 +1,55 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+
+ucc_pt_op_memcpy::ucc_pt_op_memcpy(ucc_datatype_t dt, ucc_memory_type mt,
+                                   ucc_pt_comm *communicator) :
+                                   ucc_pt_coll(communicator)
+{
+    has_inplace_   = false;
+    has_reduction_ = false;
+    has_range_     = true;
+    has_bw_        = true;
+
+    data_type = dt;
+    mem_type  = mt;
+}
+
+ucc_status_t ucc_pt_op_memcpy::init_args(size_t count,
+                                         ucc_pt_test_args_t &test_args)
+{
+    ucc_ee_executor_task_args_t &args = test_args.executor_args;
+    size_t                       size = count * ucc_dt_size(data_type);
+    ucc_status_t st;
+
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size, mem_type), exit, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size, mem_type), free_dst, st);
+
+    args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
+    args.copy.dst  = dst_header->addr;
+    args.copy.src  = src_header->addr;
+    args.copy.len  = size;
+
+    return UCC_OK;
+free_dst:
+    ucc_mc_free(dst_header);
+exit:
+    return st;
+}
+
+float ucc_pt_op_memcpy::get_bw(float time_ms, int grsize,
+                                ucc_pt_test_args_t test_args)
+{
+    ucc_ee_executor_task_args_t &args = test_args.executor_args;
+    float                        S    = args.copy.len;
+
+    return 2 * (S / time_ms) / 1000.0;
+}
+
+void ucc_pt_op_memcpy::free_args(ucc_pt_test_args_t &test_args)
+{
+    ucc_mc_free(src_header);
+    ucc_mc_free(dst_header);
+}

--- a/tools/perf/ucc_pt_op_reduce.cc
+++ b/tools/perf/ucc_pt_op_reduce.cc
@@ -1,0 +1,76 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+
+ucc_pt_op_reduce::ucc_pt_op_reduce(ucc_datatype_t dt, ucc_memory_type mt,
+                                   ucc_reduction_op_t op, int nbufs,
+                                   ucc_pt_comm *communicator) :
+                                   ucc_pt_coll(communicator)
+{
+    has_inplace_   = false;
+    has_reduction_ = true;
+    has_range_     = true;
+    has_bw_        = true;
+
+    if (nbufs < 2) {
+        throw std::runtime_error("dt reduce op requires at least 2 bufs");
+    }
+
+    if (nbufs > UCC_EE_EXECUTOR_NUM_BUFS) {
+        throw std::runtime_error("dt reduce op supports up to " +
+                                 std::to_string(UCC_EE_EXECUTOR_NUM_BUFS) +
+                                 " bufs");
+    }
+
+    data_type = dt;
+    mem_type  = mt;
+    reduce_op = op;
+    num_bufs  = nbufs;
+}
+
+ucc_status_t ucc_pt_op_reduce::init_args(size_t count,
+                                         ucc_pt_test_args_t &test_args)
+{
+    ucc_ee_executor_task_args_t &args   = test_args.executor_args;
+    size_t                       size   = count * ucc_dt_size(data_type);
+    ucc_status_t st;
+    int i;
+
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size, mem_type), exit, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size * num_bufs, mem_type),
+                  free_dst, st);
+
+    args.task_type     = UCC_EE_EXECUTOR_TASK_REDUCE;
+    args.reduce.dst    = dst_header->addr;
+    args.reduce.n_srcs = num_bufs;
+    args.reduce.count  = count;
+    args.reduce.dt     = data_type;
+    args.reduce.op     = reduce_op;
+    args.flags         = 0;
+    for (i = 0; i < num_bufs; i++) {
+        args.reduce.srcs[i] = PTR_OFFSET(src_header->addr, i * size);
+    }
+
+    return UCC_OK;
+free_dst:
+    ucc_mc_free(dst_header);
+exit:
+    return st;
+}
+
+float ucc_pt_op_reduce::get_bw(float time_ms, int grsize,
+                                ucc_pt_test_args_t test_args)
+{
+    ucc_ee_executor_task_args_t &args = test_args.executor_args;
+    float                        S    = args.reduce.count * ucc_dt_size(data_type);
+
+    return (num_bufs + 1) * (S / time_ms) / 1000.0;
+}
+
+void ucc_pt_op_reduce::free_args(ucc_pt_test_args_t &test_args)
+{
+    ucc_mc_free(src_header);
+    ucc_mc_free(dst_header);
+}

--- a/tools/perf/ucc_pt_op_reduce_strided.cc
+++ b/tools/perf/ucc_pt_op_reduce_strided.cc
@@ -1,0 +1,73 @@
+#include "ucc_pt_coll.h"
+#include "ucc_perftest.h"
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <utils/ucc_coll_utils.h>
+
+ucc_pt_op_reduce_strided::ucc_pt_op_reduce_strided(ucc_datatype_t dt,
+                                                   ucc_memory_type mt,
+                                                   ucc_reduction_op_t op,
+                                                   int nbufs,
+                                                   ucc_pt_comm *communicator) :
+                                                   ucc_pt_coll(communicator)
+{
+    has_inplace_   = false;
+    has_reduction_ = true;
+    has_range_     = true;
+    has_bw_        = true;
+
+    if (nbufs < 2) {
+        throw std::runtime_error("dt reduce op requires at least 2 bufs");
+    }
+
+    data_type = dt;
+    mem_type  = mt;
+    reduce_op = op;
+    num_bufs  = nbufs;
+}
+
+ucc_status_t ucc_pt_op_reduce_strided::init_args(size_t count,
+                                                 ucc_pt_test_args_t &test_args)
+{
+    ucc_ee_executor_task_args_t &args   = test_args.executor_args;
+    size_t                       size   = count * ucc_dt_size(data_type);
+    size_t                       stride = count * ucc_dt_size(data_type);
+    ucc_status_t st;
+
+    UCCCHECK_GOTO(ucc_mc_alloc(&dst_header, size, mem_type), exit, st);
+    UCCCHECK_GOTO(ucc_mc_alloc(&src_header, size * num_bufs, mem_type),
+                  free_dst, st);
+
+    args.task_type             = UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED;
+    args.reduce_strided.dst    = dst_header->addr;
+    args.reduce_strided.src1   = src_header->addr;
+    args.reduce_strided.src2   = PTR_OFFSET(src_header->addr, size);
+    args.reduce_strided.n_src2 = num_bufs - 1;
+    args.reduce_strided.stride = stride;
+    args.reduce_strided.count  = count;
+    args.reduce_strided.dt     = data_type;
+    args.reduce_strided.op     = reduce_op;
+    args.flags         = 0;
+
+    return UCC_OK;
+free_dst:
+    ucc_mc_free(dst_header);
+exit:
+    return st;
+}
+
+float ucc_pt_op_reduce_strided::get_bw(float time_ms, int grsize,
+                                       ucc_pt_test_args_t test_args)
+{
+    ucc_ee_executor_task_args_t &args = test_args.executor_args;
+    float                        S    = args.reduce_strided.count *
+                                        ucc_dt_size(data_type);
+
+    return (num_bufs + 1) * (S / time_ms) / 1000.0;
+}
+
+void ucc_pt_op_reduce_strided::free_args(ucc_pt_test_args_t &test_args)
+{
+    ucc_mc_free(src_header);
+    ucc_mc_free(dst_header);
+}


### PR DESCRIPTION
## What
Benchmark operation in EC components with perftest
Following operations are supported
* reducedt - strided reduce multi with different number of vectors
* memcpy - memory copy
* triggered and non-triggered modes