### PR TITLE
CORE: correctly handle failure in ctx_create epilog

### DIFF
--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -37,8 +37,6 @@ UCC_CLASS_DECLARE(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *,
 
 typedef struct ucc_cl_basic_context {
     ucc_cl_context_t   super;
-    ucc_tl_context_t **tl_ctxs;
-    unsigned           n_tl_ctxs;
 } ucc_cl_basic_context_t;
 UCC_CLASS_DECLARE(ucc_cl_basic_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -73,8 +73,6 @@ UCC_CLASS_DECLARE(ucc_cl_hier_lib_t, const ucc_base_lib_params_t *,
 
 typedef struct ucc_cl_hier_context {
     ucc_cl_context_t   super;
-    ucc_tl_context_t **tl_ctxs;
-    unsigned           n_tl_ctxs;
     ucc_mpool_t        sched_mp;
 } ucc_cl_hier_context_t;
 UCC_CLASS_DECLARE(ucc_cl_hier_context_t, const ucc_base_context_params_t *,

--- a/src/components/cl/hier/cl_hier_context.c
+++ b/src/components/cl/hier/cl_hier_context.c
@@ -27,25 +27,25 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_context_t,
         tls = &params->context->all_tls;
     }
 
-    self->tl_ctxs =
+    self->super.tl_ctxs =
         ucc_malloc(sizeof(ucc_tl_context_t *) * tls->count, "cl_hier_tl_ctxs");
-    if (!self->tl_ctxs) {
+    if (!self->super.tl_ctxs) {
         cl_error(cl_config->cl_lib, "failed to allocate %zd bytes for tl_ctxs",
                  sizeof(ucc_tl_context_t **) * tls->count);
         return UCC_ERR_NO_MEMORY;
     }
-    self->n_tl_ctxs = 0;
+    self->super.n_tl_ctxs = 0;
     for (i = 0; i < tls->count; i++) {
         status = ucc_tl_context_get(params->context, tls->names[i],
-                                    &self->tl_ctxs[self->n_tl_ctxs]);
+                                  &self->super.tl_ctxs[self->super.n_tl_ctxs]);
         if (UCC_OK != status) {
             cl_info(cl_config->cl_lib,
                     "TL %s context is not available, skipping", tls->names[i]);
         } else {
-            self->n_tl_ctxs++;
+            self->super.n_tl_ctxs++;
         }
     }
-    if (0 == self->n_tl_ctxs) {
+    if (0 == self->super.n_tl_ctxs) {
         cl_error(cl_config->cl_lib, "no TL contexts are available");
         status = UCC_ERR_NOT_FOUND;
         goto out;
@@ -64,7 +64,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_context_t,
     return UCC_OK;
 
 out:
-    ucc_free(self->tl_ctxs);
+    ucc_free(self->super.tl_ctxs);
     return status;
 }
 
@@ -74,10 +74,10 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_hier_context_t)
     cl_info(self->super.super.lib, "finalizing cl context: %p", self);
 
     ucc_mpool_cleanup(&self->sched_mp, 1);
-    for (i = 0; i < self->n_tl_ctxs; i++) {
-        ucc_tl_context_put(self->tl_ctxs[i]);
+    for (i = 0; i < self->super.n_tl_ctxs; i++) {
+        ucc_tl_context_put(self->super.tl_ctxs[i]);
     }
-    ucc_free(self->tl_ctxs);
+    ucc_free(self->super.tl_ctxs);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_hier_context_t, ucc_cl_context_t);

--- a/src/components/cl/ucc_cl.h
+++ b/src/components/cl/ucc_cl.h
@@ -35,6 +35,7 @@ typedef struct ucc_cl_lib     ucc_cl_lib_t;
 typedef struct ucc_cl_iface   ucc_cl_iface_t;
 typedef struct ucc_cl_context ucc_cl_context_t;
 typedef struct ucc_cl_team    ucc_cl_team_t;
+typedef struct ucc_tl_context ucc_tl_context_t;
 
 typedef struct ucc_cl_lib_config {
     ucc_base_lib_config_t    super;
@@ -81,6 +82,8 @@ UCC_CLASS_DECLARE(ucc_cl_lib_t, ucc_cl_iface_t *, const ucc_cl_lib_config_t *);
 
 typedef struct ucc_cl_context {
     ucc_base_context_t super;
+    ucc_tl_context_t **tl_ctxs;
+    unsigned           n_tl_ctxs;
 } ucc_cl_context_t;
 UCC_CLASS_DECLARE(ucc_cl_context_t, const ucc_cl_context_config_t *,
                   ucc_context_t *);


### PR DESCRIPTION
## What
Properly handle potential failures that happen during TL context_create_epilog call.  

## Why ?
Current behavior: if context_create_epilog fails -> ucc context creation fails -> job fails.
Expected behavior: if TL that failed to perform context_create_epilog is not explicitly required job must proceed w/o it. Example: TL/SHARP not enabled explicitly (in a "try" mode), it might fail to initialize but we should proceed.

## How ?
* Check if the TL is explicitly requested
* The order of steps during ucc_context create is: 1) create all TL contexts, 2) create all CL contexts, 3) perform global address exchange (if required via params) - all TLs/CLs ctx objects are required for that, 4) allocate topo object if required; 5) allocate ctx service team (if required); 5) call epilog
* When CL contexts are created at step 2 they check which TLs are available for them. However, some of those TLs might get invalidated later at step 5 if tl_ctx_craete_epilog will fail
* In that case we need to remove failed TL contexts from the CLs - we can do that since those TLs were NOT explicitly requested (otherwise the job would stop)
* This is done by moving array of tl_context_t ptrs to the base ucc_cl_context_t structure, so that it is available at CORE level.
