### PR TITLE
EC/CUDA: use one kernel with cooperative launch

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -63,6 +63,13 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                [AC_CHECK_LIB([cudart], [cudaGetDeviceCount],
                              [CUDA_LIBS="$CUDA_LIBS -lcudart"], [cuda_happy="no"])])
 
+         AC_CHECK_HEADERS([cooperative_groups.h],
+                        [flag=1
+                        AC_MSG_RESULT([yes])],
+                        [flag=0
+                        AC_MSG_RESULT([no])])
+           AC_DEFINE_UNQUOTED(CUDA_SUPPORTS_COOP_LAUNCH, $flag, [if CUDA supports cooperative launch.])
+
         # Check nvml header files
         AC_CHECK_HEADERS([nvml.h],
                          [nvml_happy="yes"],

--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -63,13 +63,6 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                [AC_CHECK_LIB([cudart], [cudaGetDeviceCount],
                              [CUDA_LIBS="$CUDA_LIBS -lcudart"], [cuda_happy="no"])])
 
-         AC_CHECK_HEADERS([cooperative_groups.h],
-                        [flag=1
-                        AC_MSG_RESULT([yes])],
-                        [flag=0
-                        AC_MSG_RESULT([no])])
-           AC_DEFINE_UNQUOTED(CUDA_SUPPORTS_COOP_LAUNCH, $flag, [if CUDA supports cooperative launch.])
-
         # Check nvml header files
         AC_CHECK_HEADERS([nvml.h],
                          [nvml_happy="yes"],

--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -73,10 +73,10 @@ static ucc_config_field_t ucc_ec_cuda_config_table[] = {
      ucc_offsetof(ucc_ec_cuda_config_t, reduce_num_blocks),
      UCC_CONFIG_TYPE_ULUNITS},
 
-    {"USE_COOPERATIVE_LAUNCH", "0",
+    {"USE_COOPERATIVE_LAUNCH", "1",
      "whether to use cooperative launch in persistent kernel executor",
      ucc_offsetof(ucc_ec_cuda_config_t, use_cooperative_launch),
-     UCC_CONFIG_TYPE_UINT},
+     UCC_CONFIG_TYPE_BOOL},
 
     {NULL}
 
@@ -329,11 +329,11 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
     if (cfg->use_cooperative_launch == 1) {
         cudaDeviceGetAttribute(&supportsCoopLaunch,
                                cudaDevAttrCooperativeLaunch, device);
-        if (CUDA_SUPPORTS_COOP_LAUNCH == 0 || supportsCoopLaunch == 0) {
-            ec_error(&ucc_ec_cuda.super,
+        if (!supportsCoopLaunch) {
+            cfg->use_cooperative_launch = 0;
+            ec_warn(&ucc_ec_cuda.super,
                      "CUDA cooperative groups are not supported. "
-                     "Please set UCC_EC_CUDA_USE_COOPERATIVE_LAUNCH to 0");
-            return UCC_ERR_NOT_SUPPORTED;
+                     "Fall back to non cooperative launch.");
         }
     }
 

--- a/src/components/ec/cuda/ec_cuda.h
+++ b/src/components/ec/cuda/ec_cuda.h
@@ -61,6 +61,7 @@ typedef struct ucc_ec_cuda_config {
     unsigned long                  exec_num_streams;
     unsigned long                  reduce_num_blocks;
     int                            reduce_num_threads;
+    int                            use_cooperative_launch;
 } ucc_ec_cuda_config_t;
 
 typedef struct ucc_ec_cuda {

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -18,6 +18,11 @@ extern "C" {
 
 #define WARP_SIZE 32
 #define LOOP_UNROLL 8
+#if CUDA_SUPPORTS_COOP_LAUNCH
+#include <cooperative_groups.h>
+using namespace cooperative_groups;
+#endif
+
 #define align_pow2(_n, _p) ((_n) & ((_p) - 1))
 typedef int4 vectype;
 
@@ -288,6 +293,77 @@ __device__ void executor_copy_multi(ucc_eee_task_copy_multi_t *task)
    }
 }
 
+__global__ void
+executor_kernel_cooperative(volatile ucc_ec_cuda_executor_t *eee, int q_size)
+{
+#if CUDA_SUPPORTS_COOP_LAUNCH
+    const uint32_t          worker_id   = blockIdx.x;
+    const uint32_t          num_workers = gridDim.x;
+    bool                    is_master   = (threadIdx.x == 0) ? true : false;
+    int                     cidx_local, pidx_local;
+    volatile int *          pidx, *cidx;
+    ucc_ee_executor_task_t *tasks;
+    __shared__ ucc_ee_executor_task_args_t args;
+    __shared__ bool                        worker_done;
+
+    if (is_master) {
+        *eee->dev_cidx  = 0;
+        *eee->dev_state = UCC_EC_CUDA_EXECUTOR_STARTED;
+        cidx_local      = worker_id;
+        pidx            = eee->dev_pidx;
+        cidx            = eee->dev_cidx;
+        tasks           = eee->dev_tasks;
+    }
+
+    worker_done     = false;
+    grid_group grid = this_grid();
+    grid.sync();
+    while (1) {
+        if (is_master) {
+            while ((*cidx % num_workers) != worker_id)
+                ;
+            do {
+                pidx_local = *pidx;
+            } while (*cidx == pidx_local);
+            (*cidx)++;
+            worker_done = (pidx_local == -1);
+            if (!worker_done) {
+                args = tasks[cidx_local].args;
+            }
+        }
+        __syncthreads();
+        if (worker_done) {
+            grid.sync();
+            if (is_master && (worker_id == 0)) {
+                *eee->dev_state = UCC_EC_CUDA_EXECUTOR_SHUTDOWN_ACK;
+            }
+            return;
+        }
+        switch (args.task_type) {
+        case UCC_EE_EXECUTOR_TASK_COPY:
+            executor_copy_task(&args.copy);
+            break;
+        case UCC_EE_EXECUTOR_TASK_REDUCE:
+            executor_reduce_task(&args.reduce);
+            break;
+        case UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED:
+            executor_reduce_strided_task(&args.reduce_strided);
+            break;
+        case UCC_EE_EXECUTOR_TASK_COPY_MULTI:
+            executor_copy_multi(&args.copy_multi);
+            break;
+        default:
+            break;
+        }
+        __syncthreads();
+        __threadfence_system();
+        if (is_master) {
+            tasks[cidx_local].status = UCC_OK;
+            cidx_local               = (cidx_local + num_workers) % q_size;
+        }
+    }
+#endif
+}
 
 __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
                                 int q_size)
@@ -364,10 +440,19 @@ ucc_status_t ucc_ec_cuda_persistent_kernel_start(ucc_ec_cuda_executor_t *eee)
     int          nb     = EC_CUDA_CONFIG->exec_num_workers;
     int          nt     = EC_CUDA_CONFIG->exec_num_threads;
     int          q_size = EC_CUDA_CONFIG->exec_max_tasks;
+    int          useCoopLaunch = EC_CUDA_CONFIG->use_cooperative_launch;
 
-    executor_start<<<1, 1, 0, stream>>>(eee->dev_state, eee->dev_cidx);
-    executor_kernel<<<nb, nt, 0, stream>>>(eee, q_size);
-    executor_shutdown_ack<<<1, 1, 0, stream>>>(eee->dev_state);
+    if (useCoopLaunch) {
+        void *kernelArgs[] = {&eee, &q_size};
+        dim3  dimBlock(nt, 1, 1);
+        dim3  dimGrid(nb, 1, 1);
+        cudaLaunchCooperativeKernel((void *)executor_kernel_cooperative,
+                                    dimGrid, dimBlock, kernelArgs, 0, stream);
+    } else {
+        executor_start<<<1, 1, 0, stream>>>(eee->dev_state, eee->dev_cidx);
+        executor_kernel<<<nb, nt, 0, stream>>>(eee, q_size);
+        executor_shutdown_ack<<<1, 1, 0, stream>>>(eee->dev_state);
+    }
     CUDA_CHECK(cudaGetLastError());
 
     return UCC_OK;


### PR DESCRIPTION
## What
Use one cooperative kernel for the persistent kernel in EC/CUDA. Tests show that this has little/negligible effects on the performances (cf spreadsheet [PR coop group.xlsx](https://github.com/openucx/ucc/files/9487807/PR.coop.group.xlsx)).


## Why ?
In the present implementation, we have to launch three kernels, `executor_start`, `executor_kernel`, `executor_shutdown_ack`. Only `executor_kernel` actually performs computation, whereas the two other kernels are only used to synchronize the grid, which is a primitive function in cooperative launches.

The cooperative group primitives offer more flexibility that could also result in further improvements in EC/CUDA.

## How ?
The feature is enabled by default but can be controlled by the env variable `UCC_EC_CUDA_USE_COOPERATIVE_LAUNCH`.
At initialization, a we test if the device supports cooperative launch ; if not, the feature is disabled and the program goes on without cooperative launch.