### PR TITLE
UTIL: fix sra iters computation

### DIFF
--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -82,7 +82,7 @@ UCC_KN_PHASE_EXTRA:
         }
         goto out;
     }
-    while (!ucc_knomial_pattern_loop_done_backward(p)) {
+    while (!ucc_knomial_pattern_loop_done(p)) {
         step_radix       = ucc_sra_kn_compute_step_radix(rank, size, p);
         block_count      = ucc_sra_kn_compute_block_count(count, rank, p);
         local_seg_index  = ucc_sra_kn_compute_seg_index(rank, p->radix_pow, p);


### PR DESCRIPTION
## What
Fixes "ucc_kn_pattern_pattern_loop_last_iteration". It used to return incorrect value in the case of extra ranks. This causes failure in allreduce after PR #602 . It also fixes #585 


## How ?
Compute n_iters for direct and backward KN pattern. Also change the way step_radix/block_count are computed, based n_full_subtrees.
