### PR TITLE
SCHEDULE: fixes race on n_deps_satisfied

### DIFF
--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -213,11 +213,13 @@ ucc_status_t ucc_dependency_handler(ucc_coll_task_t *parent,
                                     ucc_coll_task_t *task)
 {
     ucc_status_t status;
+    uint8_t      n_deps_satisfied;
 
-    task->n_deps_satisfied++;
+    n_deps_satisfied = ucc_atomic_fadd8(&task->n_deps_satisfied, 1);
+
     ucc_trace_req("task %p, n_deps %d, satisfied %d", task, task->n_deps,
-                  task->n_deps_satisfied);
-    if (task->n_deps == task->n_deps_satisfied) {
+                  n_deps_satisfied);
+    if (task->n_deps == n_deps_satisfied + 1) {
         task->start_time = parent->start_time;
         status = task->post(task);
         if (status >= 0) {

--- a/src/utils/ucc_atomic.h
+++ b/src/utils/ucc_atomic.h
@@ -11,6 +11,7 @@
 
 #define ucc_atomic_add32          ucs_atomic_add32
 #define ucc_atomic_fadd32         ucs_atomic_fadd32
+#define ucc_atomic_fadd8          ucs_atomic_fadd8
 #define ucc_atomic_sub32          ucs_atomic_sub32
 #define ucc_atomic_add64          ucs_atomic_add64
 #define ucc_atomic_sub64          ucs_atomic_sub64


### PR DESCRIPTION
## What
Fixes hang reproduced with "Serialized" pipeline type

## Why ?
A task can depend on 2 other tasks (e.g. from another frag of of schedule and prev task in a given frag). In that case when those 2 frags a progressed by multiple threads ucc_dependency_handler may be called concurrently which results in a race on n_deps_satisfied.

