### PR TITLE
Ucc tuning file

### DIFF
--- a/.ci/scripts/run_dlrm.sh
+++ b/.ci/scripts/run_dlrm.sh
@@ -60,4 +60,5 @@ mpirun \
     -x LD_LIBRARY_PATH \
     -x MASTER_ADDR \
     -x CPU_GPU_MODE \
+    -x UCC_CLS=basic -x UCC_CL_BASIC_TLS=nccl,ucp \
     /opt/nvidia/src/ucc/.ci/scripts/run_dlrm_s_pytorch.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,4 +43,7 @@ docs/doxygen/doxygen-doc/ucc.tag: $(doxygen_doc_files) doxygen-doc
 .dot.pdf:
 	dot -T pdf -o $@ $<
 
+sharedir=$(prefix)/share
+dist_share_DATA=contrib/ucc.conf
+
 MOSTLYCLEANFILES = $(DX_CLEANFILES) $(DOT_CLEANFILES)

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,4 @@ docs/doxygen/doxygen-doc/ucc.tag: $(doxygen_doc_files) doxygen-doc
 .dot.pdf:
 	dot -T pdf -o $@ $<
 
-sharedir=$(prefix)/share
-dist_share_DATA=contrib/ucc.conf
-
 MOSTLYCLEANFILES = $(DX_CLEANFILES) $(DOT_CLEANFILES)

--- a/contrib/ucc.conf
+++ b/contrib/ucc.conf
@@ -1,0 +1,42 @@
+# Default TLS configuration
+# We mostly use "negate" interface so that default TL config
+# never throws warnings if some TLs are not available
+
+# Currently compiled tls: ucp,cuda,nccl,shm,sharp
+
+# Default for CL_BASIC: all except sharp,nccl.
+# shm/cuda will silently disqualify themself for multinode teams
+# but will be used on a single node
+UCC_CL_BASIC_TLS=^sharp,nccl
+
+# Defaults for CL_HIER: set per SBGP
+# Sharp should be explicitly enabled
+UCC_CL_HIER_NODE_SBGP_TLS=^sharp,nccl
+
+# shm,cuda are also disabled for NODE_LEADERS and NET
+UCC_CL_HIER_NODE_LEADERS_SBGP_TLS=^sharp,nccl,shm,cuda
+UCC_CL_HIER_NET_SBGP_TLS=^sharp,nccl,shm,cuda
+
+# FULL_SBGP is currently only used for hierarchical alltoall
+# with ucp sbgp on top
+UCC_CL_HIER_FULL_SBGP_TLS=ucp
+
+[vendor=intel model=broadwell team_size=28 ppn=28 nnodes=1]
+UCC_TL_UCP_ALLREDUCE_KN_RADIX=2
+UCC_TL_UCP_ALLREDUCE_SRA_KN_RADIX=7
+UCC_TL_UCP_TUNE=allreduce:0-4k:@0#allreduce:4k-inf:@1
+
+[vendor=intel model=broadwell team_size=2 ppn=1 nnodes=2]
+UCC_TL_UCP_ALLREDUCE_KN_RADIX=2
+UCC_TL_UCP_ALLREDUCE_SRA_KN_RADIX=2
+UCC_TL_UCP_TUNE=allreduce:0-128k:@0#allreduce:128k-inf:@1
+
+[vendor=intel model=broadwell team_size=4 ppn=1 nnodes=4]
+UCC_TL_UCP_ALLREDUCE_KN_RADIX=4
+UCC_TL_UCP_ALLREDUCE_SRA_KN_RADIX=4
+UCC_TL_UCP_TUNE=allreduce:0-16k:@0#allreduce:16k-inf:@1
+
+[vendor=intel model=broadwell team_size=8 ppn=1 nnodes=8]
+UCC_TL_UCP_ALLREDUCE_KN_RADIX=8
+UCC_TL_UCP_ALLREDUCE_SRA_KN_RADIX=8
+UCC_TL_UCP_TUNE=allreduce:0-4k:@0#allreduce:4k-inf:@1

--- a/contrib/ucc.conf
+++ b/contrib/ucc.conf
@@ -2,10 +2,10 @@
 # We mostly use "negate" interface so that default TL config
 # never throws warnings if some TLs are not available
 
-# Currently compiled tls: ucp,cuda,nccl,shm,sharp
+# Currently compiled tls: ucp,cuda,nccl,sharp
 
 # Default for CL_BASIC: all except sharp,nccl.
-# shm/cuda will silently disqualify themself for multinode teams
+# cuda will silently disqualify itself for multinode teams
 # but will be used on a single node
 UCC_CL_BASIC_TLS=^sharp,nccl
 
@@ -13,9 +13,9 @@ UCC_CL_BASIC_TLS=^sharp,nccl
 # Sharp should be explicitly enabled
 UCC_CL_HIER_NODE_SBGP_TLS=^sharp,nccl
 
-# shm,cuda are also disabled for NODE_LEADERS and NET
-UCC_CL_HIER_NODE_LEADERS_SBGP_TLS=^sharp,nccl,shm,cuda
-UCC_CL_HIER_NET_SBGP_TLS=^sharp,nccl,shm,cuda
+# cuda is also disabled for NODE_LEADERS and NET
+UCC_CL_HIER_NODE_LEADERS_SBGP_TLS=^sharp,nccl,cuda
+UCC_CL_HIER_NET_SBGP_TLS=^sharp,nccl,cuda
 
 # FULL_SBGP is currently only used for hierarchical alltoall
 # with ucp sbgp on top

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,6 +64,7 @@ noinst_HEADERS =                      \
 	utils/ucc_queue.h                 \
 	utils/ucc_proc_info.h             \
 	utils/khash.h                     \
+	utils/ini.h                       \
 	utils/ucc_spinlock.h              \
 	utils/ucc_mpool.h                 \
 	utils/ucc_rcache.h                \
@@ -107,6 +108,7 @@ libucc_la_SOURCES =                   \
 	schedule/ucc_schedule_pipelined.c \
 	coll_score/ucc_coll_score.c       \
 	coll_score/ucc_coll_score_map.c   \
+	utils/ini.c                       \
 	utils/ucc_component.c             \
 	utils/ucc_status.c                \
 	utils/ucc_mpool.c                 \

--- a/src/components/base/ucc_base_iface.c
+++ b/src/components/base/ucc_base_iface.c
@@ -16,6 +16,10 @@ ucc_config_field_t ucc_base_lib_config_table[] = {
      "poll.",
      ucc_offsetof(ucc_base_lib_config_t, log_component), UCC_CONFIG_TYPE_LOG_COMP},
 
+    {"USE_TUNING", "y",
+     "Use perf tuning",
+     ucc_offsetof(ucc_base_lib_config_t, use_tuning), UCC_CONFIG_TYPE_BOOL},
+
     {NULL}};
 
 ucc_config_field_t ucc_base_ctx_config_table[] = {

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -24,6 +24,7 @@ typedef struct ucc_coll_task ucc_coll_task_t;
 
 typedef struct ucc_base_lib {
     ucc_log_component_config_t log_component;
+    int                        use_tuning;
 } ucc_base_lib_t;
 
 typedef struct ucc_base_config {
@@ -33,6 +34,7 @@ typedef struct ucc_base_config {
 typedef struct ucc_base_lib_config {
     ucc_base_config_t               super;
     ucc_log_component_config_t      log_component;
+    int                             use_tuning;
 } ucc_base_lib_config_t;
 
 typedef struct ucc_base_ctx_config {

--- a/src/components/cl/ucc_cl.c
+++ b/src/components/cl/ucc_cl.c
@@ -42,7 +42,8 @@ UCC_CLASS_INIT_FUNC(ucc_cl_lib_t, ucc_cl_iface_t *cl_iface,
     ucc_status_t status;
 
     UCC_CLASS_CALL_BASE_INIT();
-    self->iface         = cl_iface;
+    self->iface               = cl_iface;
+    self->super.use_tuning    = cl_config->super.use_tuning;
     self->super.log_component = cl_config->super.log_component;
     ucc_strncpy_safe(self->super.log_component.name,
                      cl_iface->cl_lib_config.name,

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -25,7 +25,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_lib_t, ucc_tl_iface_t *tl_iface,
                     const ucc_tl_lib_config_t *tl_config)
 {
     UCC_CLASS_CALL_BASE_INIT();
-    self->iface         = tl_iface;
+    self->iface               = tl_iface;
+    self->super.use_tuning    = tl_config->super.use_tuning;
     self->super.log_component = tl_config->super.log_component;
     ucc_strncpy_safe(self->super.log_component.name,
                      tl_iface->tl_lib_config.name,

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -23,7 +23,7 @@ void ucc_tl_ucp_allreduce_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t     *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_coll_args_t       *args = &TASK_ARGS(task);
     ucc_tl_ucp_team_t     *team = TASK_TEAM(task);
-    int                    avg_pre_op = UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
+    int                    avg_pre_op = team->cfg.reduce_avg_pre_op;
     ucc_kn_radix_t         radix      = task->allreduce_kn.p.radix;
     uint8_t                node_type  = task->allreduce_kn.p.node_type;
     ucc_knomial_pattern_t *p          = &task->allreduce_kn.p;
@@ -195,8 +195,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
                (TASK_ARGS(task).src.info.mem_type ==
                TASK_ARGS(task).dst.info.mem_type));
     ucc_knomial_pattern_init(size, rank,
-                             ucc_min(UCC_TL_UCP_TEAM_LIB(team)->
-                                     cfg.allreduce_kn_radix, size),
+                             ucc_min(team->cfg.allreduce_kn_radix, size),
                              &task->allreduce_kn.p);
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
     status =
@@ -209,12 +208,12 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
 
 ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
 {
+    ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
     size_t             count     = TASK_ARGS(task).dst.info.count;
     ucc_datatype_t     dt        = TASK_ARGS(task).dst.info.datatype;
     size_t             data_size = count * ucc_dt_size(dt);
     ucc_rank_t         size      = (ucc_rank_t)task->subset.map.ep_num;
-    ucc_kn_radix_t     radix =
-        ucc_min(TASK_LIB(task)->cfg.allreduce_kn_radix, size);
+    ucc_kn_radix_t     radix     = ucc_min(team->cfg.allreduce_kn_radix, size);
     ucc_status_t       status;
 
     task->super.flags    |= UCC_COLL_TASK_FLAG_EXECUTOR;

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -102,7 +102,7 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
     if (ucc_unlikely(UCC_OK != status)) {
         return status;
     }
-    cfg_radix = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_radix;
+    cfg_radix = tl_team->cfg.allreduce_sra_kn_radix;
     radix = ucc_knomial_pattern_get_min_radix(cfg_radix,
                                               UCC_TL_TEAM_SIZE(tl_team), count);
 
@@ -159,12 +159,13 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
                                       ucc_coll_task_t     **task_h)
 {
     ucc_tl_ucp_team_t        *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_tl_ucp_lib_config_t  *cfg     = &UCC_TL_UCP_TEAM_LIB(tl_team)->cfg;
+    ucc_tl_ucp_lib_config_t  *cfg     = &tl_team->cfg;
     int                       n_frags, pipeline_depth;
     ucc_schedule_pipelined_t *schedule_p;
     ucc_status_t         status;
     ucc_base_coll_args_t bargs;
     size_t               max_frag_count, dt_size;
+    printf("in allreduce sra\n");
 
     dt_size = ucc_dt_size(coll_args->args.dst.info.datatype);
     status  = ucc_tl_ucp_get_schedule(tl_team, coll_args,

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -165,7 +165,6 @@ ucc_tl_ucp_allreduce_sra_knomial_init(ucc_base_coll_args_t *coll_args,
     ucc_status_t         status;
     ucc_base_coll_args_t bargs;
     size_t               max_frag_count, dt_size;
-    printf("in allreduce sra\n");
 
     dt_size = ucc_dt_size(coll_args->args.dst.info.datatype);
     status  = ucc_tl_ucp_get_schedule(tl_team, coll_args,

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -139,6 +139,10 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_scatterv_ring_bidirectional),
      UCC_CONFIG_TYPE_BOOL},
 
+    {"USE_TOPO", "try", "allow usage of tl ucp topo",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, use_topo),
+     UCC_CONFIG_TYPE_TERNARY},
+
     {NULL}};
 
 static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -29,7 +29,7 @@ ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib,
 ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
                                          ucc_base_ctx_attr_t      *base_attr);
 
-static ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
+ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_ucp_lib_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)},
 

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -10,6 +10,7 @@
 #include "components/tl/ucc_tl_log.h"
 #include "core/ucc_ee.h"
 #include "utils/ucc_mpool.h"
+#include "utils/arch/cpu.h"
 #include "tl_ucp_ep_hash.h"
 #include "schedule/ucc_schedule_pipelined.h"
 #include <ucp/api/ucp.h>
@@ -40,6 +41,34 @@ typedef struct ucc_tl_ucp_iface {
 } ucc_tl_ucp_iface_t;
 /* Extern iface should follow the pattern: ucc_tl_<tl_name> */
 extern ucc_tl_ucp_iface_t ucc_tl_ucp;
+
+typedef struct ucc_cfg_team_size_range {
+	ucc_rank_t begin;
+	ucc_rank_t end;
+} ucc_cfg_team_size_range_t;
+
+typedef struct ucc_cfg_ppn_range {
+	ucc_rank_t begin;
+	ucc_rank_t end;
+} ucc_cfg_ppn_range_t;
+
+typedef struct ucc_cfg_data_size_range {
+	size_t begin;
+	size_t end;
+} ucc_cfg_data_size_range_t;
+
+//typedef struct ucc_cfg_section_param {
+//    const char *name;
+//    const char *value;
+//} ucc_cfg_section_param_t;
+//
+//typedef struct ucc_cfg_section {
+//    ucc_cpu_vendor_t          vendor;
+//    ucc_cpu_model_t           model;
+//    ucc_cfg_team_size_range_t team_sizes;
+//    ucc_cfg_ppn_range_t       ppns;
+//    ucc_cfg_section_param_t  *params;
+//} ucc_cfg_section_t;
 
 typedef struct ucc_tl_ucp_lib_config {
     ucc_tl_lib_config_t   super;
@@ -75,6 +104,8 @@ typedef struct ucc_tl_ucp_context_config {
     uint32_t                service_worker;
     uint32_t                service_throttling_thresh;
 } ucc_tl_ucp_context_config_t;
+
+typedef ucc_tl_ucp_lib_config_t ucc_tl_ucp_team_config_t;
 
 typedef struct ucc_tl_ucp_lib {
     ucc_tl_lib_t            super;
@@ -125,9 +156,12 @@ typedef struct ucc_tl_ucp_team {
     void *                     va_base[MAX_NR_SEGMENTS];
     size_t                     base_length[MAX_NR_SEGMENTS];
     ucc_tl_ucp_worker_t *      worker;
+    ucc_tl_ucp_team_config_t   cfg;
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
+
+extern ucc_config_field_t ucc_tl_ucp_lib_config_table[];
 
 #define UCC_TL_UCP_SUPPORTED_COLLS                                             \
     (UCC_COLL_TYPE_ALLGATHER |                                                 \

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -157,6 +157,7 @@ typedef struct ucc_tl_ucp_team {
     size_t                     base_length[MAX_NR_SEGMENTS];
     ucc_tl_ucp_worker_t *      worker;
     ucc_tl_ucp_team_config_t   cfg;
+    const char *               tuning_str;
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -546,6 +546,7 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
 {
     ucc_tl_ucp_context_t *ctx = ucc_derived_of(context, ucc_tl_ucp_context_t);
     uint64_t *            offset = (uint64_t *)attr->attr.ctx_addr;
+    ucc_tl_ucp_lib_t     *lib = ucc_derived_of(context->lib, ucc_tl_ucp_lib_t);
     ucs_status_t          ucs_status;
     size_t                packed_length;
     int                   i;
@@ -611,10 +612,15 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
         attr->attr.global_work_buffer_size =
             ONESIDED_SYNC_SIZE + ONESIDED_REDUCE_SIZE;
     }
-    attr->topo_required = 0;
-    if (ucc_global_config.file_cfg &&
-        ucc_global_config.file_cfg->has_tuning_sections) {
-        attr->topo_required = 1;
+    if (lib->cfg.use_topo == UCC_TRY) {
+        if (context->ucc_context->params.mask & UCC_CONTEXT_PARAM_FIELD_OOB) {
+            attr->topo_required = 1;
+        } else {
+            attr->topo_required = 0;
+        }
+    } else {
+        attr->topo_required = (lib->cfg.use_topo) ? 1 : 0;
     }
+    ctx->topo_required = attr->topo_required;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -611,6 +611,10 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
         attr->attr.global_work_buffer_size =
             ONESIDED_SYNC_SIZE + ONESIDED_REDUCE_SIZE;
     }
-    attr->topo_required = 1; //0, always 1 or add flag?
+    attr->topo_required = 0;
+    if (ucc_global_config.file_cfg &&
+        ucc_global_config.file_cfg->has_tuning_sections) {
+        attr->topo_required = 1;
+    }
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -611,6 +611,6 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
         attr->attr.global_work_buffer_size =
             ONESIDED_SYNC_SIZE + ONESIDED_REDUCE_SIZE;
     }
-    attr->topo_required = 0;
+    attr->topo_required = 1; //0, always 1 or add flag?
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -612,15 +612,10 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
         attr->attr.global_work_buffer_size =
             ONESIDED_SYNC_SIZE + ONESIDED_REDUCE_SIZE;
     }
-    if (lib->cfg.use_topo == UCC_TRY) {
-        if (context->ucc_context->params.mask & UCC_CONTEXT_PARAM_FIELD_OOB) {
-            attr->topo_required = 1;
-        } else {
-            attr->topo_required = 0;
-        }
-    } else {
-        attr->topo_required = (lib->cfg.use_topo) ? 1 : 0;
-    }
-    ctx->topo_required = attr->topo_required;
+    attr->topo_required =
+        (((lib->cfg.use_topo == UCC_TRY || lib->cfg.use_topo == UCC_AUTO) &&
+          (context->ucc_context->params.mask & UCC_CONTEXT_PARAM_FIELD_OOB)) ||
+        lib->cfg.use_topo == UCC_YES) ? 1 : 0;
+    ctx->topo_required = attr->topo_required; // needed to be reached by team
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -76,11 +76,10 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
 
     if (ucc_global_config.file_cfg && !IS_SERVICE_TEAM(self) &&
         ctx->topo_required && tl_context->lib->use_tuning) {
-        status = ucc_add_team_sections(ucc_global_config.file_cfg, &self->cfg,
-                                       ucc_tl_ucp_lib_config_table, self->topo,
-                                       &self->tuning_str, "UCC_TL_UCP_TUNE",
-                                       ucc_tl_ucp.super.tl_lib_config.prefix,
-                                       UCC_TL_TEAM_SIZE(self));
+        status = ucc_add_team_sections(&self->cfg, ucc_tl_ucp_lib_config_table,
+                                       self->topo, &self->tuning_str,
+                                       "UCC_TL_UCP_TUNE",
+                                       ucc_tl_ucp.super.tl_lib_config.prefix);
         if (status != UCC_OK) {
             ucc_debug("section not found");
         }

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -79,6 +79,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
         status = ucc_add_team_sections(&self->cfg, ucc_tl_ucp_lib_config_table,
                                        self->topo, &self->tuning_str,
                                        "UCC_TL_UCP_TUNE",
+                                       UCC_TL_CORE_CTX(self)->lib->full_prefix,
                                        ucc_tl_ucp.super.tl_lib_config.prefix);
         if (status != UCC_OK) {
             ucc_debug("section not found");

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -64,18 +64,14 @@ static inline int ucc_parse_section_name(const char* name,
     ucc_rank_t team_size_end = team_size_begin;
     if (ucc_str_split(team_size_range, "-")[1]) {
         team_size_end = (size_t) atoi(ucc_str_split(team_size_range, "-")[1]);
-        printf("inside team size end\n");
     }
-    printf("team_size_begin = %d, team_size_end = %d\n",team_size_begin, team_size_end);
 
     const char *ppn_range = ucc_str_split(split[3], "=")[1];
     ucc_rank_t ppn_min = (ucc_rank_t) atoi(ucc_str_split(ppn_range, "-")[0]);
     ucc_rank_t ppn_max = ppn_min;
     if (ucc_str_split(ppn_range, "-")[1]) {
         ppn_max = (ucc_rank_t) atoi(ucc_str_split(ppn_range, "-")[1]);
-        printf("inside ppn str max\n");
     }
-    printf("ppn_min_str = %d, ppn_max_str = %d\n",ppn_min, ppn_max);
 
     return (vendor == _vendor && model == _model &&
             _team_size >= team_size_begin && _team_size <= team_size_end &&
@@ -99,7 +95,6 @@ static ucc_status_t ucc_tl_ucp_cfg_add_section(ucc_tl_ucp_team_t *team,
     if (UCC_OK != status) {
         return status;
     }
-    printf("ppn_min = %d, ppn_max = %d\n", ppn_range.begin, ppn_range.end);
 
     for (i = kh_begin(sections); i != kh_end(sections); ++i) {
         if (!kh_exist(sections, i)) continue;

--- a/src/utils/arch/cpu.h
+++ b/src/utils/arch/cpu.h
@@ -14,7 +14,6 @@
 #endif
 
 #include "utils/ucc_compiler_def.h"
-#include "utils/ucc_log.h"
 #include <stddef.h>
 
 /* CPU models */
@@ -51,53 +50,51 @@ typedef enum ucc_cpu_vendor {
 
 static inline ucc_cpu_vendor_t ucc_get_vendor_from_str(const char *v_name)
 {
-    if (strcmp(v_name, "intel") == 0)
+    if (strcasecmp(v_name, "intel") == 0)
         return UCC_CPU_VENDOR_INTEL;
-    if (strcmp(v_name, "amd") == 0)
+    if (strcasecmp(v_name, "amd") == 0)
         return UCC_CPU_VENDOR_AMD;
-    if (strcmp(v_name, "arm") == 0)
+    if (strcasecmp(v_name, "arm") == 0)
         return UCC_CPU_VENDOR_GENERIC_ARM;
-    if (strcmp(v_name, "ppc") == 0)
+    if (strcasecmp(v_name, "ppc") == 0)
         return UCC_CPU_VENDOR_GENERIC_PPC;
-    if (strcmp(v_name, "fujitsu") == 0)
+    if (strcasecmp(v_name, "fujitsu") == 0)
         return UCC_CPU_VENDOR_FUJITSU_ARM;
-    if (strcmp(v_name, "zhaoxin") == 0)
+    if (strcasecmp(v_name, "zhaoxin") == 0)
         return UCC_CPU_VENDOR_ZHAOXIN;
-    ucc_warn("vendor not found");
     return UCC_CPU_VENDOR_UNKNOWN;
 }
 
 static inline ucc_cpu_model_t ucc_get_model_from_str(const char *m_name)
 {
-    if (strcmp(m_name, "ivybridge") == 0)
+    if (strcasecmp(m_name, "ivybridge") == 0)
         return UCC_CPU_MODEL_INTEL_IVYBRIDGE;
-    if (strcmp(m_name, "sandybridge") == 0)
+    if (strcasecmp(m_name, "sandybridge") == 0)
         return UCC_CPU_MODEL_INTEL_SANDYBRIDGE;
-    if (strcmp(m_name, "nehalem") == 0)
+    if (strcasecmp(m_name, "nehalem") == 0)
         return UCC_CPU_MODEL_INTEL_NEHALEM;
-    if (strcmp(m_name, "westmere") == 0)
+    if (strcasecmp(m_name, "westmere") == 0)
         return UCC_CPU_MODEL_INTEL_WESTMERE;
-    if (strcmp(m_name, "haswell") == 0)
+    if (strcasecmp(m_name, "haswell") == 0)
         return UCC_CPU_MODEL_INTEL_HASWELL;
-    if (strcmp(m_name, "broadwell") == 0)
+    if (strcasecmp(m_name, "broadwell") == 0)
         return UCC_CPU_MODEL_INTEL_BROADWELL;
-    if (strcmp(m_name, "skylake") == 0)
+    if (strcasecmp(m_name, "skylake") == 0)
         return UCC_CPU_MODEL_INTEL_SKYLAKE;
-    if (strcmp(m_name, "aarch64") == 0)
+    if (strcasecmp(m_name, "aarch64") == 0)
         return UCC_CPU_MODEL_ARM_AARCH64;
-    if (strcmp(m_name, "naples") == 0)
+    if (strcasecmp(m_name, "naples") == 0)
         return UCC_CPU_MODEL_AMD_NAPLES;
-    if (strcmp(m_name, "rome") == 0)
+    if (strcasecmp(m_name, "rome") == 0)
         return UCC_CPU_MODEL_AMD_ROME;
-    if (strcmp(m_name, "milan") == 0)
+    if (strcasecmp(m_name, "milan") == 0)
         return UCC_CPU_MODEL_AMD_MILAN;
-    if (strcmp(m_name, "zhangjiang") == 0)
+    if (strcasecmp(m_name, "zhangjiang") == 0)
         return UCC_CPU_MODEL_ZHAOXIN_ZHANGJIANG;
-    if (strcmp(m_name, "wudaokou") == 0)
+    if (strcasecmp(m_name, "wudaokou") == 0)
         return UCC_CPU_MODEL_ZHAOXIN_WUDAOKOU;
-    if (strcmp(m_name, "lujiazui") == 0)
+    if (strcasecmp(m_name, "lujiazui") == 0)
         return UCC_CPU_MODEL_ZHAOXIN_LUJIAZUI;
-    ucc_warn("model not found");
     return UCC_CPU_MODEL_UNKNOWN;
 }
 

--- a/src/utils/arch/cpu.h
+++ b/src/utils/arch/cpu.h
@@ -14,6 +14,7 @@
 #endif
 
 #include "utils/ucc_compiler_def.h"
+#include "utils/ucc_log.h"
 #include <stddef.h>
 
 /* CPU models */
@@ -47,6 +48,58 @@ typedef enum ucc_cpu_vendor {
     UCC_CPU_VENDOR_ZHAOXIN,
     UCC_CPU_VENDOR_LAST
 } ucc_cpu_vendor_t;
+
+static inline ucc_cpu_vendor_t ucc_get_vendor_from_str(const char *v_name)
+{
+    if (strcmp(v_name, "intel") == 0)
+        return UCC_CPU_VENDOR_INTEL;
+    if (strcmp(v_name, "amd") == 0)
+        return UCC_CPU_VENDOR_AMD;
+    if (strcmp(v_name, "arm") == 0)
+        return UCC_CPU_VENDOR_GENERIC_ARM;
+    if (strcmp(v_name, "ppc") == 0)
+        return UCC_CPU_VENDOR_GENERIC_PPC;
+    if (strcmp(v_name, "fujitsu") == 0)
+        return UCC_CPU_VENDOR_FUJITSU_ARM;
+    if (strcmp(v_name, "zhaoxin") == 0)
+        return UCC_CPU_VENDOR_ZHAOXIN;
+    ucc_warn("vendor not found");
+    return UCC_CPU_VENDOR_UNKNOWN;
+}
+
+static inline ucc_cpu_model_t ucc_get_model_from_str(const char *m_name)
+{
+    if (strcmp(m_name, "ivybridge") == 0)
+        return UCC_CPU_MODEL_INTEL_IVYBRIDGE;
+    if (strcmp(m_name, "sandybridge") == 0)
+        return UCC_CPU_MODEL_INTEL_SANDYBRIDGE;
+    if (strcmp(m_name, "nehalem") == 0)
+        return UCC_CPU_MODEL_INTEL_NEHALEM;
+    if (strcmp(m_name, "westmere") == 0)
+        return UCC_CPU_MODEL_INTEL_WESTMERE;
+    if (strcmp(m_name, "haswell") == 0)
+        return UCC_CPU_MODEL_INTEL_HASWELL;
+    if (strcmp(m_name, "broadwell") == 0)
+        return UCC_CPU_MODEL_INTEL_BROADWELL;
+    if (strcmp(m_name, "skylake") == 0)
+        return UCC_CPU_MODEL_INTEL_SKYLAKE;
+    if (strcmp(m_name, "aarch64") == 0)
+        return UCC_CPU_MODEL_ARM_AARCH64;
+    if (strcmp(m_name, "naples") == 0)
+        return UCC_CPU_MODEL_AMD_NAPLES;
+    if (strcmp(m_name, "rome") == 0)
+        return UCC_CPU_MODEL_AMD_ROME;
+    if (strcmp(m_name, "milan") == 0)
+        return UCC_CPU_MODEL_AMD_MILAN;
+    if (strcmp(m_name, "zhangjiang") == 0)
+        return UCC_CPU_MODEL_ZHAOXIN_ZHANGJIANG;
+    if (strcmp(m_name, "wudaokou") == 0)
+        return UCC_CPU_MODEL_ZHAOXIN_WUDAOKOU;
+    if (strcmp(m_name, "lujiazui") == 0)
+        return UCC_CPU_MODEL_ZHAOXIN_LUJIAZUI;
+    ucc_warn("model not found");
+    return UCC_CPU_MODEL_UNKNOWN;
+}
 
 #if defined(__x86_64__)
 #  include "x86_64/cpu.h"

--- a/src/utils/ini.c
+++ b/src/utils/ini.c
@@ -1,0 +1,297 @@
+/* inih -- simple .INI file parser
+SPDX-License-Identifier: BSD-3-Clause
+Copyright (C) 2009-2020, Ben Hoyt
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+https://github.com/benhoyt/inih
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+
+#include "ini.h"
+
+#if !INI_USE_STACK
+#if INI_CUSTOM_ALLOCATOR
+#include <stddef.h>
+void* ini_malloc(size_t size);
+void ini_free(void* ptr);
+void* ini_realloc(void* ptr, size_t size);
+#else
+#include <stdlib.h>
+#define ini_malloc malloc
+#define ini_free free
+#define ini_realloc realloc
+#endif
+#endif
+
+#define MAX_SECTION 128
+#define MAX_NAME 50
+
+/* Used by ini_parse_string() to keep track of string parsing state. */
+typedef struct {
+    const char* ptr;
+    size_t num_left;
+} ini_parse_string_ctx;
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* rstrip(char* s)
+{
+    char* p = s + strlen(s);
+    while (p > s && isspace((unsigned char)(*--p)))
+        *p = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* lskip(const char* s)
+{
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char (of chars) or inline comment in given string,
+   or pointer to NUL at end of string if neither found. Inline comment must
+   be prefixed by a whitespace character to register as a comment. */
+static char* find_chars_or_comment(const char* s, const char* chars)
+{
+#if INI_ALLOW_INLINE_COMMENTS
+    int was_space = 0;
+    while (*s && (!chars || !strchr(chars, *s)) &&
+           !(was_space && strchr(INI_INLINE_COMMENT_PREFIXES, *s))) {
+        was_space = isspace((unsigned char)(*s));
+        s++;
+    }
+#else
+    while (*s && (!chars || !strchr(chars, *s))) {
+        s++;
+    }
+#endif
+    return (char*)s;
+}
+
+/* Similar to strncpy, but ensures dest (size bytes) is
+   NUL-terminated, and doesn't pad with NULs. */
+static char* strncpy0(char* dest, const char* src, size_t size)
+{
+    /* Could use strncpy internally, but it causes gcc warnings (see issue #91) */
+    size_t i;
+    for (i = 0; i < size - 1 && src[i]; i++)
+        dest[i] = src[i];
+    dest[i] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user)
+{
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+    int max_line = INI_MAX_LINE;
+#else
+    char* line;
+    size_t max_line = INI_INITIAL_ALLOC;
+#endif
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+    char* new_line;
+    size_t offset;
+#endif
+    char section[MAX_SECTION] = "";
+    char prev_name[MAX_NAME] = "";
+
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+
+#if !INI_USE_STACK
+    line = (char*)ini_malloc(INI_INITIAL_ALLOC);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+#if INI_HANDLER_LINENO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#else
+#define HANDLER(u, s, n, v) handler(u, s, n, v)
+#endif
+
+    /* Scan through stream line by line */
+    while (reader(line, (int)max_line, stream) != NULL) {
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+        offset = strlen(line);
+        while (offset == max_line - 1 && line[offset - 1] != '\n') {
+            max_line *= 2;
+            if (max_line > INI_MAX_LINE)
+                max_line = INI_MAX_LINE;
+            new_line = ini_realloc(line, max_line);
+            if (!new_line) {
+                ini_free(line);
+                return -2;
+            }
+            line = new_line;
+            if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
+                break;
+            if (max_line >= INI_MAX_LINE)
+                break;
+            offset += strlen(line + offset);
+        }
+#endif
+
+        lineno++;
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+                           (unsigned char)start[1] == 0xBB &&
+                           (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = lskip(rstrip(start));
+
+        if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
+            /* Start-of-line comment */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+            /* Non-blank line with leading whitespace, treat as continuation
+               of previous name's value (as per Python configparser). */
+            if (!HANDLER(user, section, prev_name, start) && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = find_chars_or_comment(start + 1, "]");
+            if (*end == ']') {
+                *end = '\0';
+                strncpy0(section, start + 1, sizeof(section));
+                *prev_name = '\0';
+#if INI_CALL_HANDLER_ON_NEW_SECTION
+                if (!HANDLER(user, section, NULL, NULL) && !error)
+                    error = lineno;
+#endif
+            }
+            else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        }
+        else if (*start) {
+            /* Not a comment, must be a name[=:]value pair */
+            end = find_chars_or_comment(start, "=:");
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = rstrip(start);
+                value = end + 1;
+#if INI_ALLOW_INLINE_COMMENTS
+                end = find_chars_or_comment(value, NULL);
+                if (*end)
+                    *end = '\0';
+#endif
+                value = lskip(value);
+                rstrip(value);
+
+                /* Valid name[=:]value pair found, call handler */
+                strncpy0(prev_name, name, sizeof(prev_name));
+                if (!HANDLER(user, section, name, value) && !error)
+                    error = lineno;
+            }
+            else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+#if INI_ALLOW_NO_VALUE
+                *end = '\0';
+                name = rstrip(start);
+                if (!HANDLER(user, section, name, NULL) && !error)
+                    error = lineno;
+#else
+                error = lineno;
+#endif
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    ini_free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user)
+{
+    return ini_parse_stream((ini_reader)fgets, file, handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename, ini_handler handler, void* user)
+{
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, user);
+    fclose(file);
+    return error;
+}
+
+/* An ini_reader function to read the next line from a string buffer. This
+   is the fgets() equivalent used by ini_parse_string(). */
+static char* ini_reader_string(char* str, int num, void* stream) {
+    ini_parse_string_ctx* ctx = (ini_parse_string_ctx*)stream;
+    const char* ctx_ptr = ctx->ptr;
+    size_t ctx_num_left = ctx->num_left;
+    char* strp = str;
+    char c;
+
+    if (ctx_num_left == 0 || num < 2)
+        return NULL;
+
+    while (num > 1 && ctx_num_left != 0) {
+        c = *ctx_ptr++;
+        ctx_num_left--;
+        *strp++ = c;
+        if (c == '\n')
+            break;
+        num--;
+    }
+
+    *strp = '\0';
+    ctx->ptr = ctx_ptr;
+    ctx->num_left = ctx_num_left;
+    return str;
+}
+
+/* See documentation in header file. */
+int ini_parse_string(const char* string, ini_handler handler, void* user) {
+    ini_parse_string_ctx ctx;
+
+    ctx.ptr = string;
+    ctx.num_left = strlen(string);
+    return ini_parse_stream((ini_reader)ini_reader_string, &ctx, handler,
+                            user);
+}

--- a/src/utils/ini.h
+++ b/src/utils/ini.h
@@ -1,0 +1,150 @@
+/* inih -- simple .INI file parser
+SPDX-License-Identifier: BSD-3-Clause
+Copyright (C) 2009-2020, Ben Hoyt
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+https://github.com/benhoyt/inih
+*/
+
+#ifndef UCS_CONFIG_INI_H
+#define UCS_CONFIG_INI_H
+
+/* Make this header file easier to include in C++ code */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/* Nonzero if ini_handler callback should accept lineno parameter. */
+#ifndef INI_HANDLER_LINENO
+#define INI_HANDLER_LINENO 0
+#endif
+
+/* Typedef for prototype of handler function. */
+#if INI_HANDLER_LINENO
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value,
+                           int lineno);
+#else
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value);
+#endif
+
+/* Typedef for prototype of fgets-style reader function. */
+typedef char* (*ini_reader)(char* str, int num, void* stream);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes an ini_reader function pointer instead of
+   filename. Used for implementing custom or string-based I/O (see also
+   ini_parse_string). */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user);
+
+/* Same as ini_parse(), but takes a zero-terminated string with the INI data
+instead of a file. Useful for parsing INI data from a network socket or
+already in memory. */
+int ini_parse_string(const char* string, ini_handler handler, void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   configparser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See https://github.com/benhoyt/inih/issues/21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Chars that begin a start-of-line comment. Per Python configparser, allow
+   both ; and # comments at the start of a line by default. */
+#ifndef INI_START_COMMENT_PREFIXES
+#define INI_START_COMMENT_PREFIXES ";#"
+#endif
+
+/* Nonzero to allow inline comments (with valid inline comment characters
+   specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
+   Python 3.2+ configparser behaviour. */
+#ifndef INI_ALLOW_INLINE_COMMENTS
+#define INI_ALLOW_INLINE_COMMENTS 1
+#endif
+#ifndef INI_INLINE_COMMENT_PREFIXES
+#define INI_INLINE_COMMENT_PREFIXES ";"
+#endif
+
+/* Nonzero to use stack for line buffer, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Maximum line length for any line in INI file (stack or heap). Note that
+   this must be 3 more than the longest line (due to '\r', '\n', and '\0'). */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+/* Nonzero to allow heap line buffer to grow via realloc(), zero for a
+   fixed-size buffer of INI_MAX_LINE bytes. Only applies if INI_USE_STACK is
+   zero. */
+#ifndef INI_ALLOW_REALLOC
+#define INI_ALLOW_REALLOC 0
+#endif
+
+/* Initial size in bytes for heap line buffer. Only applies if INI_USE_STACK
+   is zero. */
+#ifndef INI_INITIAL_ALLOC
+#define INI_INITIAL_ALLOC 200
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Nonzero to call the handler at the start of each new section (with
+   name and value NULL). Default is to only call the handler on
+   each name=value pair. */
+#ifndef INI_CALL_HANDLER_ON_NEW_SECTION
+#define INI_CALL_HANDLER_ON_NEW_SECTION 0
+#endif
+
+/* Nonzero to allow a name without a value (no '=' or ':' on the line) and
+   call the handler with value NULL in this case. Default is to treat
+   no-value lines as an error. */
+#ifndef INI_ALLOW_NO_VALUE
+#define INI_ALLOW_NO_VALUE 0
+#endif
+
+/* Nonzero to use custom ini_malloc, ini_free, and ini_realloc memory
+   allocation functions (INI_USE_STACK must also be 0). These functions must
+   have the same signatures as malloc/free/realloc and behave in a similar
+   way. ini_realloc is only needed if INI_ALLOW_REALLOC is set. */
+#ifndef INI_CUSTOM_ALLOCATOR
+#define INI_CUSTOM_ALLOCATOR 0
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UCS_CONFIG_INI_H */

--- a/src/utils/ini.h
+++ b/src/utils/ini.h
@@ -6,8 +6,8 @@ home page for more info:
 https://github.com/benhoyt/inih
 */
 
-#ifndef UCS_CONFIG_INI_H
-#define UCS_CONFIG_INI_H
+#ifndef UCC_CONFIG_INI_H
+#define UCC_CONFIG_INI_H
 
 /* Make this header file easier to include in C++ code */
 #ifdef __cplusplus
@@ -17,12 +17,12 @@ extern "C" {
 #include <stdio.h>
 
 /* Nonzero if ini_handler callback should accept lineno parameter. */
-#ifndef INI_HANDLER_LINENO
-#define INI_HANDLER_LINENO 0
+#ifndef UCC_INI_HANDLER_LINENO
+#define UCC_INI_HANDLER_LINENO 0
 #endif
 
 /* Typedef for prototype of handler function. */
-#if INI_HANDLER_LINENO
+#if UCC_INI_HANDLER_LINENO
 typedef int (*ini_handler)(void* user, const char* section,
                            const char* name, const char* value,
                            int lineno);
@@ -45,101 +45,101 @@ typedef char* (*ini_reader)(char* str, int num, void* stream);
    stop on first error), -1 on file open error, or -2 on memory allocation
    error (only when INI_USE_STACK is zero).
 */
-int ini_parse(const char* filename, ini_handler handler, void* user);
+int ucc_ini_parse(const char* filename, ini_handler handler, void* user);
 
 /* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
    close the file when it's finished -- the caller must do that. */
-int ini_parse_file(FILE* file, ini_handler handler, void* user);
+int ucc_ini_parse_file(FILE* file, ini_handler handler, void* user);
 
 /* Same as ini_parse(), but takes an ini_reader function pointer instead of
    filename. Used for implementing custom or string-based I/O (see also
    ini_parse_string). */
-int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
-                     void* user);
+int ucc_ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                         void* user);
 
 /* Same as ini_parse(), but takes a zero-terminated string with the INI data
 instead of a file. Useful for parsing INI data from a network socket or
 already in memory. */
-int ini_parse_string(const char* string, ini_handler handler, void* user);
+int ucc_ini_parse_string(const char* string, ini_handler handler, void* user);
 
 /* Nonzero to allow multi-line value parsing, in the style of Python's
    configparser. If allowed, ini_parse() will call the handler with the same
    name for each subsequent line parsed. */
-#ifndef INI_ALLOW_MULTILINE
-#define INI_ALLOW_MULTILINE 1
+#ifndef UCC_INI_ALLOW_MULTILINE
+#define UCC_INI_ALLOW_MULTILINE 1
 #endif
 
 /* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
    the file. See https://github.com/benhoyt/inih/issues/21 */
-#ifndef INI_ALLOW_BOM
-#define INI_ALLOW_BOM 1
+#ifndef UCC_INI_ALLOW_BOM
+#define UCC_INI_ALLOW_BOM 1
 #endif
 
 /* Chars that begin a start-of-line comment. Per Python configparser, allow
    both ; and # comments at the start of a line by default. */
-#ifndef INI_START_COMMENT_PREFIXES
-#define INI_START_COMMENT_PREFIXES ";#"
+#ifndef UCC_INI_START_COMMENT_PREFIXES
+#define UCC_INI_START_COMMENT_PREFIXES ";#"
 #endif
 
 /* Nonzero to allow inline comments (with valid inline comment characters
    specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
    Python 3.2+ configparser behaviour. */
-#ifndef INI_ALLOW_INLINE_COMMENTS
-#define INI_ALLOW_INLINE_COMMENTS 1
+#ifndef UCC_INI_ALLOW_INLINE_COMMENTS
+#define UCC_INI_ALLOW_INLINE_COMMENTS 1
 #endif
-#ifndef INI_INLINE_COMMENT_PREFIXES
-#define INI_INLINE_COMMENT_PREFIXES ";"
+#ifndef UCC_INI_INLINE_COMMENT_PREFIXES
+#define UCC_INI_INLINE_COMMENT_PREFIXES ";"
 #endif
 
 /* Nonzero to use stack for line buffer, zero to use heap (malloc/free). */
-#ifndef INI_USE_STACK
-#define INI_USE_STACK 1
+#ifndef UCC_INI_USE_STACK
+#define UCC_INI_USE_STACK 1
 #endif
 
 /* Maximum line length for any line in INI file (stack or heap). Note that
    this must be 3 more than the longest line (due to '\r', '\n', and '\0'). */
-#ifndef INI_MAX_LINE
-#define INI_MAX_LINE 200
+#ifndef UCC_INI_MAX_LINE
+#define UCC_INI_MAX_LINE 200
 #endif
 
 /* Nonzero to allow heap line buffer to grow via realloc(), zero for a
    fixed-size buffer of INI_MAX_LINE bytes. Only applies if INI_USE_STACK is
    zero. */
-#ifndef INI_ALLOW_REALLOC
-#define INI_ALLOW_REALLOC 0
+#ifndef UCC_INI_ALLOW_REALLOC
+#define UCC_INI_ALLOW_REALLOC 0
 #endif
 
 /* Initial size in bytes for heap line buffer. Only applies if INI_USE_STACK
    is zero. */
-#ifndef INI_INITIAL_ALLOC
-#define INI_INITIAL_ALLOC 200
+#ifndef UCC_INI_INITIAL_ALLOC
+#define UCC_INI_INITIAL_ALLOC 200
 #endif
 
 /* Stop parsing on first error (default is to keep parsing). */
-#ifndef INI_STOP_ON_FIRST_ERROR
-#define INI_STOP_ON_FIRST_ERROR 0
+#ifndef UCC_INI_STOP_ON_FIRST_ERROR
+#define UCC_INI_STOP_ON_FIRST_ERROR 0
 #endif
 
 /* Nonzero to call the handler at the start of each new section (with
    name and value NULL). Default is to only call the handler on
    each name=value pair. */
-#ifndef INI_CALL_HANDLER_ON_NEW_SECTION
-#define INI_CALL_HANDLER_ON_NEW_SECTION 0
+#ifndef UCC_INI_CALL_HANDLER_ON_NEW_SECTION
+#define UCC_INI_CALL_HANDLER_ON_NEW_SECTION 0
 #endif
 
 /* Nonzero to allow a name without a value (no '=' or ':' on the line) and
    call the handler with value NULL in this case. Default is to treat
    no-value lines as an error. */
-#ifndef INI_ALLOW_NO_VALUE
-#define INI_ALLOW_NO_VALUE 0
+#ifndef UCC_INI_ALLOW_NO_VALUE
+#define UCC_INI_ALLOW_NO_VALUE 0
 #endif
 
 /* Nonzero to use custom ini_malloc, ini_free, and ini_realloc memory
    allocation functions (INI_USE_STACK must also be 0). These functions must
    have the same signatures as malloc/free/realloc and behave in a similar
    way. ini_realloc is only needed if INI_ALLOW_REALLOC is set. */
-#ifndef INI_CUSTOM_ALLOCATOR
-#define INI_CUSTOM_ALLOCATOR 0
+#ifndef UCC_INI_CUSTOM_ALLOCATOR
+#define UCC_INI_CUSTOM_ALLOCATOR 0
 #endif
 
 
@@ -147,4 +147,4 @@ int ini_parse_string(const char* string, ini_handler handler, void* user);
 }
 #endif
 
-#endif /* UCS_CONFIG_INI_H */
+#endif /* UCC_CONFIG_INI_H */

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -195,8 +195,6 @@ static int ucc_file_parse_handler(void *arg, const char *section,
 
     if (strcmp(section,"") != 0) {
         /* has section */
-        printf("section = %s, name = %s, value = %s\n", section, name, value);
-
         iter = kh_get(ucc_sections, sections, section);
         if (iter == kh_end(sections)) { /* checks if section hash table already exists */
             cfg_section = ucc_calloc(1, sizeof(*cfg_section), "section_"+section+"_cfg");
@@ -219,6 +217,7 @@ static int ucc_file_parse_handler(void *arg, const char *section,
         }
         UCC_ADD_KEY_VALUE_TO_HASH(ucc_sec, cfg_section, name, value);
     }
+    cfg->has_tuning_sections = 1;
     /* param not part of a section section */
     UCC_ADD_KEY_VALUE_TO_HASH(ucc_cfg_file, vars, name, value);
 }
@@ -237,6 +236,7 @@ ucc_status_t ucc_parse_file_config(const char *        filename,
     }
     kh_init_inplace(ucc_cfg_file, &cfg->vars);
     kh_init_inplace(ucc_sections, &cfg->sections);
+    cfg->has_tuning_sections = 0;
     ret = ini_parse(filename, ucc_file_parse_handler, cfg);
     if (-1 == ret) {
         /* according to ucs/ini.h -1 means error in

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -337,7 +337,7 @@ static int ucc_file_parse_handler(void *arg, const char *section,
         iter = kh_get(ucc_sections, sections, section);
         if (iter == kh_end(sections)) { /* section hash table doesn't exist */
             sec_wrap = ucc_calloc(1, sizeof(*sec_wrap),
-                                  "section_"+section+"_cfg");
+                                  strcat("section cfg: ", section));
             if (!sec_wrap) {
                 ucc_error("failed to allocate %zd bytes for section config",
                           sizeof(*sec_wrap));
@@ -562,7 +562,8 @@ ucc_status_t ucc_add_team_sections(void                *team_cfg,
                                    ucc_topo_t          *team_topo,
                                    const char         **tuning_str,
                                    const char          *tune_key,
-                                   const char          *prefix)
+                                   const char          *env_prefix,
+                                   const char          *component_prefix)
 {
     khash_t(ucc_sections) *sections  = &ucc_global_config.file_cfg->sections;
     ucc_cpu_vendor_t       vendor    = ucc_arch_get_cpu_vendor();
@@ -588,8 +589,8 @@ ucc_status_t ucc_add_team_sections(void                *team_cfg,
             if (j != kh_end(sec_h)) {
                 *tuning_str = kh_val(sec_h, j);
             }
-            status = ucc_apply_file_cfg(team_cfg, tl_fields, "UCC_", prefix,
-                                        sec_name);
+            status = ucc_apply_file_cfg(team_cfg, tl_fields, env_prefix,
+                                        component_prefix, sec_name);
             return status;
         }
     }

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -177,6 +177,22 @@ static int ucc_file_parse_handler(void *arg, const char *section,
     int      result;
     char    *dup;
 
+    if (!name) {
+        return 1;
+    }
+    if (NULL != getenv(name)) {
+        /* variable is set in env, skip it.
+           Env gets precedence over file */
+        ;
+        return 1;
+    }
+    if (strlen(name) < 4 || NULL == strstr(name, "UCC_")) {
+        ucc_warn("incorrect parameter name %s "
+                 "(param name should start with UCC_ or <PREFIX>_UCC_)",
+                 name);
+        return 0;
+    }
+
     if (strcmp(section,"") != 0) {
         /* has section */
         printf("section = %s, name = %s, value = %s\n", section, name, value);
@@ -203,22 +219,7 @@ static int ucc_file_parse_handler(void *arg, const char *section,
         }
         UCC_ADD_KEY_VALUE_TO_HASH(ucc_sec, cfg_section, name, value);
     }
-
-    if (!name) {
-        return 1;
-    }
-    if (NULL != getenv(name)) {
-        /* variable is set in env, skip it.
-           Env gets precedence over file */
-        ;
-        return 1;
-    }
-    if (strlen(name) < 4 || NULL == strstr(name, "UCC_")) {
-        ucc_warn("incorrect parameter name %s "
-                 "(param name should start with UCC_ or <PREFIX>_UCC_)",
-                 name);
-        return 0;
-    }
+    /* param not part of a section section */
     UCC_ADD_KEY_VALUE_TO_HASH(ucc_cfg_file, vars, name, value);
 }
 

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -145,7 +145,8 @@ ucc_status_t ucc_add_team_sections(void                *team_cfg,
                                    ucc_topo_t          *team_topo,
                                    const char         **tuning_str,
                                    const char          *tune_key,
-                                   const char          *prefix);
+                                   const char          *env_prefix,
+                                   const char          *component_prefix);
 
 static inline void
 ucc_config_parser_release_opts(void *opts, ucc_config_field_t *fields)

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -13,6 +13,7 @@
 #include "utils/ucc_datastruct.h"
 #include "utils/ucc_compiler_def.h"
 #include "utils/ucc_list.h"
+#include "utils/ini.h"
 #include "khash.h"
 
 #include <ucs/config/parser.h>
@@ -20,7 +21,6 @@
 #include <ucs/sys/compiler_def.h>
 #include <ucs/config/types.h>
 #include <ucs/config/parser.h>
-#include <ucs/config/ini.h>
 
 typedef ucs_config_field_t             ucc_config_field_t;
 typedef ucs_config_names_array_t       ucc_config_names_array_t;

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -13,6 +13,7 @@
 #include "utils/ucc_datastruct.h"
 #include "utils/ucc_compiler_def.h"
 #include "utils/ucc_list.h"
+#include "khash.h"
 
 #include <ucs/config/parser.h>
 #include <ucs/sys/preprocessor.h>
@@ -71,6 +72,15 @@ typedef struct ucc_file_config ucc_file_config_t;
 #define UCC_CONFIG_ALLOW_LIST_NEGATE    UCS_CONFIG_ALLOW_LIST_NEGATE
 #define UCC_CONFIG_ALLOW_LIST_ALLOW_ALL UCS_CONFIG_ALLOW_LIST_ALLOW_ALL
 #define UCC_CONFIG_ALLOW_LIST_ALLOW     UCS_CONFIG_ALLOW_LIST_ALLOW
+
+KHASH_MAP_INIT_STR(ucc_cfg_file, char *);
+KHASH_MAP_INIT_STR(ucc_sec, char *);
+KHASH_MAP_INIT_STR(ucc_sections, khash_t(ucc_sec) *);
+
+typedef struct ucc_file_config {
+    khash_t(ucc_cfg_file) vars;
+    khash_t(ucc_sections) sections;
+} ucc_file_config_t;
 
 /* Convenience structure used, for example, to represent TLS list.
    "requested" field is set to 1 if the list of entries was
@@ -142,6 +152,11 @@ static inline void ucc_config_parser_print_opts(FILE *stream, const char *title,
     ucs_config_parser_print_opts(stream, title, opts, fields, table_prefix,
                                  prefix, ucs_flags);
 }
+
+ucc_status_t ucc_apply_file_cfg(void *opts, ucc_config_field_t *fields,
+                                const char *env_prefix,
+                                const char *component_prefix,
+                                const char *section);
 
 void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
                                       ucc_config_print_flags_t flags,

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -140,22 +140,12 @@ ucc_status_t ucc_config_parser_fill_opts(void *opts,
                                          const char *env_prefix,
                                          int ignore_errors);
 
-int ucc_check_section(ucc_section_desc_t sec_desc,
-                      ucc_cpu_vendor_t vendor,
-                      ucc_cpu_model_t model,
-                      size_t team_size,
-                      ucc_rank_t ppn_min,
-                      ucc_rank_t ppn_max,
-                      ucc_rank_t nnodes);
-
-ucc_status_t ucc_add_team_sections(ucc_file_config_t        *cfg_file,
-                                   void                     *team_cfg,
-                                   ucc_config_field_t       *tl_field,
-                                   ucc_topo_t               *team_topo,
-                                   const char              **tuning_str,
-                                   const char               *tune_key,
-                                   const char               *prefix,
-                                   size_t                    team_size);
+ucc_status_t ucc_add_team_sections(void                *team_cfg,
+                                   ucc_config_field_t  *tl_field,
+                                   ucc_topo_t          *team_topo,
+                                   const char         **tuning_str,
+                                   const char          *tune_key,
+                                   const char          *prefix);
 
 static inline void
 ucc_config_parser_release_opts(void *opts, ucc_config_field_t *fields)
@@ -206,11 +196,6 @@ static inline void ucc_config_parser_print_opts(FILE *stream, const char *title,
     ucs_config_parser_print_opts(stream, title, opts, fields, table_prefix,
                                  prefix, ucs_flags);
 }
-
-ucc_status_t ucc_apply_file_cfg(void *opts, ucc_config_field_t *fields,
-                                const char *env_prefix,
-                                const char *component_prefix,
-                                const char *section);
 
 void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
                                       ucc_config_print_flags_t flags,

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -80,6 +80,7 @@ KHASH_MAP_INIT_STR(ucc_sections, khash_t(ucc_sec) *);
 typedef struct ucc_file_config {
     khash_t(ucc_cfg_file) vars;
     khash_t(ucc_sections) sections;
+    int                   has_tuning_sections;
 } ucc_file_config_t;
 
 /* Convenience structure used, for example, to represent TLS list.

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -15,6 +15,7 @@
 #include "utils/ucc_list.h"
 #include "utils/arch/cpu.h"
 #include "khash.h"
+#include "components/topo/ucc_topo.h"
 
 #include <ucs/config/parser.h>
 #include <ucs/sys/preprocessor.h>
@@ -76,19 +77,19 @@ typedef struct ucc_file_config ucc_file_config_t;
 #define UCC_CONFIG_TYPE_TERNARY         UCS_CONFIG_TYPE_TERNARY
 
 typedef enum ucc_ternary_auto_value {
-    UCC_NO   = 0,
-    UCC_YES  = 1,
-    UCC_TRY  = 2,
-    UCC_AUTO = 3,
+    UCC_NO   = UCS_NO,
+    UCC_YES  = UCS_YES,
+    UCC_TRY  = UCS_TRY,
+    UCC_AUTO = UCS_AUTO,
     UCC_TERNARY_LAST
 } ucc_ternary_auto_value_t;
 
 enum tuning_mask {
-    UCC_TUNING_DESC_FIELD_VENDOR    = UCC_BIT(1),
-    UCC_TUNING_DESC_FIELD_MODEL     = UCC_BIT(2),
-    UCC_TUNING_DESC_FIELD_TEAM_SIZE = UCC_BIT(3),
-    UCC_TUNING_DESC_FIELD_PPN       = UCC_BIT(4),
-    UCC_TUNING_DESC_FIELD_NNODES    = UCC_BIT(5)
+    UCC_TUNING_DESC_FIELD_VENDOR    = UCC_BIT(0),
+    UCC_TUNING_DESC_FIELD_MODEL     = UCC_BIT(1),
+    UCC_TUNING_DESC_FIELD_TEAM_SIZE = UCC_BIT(2),
+    UCC_TUNING_DESC_FIELD_PPN       = UCC_BIT(3),
+    UCC_TUNING_DESC_FIELD_NNODES    = UCC_BIT(4)
 };
 
 typedef struct ucc_section_desc {
@@ -99,8 +100,8 @@ typedef struct ucc_section_desc {
     ucc_rank_t       max_team_size;
     ucc_rank_t       min_ppn;
     ucc_rank_t       max_ppn;
-    size_t           min_nnodes;
-    size_t           max_nnodes;
+    ucc_rank_t       min_nnodes;
+    ucc_rank_t       max_nnodes;
 } ucc_section_desc_t;
 
 KHASH_MAP_INIT_STR(ucc_sec, char *);
@@ -146,6 +147,15 @@ int ucc_check_section(ucc_section_desc_t sec_desc,
                       ucc_rank_t ppn_min,
                       ucc_rank_t ppn_max,
                       ucc_rank_t nnodes);
+
+ucc_status_t ucc_add_team_sections(ucc_file_config_t        *cfg_file,
+                                   void                     *team_cfg,
+                                   ucc_config_field_t       *tl_field,
+                                   ucc_topo_t               *team_topo,
+                                   const char              **tuning_str,
+                                   const char               *tune_key,
+                                   const char               *prefix,
+                                   size_t                    team_size);
 
 static inline void
 ucc_config_parser_release_opts(void *opts, ucc_config_field_t *fields)


### PR DESCRIPTION
## What
Adding support to parse and apply tuning parameters for best perf result in ucc.conf config file.
Note - this PR creates the section based parsing infrastructure, and implements it usage in TL/UCP Allreduce as prototype. In future PR usage should be extended to all colls in TL/UCP. Later on to each TL in which is found relevant.

## Why ?
To create an extendable way for both core developers and users to add case specific perf params. 

## How ?
Extending parse handler to read "sections" from ucc.conf and saving each section in a two level hash table, where top level is a a hash table per section and second level is key-value pairs of params per section.
In cl/tl team creation, if section is applicable (running on corresponding vendore, model, etc) the values will be copied from current section hash table to team cfg and then used accordingly in tl/cl hiers and collectives. 
