### PR TITLE
CI: fixes ompi build

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -37,7 +37,7 @@ jobs:
             fi
           fi
           H1="CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC|EC|SCHEDULE|TOPO"
-          H2="CL/|TL/|MC/|EC/|UCP|NCCL|SHARP|BASIC|HIER|CUDA|CPU|EE|RCCL|ROCM|SELF|MLX5"
+          H2="CI|CL/|TL/|MC/|EC/|UCP|NCCL|SHARP|BASIC|HIER|CUDA|CPU|EE|RCCL|ROCM|SELF|MLX5"
           if ! echo $msg | grep -qP '^Merge |^'"(($H1)|($H2))"'+: \w'
           then
             echo "Wrong header"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Build OMPI
       run: |
         cd /tmp/ompi
-        ./autogen.pl --no-oshmem --exclude pml-cm,pml-ob1,mtl,coll-adapt,coll-han,coll-inter,coll-ftagree
+        ./autogen.pl  --exclude pml-cm,mtl,coll-adapt,coll-han,coll-inter,coll-ftagree
         ./configure --prefix=/tmp/ompi/install --enable-mpirun-prefix-by-default --disable-mpi-fortran --disable-man-pages --with-ucx=/tmp/ucx/install --with-ucc=/tmp/ucc/install
         make -j install
     - name: Get IMB


### PR DESCRIPTION
## What
Fixes failures observed in CI

## Why ?
build of ompi v5 without oshmem (autogen --no-oshmem) results in segfault in mpirun
