### PR TITLE
EC/CUDA: implement all the exec reductions

### DIFF
--- a/src/components/ec/cuda/ec_cuda_executor_persistent.c
+++ b/src/components/ec/cuda/ec_cuda_executor_persistent.c
@@ -16,34 +16,6 @@ ucc_cuda_executor_persistent_task_post(ucc_ee_executor_t *executor,
                                                        ucc_ec_cuda_executor_t);
     int                     max_tasks = EC_CUDA_CONFIG->exec_max_tasks;
     ucc_ee_executor_task_t *ee_task;
-    ucc_datatype_t          dt;
-    ucc_reduction_op_t      op;
-
-    if (task_args->task_type != UCC_EE_EXECUTOR_TASK_COPY &&
-        task_args->task_type != UCC_EE_EXECUTOR_TASK_COPY_MULTI) {
-        if (task_args->task_type == UCC_EE_EXECUTOR_TASK_REDUCE) {
-            dt = task_args->reduce.dt;
-            op = task_args->reduce.op;
-        } else if (task_args->task_type == UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED) {
-            dt = task_args->reduce_strided.dt;
-            op = task_args->reduce_strided.op;
-        } else {
-            dt = task_args->reduce_multi_dst.dt;
-            op = task_args->reduce_multi_dst.op;
-        }
-
-        if (op != UCC_OP_SUM) {
-            ec_error(&ucc_ec_cuda.super, "not supported reduction op: %s",
-                     ucc_reduction_op_str(op));
-            return UCC_ERR_NOT_SUPPORTED;
-        }
-        if ((dt != UCC_DT_FLOAT32) && (dt != UCC_DT_FLOAT64) &&
-            (dt != UCC_DT_INT32)) {
-            ec_error(&ucc_ec_cuda.super, "not supported reduction dtype: %s",
-                     ucc_datatype_str(dt));
-            return UCC_ERR_NOT_SUPPORTED;
-        }
-    }
 
     if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
         ucc_spin_lock(&eee->tasks_lock);

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -4,17 +4,11 @@
  * See file LICENSE for terms.
  */
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
 #include "../ec_cuda.h"
-#include "utils/ucc_math.h"
 #include <inttypes.h>
-
-#ifdef __cplusplus
 }
-#endif
+#include "ec_cuda_reduce_ops.h"
 #include <cooperative_groups.h>
 using namespace cooperative_groups;
 
@@ -121,118 +115,6 @@ __device__ void executor_reduce_float_sum_aligned_2(const float *s1,
     }
 }
 
-
-template <typename T>
-__device__ void executor_reduce_sum(const T **__restrict__ srcs,
-                                    uint16_t n_srcs, T *__restrict__ d,
-                                    size_t   count)
-{
-    const size_t step  = blockDim.x;
-    const size_t start = threadIdx.x;
-
-    for (size_t i = start; i < count; i+=step) {
-        d[i] = srcs[0][i] + srcs[1][i];
-        for (size_t j = 2; j < n_srcs; j++) {
-            d[i] = d[i] + srcs[j][i];
-        }
-    }
-}
-
-template <typename T>
-__device__ void executor_reduce_strided_sum(const T* __restrict__ s1,
-                                            const T* __restrict__ s2,
-                                            T* __restrict__ d, size_t count,
-                                            size_t n_src2, size_t stride)
-{
-    const size_t step  = blockDim.x;
-    const size_t start = threadIdx.x;
-    const size_t ld    = stride / sizeof(T);
-
-    for (size_t i = start; i < count; i+=step) {
-        d[i] = s1[i] + s2[i];
-        for (size_t j = 1; j < n_src2; j++) {
-            d[i] = d[i] + s2[i + j*ld];
-        }
-     }
- }
-
-__device__ void executor_reduce_strided_task(ucc_eee_task_reduce_strided_t *task)
-{
-    bool aligned = !(align_pow2((intptr_t)task->dst, 16) ||
-                     align_pow2((intptr_t)task->src1, 16) ||
-                     align_pow2((intptr_t)task->src2, 16));
-
-    switch (task->dt) {
-    case UCC_DT_FLOAT32:
-        if (task->n_src2 == 1 && aligned) {
-            executor_reduce_float_sum_aligned_2((float *)task->src1,
-                       (float *)task->src2, (float *)task->dst, task->count);
-        } else {
-            executor_reduce_strided_sum<float>((float *)task->src1,
-                                               (float *)task->src2, (float *)task->dst,
-                                               task->count, task->n_src2, task->stride);
-        }
-        break;
-    case UCC_DT_FLOAT64:
-        executor_reduce_strided_sum<double>((double *)task->src1,
-                                            (double *)task->src2, (double *)task->dst,
-                                            task->count, task->n_src2, task->stride);
-        break;
-    case UCC_DT_INT32:
-        executor_reduce_strided_sum<int32_t>((int32_t *)task->src1,
-                                             (int32_t *)task->src2, (int32_t *)task->dst,
-                                             task->count, task->n_src2, task->stride);
-        break;
-    default:
-        break;
-    }
-}
-
-__device__ void executor_reduce_task(ucc_eee_task_reduce_t *task)
-{
-    bool aligned = !(align_pow2((intptr_t)task->dst, 16) ||
-                     align_pow2((intptr_t)task->srcs[0], 16) ||
-                     align_pow2((intptr_t)task->srcs[1], 16));
-    switch (task->dt) {
-    case UCC_DT_FLOAT32:
-        if (task->n_srcs == 2 && aligned) {
-            executor_reduce_float_sum_aligned_2((float *)task->srcs[0],
-                      (float *)task->srcs[1], (float *)task->dst, task->count);
-        } else {
-            executor_reduce_sum<float>((const float **)task->srcs, task->n_srcs,
-                                       (float *)task->dst, task->count);
-        }
-        break;
-    case UCC_DT_FLOAT64:
-        executor_reduce_sum<double>((const double **)task->srcs, task->n_srcs,
-                                    (double *)task->dst, task->count);
-        break;
-    case UCC_DT_INT32:
-        executor_reduce_sum<int32_t>((const int32_t **)task->srcs, task->n_srcs,
-                                     (int32_t *)task->dst, task->count);
-        break;
-    default:
-        break;
-    }
-}
-
-__device__ void executor_reduce_multi_dst_task(ucc_eee_task_reduce_multi_dst_t *task)
-{
-    ucc_eee_task_reduce_t reduce_task;
-
-    for (int i = 0; i < task->n_bufs; i++) {
-        reduce_task.count   = task->counts[i];
-        reduce_task.dt      = task->dt;
-        reduce_task.op      = task->op;
-        reduce_task.dst     = task->dst[i];
-        reduce_task.srcs[0] = task->src1[i];
-        reduce_task.srcs[1] = task->src2[i];
-        reduce_task.n_srcs  = 2;
-
-        executor_reduce_task(&reduce_task);
-    }
-}
-
 __device__ void executor_copy_multi(ucc_eee_task_copy_multi_t *task)
 {
     const size_t     step     = blockDim.x;
@@ -288,6 +170,151 @@ __device__ void executor_copy_multi(ucc_eee_task_copy_multi_t *task)
         copy_task.len = task->counts[i] - left;
         executor_copy_task<LOOP_UNROLL>(copy_task);
    }
+}
+
+#define LAUNCH_REDUCE_A(NAME, _Type, _AlphaType, _task, ...)                \
+    do {                                                                \
+        if (_task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE) {          \
+            return ucc_reduce_cuda_default_##NAME<_Type, _AlphaType>    \
+                (_task->reduce, _task->flags);                          \
+        } else {                                                        \
+            return ucc_reduce_cuda_strided_##NAME<_Type, _AlphaType>    \
+                (_task->reduce_strided, _task->flags);                  \
+        }                                                               \
+    } while (0)
+
+#define LAUNCH_REDUCE(NAME, _Type, _task, ...)      \
+    LAUNCH_REDUCE_A(NAME, _Type, _Type, _task)
+
+__device__ ucc_status_t executor_reduce(ucc_ee_executor_task_args_t *task)
+{
+    bool               aligned = false;
+    ucc_reduction_op_t op;
+    ucc_datatype_t     dt;
+    size_t             count;
+    uint16_t           n_src;
+    void              *s1, *s2, *d;
+
+    if (task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE) {
+        dt      = task->reduce.dt;
+        count   = task->reduce.count;
+        op      = task->reduce.op;
+        n_src   = task->reduce.n_srcs;
+        s1      = task->reduce.srcs[0];
+        s2      = task->reduce.srcs[1];
+        d       = task->reduce.dst;
+        aligned = !(align_pow2((intptr_t)task->reduce.dst, 16) ||
+                         align_pow2((intptr_t)task->reduce.srcs[0], 16) ||
+                         align_pow2((intptr_t)task->reduce.srcs[1], 16));
+    } else {
+        ucc_assert(task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED);
+        dt      = task->reduce_strided.dt;
+        count   = task->reduce_strided.count;
+        op      = task->reduce_strided.op;
+        n_src   = task->reduce_strided.n_src2 + 1;
+        s1      = task->reduce_strided.src1;
+        s2      = task->reduce_strided.src2;
+        d       = task->reduce_strided.dst;
+        aligned = !(align_pow2((intptr_t)task->reduce_strided.dst, 16) ||
+                     align_pow2((intptr_t)task->reduce_strided.src1, 16) ||
+                     align_pow2((intptr_t)task->reduce_strided.src2, 16));
+    }
+
+    if (count == 0) {
+        return UCC_OK;
+    }
+
+    if (UCC_DT_FLOAT32 == dt && UCC_OP_SUM == op && aligned && n_src == 2) {
+            executor_reduce_float_sum_aligned_2((float *)s1, (float *)s2,
+                                                (float *)d, count);
+            return UCC_OK;
+    }
+    switch (dt) {
+    case UCC_DT_INT8:
+        DT_REDUCE_INT(int8_t, task, op);
+        break;
+    case UCC_DT_INT16:
+        DT_REDUCE_INT(int16_t, task, op);
+        break;
+    case UCC_DT_INT32:
+        DT_REDUCE_INT(int32_t, task, op);
+        break;
+    case UCC_DT_INT64:
+        DT_REDUCE_INT(int64_t, task, op);
+        break;
+    case UCC_DT_UINT8:
+        DT_REDUCE_INT(uint8_t, task, op);
+        break;
+    case UCC_DT_UINT16:
+        DT_REDUCE_INT(uint16_t, task, op);
+        break;
+    case UCC_DT_UINT32:
+        DT_REDUCE_INT(uint32_t, task, op);
+        break;
+    case UCC_DT_UINT64:
+        DT_REDUCE_INT(uint64_t, task, op);
+        break;
+    case UCC_DT_FLOAT16:
+        DT_REDUCE_FLOAT(__half, task, op);
+        break;
+    case UCC_DT_FLOAT32:
+#if SIZEOF_FLOAT == 4
+        DT_REDUCE_FLOAT(float, task, op);
+        break;
+#else
+        return UCC_ERR_NOT_SUPPORTED;
+#endif
+    case UCC_DT_FLOAT64:
+#if SIZEOF_DOUBLE == 8
+        DT_REDUCE_FLOAT(double, task, op);
+        break;
+#else
+        return UCC_ERR_NOT_SUPPORTED;
+#endif
+    case UCC_DT_FLOAT32_COMPLEX:
+#if SIZEOF_CUFLOATCOMPLEX == 8
+        DT_REDUCE_FLOAT_COMPLEX(cuFloatComplex, float, task, op);
+        break;
+#else
+        return UCC_ERR_NOT_SUPPORTED;
+#endif
+    case UCC_DT_FLOAT64_COMPLEX:
+#if SIZEOF_CUDOUBLECOMPLEX == 16
+        DT_REDUCE_FLOAT_COMPLEX(cuDoubleComplex, double, task, op);
+        break;
+#else
+        return UCC_ERR_NOT_SUPPORTED;
+#endif
+#if CUDART_VERSION >= 11000
+    case UCC_DT_BFLOAT16:
+        ucc_assert(2 == sizeof(__nv_bfloat16));
+        DT_REDUCE_FLOAT(__nv_bfloat16, task, op);
+        break;
+#endif
+    default:
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    return UCC_OK;
+}
+
+__device__ void executor_reduce_multi_dst_task(ucc_eee_task_reduce_multi_dst_t *task)
+{
+    ucc_ee_executor_task_args_t args;
+
+    args.task_type = UCC_EE_EXECUTOR_TASK_REDUCE;
+    args.flags     = 0;
+
+    for (int i = 0; i < task->n_bufs; i++) {
+        args.reduce.count   = task->counts[i];
+        args.reduce.dt      = task->dt;
+        args.reduce.op      = task->op;
+        args.reduce.dst     = task->dst[i];
+        args.reduce.srcs[0] = task->src1[i];
+        args.reduce.srcs[1] = task->src2[i];
+        args.reduce.n_srcs  = 2;
+
+        executor_reduce(&args);
+    }
 }
 
 template<bool useCoopLaunch>
@@ -348,10 +375,8 @@ __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
             executor_copy_task<LOOP_UNROLL>(args.copy);
             break;
         case UCC_EE_EXECUTOR_TASK_REDUCE:
-            executor_reduce_task(&args.reduce);
-            break;
-        case UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED:
-            executor_reduce_strided_task(&args.reduce_strided);
+        case UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED:            
+            executor_reduce(&args);
             break;
         case UCC_EE_EXECUTOR_TASK_REDUCE_MULTI_DST:
             executor_reduce_multi_dst_task(&args.reduce_multi_dst);
@@ -371,9 +396,8 @@ __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
     }
 }
 
-#ifdef __cplusplus
+
 extern "C" {
-#endif
 
 ucc_status_t ucc_ec_cuda_persistent_kernel_start(ucc_ec_cuda_executor_t *eee)
 {
@@ -459,6 +483,5 @@ ucc_status_t ucc_ec_cuda_copy_multi_kernel(const ucc_ee_executor_task_args_t *ar
     return UCC_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif
+

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -7,48 +7,288 @@
 #ifndef UCC_EC_CUDA_REDUCE_OPS_H_
 #define UCC_EC_CUDA_REDUCE_OPS_H_
 
-#include <cuda_fp16.h>
+extern "C" {
+#include "utils/ucc_math_op.h"
+}
+
+#include "ec_cuda_half_sm52.h"
 #if CUDART_VERSION >= 11000
 #include <cuda_bf16.h>
 #endif
 #include <cuComplex.h>
 
-__device__
+__device__ inline
 cuDoubleComplex operator+ (const cuDoubleComplex & first,
                            const cuDoubleComplex & second) {
     return cuCadd(first, second);
 }
 
-__device__
+__device__ inline
 cuDoubleComplex operator* (const cuDoubleComplex & first,
                            const cuDoubleComplex & second) {
     return cuCmul(first, second);
 }
 
-__device__
+__device__ inline
 cuDoubleComplex operator* (const cuDoubleComplex & first,
                            const double & second) {
     return make_cuDoubleComplex(cuCreal(first) * second,
                                 cuCimag(first) * second);
 }
 
-__device__
+__device__ inline
 cuFloatComplex operator+ (const cuFloatComplex & first,
                           const cuFloatComplex & second) {
     return cuCaddf(first, second);
 }
 
-__device__
+__device__ inline
 cuFloatComplex operator* (const cuFloatComplex & first,
                           const cuFloatComplex & second) {
     return cuCmulf(first, second);
 }
 
-__device__
+__device__ inline
 cuFloatComplex operator* (const cuFloatComplex & first,
                           const float & second) {
     return make_cuFloatComplex(cuCrealf(first) * second,
                                cuCimagf(first) * second);
 }
+
+#define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                  \
+    template <typename _Type, typename _AlphaType>                              \
+        __device__ ucc_status_t ucc_reduce_cuda_default_##NAME(                 \
+        ucc_eee_task_reduce_t task,                                             \
+        uint16_t              flags)                                            \
+    {                                                                           \
+        size_t        start  = blockIdx.x * blockDim.x + threadIdx.x;           \
+        size_t        step   = blockDim.x * gridDim.x;                          \
+        size_t        count  = task.count;                                      \
+        int           n_srcs = task.n_srcs;                                     \
+        const _Type **s      = (const _Type **)task.srcs;                       \
+        _Type *       d      = (_Type *)task.dst;                               \
+        size_t        i, j;                                                     \
+                                                                                \
+        switch (n_srcs) {                                                       \
+        case 2:                                                                 \
+            for (i = start; i < count; i += step) {                             \
+                d[i] = _OP##_2(s[0][i], s[1][i]);                               \
+            }                                                                   \
+            break;                                                              \
+        case 3:                                                                 \
+            for (i = start; i < count; i += step) {                             \
+                d[i] = _OP##_3(s[0][i], s[1][i], s[2][i]);                      \
+            }                                                                   \
+            break;                                                              \
+        case 4:                                                                 \
+            for (i = start; i < count; i += step) {                             \
+                d[i] = _OP##_4(s[0][i], s[1][i], s[2][i], s[3][i]);             \
+            }                                                                   \
+            break;                                                              \
+        default:                                                                \
+            for (i = start; i < count; i += step) {                             \
+                d[i] = _OP(s[0][i], s[1][i]);                                   \
+                for (j = 2; j < n_srcs; j++) {                                  \
+                    d[i] = _OP(d[i], s[j][i]);                                  \
+                }                                                               \
+            }                                                                   \
+            break;                                                              \
+        }                                                                       \
+        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                      \
+            for (i = start; i < count; i += step) {                             \
+                d[i] = d[i] * (_AlphaType)task.alpha;                           \
+            }                                                                   \
+        }                                                                       \
+    }                                                                           \
+    template <typename _Type, typename _AlphaType>                              \
+        __global__ void UCC_REDUCE_CUDA_DEFAULT_##NAME(                         \
+            ucc_eee_task_reduce_t task,                                         \
+            uint16_t              flags)                                        \
+    {                                                                           \
+        ucc_reduce_cuda_default_ ##NAME<_Type, _AlphaType>(task, flags);        \
+    }
+
+#define CUDA_REDUCE_WITH_OP_STRIDED(NAME, _OP)                                 \
+    template <typename _Type, typename _AlphaType>                             \
+    __device__ ucc_status_t ucc_reduce_cuda_strided_##NAME(                    \
+        ucc_eee_task_reduce_strided_t task,                                    \
+        uint16_t                     flags)                                    \
+    {                                                                          \
+        uint16_t     n_src2 = task.n_src2;                                     \
+        size_t       count  = task.count;                                      \
+        size_t       stride = task.stride;                                     \
+        size_t       start  = blockIdx.x * blockDim.x + threadIdx.x;           \
+        size_t       step   = blockDim.x * gridDim.x;                          \
+        size_t       ld     = stride / sizeof(_Type);                          \
+        const _Type *s1     = (const _Type *)task.src1;                        \
+        const _Type *s2     = (const _Type *) task.src2;                       \
+        _Type       *d      = (_Type *)task.dst;                               \
+        size_t       i, j;                                                     \
+                                                                               \
+        ucc_assert(stride % sizeof(_Type) == 0);                               \
+        switch (n_src2) {                                                      \
+        case 1:                                                                \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP##_2(s1[i], s2[i]);                                  \
+            }                                                                  \
+            break;                                                             \
+        case 2:                                                                \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP##_3(s1[i], s2[i], s2[i + ld]);                      \
+            }                                                                  \
+            break;                                                             \
+        case 3:                                                                \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP##_4(s1[i], s2[i], s2[i + ld], s2[i + 2 * ld]);      \
+            }                                                                  \
+            break;                                                             \
+        default:                                                               \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP(s1[i], s2[i]);                                      \
+                for (j = 1; j < n_src2; j++) {                                 \
+                    d[i] = _OP(d[i], s2[i + j * ld]);                          \
+                }                                                              \
+            }                                                                  \
+            break;                                                             \
+        }                                                                      \
+        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                     \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = d[i] * (_AlphaType)task.alpha;                          \
+            }                                                                  \
+        }                                                                      \
+    }                                                                          \
+    template <typename _Type, typename _AlphaType>                             \
+        __global__ void UCC_REDUCE_CUDA_STRIDED_##NAME(                        \
+            ucc_eee_task_reduce_strided_t task,                                \
+            uint16_t                     flags)                                \
+    {                                                                          \
+        ucc_reduce_cuda_strided_ ##NAME<_Type, _AlphaType>(task, flags);       \
+    }
+
+#define CUDA_REDUCE_WITH_OP_MULTI_DST(NAME, _OP)                               \
+    template <typename _Type>                                                  \
+    __global__ void UCC_REDUCE_CUDA_MULTI_DST_##NAME(                          \
+        ucc_eee_task_reduce_multi_dst_t arg)                                   \
+    {                                                                          \
+        size_t start = blockIdx.x * blockDim.x + threadIdx.x;                  \
+        size_t step  = blockDim.x * gridDim.x;                                 \
+        for (int j = 0; j < arg.n_bufs; j++) {                                 \
+            size_t count = arg.counts[j];                                      \
+            _Type *s2 = (_Type *)arg.src2[j];                                  \
+            _Type *s1 = (_Type *)arg.src1[j];                                  \
+            _Type *d  = (_Type *)arg.dst[j];                                   \
+            for (size_t i = start; i < count; i += step) {                     \
+                d[i] = _OP##_2(s1[i], s2[i]);                                  \
+            }                                                                  \
+        }                                                                      \
+    }
+
+CUDA_REDUCE_WITH_OP_DEFAULT(SUM,  DO_OP_SUM);
+CUDA_REDUCE_WITH_OP_DEFAULT(PROD, DO_OP_PROD);
+CUDA_REDUCE_WITH_OP_DEFAULT(MIN,  DO_OP_MIN);
+CUDA_REDUCE_WITH_OP_DEFAULT(MAX,  DO_OP_MAX);
+CUDA_REDUCE_WITH_OP_DEFAULT(LAND, DO_OP_LAND);
+CUDA_REDUCE_WITH_OP_DEFAULT(LOR,  DO_OP_LOR);
+CUDA_REDUCE_WITH_OP_DEFAULT(LXOR, DO_OP_LXOR);
+CUDA_REDUCE_WITH_OP_DEFAULT(BAND, DO_OP_BAND);
+CUDA_REDUCE_WITH_OP_DEFAULT(BOR,  DO_OP_BOR);
+CUDA_REDUCE_WITH_OP_DEFAULT(BXOR, DO_OP_BXOR);
+
+CUDA_REDUCE_WITH_OP_STRIDED(SUM,  DO_OP_SUM);
+CUDA_REDUCE_WITH_OP_STRIDED(PROD, DO_OP_PROD);
+CUDA_REDUCE_WITH_OP_STRIDED(MIN,  DO_OP_MIN);
+CUDA_REDUCE_WITH_OP_STRIDED(MAX,  DO_OP_MAX);
+CUDA_REDUCE_WITH_OP_STRIDED(LAND, DO_OP_LAND);
+CUDA_REDUCE_WITH_OP_STRIDED(LOR,  DO_OP_LOR);
+CUDA_REDUCE_WITH_OP_STRIDED(LXOR, DO_OP_LXOR);
+CUDA_REDUCE_WITH_OP_STRIDED(BAND, DO_OP_BAND);
+CUDA_REDUCE_WITH_OP_STRIDED(BOR,  DO_OP_BOR);
+CUDA_REDUCE_WITH_OP_STRIDED(BXOR, DO_OP_BXOR);
+
+CUDA_REDUCE_WITH_OP_MULTI_DST(SUM,  DO_OP_SUM);
+CUDA_REDUCE_WITH_OP_MULTI_DST(PROD, DO_OP_PROD);
+CUDA_REDUCE_WITH_OP_MULTI_DST(MIN,  DO_OP_MIN);
+CUDA_REDUCE_WITH_OP_MULTI_DST(MAX,  DO_OP_MAX);
+CUDA_REDUCE_WITH_OP_MULTI_DST(LAND, DO_OP_LAND);
+CUDA_REDUCE_WITH_OP_MULTI_DST(LOR,  DO_OP_LOR);
+CUDA_REDUCE_WITH_OP_MULTI_DST(LXOR, DO_OP_LXOR);
+CUDA_REDUCE_WITH_OP_MULTI_DST(BAND, DO_OP_BAND);
+CUDA_REDUCE_WITH_OP_MULTI_DST(BOR,  DO_OP_BOR);
+CUDA_REDUCE_WITH_OP_MULTI_DST(BXOR, DO_OP_BXOR);
+
+#define DT_REDUCE_INT(_Type, _task, _op, ...)               \
+    do {                                                    \
+        switch (_op) {                                      \
+        case UCC_OP_AVG:                                    \
+        case UCC_OP_SUM:                                    \
+            LAUNCH_REDUCE(SUM, _Type, _task, __VA_ARGS__);  \
+            break;                                          \
+        case UCC_OP_PROD:                                   \
+            LAUNCH_REDUCE(PROD, _Type, _task, __VA_ARGS__); \
+            break;                                          \
+        case UCC_OP_MIN:                                    \
+            LAUNCH_REDUCE(MIN, _Type, _task, __VA_ARGS__);  \
+            break;                                          \
+        case UCC_OP_MAX:                                    \
+            LAUNCH_REDUCE(MAX, _Type, _task, __VA_ARGS__);  \
+            break;                                          \
+        case UCC_OP_LAND:                                   \
+            LAUNCH_REDUCE(LAND, _Type, _task, __VA_ARGS__); \
+            break;                                          \
+        case UCC_OP_BAND:                                   \
+            LAUNCH_REDUCE(BAND, _Type, _task, __VA_ARGS__); \
+            break;                                          \
+        case UCC_OP_LOR:                                    \
+            LAUNCH_REDUCE(LOR, _Type, _task, __VA_ARGS__);  \
+            break;                                          \
+        case UCC_OP_BOR:                                    \
+            LAUNCH_REDUCE(BOR, _Type, _task, __VA_ARGS__);  \
+            break;                                          \
+        case UCC_OP_LXOR:                                   \
+            LAUNCH_REDUCE(LXOR, _Type, _task, __VA_ARGS__); \
+            break;                                          \
+        case UCC_OP_BXOR:                                   \
+            LAUNCH_REDUCE(BXOR, _Type, _task, __VA_ARGS__); \
+            break;                                          \
+        default:                                            \
+            return UCC_ERR_NOT_SUPPORTED;                   \
+        }                                                   \
+    } while (0)
+
+#define DT_REDUCE_FLOAT_COMPLEX(_Type, _alphaType, _task, _op, ...)       \
+    do {                                                                  \
+        switch (_op) {                                                    \
+        case UCC_OP_AVG:                                                  \
+        case UCC_OP_SUM:                                                  \
+            LAUNCH_REDUCE_A(SUM, _Type, _alphaType, _task, __VA_ARGS__);  \
+            break;                                                        \
+        case UCC_OP_PROD:                                                 \
+            LAUNCH_REDUCE_A(PROD, _Type, _alphaType, _task, __VA_ARGS__); \
+            break;                                                        \
+        default:                                                          \
+            return UCC_ERR_NOT_SUPPORTED;                                 \
+        }                                                                 \
+    } while (0)
+
+#define DT_REDUCE_FLOAT(_Type, _task, _op, ...)             \
+    do {                                                    \
+        switch (_op) {                                      \
+        case UCC_OP_AVG:                                    \
+        case UCC_OP_SUM:                                    \
+            LAUNCH_REDUCE(SUM, _Type, _task, __VA_ARGS__);  \
+            break;                                          \
+        case UCC_OP_PROD:                                   \
+            LAUNCH_REDUCE(PROD, _Type, _task, __VA_ARGS__); \
+            break;                                          \
+        case UCC_OP_MIN:                                    \
+            LAUNCH_REDUCE(MIN, _Type, _task, __VA_ARGS__);  \
+            break;                                          \
+        case UCC_OP_MAX:                                    \
+            LAUNCH_REDUCE(MAX, _Type, _task, __VA_ARGS__);  \
+            break;                                          \
+        default:                                            \
+            return UCC_ERR_NOT_SUPPORTED;                   \
+        }                                                   \
+    } while (0)
 
 #endif


### PR DESCRIPTION
## What
Potential Alternative for #596 . This PR implements ALL the reductinos (dt/ops) in the ec/cuda executor for persistent mode. It is done by making "device template" functions (common both for persistent and interruptible) + some macro magic + switch/case in the executor kernel. 

## Why ?
Need to support all the reductions. #596 currently demonstrates some perf degradation.

I only did a quick check on ucc_perftest -c reducedt and didn't see a regression there. However, more detail perf check is required. @samnordmann plz take this PR and do a perf regression check similar to what you did for 596. Lets then decide which approach we take.
