### PR TITLE
CORE: Add flags to enable various optimizations

### DIFF
--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1680,12 +1680,21 @@ typedef enum {
                                                             Note, the status is not guaranteed
                                                             to be global on all the processes
                                                             participating in the collective.*/
-    UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS   = UCC_BIT(7)  /*!< If set, both src
+    UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS   = UCC_BIT(7), /*!< If set, both src
                                                             and dst buffers
                                                             reside in a memory
                                                             mapped region.
                                                             Useful for one-sided
                                                             collectives. */
+    UCC_COLL_ARGS_FLAG_OPTMIZE_OVERLAP_CPU  = UCC_BIT(8), /*!< Hint for the UCC library, if flag is set
+                                                            library should select algorithm implementation
+                                                            optimized for best overlap for CPU resources. */
+    UCC_COLL_ARGS_FLAG_OPTMIZE_OVERLAP_GPU  = UCC_BIT(9), /*!< Hint for the UCC library, if flag is set
+                                                            library should select algorithm implementation
+                                                            optimized for best overlap for GPU resources. */
+    UCC_COLL_ARGS_FLAG_OPTIMIZE_LATENCY     = UCC_BIT(10) /*!< Hint for the UCC library, if flag is set
+                                                            library should select algorithm implementation
+                                                            optimized for best latency. */
 } ucc_coll_args_flags_t;
 
 /**


### PR DESCRIPTION
CORE: Add two flags to enable optimizations based on overlap and latency needs

Signed-off-by: Geoffroy Vallee <geoffroy.vallee@gmail.com>

## What
The PR adds new flags so we can provide run-time hints about the type of optimizations are required by the users.

## Why ?
There is a need to let users specify the type of optimizations that may be beneficial for applications, e.g. when libraries and applications want to benefit from DPU offloading. An example is a library that uses non-blocking collectives and big messages, for which a specific algorithm has showed concrete benefits; and an application's code that uses the blocking version of the collectives with small messages.
While the current selection mechanism proved a great level of flexibility, it is not possible to select different algorithms that would result in optimized implementations for the blocking and non-blocking collectives as described in the above example.
The addition of the proposed flags would, we think, enable the specification of new selection policies that would match our current requirements but also be flexible enough to cover all the needs in a foreseeable future.

## How ?
N/A
