### PR TITLE
SCHEDULE: 3 types of pipelines

### DIFF
--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -216,23 +216,19 @@ static ucc_status_t ucc_cl_hier_allreduce_split_rail_frag_init(
         goto err_ag;
     }
 
-    task_rs->n_deps = 1;
     UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, task_rs), err_ag, status);
-    UCC_CHECK_GOTO(ucc_event_manager_subscribe(&schedule->super,
-                                               UCC_EVENT_SCHEDULE_STARTED,
-                                               task_rs, ucc_dependency_handler),
+    UCC_CHECK_GOTO(ucc_task_subscribe_dep(&schedule->super, task_rs,
+                                          UCC_EVENT_SCHEDULE_STARTED),
                    err_ag, status);
 
-    task_ar->n_deps = 1;
     UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, task_ar), err_ag, status);
-    UCC_CHECK_GOTO(ucc_event_manager_subscribe(task_rs, UCC_EVENT_COMPLETED,
-                                               task_ar, ucc_dependency_handler),
+    UCC_CHECK_GOTO(ucc_task_subscribe_dep(task_rs, task_ar,
+                                          UCC_EVENT_COMPLETED),
                    err_ag, status);
 
-    task_ag->n_deps = 1;
     UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, task_ag), err_ag, status);
-    UCC_CHECK_GOTO(ucc_event_manager_subscribe(task_ar, UCC_EVENT_COMPLETED,
-                                               task_ag, ucc_dependency_handler),
+    UCC_CHECK_GOTO(ucc_task_subscribe_dep(task_ar, task_ag,
+                                          UCC_EVENT_COMPLETED),
                    err_ag, status);
 
     schedule->super.post     = ucc_schedule_start;
@@ -327,7 +323,7 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_split_rail_init,
     status = ucc_schedule_pipelined_init(
         coll_args, team, ucc_cl_hier_allreduce_split_rail_frag_init,
         ucc_cl_hier_allreduce_split_rail_frag_setup, pipeline_depth, n_frags,
-        cfg->allreduce_split_rail_seq, &schedule->super);
+        cfg->allreduce_split_rail_pipeline_order, &schedule->super);
 
     if (ucc_unlikely(status != UCC_OK)) {
         cl_error(team->context->lib,

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -78,10 +78,10 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
                   allreduce_split_rail_pipeline_depth),
      UCC_CONFIG_TYPE_UINT},
 
-    {"ALLREDUCE_SPLIT_RAIL_SEQUENTIAL", "n",
-     "Type of pipelined schedule for Split_Rail alg (sequential/parallel)",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_seq),
-     UCC_CONFIG_TYPE_BOOL},
+    {"ALLREDUCE_SPLIT_RAIL_PIPELINE_ORDER", "ordered",
+     "Type of pipelined schedule for Split_Rail alg (sequential/ordered/parallel)",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_pipeline_order),
+     UCC_CONFIG_TYPE_ENUM(ucc_pipeline_order_names)},
 
     {NULL}};
 

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -12,6 +12,7 @@
 #include "components/tl/ucc_tl.h"
 #include "coll_score/ucc_coll_score.h"
 #include "utils/ucc_mpool.h"
+#include "schedule/ucc_schedule_pipelined.h"
 
 #ifdef HAVE_PROFILING_CL_HIER
 #include "utils/profile/ucc_profile_on.h"
@@ -51,7 +52,7 @@ typedef struct ucc_cl_hier_lib_config {
     size_t                  a2av_node_thresh;
     uint32_t                allreduce_split_rail_n_frags;
     uint32_t                allreduce_split_rail_pipeline_depth;
-    int                     allreduce_split_rail_seq;
+    ucc_pipeline_order_t    allreduce_split_rail_pipeline_order;
     size_t                  allreduce_split_rail_frag_thresh;
     size_t                  allreduce_split_rail_frag_size;
 

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -209,7 +209,7 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
     status = ucc_schedule_pipelined_init(
         &bargs, team, ucc_tl_ucp_allreduce_sra_knomial_frag_init,
         ucc_tl_ucp_allreduce_sra_knomial_frag_setup, pipeline_depth, n_frags,
-        cfg->allreduce_sra_kn_seq, schedule_p);
+        cfg->allreduce_sra_kn_pipeline_order, schedule_p);
     if (UCC_OK != status) {
         tl_error(team->context->lib, "failed to init pipelined schedule");
         ucc_tl_ucp_put_schedule(&schedule_p->super);

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -96,10 +96,10 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_pipeline_depth),
      UCC_CONFIG_TYPE_UINT},
 
-    {"ALLREDUCE_SRA_KN_SEQUENTIAL", "n",
-     "Type of pipelined schedule for SRA knomial alg (sequential/parallel)",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_seq),
-     UCC_CONFIG_TYPE_BOOL},
+    {"ALLREDUCE_SRA_KN_PIPELINE_ORDER", "parallel",
+     "Type of pipelined schedule for SRA knomial alg (sequential/ordered/parallel)",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_pipeline_order),
+     UCC_CONFIG_TYPE_ENUM(ucc_pipeline_order_names)},
 
     {"REDUCE_SCATTER_KN_RADIX", "4",
      "Radix of the knomial reduce-scatter algorithm",

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -11,6 +11,7 @@
 #include "core/ucc_ee.h"
 #include "utils/ucc_mpool.h"
 #include "tl_ucp_ep_hash.h"
+#include "schedule/ucc_schedule_pipelined.h"
 #include <ucp/api/ucp.h>
 #include <ucs/memory/memory_type.h>
 
@@ -41,30 +42,30 @@ typedef struct ucc_tl_ucp_iface {
 extern ucc_tl_ucp_iface_t ucc_tl_ucp;
 
 typedef struct ucc_tl_ucp_lib_config {
-    ucc_tl_lib_config_t super;
-    uint32_t            kn_radix;
-    uint32_t            fanin_kn_radix;
-    uint32_t            fanout_kn_radix;
-    uint32_t            barrier_kn_radix;
-    uint32_t            allreduce_kn_radix;
-    uint32_t            allreduce_sra_kn_radix;
-    uint32_t            reduce_scatter_kn_radix;
-    uint32_t            allgather_kn_radix;
-    uint32_t            bcast_kn_radix;
-    uint32_t            bcast_sag_kn_radix;
-    uint32_t            reduce_kn_radix;
-    uint32_t            gather_kn_radix;
-    uint32_t            scatter_kn_radix;
-    uint32_t            alltoall_pairwise_num_posts;
-    uint32_t            alltoallv_pairwise_num_posts;
-    uint32_t            allreduce_sra_kn_n_frags;
-    uint32_t            allreduce_sra_kn_pipeline_depth;
-    int                 allreduce_sra_kn_seq;
-    size_t              allreduce_sra_kn_frag_thresh;
-    size_t              allreduce_sra_kn_frag_size;
-    int                 reduce_avg_pre_op;
-    int                 reduce_scatter_ring_bidirectional;
-    int                 reduce_scatterv_ring_bidirectional;
+    ucc_tl_lib_config_t  super;
+    uint32_t             kn_radix;
+    uint32_t             fanin_kn_radix;
+    uint32_t             fanout_kn_radix;
+    uint32_t             barrier_kn_radix;
+    uint32_t             allreduce_kn_radix;
+    uint32_t             allreduce_sra_kn_radix;
+    uint32_t             reduce_scatter_kn_radix;
+    uint32_t             allgather_kn_radix;
+    uint32_t             bcast_kn_radix;
+    uint32_t             bcast_sag_kn_radix;
+    uint32_t             reduce_kn_radix;
+    uint32_t             gather_kn_radix;
+    uint32_t             scatter_kn_radix;
+    uint32_t             alltoall_pairwise_num_posts;
+    uint32_t             alltoallv_pairwise_num_posts;
+    uint32_t             allreduce_sra_kn_n_frags;
+    uint32_t             allreduce_sra_kn_pipeline_depth;
+    ucc_pipeline_order_t allreduce_sra_kn_pipeline_order;
+    size_t               allreduce_sra_kn_frag_thresh;
+    size_t               allreduce_sra_kn_frag_size;
+    int                  reduce_avg_pre_op;
+    int                  reduce_scatter_ring_bidirectional;
+    int                  reduce_scatterv_ring_bidirectional;
 } ucc_tl_ucp_lib_config_t;
 
 typedef struct ucc_tl_ucp_context_config {

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -7,6 +7,13 @@
 #include "coll_score/ucc_coll_score.h"
 #include "core/ucc_context.h"
 
+const char* ucc_pipeline_order_names[] = {
+    [UCC_PIPELINE_PARALLEL]   = "parallel",
+    [UCC_PIPELINE_ORDERED]    = "ordered",
+    [UCC_PIPELINE_SEQUENTIAL] = "sequential",
+    [UCC_PIPELINE_LAST]       =  NULL
+};
+
 static ucc_status_t ucc_frag_start_handler(ucc_coll_task_t *parent,
                                            ucc_coll_task_t *task)
 {
@@ -123,7 +130,8 @@ ucc_status_t ucc_schedule_pipelined_post(ucc_coll_task_t *task)
             frags[i]->tasks[j]->n_deps = frags[i]->tasks[j]->n_deps_base;
             frags[i]->tasks[j]->n_deps_satisfied = 0;
             frags[i]->tasks[j]->super.status     = UCC_OPERATION_INITIALIZED;
-            if (i == 0 && schedule_p->n_frags > 1 && schedule_p->sequential) {
+            if (i == 0 && schedule_p->n_frags > 1 &&
+                UCC_PIPELINE_PARALLEL != schedule_p->order) {
                 frags[0]->tasks[j]->n_deps_satisfied++;
             }
         }
@@ -136,7 +144,7 @@ ucc_status_t ucc_schedule_pipelined_init(
     ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
     ucc_schedule_frag_init_fn_t  frag_init,
     ucc_schedule_frag_setup_fn_t frag_setup, int n_frags, int n_frags_total,
-    int sequential, ucc_schedule_pipelined_t *schedule)
+    ucc_pipeline_order_t order, ucc_schedule_pipelined_t *schedule)
 {
     int              i, j;
     ucc_status_t     status;
@@ -158,7 +166,7 @@ ucc_status_t ucc_schedule_pipelined_init(
 
     schedule->super.n_tasks        = n_frags_total;
     schedule->n_frags              = n_frags;
-    schedule->sequential           = sequential;
+    schedule->order                = order;
     schedule->frag_setup           = frag_setup;
     schedule->next_frag_to_post    = 0;
     schedule->n_frags_in_pipeline  = 0;
@@ -181,11 +189,13 @@ ucc_status_t ucc_schedule_pipelined_init(
     for (i = 0; i < n_frags; i++) {
         for (j = 0; j < frags[i]->n_tasks; j++) {
             frags[i]->tasks[j]->n_deps_base = frags[i]->tasks[j]->n_deps;
-            if (n_frags > 1 && sequential) {
+            if (n_frags > 1 && UCC_PIPELINE_PARALLEL != order) {
                 UCC_CHECK_GOTO(
                     ucc_event_manager_subscribe(
                         frags[(i > 0) ? (i - 1) : (n_frags - 1)]->tasks[j],
-                        UCC_EVENT_TASK_STARTED, frags[i]->tasks[j],
+                        UCC_PIPELINE_ORDERED == order
+                        ? UCC_EVENT_TASK_STARTED
+                        : UCC_EVENT_COMPLETED, frags[i]->tasks[j],
                         ucc_dependency_handler),
                     err, status);
                 frags[i]->tasks[j]->n_deps_base++;


### PR DESCRIPTION
## What
Adds 3rd type of pipeline (sequential): a task in a fragment only starts when the previous task has completed. Parallel - all start the same time. Ordered - a task in a fragment starts when the previous task has started. We used to have only "parallel" and "ordered" in master.

## Why ?
Sequential - may potentially be useful when we don't want to oversubscribe a TL (can be useful for TL/SHM, TL/CUDA?).
PR also adds a better cfg parsing with explicit naming of pipeline types.


