### PR TITLE
TL/CUDA: fixes hang on sync_state

### DIFF
--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -85,8 +85,8 @@ ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
 
 static inline ucc_status_t ucc_tl_cuda_get_sync(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t       *team  = TASK_TEAM(task);
-    ucc_tl_cuda_sync_state_t *state = &team->sync_state[task->coll_id];
+    ucc_tl_cuda_team_t                *team  = TASK_TEAM(task);
+    volatile ucc_tl_cuda_sync_state_t *state = &team->sync_state[task->coll_id];
 
     if ((UCC_TL_TEAM_RANK(team) == 0) && (*state == 0)) {
         *state = task->seq_num;


### PR DESCRIPTION
## What
Fixes #622  

## Why ?
The hang is caused by the function ucc_tl_cuda_get_sync. It checks the value state which is located in shared memory. For ranks != 0 compiler optimizes it out: it loads the value once and stores into register. If *state != seq_num it is never checked (re-loaded) again, because compiler thinks that it is never updated (only rank 0 will update it). And the ucc_tl_cuda_get_sync fn is inlined, so register value of *state is never reloaded.

The test would work if rank 0 is fast enough and the *state contains updated seq_num when rank 1 enters.


## How ?
Declare variable as "volatile" to avoid compiler optimization.
