### PR TITLE
SCHEDULE: support arbitrary number of subscribers

### DIFF
--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -101,11 +101,11 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
         n_tasks++;
     }
 
-    ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
+    ucc_event_manager_subscribe(&schedule->super, UCC_EVENT_SCHEDULE_STARTED,
                                 tasks[0], ucc_task_start_handler);
     ucc_schedule_add_task(schedule, tasks[0]);
     for (i = 1; i < n_tasks; i++) {
-        ucc_event_manager_subscribe(&tasks[i - 1]->em, UCC_EVENT_COMPLETED,
+        ucc_event_manager_subscribe(tasks[i - 1], UCC_EVENT_COMPLETED,
                                     tasks[i], ucc_task_start_handler);
         ucc_schedule_add_task(schedule, tasks[i]);
     }

--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -50,10 +50,7 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
     memcpy(&args, coll_args, sizeof(args));
     args.args.root = 0; /* TODO: we can select the rank closest to HCA */
     n_tasks        = 0;
-    status         = ucc_schedule_init(schedule, &args, team);
-    if (ucc_unlikely(UCC_OK != status)) {
-        goto out;
-    }
+    UCC_CHECK_GOTO(ucc_schedule_init(schedule, &args, team), out, status);
 
     if (SBGP_ENABLED(cl_team, NODE)) {
         ucc_assert(n_tasks == 0);
@@ -66,11 +63,9 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
                 args.args.src.info = args.args.dst.info;
             }
         }
-        status =
-            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
-        if (ucc_unlikely(UCC_OK != status)) {
-            goto out;
-        }
+        UCC_CHECK_GOTO(
+            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]),
+            out, status);
         n_tasks++;
         args.args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
         args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
@@ -79,11 +74,9 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
     if (SBGP_ENABLED(cl_team, NODE_LEADERS)) {
         ucc_assert(cl_team->top_sbgp == UCC_HIER_SBGP_NODE_LEADERS);
         args.args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
-        status = ucc_coll_init(SCORE_MAP(cl_team, NODE_LEADERS), &args,
-                               &tasks[n_tasks]);
-        if (ucc_unlikely(UCC_OK != status)) {
-            goto out;
-        }
+        UCC_CHECK_GOTO(ucc_coll_init(SCORE_MAP(cl_team, NODE_LEADERS), &args,
+                                     &tasks[n_tasks]),
+                       out, status);
         n_tasks++;
     }
 
@@ -93,21 +86,24 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
         /* For bcast src should point to origin dst of allreduce */
         args.args.src.info  = args.args.dst.info;
         args.args.coll_type = UCC_COLL_TYPE_BCAST;
-        status =
-            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
-        if (ucc_unlikely(UCC_OK != status)) {
-            goto out;
-        }
+        UCC_CHECK_GOTO(
+            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]),
+            out, status);
         n_tasks++;
     }
 
-    ucc_event_manager_subscribe(&schedule->super, UCC_EVENT_SCHEDULE_STARTED,
-                                tasks[0], ucc_task_start_handler);
-    ucc_schedule_add_task(schedule, tasks[0]);
+    UCC_CHECK_GOTO(ucc_event_manager_subscribe(
+                       &schedule->super, UCC_EVENT_SCHEDULE_STARTED, tasks[0],
+                       ucc_task_start_handler),
+                   out, status);
+
+    UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, tasks[0]), out, status);
     for (i = 1; i < n_tasks; i++) {
-        ucc_event_manager_subscribe(tasks[i - 1], UCC_EVENT_COMPLETED,
-                                    tasks[i], ucc_task_start_handler);
-        ucc_schedule_add_task(schedule, tasks[i]);
+        UCC_CHECK_GOTO(
+            ucc_event_manager_subscribe(tasks[i - 1], UCC_EVENT_COMPLETED,
+                                        tasks[i], ucc_task_start_handler),
+            out, status);
+        UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, tasks[i]), out, status);
     }
 
     schedule->super.post     = ucc_cl_hier_allreduce_rab_start;

--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -218,17 +218,17 @@ static ucc_status_t ucc_cl_hier_allreduce_split_rail_frag_init(
 
     task_rs->n_deps = 1;
     ucc_schedule_add_task(schedule, task_rs);
-    ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
+    ucc_event_manager_subscribe(&schedule->super, UCC_EVENT_SCHEDULE_STARTED,
                                 task_rs, ucc_dependency_handler);
 
     task_ar->n_deps = 1;
     ucc_schedule_add_task(schedule, task_ar);
-    ucc_event_manager_subscribe(&task_rs->em, UCC_EVENT_COMPLETED, task_ar,
+    ucc_event_manager_subscribe(task_rs, UCC_EVENT_COMPLETED, task_ar,
                                 ucc_dependency_handler);
 
     task_ag->n_deps = 1;
     ucc_schedule_add_task(schedule, task_ag);
-    ucc_event_manager_subscribe(&task_ar->em, UCC_EVENT_COMPLETED, task_ag,
+    ucc_event_manager_subscribe(task_ar, UCC_EVENT_COMPLETED, task_ag,
                                 ucc_dependency_handler);
 
     schedule->super.post     = ucc_schedule_start;

--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -217,19 +217,23 @@ static ucc_status_t ucc_cl_hier_allreduce_split_rail_frag_init(
     }
 
     task_rs->n_deps = 1;
-    ucc_schedule_add_task(schedule, task_rs);
-    ucc_event_manager_subscribe(&schedule->super, UCC_EVENT_SCHEDULE_STARTED,
-                                task_rs, ucc_dependency_handler);
+    UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, task_rs), err_ag, status);
+    UCC_CHECK_GOTO(ucc_event_manager_subscribe(&schedule->super,
+                                               UCC_EVENT_SCHEDULE_STARTED,
+                                               task_rs, ucc_dependency_handler),
+                   err_ag, status);
 
     task_ar->n_deps = 1;
-    ucc_schedule_add_task(schedule, task_ar);
-    ucc_event_manager_subscribe(task_rs, UCC_EVENT_COMPLETED, task_ar,
-                                ucc_dependency_handler);
+    UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, task_ar), err_ag, status);
+    UCC_CHECK_GOTO(ucc_event_manager_subscribe(task_rs, UCC_EVENT_COMPLETED,
+                                               task_ar, ucc_dependency_handler),
+                   err_ag, status);
 
     task_ag->n_deps = 1;
-    ucc_schedule_add_task(schedule, task_ag);
-    ucc_event_manager_subscribe(task_ar, UCC_EVENT_COMPLETED, task_ag,
-                                ucc_dependency_handler);
+    UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, task_ag), err_ag, status);
+    UCC_CHECK_GOTO(ucc_event_manager_subscribe(task_ar, UCC_EVENT_COMPLETED,
+                                               task_ag, ucc_dependency_handler),
+                   err_ag, status);
 
     schedule->super.post     = ucc_schedule_start;
     schedule->super.progress = NULL;

--- a/src/components/cl/hier/barrier/barrier.c
+++ b/src/components/cl/hier/barrier/barrier.c
@@ -90,11 +90,11 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_barrier_init,
         n_tasks++;
     }
 
-    ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
+    ucc_event_manager_subscribe(&schedule->super, UCC_EVENT_SCHEDULE_STARTED,
                                 tasks[0], ucc_task_start_handler);
     ucc_schedule_add_task(schedule, tasks[0]);
     for (i = 1; i < n_tasks; i++) {
-        ucc_event_manager_subscribe(&tasks[i - 1]->em, UCC_EVENT_COMPLETED,
+        ucc_event_manager_subscribe(tasks[i - 1], UCC_EVENT_COMPLETED,
                                     tasks[i], ucc_task_start_handler);
         ucc_schedule_add_task(schedule, tasks[i]);
     }

--- a/src/components/cl/hier/cl_hier_context.c
+++ b/src/components/cl/hier/cl_hier_context.c
@@ -52,8 +52,9 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_context_t,
     }
 
     status = ucc_mpool_init(&self->sched_mp, 0, sizeof(ucc_cl_hier_schedule_t),
-                            0, UCC_CACHE_LINE_SIZE, 2, UINT_MAX, NULL,
-                            params->thread_mode, "cl_hier_sched_mp");
+                            0, UCC_CACHE_LINE_SIZE, 2, UINT_MAX,
+                            &ucc_coll_task_mpool_ops, params->thread_mode,
+                            "cl_hier_sched_mp");
     if (UCC_OK != status) {
         cl_error(cl_config->cl_lib, "failed to initialize cl_hier_sched mpool");
         goto out;

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -11,13 +11,6 @@
 #include <cuda_runtime.h>
 #include <cuda.h>
 
-static ucc_mpool_ops_t ucc_tl_cuda_req_mpool_ops = {
-    .chunk_alloc   = ucc_mpool_hugetlb_malloc,
-    .chunk_release = ucc_mpool_hugetlb_free,
-    .obj_init      = NULL,
-    .obj_cleanup   = NULL,
-};
-
 UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
                     const ucc_base_context_params_t *params,
                     const ucc_base_config_t *config)
@@ -53,7 +46,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
 
     status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_cuda_task_t), 0,
                             UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
-                            &ucc_tl_cuda_req_mpool_ops, params->thread_mode,
+                            &ucc_coll_task_mpool_ops, params->thread_mode,
                             "tl_cuda_req_mp");
     if (status != UCC_OK) {
         tl_error(self->super.super.lib,

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -38,10 +38,17 @@ void ucc_tl_nccl_driver_collective_progress(ucc_coll_task_t *coll_task)
 #endif
 }
 
+static void ucc_tl_nccl_req_mpool_obj_cleanup(ucc_mpool_t *mp, void *obj)
+{
+    ucc_coll_task_destruct(obj);
+}
+
 static void ucc_tl_nccl_req_mpool_obj_init(ucc_mpool_t *mp, void *obj,
                                            void *chunk)
 {
     ucc_tl_nccl_task_t *req = (ucc_tl_nccl_task_t*) obj;
+
+    ucc_coll_task_construct(&req->super);
     req->super.progress = ucc_tl_nccl_event_collective_progress;
 }
 
@@ -50,7 +57,7 @@ static ucc_mpool_ops_t ucc_tl_nccl_req_mpool_ops = {
     .chunk_alloc   = ucc_mpool_hugetlb_malloc,
     .chunk_release = ucc_mpool_hugetlb_free,
     .obj_init      = ucc_tl_nccl_req_mpool_obj_init,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = ucc_tl_nccl_req_mpool_obj_cleanup
 };
 
 static ucc_status_t ucc_tl_nccl_req_mapped_mpool_chunk_malloc(ucc_mpool_t *mp,
@@ -83,6 +90,7 @@ static void ucc_tl_nccl_req_mapped_mpool_obj_init(ucc_mpool_t *mp, void *obj,
     if (st != cudaSuccess) {
         req->super.status = UCC_ERR_NO_MESSAGE;
     }
+    ucc_coll_task_construct(&req->super);
     req->super.progress = ucc_tl_nccl_driver_collective_progress;
 }
 
@@ -90,7 +98,7 @@ static ucc_mpool_ops_t ucc_tl_nccl_req_mapped_mpool_ops = {
     .chunk_alloc   = ucc_tl_nccl_req_mapped_mpool_chunk_malloc,
     .chunk_release = ucc_tl_nccl_req_mapped_mpool_chunk_free,
     .obj_init      = ucc_tl_nccl_req_mapped_mpool_obj_init,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = ucc_tl_nccl_req_mpool_obj_cleanup
 };
 
 UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,

--- a/src/components/tl/rccl/tl_rccl_context.c
+++ b/src/components/tl/rccl/tl_rccl_context.c
@@ -43,7 +43,13 @@ static void ucc_tl_rccl_req_mpool_obj_init(ucc_mpool_t *mp, void *obj,
 {
     ucc_tl_rccl_task_t *req = (ucc_tl_rccl_task_t*) obj;
 
+    ucc_coll_task_construct(&req->super);
     req->super.progress = ucc_tl_rccl_event_collective_progress;
+}
+
+static void ucc_tl_rccl_req_mpool_obj_cleanup(ucc_mpool_t *mp, void *obj)
+{
+    ucc_coll_task_destruct(obj);
 }
 
 
@@ -51,7 +57,7 @@ static ucc_mpool_ops_t ucc_tl_rccl_req_mpool_ops = {
     .chunk_alloc   = ucc_mpool_hugetlb_malloc,
     .chunk_release = ucc_mpool_hugetlb_free,
     .obj_init      = ucc_tl_rccl_req_mpool_obj_init,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = ucc_tl_rccl_req_mpool_obj_cleanup
 };
 
 UCC_CLASS_INIT_FUNC(ucc_tl_rccl_context_t,

--- a/src/components/tl/self/tl_self_context.c
+++ b/src/components/tl/self/tl_self_context.c
@@ -22,8 +22,9 @@ UCC_CLASS_INIT_FUNC(ucc_tl_self_context_t,
     memcpy(&self->cfg, tl_self_config, sizeof(*tl_self_config));
 
     status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_self_task_t), 0,
-                            UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL,
-                            params->thread_mode, "tl_self_req_mp");
+                            UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
+                            &ucc_coll_task_mpool_ops, params->thread_mode,
+                            "tl_self_req_mp");
     if (status != UCC_OK) {
         tl_error(self->super.super.lib,
                  "failed to initialize tl_self_req mpool");

--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -8,13 +8,6 @@
 #include "tl_sharp.h"
 #include "utils/arch/cpu.h"
 
-static ucc_mpool_ops_t ucc_tl_sharp_req_mpool_ops = {
-    .chunk_alloc   = ucc_mpool_hugetlb_malloc,
-    .chunk_release = ucc_mpool_hugetlb_free,
-    .obj_init      = NULL,
-    .obj_cleanup   = NULL
-};
-
 static int ucc_tl_sharp_oob_barrier(void *arg)
 {
     ucc_tl_sharp_oob_ctx_t *oob_ctx  = (ucc_tl_sharp_oob_ctx_t *)arg;
@@ -373,7 +366,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_context_t,
 
     status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_sharp_task_t), 0,
                             UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
-                            &ucc_tl_sharp_req_mpool_ops, params->thread_mode,
+                            &ucc_coll_task_mpool_ops, params->thread_mode,
                             "tl_sharp_req_mp");
     if (status != UCC_OK) {
         tl_error(self->super.super.lib,

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -92,7 +92,7 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
         goto out;
     }
     ucc_schedule_add_task(schedule, task);
-    ucc_event_manager_subscribe(&schedule->super.em, UCC_EVENT_SCHEDULE_STARTED,
+    ucc_event_manager_subscribe(&schedule->super, UCC_EVENT_SCHEDULE_STARTED,
                                 task, ucc_task_start_handler);
     rs_task = task;
 
@@ -108,7 +108,7 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
     }
 
     ucc_schedule_add_task(schedule, task);
-    ucc_event_manager_subscribe(&rs_task->em, UCC_EVENT_COMPLETED, task,
+    ucc_event_manager_subscribe(rs_task, UCC_EVENT_COMPLETED, task,
                                 ucc_task_start_handler);
 
     schedule->super.post           = ucc_tl_ucp_bcast_sag_knomial_start;

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -400,7 +400,7 @@ ucc_tl_ucp_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_args,
         }
         ctask->n_deps = 1;
         ucc_schedule_add_task(schedule, ctask);
-        ucc_event_manager_subscribe(&schedule->super.em,
+        ucc_event_manager_subscribe(&schedule->super,
                                     UCC_EVENT_SCHEDULE_STARTED, ctask,
                                     ucc_task_start_handler);
     }

--- a/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
@@ -417,7 +417,7 @@ ucc_tl_ucp_reduce_scatterv_ring_init(ucc_base_coll_args_t *coll_args,
         }
         ctask->n_deps = 1;
         ucc_schedule_add_task(schedule, ctask);
-        ucc_event_manager_subscribe(&schedule->super.em,
+        ucc_event_manager_subscribe(&schedule->super,
                                     UCC_EVENT_SCHEDULE_STARTED, ctask,
                                     ucc_task_start_handler);
     }

--- a/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
@@ -398,32 +398,35 @@ ucc_tl_ucp_reduce_scatterv_ring_init(ucc_base_coll_args_t *coll_args,
     count_per_set = (max_segcount + n_subsets - 1) / n_subsets;
 
     to_alloc_per_set = count_per_set * 3;
-    status           = ucc_mc_alloc(&tl_schedule->scratch_mc_header,
-                          to_alloc_per_set * dt_size * n_subsets, mem_type);
-    if (status != UCC_OK) {
-        ucc_tl_ucp_put_schedule(schedule);
-        return status;
-    }
+    UCC_CHECK_GOTO(ucc_mc_alloc(&tl_schedule->scratch_mc_header,
+                                to_alloc_per_set * dt_size * n_subsets,
+                                mem_type),
+                   out, status);
 
     for (i = 0; i < n_subsets; i++) {
-        status = ucc_tl_ucp_reduce_scatterv_ring_init_subset(
-            coll_args, team, &ctask, s[i], n_subsets, i,
-            PTR_OFFSET(tl_schedule->scratch_mc_header->addr,
-                       to_alloc_per_set * i * dt_size),
-            count_per_set);
-        if (UCC_OK != status) {
-            tl_error(UCC_TL_TEAM_LIB(tl_team), "failed to allocate ring task");
-            return status;
-        }
+        UCC_CHECK_GOTO(ucc_tl_ucp_reduce_scatterv_ring_init_subset(
+                           coll_args, team, &ctask, s[i], n_subsets, i,
+                           PTR_OFFSET(tl_schedule->scratch_mc_header->addr,
+                                      to_alloc_per_set * i * dt_size),
+                           count_per_set),
+                       out_free, status);
         ctask->n_deps = 1;
-        ucc_schedule_add_task(schedule, ctask);
-        ucc_event_manager_subscribe(&schedule->super,
-                                    UCC_EVENT_SCHEDULE_STARTED, ctask,
-                                    ucc_task_start_handler);
+        UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, ctask), out_free,
+                       status);
+        UCC_CHECK_GOTO(ucc_event_manager_subscribe(
+                           &schedule->super, UCC_EVENT_SCHEDULE_STARTED, ctask,
+                           ucc_task_start_handler),
+                       out_free, status);
     }
     schedule->super.flags   |= UCC_COLL_TASK_FLAG_EXECUTOR;
     schedule->super.post     = ucc_tl_ucp_reduce_scatterv_ring_sched_post;
     schedule->super.finalize = ucc_tl_ucp_reduce_scatterv_ring_sched_finalize;
     *task_h                  = &schedule->super;
     return UCC_OK;
+
+out_free:
+    ucc_mc_free(tl_schedule->scratch_mc_header);
+out:
+    ucc_tl_ucp_put_schedule(schedule);
+    return status;
 }

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -117,8 +117,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     ucc_status = ucc_mpool_init(
         &self->req_mp, 0,
         ucc_max(sizeof(ucc_tl_ucp_task_t), sizeof(ucc_tl_ucp_schedule_t)), 0,
-        UCC_CACHE_LINE_SIZE, 8, UINT_MAX, NULL, params->thread_mode,
-        "tl_ucp_req_mp");
+        UCC_CACHE_LINE_SIZE, 8, UINT_MAX, &ucc_coll_task_mpool_ops,
+        params->thread_mode, "tl_ucp_req_mp");
     if (UCC_OK != ucc_status) {
         tl_error(self->super.super.lib,
                  "failed to initialize tl_ucp_req mpool");

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -372,7 +372,7 @@ static ucc_status_t ucc_trigger_complete(ucc_coll_task_t *parent_task,
     } else {
         ucc_assert(task->super.status == UCC_INPROGRESS);
         // TODO use CB instead of EM
-        ucc_event_manager_subscribe(&task->em, UCC_EVENT_COMPLETED, task,
+        ucc_event_manager_subscribe(task, UCC_EVENT_COMPLETED, task,
                                     ucc_triggered_coll_complete);
     }
     return UCC_OK;
@@ -465,6 +465,7 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
         return UCC_ERR_NO_MEMORY;
     }
 
+    ucc_coll_task_construct(ev_task);
     ucc_coll_task_init(ev_task, NULL, task->team);
     ev_task->ee             = ee;
     ev_task->ev             = NULL;
@@ -479,7 +480,7 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
     if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
         UCC_COLL_SET_TIMEOUT(ev_task, task->bargs.args.timeout);
     }
-    ucc_event_manager_subscribe(&ev_task->em, UCC_EVENT_COMPLETED, task,
+    ucc_event_manager_subscribe(ev_task, UCC_EVENT_COMPLETED, task,
                                 ucc_trigger_complete);
 
     return ucc_progress_queue_enqueue(UCC_TASK_CORE_CTX(ev_task)->pq, ev_task);

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -369,13 +369,11 @@ static ucc_status_t ucc_trigger_complete(ucc_coll_task_t *parent_task,
 
     if (task->super.status == UCC_OK) {
         return ucc_triggered_coll_complete(task, task);
-    } else {
-        ucc_assert(task->super.status == UCC_INPROGRESS);
-        // TODO use CB instead of EM
-        ucc_event_manager_subscribe(task, UCC_EVENT_COMPLETED, task,
-                                    ucc_triggered_coll_complete);
     }
-    return UCC_OK;
+    ucc_assert(task->super.status == UCC_INPROGRESS);
+    // TODO use CB instead of EM
+    return ucc_event_manager_subscribe(task, UCC_EVENT_COMPLETED, task,
+                                       ucc_triggered_coll_complete);
 }
 
 static void ucc_trigger_test(ucc_coll_task_t *task)
@@ -452,6 +450,7 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
                                 ucc_coll_task_t *task)
 {
     ucc_coll_task_t *ev_task;
+    ucc_status_t     status;
 
     if (ev->ev_type != UCC_EVENT_COMPUTE_COMPLETE) {
         ucc_error("event type %d is not supported", ev->ev_type);
@@ -480,8 +479,11 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
     if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
         UCC_COLL_SET_TIMEOUT(ev_task, task->bargs.args.timeout);
     }
-    ucc_event_manager_subscribe(ev_task, UCC_EVENT_COMPLETED, task,
-                                ucc_trigger_complete);
+    status = ucc_event_manager_subscribe(ev_task, UCC_EVENT_COMPLETED, task,
+                                         ucc_trigger_complete);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
 
     return ucc_progress_queue_enqueue(UCC_TASK_CORE_CTX(ev_task)->pq, ev_task);
 }

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -183,19 +183,18 @@ ucc_status_t ucc_schedule_pipelined_init(
             frags[i]->tasks[j]->n_deps_base = frags[i]->tasks[j]->n_deps;
             if (n_frags > 1 && sequential) {
                 ucc_event_manager_subscribe(
-                    &frags[(i > 0) ? (i - 1) : (n_frags - 1)]->tasks[j]->em,
+                    frags[(i > 0) ? (i - 1) : (n_frags - 1)]->tasks[j],
                     UCC_EVENT_TASK_STARTED, frags[i]->tasks[j],
                     ucc_dependency_handler);
                 frags[i]->tasks[j]->n_deps_base++;
             }
         }
-        ucc_event_manager_subscribe(&schedule->super.super.em,
+        ucc_event_manager_subscribe(&schedule->super.super,
                                     UCC_EVENT_SCHEDULE_STARTED,
                                     &frags[i]->super, ucc_frag_start_handler);
         ucc_event_manager_subscribe(
-            &frags[i]->super.em, UCC_EVENT_COMPLETED_SCHEDULE,
-            &schedule->super.super,
-            ucc_schedule_pipelined_completed_handler);
+            &frags[i]->super, UCC_EVENT_COMPLETED_SCHEDULE,
+            &schedule->super.super, ucc_schedule_pipelined_completed_handler);
     }
     return UCC_OK;
 err:

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -105,4 +105,13 @@ static inline ucs_status_t ucc_status_to_ucs_status(ucc_status_t status)
 #endif
 
 #define ucc_for_each_bit ucs_for_each_bit
+
+#define UCC_CHECK_GOTO(_cmd, _label, _status)                                  \
+    do {                                                                       \
+        _status = (_cmd);                                                      \
+        if (ucc_unlikely(_status != UCC_OK)) {                                 \
+            goto _label;                                                       \
+        }                                                                      \
+    } while (0)
+
 #endif

--- a/src/utils/ucc_list.h
+++ b/src/utils/ucc_list.h
@@ -19,6 +19,7 @@
 #define ucc_list_extract_head  ucs_list_extract_head
 #define ucc_list_length        ucs_list_length
 #define ucc_list_head          ucs_list_head
+#define ucc_list_tail          ucs_list_tail
 #define ucc_list_next          ucs_list_next
 #define ucc_list_insert_after  ucs_list_insert_after
 #define ucc_list_insert_before ucs_list_insert_before

--- a/test/gtest/core/test_schedule.cc
+++ b/test/gtest/core/test_schedule.cc
@@ -7,21 +7,35 @@
 extern "C" {
 #include "schedule/ucc_schedule.h"
 }
-typedef std::tuple<ucc_coll_task_t*, int> rst_t;
-class test_schedule : public ucc_coll_task_t, public ucc::test
+
+class test_coll_task : public ucc_coll_task_t {
+public:
+    test_coll_task() {
+        ucc_coll_task_construct(this);
+        EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t *)this, NULL, NULL));
+    }
+    ~test_coll_task() {
+        ucc_coll_task_destruct(this);
+    }
+};
+
+typedef std::tuple<test_coll_task*, int> rst_t;
+
+
+class test_schedule : public test_coll_task, public ucc::test
 {
 public:
     std::vector<rst_t> rst;
     static ucc_status_t handler_1(ucc_coll_task_t *parent,
                                   ucc_coll_task_t *task) {
         test_schedule *ts = (test_schedule*)task;
-        ts->rst.push_back(rst_t(parent, 1));
+        ts->rst.push_back(rst_t((test_coll_task*)parent, 1));
         return UCC_OK;
     }
     static ucc_status_t handler_2(ucc_coll_task_t *parent,
                                   ucc_coll_task_t *task) {
         test_schedule *ts = (test_schedule*)task;
-        ts->rst.push_back(rst_t(parent, 2));
+        ts->rst.push_back(rst_t((test_coll_task*)parent, 2));
         return UCC_OK;
     }
 };
@@ -30,12 +44,10 @@ public:
    handler */
 UCC_TEST_F(test_schedule, single_handler)
 {
-    std::vector<ucc_coll_task_t> tasks(2);
+    std::vector<test_coll_task> tasks(2);
 
-    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t *)this, NULL, NULL));
     for (auto &t :  tasks) {
-        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t, NULL, NULL));
-        ucc_event_manager_subscribe(&t.em, UCC_EVENT_COMPLETED,
+        ucc_event_manager_subscribe(&t, UCC_EVENT_COMPLETED,
                                     (ucc_coll_task_t*)this,
                                     test_schedule::handler_1);
     }
@@ -54,16 +66,12 @@ UCC_TEST_F(test_schedule, single_handler)
    handlers */
 UCC_TEST_F(test_schedule, different_handlers)
 {
-    std::vector<ucc_coll_task_t> tasks(2);
+    std::vector<test_coll_task> tasks(2);
 
-    EXPECT_EQ(UCC_OK, ucc_coll_task_init((ucc_coll_task_t *)this, NULL, NULL));
-    for (auto &t :  tasks) {
-        EXPECT_EQ(UCC_OK, ucc_coll_task_init(&t, NULL, NULL));
-    }
-    ucc_event_manager_subscribe(&tasks[0].em, UCC_EVENT_COMPLETED,
+    ucc_event_manager_subscribe(&tasks[0], UCC_EVENT_COMPLETED,
                                 (ucc_coll_task_t*)this,
                                 test_schedule::handler_1);
-    ucc_event_manager_subscribe(&tasks[1].em, UCC_EVENT_COMPLETED,
+    ucc_event_manager_subscribe(&tasks[1], UCC_EVENT_COMPLETED,
                                 (ucc_coll_task_t*)this,
                                 test_schedule::handler_2);
 
@@ -76,4 +84,28 @@ UCC_TEST_F(test_schedule, different_handlers)
               (std::get<1>(rst[0]) == 1));
     EXPECT_EQ(true, (std::get<0>(rst[1]) == &tasks[1]) &&
               (std::get<1>(rst[1]) == 2));
+}
+
+/* Tasks subscribes to multiple tasks exceeding MAX_LISTENERS */
+UCC_TEST_F(test_schedule, multiple)
+{
+    const int n_subscribers = 16;
+    std::vector<test_coll_task> tasks(n_subscribers);
+
+    for (int i = 0; i < n_subscribers; i++) {
+        ucc_event_manager_subscribe(&tasks[i], UCC_EVENT_COMPLETED,
+                                    (ucc_coll_task_t*)this,
+                                    ((i % 2) == 0 ? test_schedule::handler_1
+                                     : test_schedule::handler_2));
+    }
+
+    for (auto &t :  tasks) {
+        EXPECT_EQ(UCC_OK, ucc_event_manager_notify(&t, UCC_EVENT_COMPLETED));
+    }
+
+    EXPECT_EQ(n_subscribers, rst.size());
+    for (int i = 0; i < n_subscribers; i++) {
+        EXPECT_EQ(true, (std::get<0>(rst[i]) == &tasks[i]) &&
+                  (std::get<1>(rst[i]) == ((i % 2) + 1)));
+    }
 }


### PR DESCRIPTION
## What
Modifies event_manager implementation to support arbitrary number of subscribers

## Why ?
In master any task can only have up to 4 subscribers otherwise code crashes. However, we already have use case for more: cl/hier split_rail allreduce would hit that case if the 1st reduce_scatterv is a schedule as well (and cl/hier schedule is ordered)

## How ?
coll_task now contains list of event_manager structs each containing up to MAX_LISTENERS objects. event_manager entries are allocated on demand (on the first event_manager subscribe call). coll_task now has 2 more apis: coll_task_construct and destruct that must be called once (or via obj_init callback of an mpool).

I did a smoke perf test on most latency sensitive colls (1 node tl/shm allreduce/bcast) and did not measure any degradation.
