### PR TITLE
Cl/HIER: reduce 2step algorithm

### DIFF
--- a/src/components/cl/hier/Makefile.am
+++ b/src/components/cl/hier/Makefile.am
@@ -20,6 +20,11 @@ barrier =                     \
 	barrier/barrier.h         \
 	barrier/barrier.c
 
+bcast =                       \
+	bcast/bcast.h             \
+	bcast/bcast.c             \
+	bcast/bcast_2step.c
+
 sources =             \
 	cl_hier.h         \
 	cl_hier.c         \
@@ -31,7 +36,8 @@ sources =             \
 	$(allreduce)      \
 	$(alltoallv)      \
 	$(alltoall)       \
-	$(barrier)
+	$(barrier)        \
+	$(bcast)
 
 module_LTLIBRARIES         = libucc_cl_hier.la
 libucc_cl_hier_la_SOURCES  = $(sources)

--- a/src/components/cl/hier/Makefile.am
+++ b/src/components/cl/hier/Makefile.am
@@ -25,6 +25,11 @@ bcast =                       \
 	bcast/bcast.c             \
 	bcast/bcast_2step.c
 
+reduce =                      \
+	reduce/reduce.h           \
+	reduce/reduce.c           \
+	reduce/reduce_2step.c
+
 sources =             \
 	cl_hier.h         \
 	cl_hier.c         \
@@ -37,7 +42,8 @@ sources =             \
 	$(alltoallv)      \
 	$(alltoall)       \
 	$(barrier)        \
-	$(bcast)
+	$(bcast)          \
+	$(reduce)
 
 module_LTLIBRARIES         = libucc_cl_hier.la
 libucc_cl_hier_la_SOURCES  = $(sources)

--- a/src/components/cl/hier/allreduce/allreduce_rab.c
+++ b/src/components/cl/hier/allreduce/allreduce_rab.c
@@ -27,10 +27,59 @@ static ucc_status_t ucc_cl_hier_allreduce_rab_finalize(ucc_coll_task_t *task)
     return status;
 }
 
-UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
-                         (coll_args, team, task),
-                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
-                         ucc_coll_task_t **task)
+static ucc_status_t ucc_cl_hier_ar_rab_schedule_finalize(ucc_coll_task_t *task)
+{
+    ucc_cl_hier_schedule_t *schedule =
+        ucc_derived_of(task, ucc_cl_hier_schedule_t);
+    ucc_status_t status;
+
+    status = ucc_schedule_pipelined_finalize(&schedule->super.super.super);
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}
+
+static ucc_status_t
+ucc_cl_hier_allreduce_rab_frag_setup(ucc_schedule_pipelined_t *schedule_p,
+                                     ucc_schedule_t *frag, int frag_num)
+{
+    ucc_cl_hier_team_t *cl_team =
+        ucc_derived_of(schedule_p->super.super.team, ucc_cl_hier_team_t);
+    ucc_coll_args_t *args    = &schedule_p->super.super.bargs.args;
+    size_t           dt_size = ucc_dt_size(args->dst.info.datatype);
+    int              n_frags = schedule_p->super.n_tasks;
+    int              inplace = UCC_IS_INPLACE(*args);
+    size_t           frag_count, frag_offset;
+    ucc_coll_task_t *task;
+    int              i;
+
+    frag_count =
+        ucc_buffer_block_count(args->dst.info.count, n_frags, frag_num);
+    frag_offset =
+        ucc_buffer_block_offset(args->dst.info.count, n_frags, frag_num);
+
+    for (i = 0; i < frag->n_tasks; i++) {
+        task                             = frag->tasks[i];
+        task->bargs.args.src.info.count  = frag_count;
+        task->bargs.args.dst.info.count  = frag_count;
+        task->bargs.args.dst.info.buffer =
+            PTR_OFFSET(args->dst.info.buffer, frag_offset * dt_size);
+        if ((task->bargs.args.coll_type == UCC_COLL_TYPE_BCAST) ||
+            (task->bargs.args.coll_type == UCC_COLL_TYPE_REDUCE && inplace &&
+             (SBGP_RANK(cl_team, NODE) != args->root))) {
+            task->bargs.args.src.info.buffer =
+                PTR_OFFSET(args->dst.info.buffer, frag_offset * dt_size);
+        } else {
+            task->bargs.args.src.info.buffer =
+                PTR_OFFSET(args->src.info.buffer, frag_offset * dt_size);
+        }
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t
+ucc_cl_hier_allreduce_rab_init_schedule(ucc_base_coll_args_t *coll_args,
+                                        ucc_base_team_t *     team,
+                                        ucc_schedule_t **sched_p, int n_frags)
 {
     ucc_cl_hier_team_t  *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
     ucc_coll_task_t     *tasks[MAX_AR_RAB_TASKS] = {NULL};
@@ -39,19 +88,21 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
     ucc_base_coll_args_t args;
     int                  n_tasks, i;
 
-    if (coll_args->args.op == UCC_OP_AVG) {
-        return UCC_ERR_NOT_SUPPORTED;
-    }
     schedule = &ucc_cl_hier_get_schedule(cl_team)->super.super;
     if (ucc_unlikely(!schedule)) {
         return UCC_ERR_NO_MEMORY;
     }
 
-    memcpy(&args, coll_args, sizeof(args));
+    args           = *coll_args;
     args.args.root = 0; /* TODO: we can select the rank closest to HCA */
     n_tasks        = 0;
     UCC_CHECK_GOTO(ucc_schedule_init(schedule, &args, team), out, status);
 
+    if (n_frags > 1) {
+        args.max_frag_count =
+            ucc_buffer_block_count(args.args.dst.info.count, n_frags, 0);
+        args.mask |= UCC_BASE_CARGS_MAX_FRAG_COUNT;
+    }
     if (SBGP_ENABLED(cl_team, NODE)) {
         ucc_assert(n_tasks == 0);
         if (cl_team->top_sbgp == UCC_HIER_SBGP_NODE) {
@@ -67,7 +118,7 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
             ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]),
             out, status);
         n_tasks++;
-        args.args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
+        args.args.mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
         args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
     }
 
@@ -106,9 +157,11 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
         UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, tasks[i]), out, status);
     }
 
-    schedule->super.post     = ucc_cl_hier_allreduce_rab_start;
-    schedule->super.finalize = ucc_cl_hier_allreduce_rab_finalize;
-    *task                    = &schedule->super;
+    schedule->super.post           = ucc_cl_hier_allreduce_rab_start;
+    schedule->super.progress       = NULL;
+    schedule->super.finalize       = ucc_cl_hier_allreduce_rab_finalize;
+    schedule->super.triggered_post = ucc_triggered_post;
+    *sched_p                       = schedule;
     return UCC_OK;
 
 out:
@@ -116,5 +169,100 @@ out:
         tasks[i]->finalize(tasks[i]);
     }
     ucc_cl_hier_put_schedule(schedule);
+    return status;
+}
+
+static ucc_status_t ucc_cl_hier_allreduce_rab_frag_init(
+    ucc_base_coll_args_t *coll_args, ucc_schedule_pipelined_t *sp,
+    ucc_base_team_t *team, ucc_schedule_t **frag_p)
+{
+    int          n_frags = sp->super.n_tasks;
+    ucc_status_t status;
+
+    status = ucc_cl_hier_allreduce_rab_init_schedule(coll_args, team, frag_p,
+                                                     n_frags);
+    return status;
+}
+
+static inline void get_n_frags(ucc_base_coll_args_t *coll_args,
+                               ucc_cl_hier_team_t *team, int *n_frags,
+                               int *pipeline_depth)
+{
+    ucc_cl_hier_lib_config_t *cfg     = &UCC_CL_HIER_TEAM_LIB(team)->cfg;
+    size_t                    msgsize = coll_args->args.dst.info.count *
+                     ucc_dt_size(coll_args->args.dst.info.datatype);
+    int min_num_frags;
+
+    *n_frags = 1;
+    if (msgsize > cfg->allreduce_rab_frag_thresh) {
+        min_num_frags = msgsize / cfg->allreduce_rab_frag_size;
+        *n_frags      = ucc_max(min_num_frags, cfg->allreduce_rab_n_frags);
+    }
+    *pipeline_depth = ucc_min(*n_frags, cfg->allreduce_rab_pipeline_depth);
+}
+
+static ucc_status_t ucc_cl_hier_rab_allreduce_start(ucc_coll_task_t *task)
+{
+    ucc_schedule_pipelined_t *schedule =
+        ucc_derived_of(task, ucc_schedule_pipelined_t);
+
+    cl_debug(task->team->context->lib,
+             "posting rab ar, sbuf %p, rbuf %p, count %zd, dt %s, op %s, "
+             "inplace %d, pdepth %d, frags_total %d",
+             task->bargs.args.src.info.buffer, task->bargs.args.dst.info.buffer,
+             task->bargs.args.dst.info.count,
+             ucc_datatype_str(task->bargs.args.src.info.datatype),
+             ucc_reduction_op_str(task->bargs.args.op),
+             UCC_IS_INPLACE(task->bargs.args), schedule->n_frags,
+             schedule->super.n_tasks);
+
+    return ucc_schedule_pipelined_post(task);
+}
+
+UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_rab_init,
+                         (coll_args, team, task),
+                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+                         ucc_coll_task_t **task)
+{
+    ucc_cl_hier_team_t *cl_team   = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_cl_hier_lib_config_t *cfg = &UCC_CL_HIER_TEAM_LIB(cl_team)->cfg;
+    ucc_cl_hier_schedule_t *  schedule;
+    int                       n_frags, pipeline_depth;
+    ucc_status_t              status;
+
+    if (coll_args->args.op == UCC_OP_AVG) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    get_n_frags(coll_args, cl_team, &n_frags, &pipeline_depth);
+
+    if (n_frags == 1) {
+        return ucc_cl_hier_allreduce_rab_init_schedule(
+            coll_args, team, (ucc_schedule_t **)task, n_frags);
+    }
+
+    schedule = ucc_cl_hier_get_schedule(cl_team);
+    if (ucc_unlikely(!schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    status = ucc_schedule_pipelined_init(
+        coll_args, team, ucc_cl_hier_allreduce_rab_frag_init,
+        ucc_cl_hier_allreduce_rab_frag_setup, pipeline_depth, n_frags,
+        cfg->allreduce_rab_seq, &schedule->super);
+
+    if (ucc_unlikely(status != UCC_OK)) {
+        cl_error(team->context->lib,
+                 "failed to init pipelined rab ar schedule");
+        goto err_pipe_init;
+    }
+
+    schedule->super.super.super.post = ucc_cl_hier_rab_allreduce_start;
+    schedule->super.super.super.triggered_post = ucc_triggered_post;
+    schedule->super.super.super.finalize = ucc_cl_hier_ar_rab_schedule_finalize;
+    *task                                = &schedule->super.super.super;
+    return UCC_OK;
+
+err_pipe_init:
+    ucc_cl_hier_put_schedule(&schedule->super.super);
     return status;
 }

--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -251,24 +251,6 @@ err_rs:
     return status;
 }
 
-static inline void get_n_frags(ucc_base_coll_args_t *coll_args,
-                               ucc_cl_hier_team_t *team, int *n_frags,
-                               int *pipeline_depth)
-{
-    ucc_cl_hier_lib_config_t *cfg     = &UCC_CL_HIER_TEAM_LIB(team)->cfg;
-    size_t                    msgsize = coll_args->args.dst.info.count *
-                     ucc_dt_size(coll_args->args.dst.info.datatype);
-    int min_num_frags;
-
-    *n_frags = 1;
-    if (msgsize > cfg->allreduce_split_rail_frag_thresh) {
-        min_num_frags = msgsize / cfg->allreduce_split_rail_frag_size;
-        *n_frags = ucc_max(min_num_frags, cfg->allreduce_split_rail_n_frags);
-    }
-    *pipeline_depth =
-        ucc_min(*n_frags, cfg->allreduce_split_rail_pipeline_depth);
-}
-
 static ucc_status_t
 ucc_cl_hier_split_rail_allreduce_start(ucc_coll_task_t *task)
 {
@@ -318,12 +300,15 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_split_rail_init,
         return UCC_ERR_NO_MEMORY;
     }
 
-    get_n_frags(coll_args, cl_team, &n_frags, &pipeline_depth);
+    ucc_pipeline_nfrags_pdepth(&cfg->allreduce_split_rail_pipeline,
+                               coll_args->args.dst.info.count *
+                               ucc_dt_size(coll_args->args.dst.info.datatype),
+                               &n_frags, &pipeline_depth);
 
     status = ucc_schedule_pipelined_init(
         coll_args, team, ucc_cl_hier_allreduce_split_rail_frag_init,
         ucc_cl_hier_allreduce_split_rail_frag_setup, pipeline_depth, n_frags,
-        cfg->allreduce_split_rail_pipeline_order, &schedule->super);
+        cfg->allreduce_split_rail_pipeline.order, &schedule->super);
 
     if (ucc_unlikely(status != UCC_OK)) {
         cl_error(team->context->lib,

--- a/src/components/cl/hier/bcast/bcast.c
+++ b/src/components/cl/hier/bcast/bcast.c
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "bcast.h"
+#include "../bcast/bcast.h"
+
+ucc_base_coll_alg_info_t
+    ucc_cl_hier_bcast_algs[UCC_CL_HIER_BCAST_ALG_LAST + 1] = {
+        [UCC_CL_HIER_BCAST_ALG_2STEP] =
+            {.id   = UCC_CL_HIER_BCAST_ALG_2STEP,
+             .name = "2step",
+             .desc = "intra-node and inter-node bcasts executed in parallel"},
+        [UCC_CL_HIER_BCAST_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};

--- a/src/components/cl/hier/bcast/bcast.h
+++ b/src/components/cl/hier/bcast/bcast.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef BCAST_H_
+#define BCAST_H_
+#include "../cl_hier.h"
+
+enum
+{
+    UCC_CL_HIER_BCAST_ALG_2STEP,
+    UCC_CL_HIER_BCAST_ALG_SPLIT_RAIL,
+    UCC_CL_HIER_BCAST_ALG_LAST,
+};
+
+extern ucc_base_coll_alg_info_t
+    ucc_cl_hier_bcast_algs[UCC_CL_HIER_BCAST_ALG_LAST + 1];
+
+#define UCC_CL_HIER_BCAST_DEFAULT_ALG_SELECT_STR "bcast:0-4k:@2step"
+
+ucc_status_t ucc_cl_hier_bcast_2step_init(ucc_base_coll_args_t *coll_args,
+                                          ucc_base_team_t      *team,
+                                          ucc_coll_task_t     **task);
+
+static inline int ucc_cl_hier_bcast_alg_from_str(const char *str)
+{
+    int i;
+
+    for (i = 0; i < UCC_CL_HIER_BCAST_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_cl_hier_bcast_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
+
+#endif

--- a/src/components/cl/hier/bcast/bcast_2step.c
+++ b/src/components/cl/hier/bcast/bcast_2step.c
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "bcast.h"
+#include "core/ucc_team.h"
+#include "../cl_hier_coll.h"
+
+#define MAX_AR_2STEP_TASKS 3
+
+static ucc_status_t ucc_cl_hier_bcast_2step_start(ucc_coll_task_t *task)
+{
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_bcast_2step_start", 0);
+    return ucc_schedule_start(task);
+}
+
+static ucc_status_t ucc_cl_hier_bcast_2step_finalize(ucc_coll_task_t *task)
+{
+    ucc_schedule_t *schedule = ucc_derived_of(task, ucc_schedule_t);
+    ucc_status_t    status;
+
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_bcast_2step_finalize",
+                                      0);
+    status = ucc_schedule_finalize(task);
+    ucc_cl_hier_put_schedule(schedule);
+    return status;
+}
+
+static ucc_status_t ucc_cl_hier_ar_2step_schedule_finalize(ucc_coll_task_t *task)
+{
+    ucc_cl_hier_schedule_t *schedule =
+        ucc_derived_of(task, ucc_cl_hier_schedule_t);
+    ucc_status_t status;
+
+    status = ucc_schedule_pipelined_finalize(&schedule->super.super.super);
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}
+
+static ucc_status_t
+ucc_cl_hier_bcast_2step_frag_setup(ucc_schedule_pipelined_t *schedule_p,
+                                     ucc_schedule_t *frag, int frag_num)
+{
+    ucc_coll_args_t *args    = &schedule_p->super.super.bargs.args;
+    size_t           dt_size = ucc_dt_size(args->src.info.datatype);
+    int              n_frags = schedule_p->super.n_tasks;
+    size_t           frag_count, frag_offset;
+    ucc_coll_task_t *task;
+    int              i;
+
+    frag_count =
+        ucc_buffer_block_count(args->src.info.count, n_frags, frag_num);
+    frag_offset =
+        ucc_buffer_block_offset(args->src.info.count, n_frags, frag_num);
+
+    for (i = 0; i < frag->n_tasks; i++) {
+        task                             = frag->tasks[i];
+        task->bargs.args.src.info.count  = frag_count;
+        task->bargs.args.src.info.buffer =
+            PTR_OFFSET(args->src.info.buffer, frag_offset * dt_size);
+    }
+    return UCC_OK;
+}
+
+static inline ucc_rank_t
+find_root_net_rank(ucc_host_id_t root_host_id, ucc_cl_hier_team_t *cl_team)
+{
+    ucc_rank_t  net_rank  = UCC_RANK_INVALID;
+    ucc_sbgp_t *sbgp      = cl_team->sbgps[UCC_HIER_SBGP_NODE_LEADERS].sbgp;
+    ucc_team_t *core_team = cl_team->super.super.params.team;
+    ucc_rank_t  i, rank;
+
+    for (i = 0; i < sbgp->group_size; i++) {
+        rank = ucc_ep_map_eval(sbgp->map, i);
+        if (ucc_team_rank_host_id(rank, core_team) == root_host_id) {
+            net_rank = i;
+            break;
+        }
+    }
+    return net_rank;
+}
+
+static inline ucc_rank_t
+find_root_node_rank(ucc_rank_t root, ucc_cl_hier_team_t *cl_team)
+{
+    ucc_rank_t  node_rank  = UCC_RANK_INVALID;
+    ucc_sbgp_t *sbgp       = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp;
+    ucc_rank_t  i;
+
+    for (i = 0; i < sbgp->group_size; i++) {
+        if (ucc_ep_map_eval(sbgp->map, i) == root) {
+            node_rank = i;
+            break;
+        }
+    }
+    return node_rank;
+}
+
+static ucc_status_t
+ucc_cl_hier_bcast_2step_init_schedule(ucc_base_coll_args_t *coll_args,
+                                        ucc_base_team_t *     team,
+                                        ucc_schedule_t **sched_p, int n_frags)
+{
+    ucc_cl_hier_team_t *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_team_t         *core_team = team->params.team;
+    ucc_coll_task_t    *tasks[2] = {NULL, NULL};
+    int root                        = coll_args->args.root;
+    int rank                        = UCC_TL_TEAM_RANK(cl_team);
+    int root_on_local_node          = ucc_team_ranks_on_same_node(root, rank, core_team);
+
+    ucc_schedule_t      *schedule;
+    ucc_status_t         status;
+    ucc_base_coll_args_t args;
+    int                  n_tasks, i, first_task;
+
+    args           = *coll_args;
+    n_tasks        = 0;
+    first_task     = 0;
+
+    schedule = &ucc_cl_hier_get_schedule(cl_team)->super.super;
+    if (ucc_unlikely(!schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+    status         = ucc_schedule_init(schedule, &args, team);
+    if (ucc_unlikely(UCC_OK != status)) {
+        goto out;
+    }
+
+    if (n_frags > 1) {
+        args.max_frag_count =
+            ucc_buffer_block_count(args.args.src.info.count, n_frags, 0);
+        args.mask |= UCC_BASE_CARGS_MAX_FRAG_COUNT;
+    }
+
+    if (SBGP_ENABLED(cl_team, NODE_LEADERS)) {
+        args.args.root = find_root_net_rank(ucc_team_rank_host_id(root, core_team), cl_team);
+        status =
+            ucc_coll_init(SCORE_MAP(cl_team, NODE_LEADERS), &args, &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+        if (root_on_local_node && (root != rank)) {
+            first_task = 1;
+        }
+    }
+
+    if (SBGP_ENABLED(cl_team, NODE)) {
+        args.args.root = root_on_local_node
+            ? find_root_node_rank(root, cl_team) : 0;
+
+        status =
+            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+    }
+
+    ucc_task_subscribe_dep(&schedule->super, tasks[first_task], UCC_EVENT_SCHEDULE_STARTED);
+    ucc_schedule_add_task(schedule, tasks[first_task]);
+    if (n_tasks > 1) {
+        if (root == rank) {
+            ucc_task_subscribe_dep(&schedule->super, tasks[(first_task + 1) % 2],
+                                   UCC_EVENT_SCHEDULE_STARTED);
+        } else {
+            ucc_task_subscribe_dep(tasks[first_task],
+                                   tasks[(first_task + 1) % 2], UCC_EVENT_COMPLETED);
+        }
+        ucc_schedule_add_task(schedule, tasks[(first_task + 1) % 2]);
+    }
+
+    schedule->super.post           = ucc_cl_hier_bcast_2step_start;
+    schedule->super.progress       = NULL;
+    schedule->super.finalize       = ucc_cl_hier_bcast_2step_finalize;
+    schedule->super.triggered_post = ucc_triggered_post;
+    *sched_p                       = schedule;
+    return UCC_OK;
+
+out:
+    for (i = 0; i < n_tasks; i++) {
+        tasks[i]->finalize(tasks[i]);
+    }
+    ucc_cl_hier_put_schedule(schedule);
+    return status;
+}
+
+static ucc_status_t ucc_cl_hier_bcast_2step_frag_init(
+    ucc_base_coll_args_t *coll_args, ucc_schedule_pipelined_t *sp,
+    ucc_base_team_t *team, ucc_schedule_t **frag_p)
+{
+    int          n_frags = sp->super.n_tasks;
+    ucc_status_t status;
+
+    status = ucc_cl_hier_bcast_2step_init_schedule(coll_args, team, frag_p,
+                                                     n_frags);
+    return status;
+}
+
+static ucc_status_t ucc_cl_hier_2step_bcast_start(ucc_coll_task_t *task)
+{
+    ucc_schedule_pipelined_t *schedule =
+        ucc_derived_of(task, ucc_schedule_pipelined_t);
+
+    cl_debug(task->team->context->lib,
+             "posting 2step ar, buf %p, count %zd, dt %s"
+             " pdepth %d, frags_total %d",
+             task->bargs.args.src.info.buffer,
+             task->bargs.args.src.info.count,
+             ucc_datatype_str(task->bargs.args.src.info.datatype),
+             schedule->n_frags, schedule->super.n_tasks);
+
+    return ucc_schedule_pipelined_post(task);
+}
+
+UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_bcast_2step_init,
+                         (coll_args, team, task),
+                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+                         ucc_coll_task_t **task)
+{
+    ucc_cl_hier_team_t *cl_team   = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_cl_hier_lib_config_t *cfg = &UCC_CL_HIER_TEAM_LIB(cl_team)->cfg;
+    ucc_cl_hier_schedule_t *  schedule;
+    int                       n_frags, pipeline_depth;
+    ucc_status_t              status;
+
+    if (coll_args->args.op == UCC_OP_AVG) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    ucc_pipeline_nfrags_pdepth(&cfg->bcast_2step_pipeline,
+                               coll_args->args.src.info.count *
+                               ucc_dt_size(coll_args->args.src.info.datatype),
+                               &n_frags, &pipeline_depth);
+
+    if (n_frags == 1) {
+        return ucc_cl_hier_bcast_2step_init_schedule(
+            coll_args, team, (ucc_schedule_t **)task, n_frags);
+    }
+
+    schedule = ucc_cl_hier_get_schedule(cl_team);
+    if (ucc_unlikely(!schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    status = ucc_schedule_pipelined_init(
+        coll_args, team, ucc_cl_hier_bcast_2step_frag_init,
+        ucc_cl_hier_bcast_2step_frag_setup, pipeline_depth, n_frags,
+        cfg->bcast_2step_pipeline.order, &schedule->super);
+
+    if (ucc_unlikely(status != UCC_OK)) {
+        cl_error(team->context->lib,
+                 "failed to init pipelined 2step ar schedule");
+        goto err_pipe_init;
+    }
+
+    schedule->super.super.super.post = ucc_cl_hier_2step_bcast_start;
+    schedule->super.super.super.triggered_post = ucc_triggered_post;
+    schedule->super.super.super.finalize = ucc_cl_hier_ar_2step_schedule_finalize;
+    *task                                = &schedule->super.super.super;
+    return UCC_OK;
+
+err_pipe_init:
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -68,6 +68,11 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      ucc_offsetof(ucc_cl_hier_lib_config_t, bcast_2step_pipeline),
      UCC_CONFIG_TYPE_PIPELINE_PARAMS},
 
+    {"REDUCE_2STEP_PIPELINE", "n",
+     "Pipelining settings for RAB reduce algorithm",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, reduce_2step_pipeline),
+     UCC_CONFIG_TYPE_PIPELINE_PARAMS},
+
     {NULL}};
 
 static ucs_config_field_t ucc_cl_hier_context_config_table[] = {

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -83,6 +83,35 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_pipeline_order),
      UCC_CONFIG_TYPE_ENUM(ucc_pipeline_order_names)},
 
+    {"ALLREDUCE_RAB_FRAG_THRESH", "inf",
+     "Threshold to enable fragmentation and pipelining of Rab "
+     "allreduce alg",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_frag_thresh),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"ALLREDUCE_RAB_FRAG_SIZE", "inf",
+     "Maximum allowed fragment size of Rab alg",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_frag_size),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"ALLREDUCE_RAB_N_FRAGS", "2",
+     "Number of fragments each allreduce is split into when Rab alg is "
+     "used\n"
+     "The actual number of fragments can be larger if fragment size exceeds\n"
+     "ALLREDUCE_RAB_FRAG_SIZE",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_n_frags),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLREDUCE_RAB_PIPELINE_DEPTH", "2",
+     "Number of fragments simultaneously progressed by the Rab alg",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_pipeline_depth),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLREDUCE_RAB_SEQUENTIAL", "n",
+     "Type of pipelined schedule for Rab alg (sequential/parallel)",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_seq),
+     UCC_CONFIG_TYPE_BOOL},
+
     {NULL}};
 
 static ucs_config_field_t ucc_cl_hier_context_config_table[] = {

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -53,64 +53,15 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      ucc_offsetof(ucc_cl_hier_lib_config_t, a2av_node_thresh),
      UCC_CONFIG_TYPE_MEMUNITS},
 
-    {"ALLREDUCE_SPLIT_RAIL_FRAG_THRESH", "inf",
-     "Threshold to enable fragmentation and pipelining of Split_Rail "
-     "allreduce alg",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_frag_thresh),
-     UCC_CONFIG_TYPE_MEMUNITS},
+    {"ALLREDUCE_SPLIT_RAIL_PIPELINE", "n",
+     "Pipelining settings for SplitRail allreduce algorithm",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_pipeline),
+     UCC_CONFIG_TYPE_PIPELINE_PARAMS},
 
-    {"ALLREDUCE_SPLIT_RAIL_FRAG_SIZE", "inf",
-     "Maximum allowed fragment size of Split_Rail alg",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_frag_size),
-     UCC_CONFIG_TYPE_MEMUNITS},
-
-    {"ALLREDUCE_SPLIT_RAIL_N_FRAGS", "2",
-     "Number of fragments each allreduce is split into when Split_Rail alg is "
-     "used\n"
-     "The actual number of fragments can be larger if fragment size exceeds\n"
-     "ALLREDUCE_SPLIT_RAIL_FRAG_SIZE",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_n_frags),
-     UCC_CONFIG_TYPE_UINT},
-
-    {"ALLREDUCE_SPLIT_RAIL_PIPELINE_DEPTH", "2",
-     "Number of fragments simultaneously progressed by the Split_Rail alg",
-     ucc_offsetof(ucc_cl_hier_lib_config_t,
-                  allreduce_split_rail_pipeline_depth),
-     UCC_CONFIG_TYPE_UINT},
-
-    {"ALLREDUCE_SPLIT_RAIL_PIPELINE_ORDER", "ordered",
-     "Type of pipelined schedule for Split_Rail alg (sequential/ordered/parallel)",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_split_rail_pipeline_order),
-     UCC_CONFIG_TYPE_ENUM(ucc_pipeline_order_names)},
-
-    {"ALLREDUCE_RAB_FRAG_THRESH", "inf",
-     "Threshold to enable fragmentation and pipelining of Rab "
-     "allreduce alg",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_frag_thresh),
-     UCC_CONFIG_TYPE_MEMUNITS},
-
-    {"ALLREDUCE_RAB_FRAG_SIZE", "inf",
-     "Maximum allowed fragment size of Rab alg",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_frag_size),
-     UCC_CONFIG_TYPE_MEMUNITS},
-
-    {"ALLREDUCE_RAB_N_FRAGS", "2",
-     "Number of fragments each allreduce is split into when Rab alg is "
-     "used\n"
-     "The actual number of fragments can be larger if fragment size exceeds\n"
-     "ALLREDUCE_RAB_FRAG_SIZE",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_n_frags),
-     UCC_CONFIG_TYPE_UINT},
-
-    {"ALLREDUCE_RAB_PIPELINE_DEPTH", "2",
-     "Number of fragments simultaneously progressed by the Rab alg",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_pipeline_depth),
-     UCC_CONFIG_TYPE_UINT},
-
-    {"ALLREDUCE_RAB_SEQUENTIAL", "n",
-     "Type of pipelined schedule for Rab alg (sequential/parallel)",
-     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_seq),
-     UCC_CONFIG_TYPE_BOOL},
+    {"ALLREDUCE_RAB_PIPELINE", "n",
+     "Pipelining settings for RAB allreduce algorithm",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_pipeline),
+     UCC_CONFIG_TYPE_PIPELINE_PARAMS},
 
     {NULL}};
 

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -63,6 +63,11 @@ static ucc_config_field_t ucc_cl_hier_lib_config_table[] = {
      ucc_offsetof(ucc_cl_hier_lib_config_t, allreduce_rab_pipeline),
      UCC_CONFIG_TYPE_PIPELINE_PARAMS},
 
+    {"BCAST_2STEP_PIPELINE", "n",
+     "Pipelining settings for RAB bcast algorithm",
+     ucc_offsetof(ucc_cl_hier_lib_config_t, bcast_2step_pipeline),
+     UCC_CONFIG_TYPE_PIPELINE_PARAMS},
+
     {NULL}};
 
 static ucs_config_field_t ucc_cl_hier_context_config_table[] = {

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -50,16 +50,8 @@ typedef struct ucc_cl_hier_lib_config {
        which are selected based on the TL scores */
     ucc_config_names_list_t sbgp_tls[UCC_HIER_SBGP_LAST];
     size_t                  a2av_node_thresh;
-    uint32_t                allreduce_split_rail_n_frags;
-    uint32_t                allreduce_split_rail_pipeline_depth;
-    ucc_pipeline_order_t    allreduce_split_rail_pipeline_order;
-    size_t                  allreduce_split_rail_frag_thresh;
-    size_t                  allreduce_split_rail_frag_size;
-    uint32_t                allreduce_rab_n_frags;
-    uint32_t                allreduce_rab_pipeline_depth;
-    int                     allreduce_rab_seq;
-    size_t                  allreduce_rab_frag_thresh;
-    size_t                  allreduce_rab_frag_size;
+    ucc_pipeline_params_t   allreduce_split_rail_pipeline;
+    ucc_pipeline_params_t   allreduce_rab_pipeline;
 
 } ucc_cl_hier_lib_config_t;
 

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -55,6 +55,11 @@ typedef struct ucc_cl_hier_lib_config {
     ucc_pipeline_order_t    allreduce_split_rail_pipeline_order;
     size_t                  allreduce_split_rail_frag_thresh;
     size_t                  allreduce_split_rail_frag_size;
+    uint32_t                allreduce_rab_n_frags;
+    uint32_t                allreduce_rab_pipeline_depth;
+    int                     allreduce_rab_seq;
+    size_t                  allreduce_rab_frag_thresh;
+    size_t                  allreduce_rab_frag_size;
 
 } ucc_cl_hier_lib_config_t;
 

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -53,6 +53,7 @@ typedef struct ucc_cl_hier_lib_config {
     ucc_pipeline_params_t   allreduce_split_rail_pipeline;
     ucc_pipeline_params_t   allreduce_rab_pipeline;
     ucc_pipeline_params_t   bcast_2step_pipeline;
+    ucc_pipeline_params_t   reduce_2step_pipeline;
 } ucc_cl_hier_lib_config_t;
 
 typedef struct ucc_cl_hier_context_config {

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -52,7 +52,7 @@ typedef struct ucc_cl_hier_lib_config {
     size_t                  a2av_node_thresh;
     ucc_pipeline_params_t   allreduce_split_rail_pipeline;
     ucc_pipeline_params_t   allreduce_rab_pipeline;
-
+    ucc_pipeline_params_t   bcast_2step_pipeline;
 } ucc_cl_hier_lib_config_t;
 
 typedef struct ucc_cl_hier_context_config {

--- a/src/components/cl/hier/cl_hier_coll.c
+++ b/src/components/cl/hier/cl_hier_coll.c
@@ -12,7 +12,8 @@
 
 const char *
     ucc_cl_hier_default_alg_select_str[UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR] = {
-        UCC_CL_HIER_ALLREDUCE_DEFAULT_ALG_SELECT_STR};
+    UCC_CL_HIER_ALLREDUCE_DEFAULT_ALG_SELECT_STR,
+    UCC_CL_HIER_BCAST_DEFAULT_ALG_SELECT_STR};
 
 ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t      *team,
@@ -27,6 +28,8 @@ ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
         return ucc_cl_hier_alltoall_init(coll_args, team, task);
     case UCC_COLL_TYPE_ALLTOALLV:
         return ucc_cl_hier_alltoallv_init(coll_args, team, task);
+    case UCC_COLL_TYPE_BCAST:
+        return ucc_cl_hier_bcast_2step_init(coll_args, team, task);
     default:
         cl_error(team->context->lib, "coll_type %s is not supported",
                  ucc_coll_type_str(coll_args->args.coll_type));
@@ -44,6 +47,8 @@ static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
         return ucc_cl_hier_alltoall_alg_from_str(str);
     case UCC_COLL_TYPE_ALLREDUCE:
         return ucc_cl_hier_allreduce_alg_from_str(str);
+    case UCC_COLL_TYPE_BCAST:
+        return ucc_cl_hier_bcast_alg_from_str(str);
     default:
         break;
     }
@@ -88,6 +93,16 @@ ucc_status_t ucc_cl_hier_alg_id_to_init(int alg_id, const char *alg_id_str,
             break;
         case UCC_CL_HIER_ALLREDUCE_ALG_SPLIT_RAIL:
             *init = ucc_cl_hier_allreduce_split_rail_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    case UCC_COLL_TYPE_BCAST:
+        switch (alg_id) {
+        case UCC_CL_HIER_BCAST_ALG_2STEP:
+            *init = ucc_cl_hier_bcast_2step_init;
             break;
         default:
             status = UCC_ERR_INVALID_PARAM;

--- a/src/components/cl/hier/cl_hier_coll.c
+++ b/src/components/cl/hier/cl_hier_coll.c
@@ -13,7 +13,8 @@
 const char *
     ucc_cl_hier_default_alg_select_str[UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR] = {
     UCC_CL_HIER_ALLREDUCE_DEFAULT_ALG_SELECT_STR,
-    UCC_CL_HIER_BCAST_DEFAULT_ALG_SELECT_STR};
+    UCC_CL_HIER_BCAST_DEFAULT_ALG_SELECT_STR,
+    UCC_CL_HIER_REDUCE_DEFAULT_ALG_SELECT_STR};
 
 ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t      *team,
@@ -30,6 +31,8 @@ ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
         return ucc_cl_hier_alltoallv_init(coll_args, team, task);
     case UCC_COLL_TYPE_BCAST:
         return ucc_cl_hier_bcast_2step_init(coll_args, team, task);
+    case UCC_COLL_TYPE_REDUCE:
+        return ucc_cl_hier_reduce_2step_init(coll_args, team, task);
     default:
         cl_error(team->context->lib, "coll_type %s is not supported",
                  ucc_coll_type_str(coll_args->args.coll_type));
@@ -49,6 +52,8 @@ static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
         return ucc_cl_hier_allreduce_alg_from_str(str);
     case UCC_COLL_TYPE_BCAST:
         return ucc_cl_hier_bcast_alg_from_str(str);
+    case UCC_COLL_TYPE_REDUCE:
+        return ucc_cl_hier_reduce_alg_from_str(str);
     default:
         break;
     }
@@ -103,6 +108,16 @@ ucc_status_t ucc_cl_hier_alg_id_to_init(int alg_id, const char *alg_id_str,
         switch (alg_id) {
         case UCC_CL_HIER_BCAST_ALG_2STEP:
             *init = ucc_cl_hier_bcast_2step_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    case UCC_COLL_TYPE_REDUCE:
+        switch (alg_id) {
+        case UCC_CL_HIER_REDUCE_ALG_2STEP:
+            *init = ucc_cl_hier_reduce_2step_init;
             break;
         default:
             status = UCC_ERR_INVALID_PARAM;

--- a/src/components/cl/hier/cl_hier_coll.h
+++ b/src/components/cl/hier/cl_hier_coll.h
@@ -13,8 +13,9 @@
 #include "alltoallv/alltoallv.h"
 #include "alltoall/alltoall.h"
 #include "barrier/barrier.h"
+#include "bcast/bcast.h"
 
-#define UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR 1
+#define UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR 2
 
 extern const char
     *ucc_cl_hier_default_alg_select_str[UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR];

--- a/src/components/cl/hier/cl_hier_coll.h
+++ b/src/components/cl/hier/cl_hier_coll.h
@@ -14,8 +14,9 @@
 #include "alltoall/alltoall.h"
 #include "barrier/barrier.h"
 #include "bcast/bcast.h"
+#include "reduce/reduce.h"
 
-#define UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR 2
+#define UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR 3
 
 extern const char
     *ucc_cl_hier_default_alg_select_str[UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR];

--- a/src/components/cl/hier/reduce/reduce.c
+++ b/src/components/cl/hier/reduce/reduce.c
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "reduce.h"
+#include "../reduce/reduce.h"
+
+ucc_base_coll_alg_info_t
+    ucc_cl_hier_reduce_algs[UCC_CL_HIER_REDUCE_ALG_LAST + 1] = {
+        [UCC_CL_HIER_REDUCE_ALG_2STEP] =
+            {.id   = UCC_CL_HIER_REDUCE_ALG_2STEP,
+             .name = "2step",
+             .desc = "intra-node and inter-node reduces executed in parallel"},
+        [UCC_CL_HIER_REDUCE_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};

--- a/src/components/cl/hier/reduce/reduce.h
+++ b/src/components/cl/hier/reduce/reduce.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef REDUCE_H_
+#define REDUCE_H_
+#include "../cl_hier.h"
+
+enum
+{
+    UCC_CL_HIER_REDUCE_ALG_2STEP,
+    UCC_CL_HIER_REDUCE_ALG_SPLIT_RAIL,
+    UCC_CL_HIER_REDUCE_ALG_LAST,
+};
+
+extern ucc_base_coll_alg_info_t
+    ucc_cl_hier_reduce_algs[UCC_CL_HIER_REDUCE_ALG_LAST + 1];
+
+#define UCC_CL_HIER_REDUCE_DEFAULT_ALG_SELECT_STR "reduce:0-4k:@2step"
+
+ucc_status_t ucc_cl_hier_reduce_2step_init(ucc_base_coll_args_t *coll_args,
+                                          ucc_base_team_t      *team,
+                                          ucc_coll_task_t     **task);
+
+static inline int ucc_cl_hier_reduce_alg_from_str(const char *str)
+{
+    int i;
+
+    for (i = 0; i < UCC_CL_HIER_REDUCE_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_cl_hier_reduce_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
+
+#endif

--- a/src/components/cl/hier/reduce/reduce_2step.c
+++ b/src/components/cl/hier/reduce/reduce_2step.c
@@ -1,0 +1,311 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "reduce.h"
+#include "core/ucc_team.h"
+#include "../cl_hier_coll.h"
+
+#define MAX_AR_2STEP_TASKS 3
+
+static ucc_status_t ucc_cl_hier_reduce_2step_start(ucc_coll_task_t *task)
+{
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_reduce_2step_start", 0);
+    return ucc_schedule_start(task);
+}
+
+static ucc_status_t ucc_cl_hier_reduce_2step_finalize(ucc_coll_task_t *task)
+{
+    ucc_cl_hier_schedule_t *schedule = ucc_derived_of(task, ucc_cl_hier_schedule_t);
+    ucc_status_t    status;
+
+    UCC_CL_HIER_PROFILE_REQUEST_EVENT(task, "cl_hier_reduce_2step_finalize",
+                                      0);
+    status = ucc_schedule_finalize(task);
+    if (schedule->scratch) {
+        ucc_mc_free(schedule->scratch);
+    }
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}
+
+static ucc_status_t ucc_cl_hier_ar_2step_schedule_finalize(ucc_coll_task_t *task)
+{
+    ucc_cl_hier_schedule_t *schedule =
+        ucc_derived_of(task, ucc_cl_hier_schedule_t);
+    ucc_status_t status;
+
+    status = ucc_schedule_pipelined_finalize(&schedule->super.super.super);
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}
+
+static ucc_status_t
+ucc_cl_hier_reduce_2step_frag_setup(ucc_schedule_pipelined_t *schedule_p,
+                                     ucc_schedule_t *frag, int frag_num)
+{
+    ucc_cl_hier_team_t *cl_team =
+        ucc_derived_of(schedule_p->super.super.team, ucc_cl_hier_team_t);
+    ucc_coll_args_t *args    = &schedule_p->super.super.bargs.args;
+    size_t           dt_size = ucc_dt_size(args->src.info.datatype);
+    int              n_frags = schedule_p->super.n_tasks;
+    ucc_cl_hier_schedule_t * cl_schedule = ucc_derived_of(frag, ucc_cl_hier_schedule_t);
+    void             *scratch = cl_schedule->scratch ? cl_schedule->scratch->addr : NULL;
+    int root                        = args->root;
+    int rank                        = UCC_TL_TEAM_RANK(cl_team);
+    size_t    count = (rank == root) ? args->dst.info.count :
+        args->src.info.count;
+
+    size_t           frag_count, frag_offset;
+    ucc_coll_task_t *task;
+    int              i;
+
+    frag_count =
+        ucc_buffer_block_count(count, n_frags, frag_num);
+    frag_offset =
+        ucc_buffer_block_offset(count, n_frags, frag_num);
+
+    for (i = 0; i < frag->n_tasks; i++) {
+        task                             = frag->tasks[i];
+        task->bargs.args.src.info.count  = frag_count;
+        task->bargs.args.dst.info.count  = frag_count;
+        if (task->bargs.args.src.info.buffer != scratch) {
+            task->bargs.args.src.info.buffer =
+                PTR_OFFSET(args->src.info.buffer, frag_offset * dt_size);
+        }
+        if (task->bargs.args.dst.info.buffer != scratch) {
+            task->bargs.args.dst.info.buffer =
+                PTR_OFFSET(args->dst.info.buffer, frag_offset * dt_size);
+        }
+    }
+    return UCC_OK;
+}
+
+static inline ucc_rank_t
+find_root_net_rank(ucc_host_id_t root_host_id, ucc_cl_hier_team_t *cl_team)
+{
+    ucc_rank_t  net_rank  = UCC_RANK_INVALID;
+    ucc_sbgp_t *sbgp      = cl_team->sbgps[UCC_HIER_SBGP_NODE_LEADERS].sbgp;
+    ucc_team_t *core_team = cl_team->super.super.params.team;
+    ucc_rank_t  i, rank;
+
+    for (i = 0; i < sbgp->group_size; i++) {
+        rank = ucc_ep_map_eval(sbgp->map, i);
+        if (ucc_team_rank_host_id(rank, core_team) == root_host_id) {
+            net_rank = i;
+            break;
+        }
+    }
+    return net_rank;
+}
+
+static inline ucc_rank_t
+find_root_node_rank(ucc_rank_t root, ucc_cl_hier_team_t *cl_team)
+{
+    ucc_rank_t  node_rank  = UCC_RANK_INVALID;
+    ucc_sbgp_t *sbgp       = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp;
+    ucc_rank_t  i;
+
+    for (i = 0; i < sbgp->group_size; i++) {
+        if (ucc_ep_map_eval(sbgp->map, i) == root) {
+            node_rank = i;
+            break;
+        }
+    }
+    return node_rank;
+}
+
+static ucc_status_t
+ucc_cl_hier_reduce_2step_init_schedule(ucc_base_coll_args_t *coll_args,
+                                        ucc_base_team_t *     team,
+                                        ucc_schedule_t **sched_p, int n_frags)
+{
+    ucc_cl_hier_team_t *cl_team = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_team_t         *core_team = team->params.team;
+    ucc_coll_task_t    *tasks[2] = {NULL, NULL};
+    int root                        = coll_args->args.root;
+    int rank                        = UCC_TL_TEAM_RANK(cl_team);
+    int root_on_local_node          = ucc_team_ranks_on_same_node(root, rank, core_team);
+    ucc_base_coll_args_t args = *coll_args;
+    size_t    count = (rank == root) ? args.args.dst.info.count :
+        args.args.src.info.count;
+    ucc_cl_hier_schedule_t      *cl_schedule;
+    ucc_schedule_t      *schedule;
+    ucc_status_t         status;
+
+    int                  n_tasks, i, first_task;
+
+    n_tasks        = 0;
+    first_task     = 0;
+
+    if (root != rank) {
+        args.args.dst.info.count    = args.args.src.info.count;
+        args.args.dst.info.mem_type = args.args.src.info.mem_type;
+        args.args.dst.info.datatype = args.args.src.info.datatype;
+        args.args.mask &= (~UCC_COLL_ARGS_FLAG_IN_PLACE);
+    }
+
+    cl_schedule = ucc_cl_hier_get_schedule(cl_team);
+    if (ucc_unlikely(!cl_schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+    schedule = &cl_schedule->super.super;
+    status         = ucc_schedule_init(schedule, &args, team);
+    if (ucc_unlikely(UCC_OK != status)) {
+        goto out;
+    }
+
+    args.max_frag_count = ucc_buffer_block_count(count, n_frags, 0);
+
+    if (n_frags > 1) {
+        args.mask |= UCC_BASE_CARGS_MAX_FRAG_COUNT;
+    }
+
+
+    if (SBGP_ENABLED(cl_team, NODE)) {
+        args.args.root = root_on_local_node
+            ? find_root_node_rank(root, cl_team) : 0;
+
+        if (root != rank && SBGP_ENABLED(cl_team, NODE_LEADERS)) {
+            status = ucc_mc_alloc(&cl_schedule->scratch, args.max_frag_count,
+                                  args.args.src.info.mem_type);
+            if (ucc_unlikely(UCC_OK != status)) {
+                goto out;
+            }
+            args.args.dst.info.buffer = cl_schedule->scratch->addr;
+            if (root_on_local_node) {
+                first_task = 1;
+                args.args.src.info.buffer = cl_schedule->scratch->addr;
+            }
+        }
+        status =
+            ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+    }
+
+    if (SBGP_ENABLED(cl_team, NODE_LEADERS)) {
+        if (n_tasks == 1) {
+            if (root != rank) {
+                /* args.args.dst.info.buffer = cl_schedule->scratch->addr; */
+                args.args.src.info.buffer = root_on_local_node ?
+                    coll_args->args.src.info.buffer : cl_schedule->scratch->addr;
+            } else {
+                args.args.mask |= UCC_COLL_ARGS_FIELD_FLAGS;
+                args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+            }
+        }
+        args.args.root = find_root_net_rank(ucc_team_rank_host_id(root, core_team), cl_team);
+        status =
+            ucc_coll_init(SCORE_MAP(cl_team, NODE_LEADERS), &args, &tasks[n_tasks]);
+        if (ucc_unlikely(UCC_OK != status)) {
+            goto out;
+        }
+        n_tasks++;
+    }
+
+    ucc_task_subscribe_dep(&schedule->super, tasks[first_task], UCC_EVENT_SCHEDULE_STARTED);
+    ucc_schedule_add_task(schedule, tasks[first_task]);
+
+    if (n_tasks > 1) {
+        ucc_task_subscribe_dep(tasks[first_task],
+                               tasks[(first_task + 1) % 2], UCC_EVENT_COMPLETED);
+        ucc_schedule_add_task(schedule, tasks[(first_task + 1) % 2]);
+    }
+
+    schedule->super.post           = ucc_cl_hier_reduce_2step_start;
+    schedule->super.progress       = NULL;
+    schedule->super.finalize       = ucc_cl_hier_reduce_2step_finalize;
+    schedule->super.triggered_post = ucc_triggered_post;
+    *sched_p                       = schedule;
+    return UCC_OK;
+
+out:
+    for (i = 0; i < n_tasks; i++) {
+        tasks[i]->finalize(tasks[i]);
+    }
+    ucc_cl_hier_put_schedule(schedule);
+    return status;
+}
+
+static ucc_status_t ucc_cl_hier_reduce_2step_frag_init(
+    ucc_base_coll_args_t *coll_args, ucc_schedule_pipelined_t *sp,
+    ucc_base_team_t *team, ucc_schedule_t **frag_p)
+{
+    int          n_frags = sp->super.n_tasks;
+    ucc_status_t status;
+
+    status = ucc_cl_hier_reduce_2step_init_schedule(coll_args, team, frag_p,
+                                                     n_frags);
+    return status;
+}
+
+static ucc_status_t ucc_cl_hier_2step_reduce_start(ucc_coll_task_t *task)
+{
+    ucc_schedule_pipelined_t *schedule =
+        ucc_derived_of(task, ucc_schedule_pipelined_t);
+
+    cl_debug(task->team->context->lib,
+             "posting reduce_2step, count %zd, dt %s"
+             " pdepth %d, frags_total %d",
+             task->bargs.args.src.info.count,
+             ucc_datatype_str(task->bargs.args.src.info.datatype),
+             schedule->n_frags, schedule->super.n_tasks);
+
+    return ucc_schedule_pipelined_post(task);
+}
+
+UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_reduce_2step_init,
+                         (coll_args, team, task),
+                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+                         ucc_coll_task_t **task)
+{
+    ucc_cl_hier_team_t *cl_team   = ucc_derived_of(team, ucc_cl_hier_team_t);
+    ucc_cl_hier_lib_config_t *cfg = &UCC_CL_HIER_TEAM_LIB(cl_team)->cfg;
+    ucc_cl_hier_schedule_t *  schedule;
+    int                       n_frags, pipeline_depth;
+    ucc_status_t              status;
+
+    if (coll_args->args.op == UCC_OP_AVG) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    ucc_pipeline_nfrags_pdepth(&cfg->reduce_2step_pipeline,
+                               coll_args->args.src.info.count *
+                               ucc_dt_size(coll_args->args.src.info.datatype),
+                               &n_frags, &pipeline_depth);
+
+    if (n_frags == 1) {
+        return ucc_cl_hier_reduce_2step_init_schedule(
+            coll_args, team, (ucc_schedule_t **)task, n_frags);
+    }
+
+    schedule = ucc_cl_hier_get_schedule(cl_team);
+    if (ucc_unlikely(!schedule)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    status = ucc_schedule_pipelined_init(
+        coll_args, team, ucc_cl_hier_reduce_2step_frag_init,
+        ucc_cl_hier_reduce_2step_frag_setup, pipeline_depth, n_frags,
+        cfg->reduce_2step_pipeline.order, &schedule->super);
+
+    if (ucc_unlikely(status != UCC_OK)) {
+        cl_error(team->context->lib,
+                 "failed to init pipelined 2step ar schedule");
+        goto err_pipe_init;
+    }
+
+    schedule->super.super.super.post = ucc_cl_hier_2step_reduce_start;
+    schedule->super.super.super.triggered_post = ucc_triggered_post;
+    schedule->super.super.super.finalize = ucc_cl_hier_ar_2step_schedule_finalize;
+    *task                                = &schedule->super.super.super;
+    return UCC_OK;
+
+err_pipe_init:
+    ucc_cl_hier_put_schedule(&schedule->super.super);
+    return status;
+}

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -38,6 +38,20 @@
  */
 ucc_status_t ucc_tl_ucp_bcast_sag_knomial_start(ucc_coll_task_t *coll_task)
 {
+    ucc_schedule_t  *schedule = ucc_derived_of(coll_task, ucc_schedule_t);
+    ucc_coll_args_t *args     = &schedule->super.bargs.args;
+    ucc_coll_task_t *ag_task, *scatter_task;
+
+    scatter_task                             = schedule->tasks[0];
+    scatter_task->bargs.args.src.info.buffer = args->src.info.buffer;
+    scatter_task->bargs.args.dst.info.buffer = args->src.info.buffer;
+    scatter_task->bargs.args.src.info.count  = args->src.info.count;
+    scatter_task->bargs.args.dst.info.count  = args->src.info.count;
+
+    ag_task                             = schedule->tasks[1];
+    ag_task->bargs.args.dst.info.buffer = args->src.info.buffer;
+    ag_task->bargs.args.dst.info.count  = args->src.info.count;
+
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_bcast_sag_kn_start", 0);
     return ucc_schedule_start(coll_task);
 }

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -72,34 +72,10 @@ static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
-    {"ALLREDUCE_SRA_KN_FRAG_THRESH", "inf",
-     "Threshold to enable fragmentation and pipelining of SRA Knomial "
-     "allreduce alg",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_frag_thresh),
-     UCC_CONFIG_TYPE_MEMUNITS},
-
-    {"ALLREDUCE_SRA_KN_FRAG_SIZE", "inf",
-     "Maximum allowed fragment size of SRA knomial alg",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_frag_size),
-     UCC_CONFIG_TYPE_MEMUNITS},
-
-    {"ALLREDUCE_SRA_KN_N_FRAGS", "2",
-     "Number of fragments each allreduce is split into when SRA knomial alg is "
-     "used\n"
-     "The actual number of fragments can be larger if fragment size exceeds\n"
-     "ALLREDUCE_SRA_KN_FRAG_SIZE",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_n_frags),
-     UCC_CONFIG_TYPE_UINT},
-
-    {"ALLREDUCE_SRA_KN_PIPELINE_DEPTH", "2",
-     "Number of fragments simultaneously progressed by the SRA knomial alg",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_pipeline_depth),
-     UCC_CONFIG_TYPE_UINT},
-
-    {"ALLREDUCE_SRA_KN_PIPELINE_ORDER", "parallel",
-     "Type of pipelined schedule for SRA knomial alg (sequential/ordered/parallel)",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_pipeline_order),
-     UCC_CONFIG_TYPE_ENUM(ucc_pipeline_order_names)},
+    {"ALLREDUCE_SRA_KN_PIPELINE", "n",
+     "Pipelining settings for SRA Knomial allreduce algorithm",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_pipeline),
+     UCC_CONFIG_TYPE_PIPELINE_PARAMS},
 
     {"REDUCE_SCATTER_KN_RADIX", "4",
      "Radix of the knomial reduce-scatter algorithm",

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -42,30 +42,26 @@ typedef struct ucc_tl_ucp_iface {
 extern ucc_tl_ucp_iface_t ucc_tl_ucp;
 
 typedef struct ucc_tl_ucp_lib_config {
-    ucc_tl_lib_config_t  super;
-    uint32_t             kn_radix;
-    uint32_t             fanin_kn_radix;
-    uint32_t             fanout_kn_radix;
-    uint32_t             barrier_kn_radix;
-    uint32_t             allreduce_kn_radix;
-    uint32_t             allreduce_sra_kn_radix;
-    uint32_t             reduce_scatter_kn_radix;
-    uint32_t             allgather_kn_radix;
-    uint32_t             bcast_kn_radix;
-    uint32_t             bcast_sag_kn_radix;
-    uint32_t             reduce_kn_radix;
-    uint32_t             gather_kn_radix;
-    uint32_t             scatter_kn_radix;
-    uint32_t             alltoall_pairwise_num_posts;
-    uint32_t             alltoallv_pairwise_num_posts;
-    uint32_t             allreduce_sra_kn_n_frags;
-    uint32_t             allreduce_sra_kn_pipeline_depth;
-    ucc_pipeline_order_t allreduce_sra_kn_pipeline_order;
-    size_t               allreduce_sra_kn_frag_thresh;
-    size_t               allreduce_sra_kn_frag_size;
-    int                  reduce_avg_pre_op;
-    int                  reduce_scatter_ring_bidirectional;
-    int                  reduce_scatterv_ring_bidirectional;
+    ucc_tl_lib_config_t   super;
+    uint32_t              kn_radix;
+    uint32_t              fanin_kn_radix;
+    uint32_t              fanout_kn_radix;
+    uint32_t              barrier_kn_radix;
+    uint32_t              allreduce_kn_radix;
+    uint32_t              allreduce_sra_kn_radix;
+    uint32_t              reduce_scatter_kn_radix;
+    uint32_t              allgather_kn_radix;
+    uint32_t              bcast_kn_radix;
+    uint32_t              bcast_sag_kn_radix;
+    uint32_t              reduce_kn_radix;
+    uint32_t              gather_kn_radix;
+    uint32_t              scatter_kn_radix;
+    uint32_t              alltoall_pairwise_num_posts;
+    uint32_t              alltoallv_pairwise_num_posts;
+    ucc_pipeline_params_t allreduce_sra_kn_pipeline;
+    int                   reduce_avg_pre_op;
+    int                   reduce_scatter_ring_bidirectional;
+    int                   reduce_scatterv_ring_bidirectional;
 } ucc_tl_ucp_lib_config_t;
 
 typedef struct ucc_tl_ucp_context_config {

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -105,6 +105,11 @@ static inline ucc_rank_t ucc_get_ctx_rank(ucc_team_t *team, ucc_rank_t team_rank
     return ucc_ep_map_eval(team->ctx_map, team_rank);
 }
 
+static inline ucc_host_id_t ucc_team_rank_host_id(ucc_rank_t rank, ucc_team_t *team)
+{
+    return team->topo->topo->procs[ucc_get_ctx_rank(team, rank)].host_id;
+}
+
 static inline int ucc_team_ranks_on_same_node(ucc_rank_t rank1, ucc_rank_t rank2,
                                               ucc_team_t *team)
 {

--- a/src/schedule/ucc_schedule_pipelined.h
+++ b/src/schedule/ucc_schedule_pipelined.h
@@ -42,6 +42,28 @@ typedef enum {
     UCC_PIPELINE_LAST
 } ucc_pipeline_order_t;
 
+typedef struct ucc_pipeline_params {
+    size_t               threshold;
+    size_t               frag_size;
+    unsigned             n_frags;
+    unsigned             pdepth;
+    ucc_pipeline_order_t order;
+} ucc_pipeline_params_t;
+
+static inline void ucc_pipeline_nfrags_pdepth(ucc_pipeline_params_t *p,
+                                              size_t msgsize, int *n_frags,
+                                              int *pipeline_depth)
+{
+    int min_num_frags;
+
+    *n_frags = 1;
+    if (msgsize > p->threshold) {
+        min_num_frags = ucc_div_round_up(msgsize, p->frag_size);
+        *n_frags      = ucc_max(min_num_frags, p->n_frags);
+    }
+    *pipeline_depth = ucc_min(*n_frags, p->pdepth);
+}
+
 extern const char* ucc_pipeline_order_names[];
 typedef struct ucc_schedule_pipelined {
     ucc_schedule_t               super;

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -7,6 +7,9 @@
 #include "ucc_malloc.h"
 #include "ucc_log.h"
 #include "khash.h"
+#include "schedule/ucc_schedule.h"
+#include "schedule/ucc_schedule_pipelined.h"
+#include "utils/ucc_string.h"
 
 ucc_status_t ucc_config_names_array_merge(ucc_config_names_array_t *dst,
                                           const ucc_config_names_array_t *src)
@@ -374,4 +377,142 @@ void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
         ucs_config_parser_release_opts(opts, entry->table);
         ucc_free(opts);
     }
+}
+
+#define UCC_UUNITS_AUTO    ((unsigned)-2)
+
+static ucc_pipeline_params_t ucc_pipeline_params_auto = {
+    .threshold = 0,
+    .n_frags   = 0,
+    .frag_size = 0,
+    .pdepth    = 0,
+    .order     = 0
+};
+
+static ucc_pipeline_params_t ucc_pipeline_params_no = {
+    .threshold = SIZE_MAX,
+    .n_frags   = 0,
+    .frag_size = 0,
+    .pdepth    = 1,
+    .order     = 0
+};
+
+static ucc_pipeline_params_t ucc_pipeline_params_default = {
+    .threshold = SIZE_MAX,
+    .n_frags   = 2,
+    .frag_size = SIZE_MAX,
+    .pdepth    = 2,
+    .order     = UCC_PIPELINE_SEQUENTIAL
+};
+
+int ucc_pipeline_params_is_auto(const ucc_pipeline_params_t *p)
+{
+    return 0 == memcmp(p, &ucc_pipeline_params_auto, sizeof(*p));
+}
+
+int ucc_config_sscanf_pipeline_params(const char *buf, void *dest,
+                                      const void *arg)
+{
+    ucc_pipeline_params_t *p = dest;
+    ucc_status_t           status;
+    int                    i, n_tokens, order;
+    char **                tokens, **t2;
+
+    if (strlen(buf) == 0) {
+        return 0;
+    }
+
+    /* Special value: auto */
+    if (!strcasecmp(buf, UCS_VALUE_AUTO_STR)) {
+        *p = ucc_pipeline_params_auto;
+        return 1;
+    }
+
+    if (!strcasecmp(buf, "n")) {
+        *p = ucc_pipeline_params_no;
+        return 1;
+    }
+
+    *p     = ucc_pipeline_params_default;
+    tokens = ucc_str_split(buf, ":");
+    if (!tokens) {
+        return 0;
+    }
+    n_tokens = ucc_str_split_count(tokens);
+
+    for (i = 0; i < n_tokens; i++) {
+        if ((order = ucs_string_find_in_list(
+                 tokens[i], ucc_pipeline_order_names, 0)) >= 0) {
+            p->order = (ucc_pipeline_order_t)order;
+            continue;
+        }
+        t2 = ucc_str_split(tokens[i], "=");
+        if (!t2) {
+            goto out;
+        }
+        if (ucc_str_split_count(t2) != 2) {
+            goto out;
+        }
+        if (0 == strcmp(t2[0], "thresh")) {
+            status = ucc_str_to_memunits(t2[1], &p->threshold);
+            if (UCC_OK != status) {
+                goto out;
+            }
+        } else if (0 == strcmp(t2[0], "fragsize")) {
+            status = ucc_str_to_memunits(t2[1], &p->frag_size);
+            if (UCC_OK != status) {
+                goto out;
+            }
+        } else if (0 == strcmp(t2[0], "nfrags")) {
+            status = ucc_str_is_number(t2[1]);
+            if (UCC_OK != status) {
+                goto out;
+            }
+            p->n_frags = atoi(t2[1]);
+        } else if (0 == strcmp(t2[0], "pdepth")) {
+            status = ucc_str_is_number(t2[1]);
+            if (UCC_OK != status) {
+                goto out;
+            }
+            p->pdepth = atoi(t2[1]);
+        }
+        ucc_str_split_free(t2);
+    }
+    return 1;
+out:
+    if (t2) {
+        ucc_str_split_free(t2);
+    }
+    ucc_str_split_free(tokens);
+    return 0;
+}
+
+int ucc_config_sprintf_pipeline_params(char *buf, size_t max, const void *src,
+                                       const void *arg)
+{
+    const ucc_pipeline_params_t *p = src;
+    char                         thresh[32], frag_size[32];
+
+    if (ucc_pipeline_params_is_auto(p)) {
+        return snprintf(buf, max, "auto");
+    }
+    if (!memcmp(p, &ucc_pipeline_params_no, sizeof(*p))) {
+        return snprintf(buf, max, "n");
+    }
+    return snprintf(
+        buf, max, "thresh=%s:nfrags=%d:fragsize=%s:pdepth=%d:order=%s",
+        ucs_memunits_to_str(p->threshold, thresh, sizeof(thresh)), p->n_frags,
+        ucs_memunits_to_str(p->frag_size, frag_size, sizeof(frag_size)),
+        p->pdepth, ucc_pipeline_order_names[p->order]);
+}
+
+ucs_status_t ucc_config_clone_pipeline_params(const void *src, void *dest,
+                                              const void *arg)
+{
+    memcpy(dest, src, sizeof(ucc_pipeline_params_t));
+    return UCS_OK;
+}
+
+void ucc_config_release_pipeline_params(void *ptr, const void *arg)
+{
 }

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -148,4 +148,28 @@ ucc_status_t ucc_parse_file_config(const char *        filename,
                                    ucc_file_config_t **cfg);
 void         ucc_release_file_config(ucc_file_config_t *cfg);
 
+typedef struct ucc_pipeline_params ucc_pipeline_params_t;
+
+int ucc_pipeline_params_is_auto(const ucc_pipeline_params_t *p);
+
+int ucc_config_sscanf_pipeline_params(const char *buf, void *dest,
+                                      const void *arg);
+
+int ucc_config_sprintf_pipeline_params(char *buf, size_t max, const void *src,
+                                       const void *arg);
+
+ucs_status_t ucc_config_clone_pipeline_params(const void *src, void *dest,
+                                              const void *arg);
+
+void ucc_config_release_pipeline_params(void *ptr, const void *arg);
+
+#define UCC_CONFIG_TYPE_PIPELINE_PARAMS                                        \
+    {                                                                          \
+        ucc_config_sscanf_pipeline_params, ucc_config_sprintf_pipeline_params, \
+            ucc_config_clone_pipeline_params,                                  \
+            ucc_config_release_pipeline_params, ucs_config_help_generic,       \
+            "thresh=<memunit>:fragsize=<memunit>:nfrags="                      \
+            "<uint>:pdepth=<uint>:<ordered/parallel/serial>"                   \
+    }
+
 #endif


### PR DESCRIPTION
## What
Adds 2 lvl pipelined reduce algorithm to CL/HIER

Perf improvement. Example on 32nodes, ppn=56.

UCC master   (tl/ucp) | UCC new (cl/hier, shm+ucp) | UCC new (cl/hier, shm+ucp) +   REDUCE_KN_RADIX=8
-- | -- | --
10.64 | 10.15 | 8.34
10.18 | 9.63 | 9.87
10.98 | 10.57 | 9.28
11.27 | 10.49 | 8.45
69.87 | 11.08 | 9.26
11.86 | 11.51 | 9.96
14.98 | 50.65 | 18.77
16.34 | 13.47 | 14
19.4 | 15.01 | 12.97
22.9 | 16.88 | 15.29
31.99 | 26.22 | 24.42



