### PR TITLE
BUILD: Build for GPU architecture 52 and 86

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -6,7 +6,7 @@
 CUDA_MIN_REQUIRED_MAJOR=11
 CUDA_MIN_REQUIRED_MINOR=0
 
-ARCH6="-gencode=arch=compute_50,code=sm_50"
+ARCH7="-gencode=arch=compute_52,code=sm_52"
 ARCH8="-gencode=arch=compute_60,code=sm_60 \
 -gencode=arch=compute_61,code=sm_61 \
 -gencode=arch=compute_61,code=compute_61"
@@ -15,6 +15,8 @@ ARCH9="-gencode=arch=compute_70,code=sm_70 \
 ARCH10="-gencode=arch=compute_75,code=sm_75"
 ARCH11="-gencode=arch=compute_80,code=sm_80 \
 -gencode=arch=compute_80,code=compute_80"
+ARCH12="-gencode=arch=compute_86,code=sm_86 \
+-gencode=arch=compute_86,code=compute_86"
 
 AC_DEFUN([CHECK_CUDA],[
 AS_IF([test "x$cuda_checked" != "xyes"],
@@ -105,7 +107,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AS_IF([test "x$with_nvcc_gencode" = "xdefault"],
                       [AS_IF([test $CUDA_MAJOR_VERSION -eq 11],
-                             [NVCC_ARCH="${ARCH8} ${ARCH9} ${ARCH10} ${ARCH11}"])],
+                             [NVCC_ARCH="${ARCH7} ${ARCH8} ${ARCH9} ${ARCH10} ${ARCH11} ${ARCH12}"])],
                       [NVCC_ARCH="$with_nvcc_gencode"])
                 AC_SUBST([NVCC_ARCH], ["$NVCC_ARCH"])])
          LDFLAGS="$save_LDFLAGS"

--- a/src/components/ec/cuda/kernel/ec_cuda_half_sm52.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_half_sm52.h
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms of ucc.
+ *
+ * This file is copy-pasted from cuda_fp16.hpp in the CUDA toolkit and modified.
+ * See the original cuda_fp16.hpp for terms of cuda_fp16.hpp.
+ */
+
+/**
+ * We copy-pasted and modify cuda_fp16.hpp because half operators are only available
+ * for SM>=5.3 but we need to support earlier architectures. On earlier architectures,
+ * we emulate the operators by converting half to float, do the operation, then convert
+ * the result back to half
+ */
+
+#pragma once
+
+#include <cuda_fp16.h>
+
+/* Global-space operator functions are only available to nvcc compilation */
+#if defined(__CUDACC__)
+
+/* Arithmetic FP16 operations in cuda_fp16.hpp only supported on arch >= 5.3,
+ * however, we support early architectures*/
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 530)
+#if !defined(__CUDA_NO_HALF_OPERATORS__)
+
+/* Some basic arithmetic operations expected of a builtin */
+__device__ __forceinline__ __half operator+(const __half &lh, const __half &rh)
+{
+    return __float2half(__half2float(lh) + __half2float(rh));
+}
+__device__ __forceinline__ __half operator-(const __half &lh, const __half &rh)
+{
+    return __float2half(__half2float(lh) - __half2float(rh));
+}
+__device__ __forceinline__ __half operator*(const __half &lh, const __half &rh)
+{
+    return __float2half(__half2float(lh) * __half2float(rh));
+}
+__device__ __forceinline__ __half operator/(const __half &lh, const __half &rh)
+{
+    return __float2half(__half2float(lh) / __half2float(rh));
+}
+
+__device__ __forceinline__ __half &operator+=(__half &lh, const __half &rh)
+{
+    lh = __float2half(__half2float(lh) + __half2float(rh));
+    return lh;
+}
+__device__ __forceinline__ __half &operator-=(__half &lh, const __half &rh)
+{
+    lh = __float2half(__half2float(lh) - __half2float(rh));
+    return lh;
+}
+__device__ __forceinline__ __half &operator*=(__half &lh, const __half &rh)
+{
+    lh = __float2half(__half2float(lh) * __half2float(rh));
+    return lh;
+}
+__device__ __forceinline__ __half &operator/=(__half &lh, const __half &rh)
+{
+    lh = __float2half(__half2float(lh) / __half2float(rh));
+    return lh;
+}
+
+/* Note for increment and decrement we use the raw value 0x3C00U equating to half(1.0F), to avoid the extra conversion */
+__device__ __forceinline__ __half &operator++(__half &h)
+{
+    __half_raw one;
+    one.x = 0x3C00U;
+    h += one;
+    return h;
+}
+__device__ __forceinline__ __half &operator--(__half &h)
+{
+    __half_raw one;
+    one.x = 0x3C00U;
+    h -= one;
+    return h;
+}
+__device__ __forceinline__ __half operator++(__half &h, const int ignored)
+{
+    // ignored on purpose. Parameter only needed to distinguish the function declaration from other types of operators.
+    static_cast<void>(ignored);
+
+    const __half ret = h;
+    __half_raw   one;
+    one.x = 0x3C00U;
+    h += one;
+    return ret;
+}
+__device__ __forceinline__ __half operator--(__half &h, const int ignored)
+{
+    // ignored on purpose. Parameter only needed to distinguish the function declaration from other types of operators.
+    static_cast<void>(ignored);
+
+    const __half ret = h;
+    __half_raw   one;
+    one.x = 0x3C00U;
+    h -= one;
+    return ret;
+}
+
+/* Unary plus and inverse operators */
+__device__ __forceinline__ __half operator+(const __half &h)
+{
+    return h;
+}
+__device__ __forceinline__ __half operator-(const __half &h)
+{
+    return __float2half(-__half2float(h));
+}
+
+/* Some basic comparison operations to make it look like a builtin */
+__device__ __forceinline__ bool operator==(const __half &lh, const __half &rh)
+{
+    return __half2float(lh) ==  __half2float(rh);
+}
+__device__ __forceinline__ bool operator!=(const __half &lh, const __half &rh)
+{
+    return __half2float(lh) !=  __half2float(rh);
+}
+__device__ __forceinline__ bool operator>(const __half &lh, const __half &rh)
+{
+    return __half2float(lh) >  __half2float(rh);
+}
+__device__ __forceinline__ bool operator<(const __half &lh, const __half &rh)
+{
+    return __half2float(lh) <  __half2float(rh);
+}
+__device__ __forceinline__ bool operator>=(const __half &lh, const __half &rh)
+{
+    return __half2float(lh) >=  __half2float(rh);
+}
+__device__ __forceinline__ bool operator<=(const __half &lh, const __half &rh)
+{
+    return __half2float(lh) <=  __half2float(rh);
+}
+
+#endif /* !defined(__CUDA_NO_HALF_OPERATORS__) */
+#endif /* defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 530) */
+#endif /* defined(__CUDACC__) */

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
@@ -15,6 +15,7 @@ extern "C" {
 }
 #endif
 
+#include "ec_cuda_half_sm52.h"
 #include "ec_cuda_reduce_ops.h"
 
 #define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                  \


### PR DESCRIPTION
## What

This PR add builds for GPU architecture 50, 52 and 86

## Why ?

I am enabling PyTorch's distributed unit tests on the ProcessGroupUCC in https://github.com/pytorch/pytorch/pull/83285, but I am seeing lots of errors like:
```C++
2022-08-18T20:47:14.5411762Z [1660855634.540897] [0e25f152ba11:26395:0] ec_cuda_executor.cu:319  UCC  ERROR cudaGetLastError()() failed: 209(no kernel image is available for execution on the device)
2022-08-18T20:47:14.5412299Z [1660855634.540920] [0e25f152ba11:26395:0] ec_cuda_executor_persistent.c:78   cuda ec ERROR failed to launch executor kernel
2022-08-18T20:47:14.5412771Z [1660855634.540926] [0e25f152ba11:26395:0]        ucc_coll.c:424  UCC  ERROR error in ee executor start, Unhandled error
2022-08-18T20:47:14.5413218Z [1660855634.540942] [0e25f152ba11:26395:0]    ucc_schedule.h:185  UCC  ERROR failure in task 0x556c319a17c0, Unhandled error
2022-08-18T20:47:14.5414291Z [1660855634.541153] [0e25f152ba11:26394:0] ec_cuda_executor.cu:319  UCC  ERROR cudaGetLastError()() failed: 209(no kernel image is available for execution on the device)
2022-08-18T20:47:14.5414802Z [1660855634.541178] [0e25f152ba11:26394:0] ec_cuda_executor_persistent.c:78   cuda ec ERROR failed to launch executor kernel
2022-08-18T20:47:14.5415259Z [1660855634.541184] [0e25f152ba11:26394:0]        ucc_coll.c:424  UCC  ERROR error in ee executor start, Unhandled error
2022-08-18T20:47:14.5415710Z [1660855634.541200] [0e25f152ba11:26394:0]    ucc_schedule.h:185  UCC  ERROR failure in task 0x55ab95cdcb10, Unhandled error
```

Looks like the root cause of this is because UCC's build system does not build for SM52, which is the GPU used by PyTorch's CI.
