### PR TITLE
UTIL: fix coll_args_msgsize routine

### DIFF
--- a/src/coll_score/ucc_coll_score_map.c
+++ b/src/coll_score/ucc_coll_score_map.c
@@ -10,6 +10,11 @@
 
 typedef struct ucc_score_map {
     ucc_coll_score_t *score;
+    /* Size, rank of the process in the base_team associated with that
+       score_map. It can be CL or TL team, which can be a subset of a
+       core UCC team */
+    ucc_rank_t        team_size;
+    ucc_rank_t        team_rank;
 } ucc_score_map_t;
 
 ucc_status_t ucc_coll_score_build_map(ucc_coll_score_t *score,
@@ -20,7 +25,7 @@ ucc_status_t ucc_coll_score_build_map(ucc_coll_score_t *score,
     ucc_list_link_t *lst;
     int              i, j;
 
-    map = ucc_malloc(sizeof(*map), "ucc_score_map");
+    map = ucc_calloc(1, sizeof(*map), "ucc_score_map");
     if (!map) {
         ucc_error("failed to allocate %zd bytes for score map", sizeof(*map));
         return UCC_ERR_NO_MEMORY;
@@ -33,6 +38,13 @@ ucc_status_t ucc_coll_score_build_map(ucc_coll_score_t *score,
     for (i = 0; i < UCC_COLL_TYPE_NUM; i++) {
         for (j = 0; j < UCC_MEMORY_TYPE_LAST; j++) {
             lst = &score->scores[i][j];
+            if (!ucc_list_is_empty(lst) && map->team_size == 0) {
+                /* For a given score_map all the entries refer to the base_teams
+                   (CL/TL) of the same size/rank. So we can take the first one. */
+                range = ucc_list_head(lst, ucc_msg_range_t, super.list_elem);
+                map->team_size = range->super.team->params.size;
+                map->team_rank = range->super.team->params.rank;
+            }
             ucc_list_for_each_safe(range, temp, lst, super.list_elem) {
                 if (range->super.list_elem.next != lst) {
                     next = ucc_container_of(range->super.list_elem.next,
@@ -66,9 +78,12 @@ ucc_status_t ucc_coll_score_map_lookup(ucc_score_map_t      *map,
                                        ucc_base_coll_args_t *bargs,
                                        ucc_msg_range_t     **range)
 {
-    ucc_memory_type_t mt      = ucc_coll_args_mem_type(bargs);
+    ucc_memory_type_t mt      = ucc_coll_args_mem_type(&bargs->args,
+                                                       map->team_rank);
     unsigned          ct      = ucc_ilog2(bargs->args.coll_type);
-    size_t            msgsize = ucc_coll_args_msgsize(bargs);
+    size_t            msgsize = ucc_coll_args_msgsize(&bargs->args,
+                                                      map->team_rank,
+                                                      map->team_size);
     ucc_list_link_t  *list;
     ucc_msg_range_t  *r;
 

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -202,7 +202,7 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
     task->flags |= UCC_COLL_TASK_FLAG_TOP_LEVEL;
     if (task->flags & UCC_COLL_TASK_FLAG_EXECUTOR) {
         task->flags |= UCC_COLL_TASK_FLAG_EXECUTOR_STOP;
-        coll_mem_type = ucc_coll_args_mem_type(&op_args);
+        coll_mem_type = ucc_coll_args_mem_type(coll_args, team->rank);
         switch(coll_mem_type) {
         case UCC_MEMORY_TYPE_CUDA:
             coll_ee_type = UCC_EE_CUDA_STREAM;

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -153,9 +153,11 @@ ucc_coll_type_t   ucc_coll_type_from_str(const char *str);
 
 ucc_memory_type_t ucc_mem_type_from_str(const char *str);
 
-size_t            ucc_coll_args_msgsize(const ucc_base_coll_args_t *bargs);
+size_t            ucc_coll_args_msgsize(const ucc_coll_args_t *args,
+                                        ucc_rank_t rank, ucc_rank_t size);
 
-ucc_memory_type_t ucc_coll_args_mem_type(const ucc_base_coll_args_t *bargs);
+ucc_memory_type_t ucc_coll_args_mem_type(const ucc_coll_args_t *args,
+                                         ucc_rank_t rank);
 
 
 static inline ucc_rank_t ucc_ep_map_eval(ucc_ep_map_t map, ucc_rank_t rank)

--- a/test/gtest/core/test_utils.cc
+++ b/test/gtest/core/test_utils.cc
@@ -46,7 +46,8 @@ UCC_TEST_P(test_coll_args_msgsize, dst_vector)
 
     for (auto c : colls) {
         args.args.coll_type = c;
-        EXPECT_EQ(total_size(), ucc_coll_args_msgsize(&args));
+        EXPECT_EQ(total_size(), ucc_coll_args_msgsize(&args.args, team.rank,
+                                                      team.size));
     }
 }
 
@@ -59,7 +60,7 @@ UCC_TEST_P(test_coll_args_msgsize, always_zero)
     _init(std::get<0>(p), std::get<1>(p), std::get<2>(p));
     for (auto c : colls) {
         args.args.coll_type = c;
-        EXPECT_EQ(0, ucc_coll_args_msgsize(&args));
+        EXPECT_EQ(0, ucc_coll_args_msgsize(&args.args, team.rank, team.size));
     }
 }
 
@@ -77,7 +78,8 @@ UCC_TEST_P(test_coll_args_msgsize, scalar)
     for (auto c : colls) {
         args.args.coll_type = c;
         args.args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
-        EXPECT_EQ(total_size(), ucc_coll_args_msgsize(&args));
+        EXPECT_EQ(total_size(), ucc_coll_args_msgsize(&args.args, team.rank,
+                                                      team.size));
     }
 }
 
@@ -96,7 +98,8 @@ UCC_TEST_P(test_coll_args_msgsize, reduce)
             args.args.dst.info.count    = total;
             args.args.dst.info.datatype = dt;
         }
-        EXPECT_EQ(total_size(), ucc_coll_args_msgsize(&args));
+        EXPECT_EQ(total_size(), ucc_coll_args_msgsize(&args.args, team.rank,
+                                                      team.size));
     }
 
 }
@@ -116,7 +119,8 @@ UCC_TEST_P(test_coll_args_msgsize, scatter)
             args.args.src.info.count    = total * team.size;
             args.args.src.info.datatype = dt;
         }
-        EXPECT_EQ(total_size() * team.size, ucc_coll_args_msgsize(&args));
+        EXPECT_EQ(total_size() * team.size,
+                  ucc_coll_args_msgsize(&args.args, team.rank, team.size));
     }
 }
 
@@ -135,7 +139,8 @@ UCC_TEST_P(test_coll_args_msgsize, gather)
             args.args.dst.info.count    = total * team.size;
             args.args.dst.info.datatype = dt;
         }
-        EXPECT_EQ(total_size() * team.size, ucc_coll_args_msgsize(&args));
+        EXPECT_EQ(total_size() * team.size,
+                  ucc_coll_args_msgsize(&args.args, team.rank, team.size));
     }
 
 }


### PR DESCRIPTION
## What
ucc_coll_args_msgsize is used to  compute msgsize of collective operation which is defined by the ucc_coll_args_t. However args is not enough. For some collectives the msgsize depends on team_size and team_rank (to detect root). At the same time this fn can be called for a collective defined on a TL team which is a subset of CORE ucc_team. In this case we need to use proper  rank/size info to compute total coll size, i.e. using core team->rank/size is incorrect.

## Why ?
Current implementation leads to crash with CL/HIER (when ucc_coll_init is called for a subgroup).

## How ?
Pass rank/size explicitly to ucc_coll_args_msgsize. For ucc_coll_init we will store rank/size on the score_map.
