### PR TITLE
EC/ROCM: add host execution capability

### DIFF
--- a/src/components/ec/rocm/ec_rocm.c
+++ b/src/components/ec/rocm/ec_rocm.c
@@ -65,7 +65,7 @@ static ucc_config_field_t ucc_ec_rocm_config_table[] = {
      ucc_offsetof(ucc_ec_rocm_config_t, exec_max_tasks),
      UCC_CONFIG_TYPE_ULUNITS},
 
-    {"EXEC_NUM_STREAMS", "16",
+    {"EXEC_NUM_STREAMS", "8",
      "Number of streams used by interruptible executor",
      ucc_offsetof(ucc_ec_rocm_config_t, exec_num_streams),
      UCC_CONFIG_TYPE_ULUNITS},
@@ -74,6 +74,19 @@ static ucc_config_field_t ucc_ec_rocm_config_table[] = {
      "Number of thread blocks to use for reduction in interruptible mode",
      ucc_offsetof(ucc_ec_rocm_config_t, reduce_num_blocks),
      UCC_CONFIG_TYPE_ULUNITS},
+
+     {"REDUCE_HOST_LIMIT", "256",
+     "Maximum data size for which to use host-based reduction operations",
+      ucc_offsetof(ucc_ec_rocm_config_t, reduce_host_limit),
+      UCC_CONFIG_TYPE_MEMUNITS},
+
+     /* Disabled by default.
+      * Recommended settings: MI100: 64 bytes, MI200: 4kbytes
+      */
+     {"COPY_HOST_LIMIT", "0",
+     "Maximum data size for which to use host-based copy operations",
+      ucc_offsetof(ucc_ec_rocm_config_t, copy_host_limit),
+      UCC_CONFIG_TYPE_MEMUNITS},
 
     {NULL}
 

--- a/src/components/ec/rocm/ec_rocm.h
+++ b/src/components/ec/rocm/ec_rocm.h
@@ -10,6 +10,7 @@
 
 #include "components/ec/base/ucc_ec_base.h"
 #include "components/ec/ucc_ec_log.h"
+#include "core/ucc_ee.h"
 #include "utils/ucc_mpool.h"
 #include "utils/arch/rocm_def.h"
 #include <hip/hip_runtime.h>
@@ -80,6 +81,8 @@ typedef struct ucc_ec_rocm_config {
     unsigned long                  exec_num_streams;
     unsigned long                  reduce_num_blocks;
     int                            reduce_num_threads;
+    int                            reduce_host_limit;
+    int                            copy_host_limit;
 } ucc_ec_rocm_config_t;
 
 typedef struct ucc_ec_rocm {
@@ -97,6 +100,7 @@ typedef struct ucc_ec_rocm {
     ucc_ec_rocm_task_stream_type_t task_strm_type;
     ucc_ec_rocm_task_post_fn       post_strm_task;
     ucc_spinlock_t                 init_spinlock;
+    ucc_ee_executor_t             *cpu_executor;
 } ucc_ec_rocm_t;
 
 typedef struct ucc_rocm_ec_event {

--- a/src/components/ec/rocm/kernel/ec_rocm_executor_kernel.cu
+++ b/src/components/ec/rocm/kernel/ec_rocm_executor_kernel.cu
@@ -46,9 +46,11 @@ __device__ void executor_copy_aligned(T* __restrict__ d, T* __restrict__ s,
     char1 *s1 = (char1*)s;
     char1 *d1 = (char1*)d;
 
-#pragma unroll 4
-    for(int i = 0; i < num_iter; i++) {
-        d[i * step + idx] = s[i * step + idx];
+    for(int i = 0; i < num_iter; i+=4) {
+        d[i     * step + idx] = s[i     * step + idx];
+        d[(i+1) * step + idx] = s[(i+1) * step + idx];
+        d[(i+2) * step + idx] = s[(i+2) * step + idx];
+        d[(i+3) * step + idx] = s[(i+3) * step + idx];
     }
 
     if (idx < count % sizeof(T)) {
@@ -229,7 +231,6 @@ __device__ void executor_copy_multi(ucc_eee_task_copy_multi_t *task)
     const int num_iter = n / step + ((threadIdx.x < n % step) ? 1 : 0);
 
     for (size_t i = 0; i < num_iter; i++) {
-#pragma unroll
         for (int j = 0; j < task->num_vectors; j++) {
             dsts[j][idx] = srcs[j][idx];
         }

--- a/src/components/ec/rocm/kernel/ec_rocm_wait_kernel.cu
+++ b/src/components/ec/rocm/kernel/ec_rocm_wait_kernel.cu
@@ -12,7 +12,7 @@ __global__ void wait_kernel(volatile uint32_t *status) {
     *status = UCC_EC_ROCM_TASK_STARTED;
     do {
         st = (ucc_status_t)*status;
-    } while(st != UCC_EC_ROCM_TASK_COMPLETED);
+    } while(st != (ucc_status_t)UCC_EC_ROCM_TASK_COMPLETED);
     *status = UCC_EC_ROCM_TASK_COMPLETED_ACK;
     return;
 }


### PR DESCRIPTION
## What
Introduce the ability to use host based reduction and copy operations

## Why?
This avoids the cost of a kernel launch., which can be beneficial for short messages and when trying to overlap communication and computation occurring on the GPU.
