### PR TITLE
CL/HIER: allreduce rab fix

### DIFF
--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -39,6 +39,9 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
     ucc_base_coll_args_t args;
     int                  n_tasks, i;
 
+    if (coll_args->args.op == UCC_OP_AVG) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
     schedule = &ucc_cl_hier_get_schedule(cl_team)->super.super;
     if (ucc_unlikely(!schedule)) {
         return UCC_ERR_NO_MEMORY;

--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -88,7 +88,7 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
     if (SBGP_ENABLED(cl_team, NODE) &&
         cl_team->top_sbgp != UCC_HIER_SBGP_NODE) {
         /* For bcast src should point to origin dst of allreduce */
-        args.args.src.info = args.args.dst.info;
+        args.args.src.info  = args.args.dst.info;
         args.args.coll_type = UCC_COLL_TYPE_BCAST;
         status =
             ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);

--- a/src/components/tl/ucp/scatter/scatter_knomial.c
+++ b/src/components/tl/ucp/scatter/scatter_knomial.c
@@ -219,11 +219,6 @@ ucc_status_t ucc_tl_ucp_scatter_knomial_init_r(
     ucc_rank_t         rank    = UCC_TL_TEAM_RANK(tl_team);
     ucc_tl_ucp_task_t *task;
 
-    /* In place currently not supported */
-    if (UCC_IS_INPLACE(coll_args->args)) {
-        return UCC_ERR_NOT_SUPPORTED;
-    }
-
     task                 = ucc_tl_ucp_init_task(coll_args, team);
     task->super.post     = ucc_tl_ucp_scatter_knomial_start;
     task->super.progress = ucc_tl_ucp_scatter_knomial_progress;


### PR DESCRIPTION
## What
Fixes:
[1660824500.613377] [swx-clx02:46991:0] bcast_sag_knomial.c:90   TL_UCP ERROR failed to init scatter_knomial task
observed in ucc_test_mpi with CL/HIER


## How ?
Don't check for INPLACE flag in tl_ucp_scatter_knomial. Currently it is not generic scatter - it is special implementation for bcast_sag.
