### PR TITLE
TL/UCP: fanin don't need executor

### DIFF
--- a/src/components/tl/ucp/reduce/reduce_knomial.c
+++ b/src/components/tl/ucp/reduce/reduce_knomial.c
@@ -83,7 +83,7 @@ UCC_REDUCE_KN_PHASE_INIT:
                 SAVE_STATE(UCC_REDUCE_KN_PHASE_MULTI);
                 goto UCC_REDUCE_KN_PHASE_PROGRESS;
 UCC_REDUCE_KN_PHASE_MULTI:
-                if (task->reduce_kn.children_per_cycle) {
+                if (task->reduce_kn.children_per_cycle && count > 0) {
                     is_avg = args->op == UCC_OP_AVG &&
                              (avg_pre_op ? (task->reduce_kn.dist == 1)
                                          : (task->reduce_kn.dist ==
@@ -164,6 +164,14 @@ ucc_status_t ucc_tl_ucp_reduce_knomial_start(ucc_coll_task_t *coll_task)
 
     if (isleaf && !self_avg) {
     	task->reduce_kn.scratch = args->src.info.buffer;
+    }
+
+    if (args->coll_type != UCC_COLL_TYPE_FANIN) {
+        status =
+            ucc_coll_task_get_executor(&task->super, &task->reduce_kn.executor);
+        if (ucc_unlikely(status != UCC_OK)) {
+            return status;
+        }
     }
 
     if (isleaf && self_avg) {


### PR DESCRIPTION
## What
Fixes failure with TL/UCP fanin (used as step in CL/HIER barrier):
 [1659649645.578779] [swx-clx01:440  :0]    ucc_schedule.c:64   UCC  ERROR executor wasn't initialized for the collective

