### PR TITLE
TEST: support topo/hierarchy in gtest

### DIFF
--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -551,10 +551,11 @@ poll:
     return UCC_OK;
 }
 
-ucc_status_t ucc_context_create(ucc_lib_h lib,
-                                const ucc_context_params_t *params,
-                                const ucc_context_config_h  config,
-                                ucc_context_h *context)
+ucc_status_t ucc_context_create_proc_info(ucc_lib_h                   lib,
+                                          const ucc_context_params_t *params,
+                                          const ucc_context_config_h  config,
+                                          ucc_context_h              *context,
+                                          ucc_proc_info_t            *proc_info)
 {
     uint32_t                   topo_required = 0;
     ucc_base_context_params_t  b_params;
@@ -669,7 +670,7 @@ ucc_status_t ucc_context_create(ucc_lib_h lib,
         ucc_error("failed to init progress queue for context %p", ctx);
         goto error_ctx_create;
     }
-    ctx->id.pi      = ucc_local_proc;
+    ctx->id.pi      = *proc_info;
     ctx->id.seq_num = ucc_atomic_fadd32(&ucc_context_seq_num, 1);
     if (params->mask & UCC_CONTEXT_PARAM_FIELD_OOB &&
         params->oob.n_oob_eps > 1) {
@@ -780,6 +781,15 @@ error_ctx:
     ucc_free(ctx);
 error:
     return status;
+}
+
+ucc_status_t ucc_context_create(ucc_lib_h lib,
+                                const ucc_context_params_t *params,
+                                const ucc_context_config_h  config,
+                                ucc_context_h *context)
+{
+    return ucc_context_create_proc_info(lib, params, config, context,
+                                        &ucc_local_proc);
 }
 
 static ucc_status_t ucc_context_free_attr(ucc_context_attr_t *context_attr)

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -83,6 +83,14 @@ typedef struct ucc_context_config {
     uint32_t                  internal_oob;
 } ucc_context_config_t;
 
+/* Internal function for context creation that takes explicit
+   pointer for proc_info */
+ucc_status_t ucc_context_create_proc_info(ucc_lib_h                   lib,
+                                          const ucc_context_params_t *params,
+                                          const ucc_context_config_h  config,
+                                          ucc_context_h              *context,
+                                          ucc_proc_info_t            *proc_info);
+
 /* Any internal UCC component (TL, CL, etc) may register its own
    progress callback fn (and argument for the callback) into core
    ucc context. Those callbacks will be triggered as part of

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -202,9 +202,9 @@ public:
         UCC_JOB_CTX_GLOBAL, /*< ucc ctx create with OOB */
         UCC_JOB_CTX_GLOBAL_ONESIDED
     } ucc_job_ctx_mode_t;
-    static const int nStaticTeams     = 4;
+    static const int nStaticTeams     = 5;
     static const int staticUccJobSize = 16;
-    static constexpr int staticTeamSizes[nStaticTeams] = {1, 2, 11, staticUccJobSize};
+    static constexpr int staticTeamSizes[nStaticTeams] = {1, 2, 8, 11, staticUccJobSize};
     static void cleanup();
     static UccJob* getStaticJob();
     static const std::vector<UccTeam_h> &getStaticTeams();


### PR DESCRIPTION
## What
Adds topo information for each process in gtest. All "virtual processes" (created by gtest) get their own "local_proc_info" to generate topology

## Why ?
This enables bigger coverage: CL/HIER and TL/SHM

