### PR TITLE
BUILD: fixes ec/cuda build on rhel7.2

### DIFF
--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -17,6 +17,10 @@
 #include <assert.h>
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX ((size_t) -1)
+#endif
+
 #define ucc_offsetof      ucs_offsetof
 #define ucc_container_of  ucs_container_of
 #define ucc_derived_of    ucs_derived_of


### PR DESCRIPTION
## What
Fixes ec/cuda kernels build on rhel 7.2
```
[root@sharp-ci-01 kernel]# /hpc/local/oss/cuda11.7/bin/nvcc  -c /workspace/ucc_private/src/components/ec/cuda/kernel/ec_cuda_wait_kernel.cu -I/tmp/ucx_build/install/include/ -O3 -g -DNDEBUG -I/tmp/ucc_build -I/workspace/ucc_private/src
 -I/tmp/ucc_build/src --compiler-options -fno-rtti,-fno-exceptions -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_61,code=compute_61 -gencode=arch=compu
te_70,code=sm_70 -gencode=arch=compute_70,code=compute_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_80,code=compute_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_86,cod
e=compute_86 -Xcompiler -fPIC -o ./.libs/ec_cuda_wait_kernel.o
/workspace/ucc_private/src/core/ucc_dt.h(67): error: identifier "SIZE_MAX" is undefined

```
## Why ?
on old glibc version g++ might not take all the correct definitions from stdint.h (which is C header). Because of that nvcc that builds ec/cuda kernels can fail to compile, since SIZE_MAX is not defined. (included from ucc_dt.h).

## How ?
define SIZE_MAX if not defined
