### PR TITLE
MC/ROCM: add support for unsigned dts

### DIFF
--- a/src/components/mc/rocm/kernel/mc_rocm_reduce.cu
+++ b/src/components/mc/rocm/kernel/mc_rocm_reduce.cu
@@ -190,6 +190,15 @@ ucc_status_t ucc_mc_rocm_reduce(const void *src1, const void *src2, void *dst,
         case UCC_DT_INT64:
             DT_REDUCE_INT(int64_t, op, src1, src2, dst, count, stream, bk, th);
             break;
+        case UCC_DT_UINT16:
+            DT_REDUCE_INT(uint16_t, op, src1, src2, dst, count, stream, bk, th);
+            break;
+        case UCC_DT_UINT32:
+            DT_REDUCE_INT(uint32_t, op, src1, src2, dst, count, stream, bk, th);
+            break;
+        case UCC_DT_UINT64:
+            DT_REDUCE_INT(uint64_t, op, src1, src2, dst, count, stream, bk, th);
+            break;
         case UCC_DT_FLOAT16:
             ucc_assert(2 == sizeof(__half));
             DT_REDUCE_FLOAT(__half, op, src1, src2, dst, count, stream, bk, th);

--- a/src/components/mc/rocm/kernel/mc_rocm_reduce_multi.cu
+++ b/src/components/mc/rocm/kernel/mc_rocm_reduce_multi.cu
@@ -226,6 +226,18 @@ ucc_status_t ucc_mc_rocm_reduce_multi(const void *src1, const void *src2,
             DT_REDUCE_INT(int64_t, op, src1, src2, dst, n_vectors, count, ld,
                           stream, bk, th);
             break;
+        case UCC_DT_UINT16:
+            DT_REDUCE_INT(uint16_t, op, src1, src2, dst, n_vectors, count, ld,
+                          stream, bk, th);
+            break;
+        case UCC_DT_UINT32:
+            DT_REDUCE_INT(uint32_t, op, src1, src2, dst, n_vectors, count, ld,
+                          stream, bk, th);
+            break;
+        case UCC_DT_UINT64:
+            DT_REDUCE_INT(uint64_t, op, src1, src2, dst, n_vectors, count, ld,
+                          stream, bk, th);
+            break;
         case UCC_DT_FLOAT16:
             ucc_assert(2 == sizeof(__half));
             DT_REDUCE_FLOAT(__half, op, src1, src2, dst, n_vectors, count, ld,


### PR DESCRIPTION
## What
add support for unsigned integers for rocm reduction operations.
This is a v1.1 patch only, master already supports the operations,
which were added with the reduce-to-ec patch in that case.

## Why ?
to support unsigned ints in v1.1. for rocm buffers with tl/ucp