### PR TITLE
EC/CUDA: fix finalize

### DIFF
--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -486,6 +486,7 @@ static ucc_status_t ucc_ec_cuda_finalize()
     ucc_mpool_cleanup(&ucc_ec_cuda.events, 1);
     ucc_mpool_cleanup(&ucc_ec_cuda.strm_reqs, 1);
     ucc_mpool_cleanup(&ucc_ec_cuda.executors, 1);
+    ucc_mpool_cleanup(&ucc_ec_cuda.executor_interruptible_tasks, 1);
     ucc_free(ucc_ec_cuda.exec_streams);
 
     return UCC_OK;

--- a/src/components/ec/ucc_ec.c
+++ b/src/components/ec/ucc_ec.c
@@ -102,7 +102,7 @@ ucc_status_t ucc_ec_finalize()
     ucc_ee_type_t  et;
     ucc_ec_base_t *ec;
 
-    for (et = UCC_EE_CPU_THREAD; et < UCC_EE_LAST; et++) {
+    for (et = UCC_EE_FIRST; et < UCC_EE_LAST; et++) {
         if (NULL != ec_ops[et]) {
             ec = ucc_container_of(ec_ops[et], ucc_ec_base_t, ops);
             ec->ref_cnt--;

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1957,7 +1957,8 @@ typedef enum ucc_event_type {
  *
  */
 typedef enum ucc_ee_type {
-    UCC_EE_CUDA_STREAM = 0,
+    UCC_EE_FIRST = 0,
+    UCC_EE_CUDA_STREAM = UCC_EE_FIRST,
     UCC_EE_CPU_THREAD,
     UCC_EE_ROCM_STREAM,
     UCC_EE_LAST,


### PR DESCRIPTION
## What
Fixes EC CUDA finalize
* EC CUDA destructor is not called
* interruptible executor tasks mpool is not freed