### PR TITLE
EC/CUDA: opt persistent multi ops

### DIFF
--- a/src/components/ec/base/ucc_ec_base.h
+++ b/src/components/ec/base/ucc_ec_base.h
@@ -67,7 +67,8 @@ typedef enum ucc_ee_executor_task_type {
     UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED   = UCC_BIT(1),
     UCC_EE_EXECUTOR_TASK_REDUCE_MULTI_DST = UCC_BIT(2),
     UCC_EE_EXECUTOR_TASK_COPY             = UCC_BIT(3),
-    UCC_EE_EXECUTOR_TASK_COPY_MULTI       = UCC_BIT(4)
+    UCC_EE_EXECUTOR_TASK_COPY_MULTI       = UCC_BIT(4),
+    UCC_EE_EXECUTOR_TASK_LAST
 } ucc_ee_executor_task_type_t;
 
 typedef struct ucc_ee_executor_params {

--- a/src/components/ec/cuda/ec_cuda.h
+++ b/src/components/ec/cuda/ec_cuda.h
@@ -74,6 +74,7 @@ typedef struct ucc_ec_cuda {
     ucc_mpool_t                    strm_reqs;
     ucc_mpool_t                    executors;
     ucc_mpool_t                    executor_interruptible_tasks;
+    ucc_mpool_t                    executor_persistent_tasks;
     ucc_thread_mode_t              thread_mode;
     ucc_ec_cuda_strm_task_mode_t   strm_task_mode;
     ucc_ec_cuda_task_stream_type_t task_strm_type;
@@ -96,6 +97,13 @@ typedef struct ucc_ec_cuda_executor_interruptible_task {
     void                   *event;
 } ucc_ec_cuda_executor_interruptible_task_t;
 
+#define MAX_SUBTASKS 12
+typedef struct ucc_ec_cuda_executor_persistent_task {
+    ucc_ee_executor_task_t       super;
+    int                          num_subtasks;
+    ucc_ee_executor_task_args_t *subtasks[MAX_SUBTASKS];
+} ucc_ec_cuda_executor_persistent_task_t;
+
 typedef struct ucc_ec_cuda_executor_task_ops {
     ucc_status_t (*task_post)(ucc_ee_executor_t *executor,
                               const ucc_ee_executor_task_args_t *task_args,
@@ -111,9 +119,9 @@ typedef struct ucc_ec_cuda_executor {
     ucc_spinlock_t                   tasks_lock;
     ucc_ec_cuda_executor_state_t     state;
     int                              pidx;
-    ucc_ee_executor_task_t          *tasks;
+    ucc_ee_executor_task_args_t     *tasks;
     ucc_ec_cuda_executor_state_t    *dev_state;
-    ucc_ee_executor_task_t          *dev_tasks;
+    ucc_ee_executor_task_args_t     *dev_tasks;
     int                             *dev_pidx;
     int                             *dev_cidx;
 } ucc_ec_cuda_executor_t;

--- a/src/components/ec/cuda/ec_cuda_executor_interruptible.c
+++ b/src/components/ec/cuda/ec_cuda_executor_interruptible.c
@@ -139,6 +139,7 @@ ucc_cuda_executor_interruptible_task_finalize(ucc_ee_executor_task_t *task)
         ucc_derived_of(task, ucc_ec_cuda_executor_interruptible_task_t);
     ucc_status_t status;
 
+    ucc_assert(task->status == UCC_OK);
     status = ucc_ec_cuda_event_destroy(ee_task->event);
     ucc_mpool_put(task);
     return status;

--- a/src/components/ec/cuda/ec_cuda_executor_persistent.c
+++ b/src/components/ec/cuda/ec_cuda_executor_persistent.c
@@ -15,9 +15,11 @@ ucc_cuda_executor_persistent_task_post(ucc_ee_executor_t *executor,
     ucc_ec_cuda_executor_t *eee       = ucc_derived_of(executor,
                                                        ucc_ec_cuda_executor_t);
     int                     max_tasks = EC_CUDA_CONFIG->exec_max_tasks;
-    ucc_ee_executor_task_t *ee_task;
-    ucc_datatype_t          dt;
-    ucc_reduction_op_t      op;
+    ucc_ee_executor_task_args_t            *subtask_args;
+    ucc_ec_cuda_executor_persistent_task_t *ee_task;
+    ucc_datatype_t                          dt;
+    ucc_reduction_op_t                      op;
+    int                                     i;
 
     if (task_args->task_type != UCC_EE_EXECUTOR_TASK_COPY &&
         task_args->task_type != UCC_EE_EXECUTOR_TASK_COPY_MULTI) {
@@ -48,32 +50,92 @@ ucc_cuda_executor_persistent_task_post(ucc_ee_executor_t *executor,
     if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
         ucc_spin_lock(&eee->tasks_lock);
     }
-    ee_task         = &(eee->tasks[eee->pidx % max_tasks]);
-    ee_task->eee    = executor;
-    ee_task->status = UCC_OPERATION_INITIALIZED;
-    memcpy(&ee_task->args, task_args, sizeof(ucc_ee_executor_task_args_t));
+
+    ee_task = ucc_mpool_get(&ucc_ec_cuda.executor_persistent_tasks);
+    if (ucc_unlikely(!ee_task)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    ee_task->super.status = UCC_INPROGRESS;
+    ee_task->super.eee    = executor;
+
+    if (task_args->task_type == UCC_EE_EXECUTOR_TASK_COPY_MULTI) {
+        ee_task->num_subtasks = task_args->copy_multi.num_vectors;
+        for (i = 0; i < ee_task->num_subtasks; i++) {
+            subtask_args = &(eee->tasks[(eee->pidx + i) % max_tasks]);
+            subtask_args->task_type = UCC_EE_EXECUTOR_TASK_COPY;
+            subtask_args->copy.src  = task_args->copy_multi.src[i];
+            subtask_args->copy.dst  = task_args->copy_multi.dst[i];
+            subtask_args->copy.len  = task_args->copy_multi.counts[i];
+
+            ee_task->subtasks[i] = subtask_args;
+        }
+    } else if (task_args->task_type == UCC_EE_EXECUTOR_TASK_REDUCE_MULTI_DST) {
+        ee_task->num_subtasks = task_args->reduce_multi_dst.n_bufs;
+        for (i = 0; i < ee_task->num_subtasks; i++) {
+            subtask_args = &(eee->tasks[(eee->pidx + i) % max_tasks]);
+            subtask_args->task_type      = UCC_EE_EXECUTOR_TASK_REDUCE;
+            subtask_args->reduce.srcs[0] = task_args->reduce_multi_dst.src1[i];
+            subtask_args->reduce.srcs[1] = task_args->reduce_multi_dst.src2[i];
+            subtask_args->reduce.dst     = task_args->reduce_multi_dst.dst[i];
+            subtask_args->reduce.count   = task_args->reduce_multi_dst.counts[i];
+            subtask_args->reduce.dt      = task_args->reduce_multi_dst.dt;
+            subtask_args->reduce.op      = task_args->reduce_multi_dst.op;
+            subtask_args->reduce.n_srcs  = 2;
+
+            ee_task->subtasks[i] = subtask_args;
+        }
+    } else {
+        ee_task->num_subtasks = 1;
+        ee_task->subtasks[0] = &(eee->tasks[eee->pidx % max_tasks]);
+        memcpy(ee_task->subtasks[0], task_args,
+               sizeof(ucc_ee_executor_task_args_t));
+    }
     ucc_memory_cpu_store_fence();
-    eee->pidx += 1;
+    eee->pidx += ee_task->num_subtasks;
     if (ucc_ec_cuda.thread_mode == UCC_THREAD_MULTIPLE) {
         ucc_spin_unlock(&eee->tasks_lock);
     }
     ec_debug(&ucc_ec_cuda.super, "executor task post, eee: %p", eee);
 
-    *task = ee_task;
+    *task = &ee_task->super;
     return UCC_OK;
 }
-
 
 ucc_status_t
 ucc_cuda_executor_persistent_task_test(const ucc_ee_executor_task_t *task)
 {
-    CUDA_CHECK(cudaGetLastError());
-    return task->status;
+    ucc_ec_cuda_executor_persistent_task_t *ee_task;
+    ucc_status_t status;
+    int i;
+
+    ee_task = ucc_derived_of(task, ucc_ec_cuda_executor_persistent_task_t);
+
+    if (ee_task->super.status != UCC_INPROGRESS) {
+        goto exit;
+    }
+
+    status = CUDA_FUNC(cudaGetLastError());
+    if (ucc_unlikely(status != UCC_OK)) {
+        ee_task->super.status = status;
+        goto exit;
+    }
+
+    for (i = 0; i < ee_task->num_subtasks; i++) {
+        if (ee_task->subtasks[i]->task_type != UCC_EE_EXECUTOR_TASK_LAST) {
+            goto exit;
+        }
+    }
+    ee_task->super.status = UCC_OK;
+exit:
+    return ee_task->super.status;
 }
 
 ucc_status_t
 ucc_cuda_executor_persistent_task_finalize(ucc_ee_executor_task_t *task)
 {
+    ucc_assert(task->status == UCC_OK);
+    ucc_mpool_put(task);
     return UCC_OK;
 }
 

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -300,7 +300,7 @@ __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
     grid_group      grid        = this_grid();
     int cidx_local, pidx_local;
     volatile int *pidx, *cidx;
-    ucc_ee_executor_task_t *tasks;
+    ucc_ee_executor_task_args_t *tasks;
     __shared__ ucc_ee_executor_task_args_t args;
     __shared__ bool worker_done;
 
@@ -330,7 +330,7 @@ __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
             (*cidx)++;
             worker_done = (pidx_local == -1);
             if (!worker_done) {
-                args = tasks[cidx_local].args;
+                args = tasks[cidx_local];
             }
         }
         __syncthreads();
@@ -365,8 +365,8 @@ __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
         __syncthreads();
         __threadfence_system();
         if (is_master) {
-            tasks[cidx_local].status = UCC_OK;
-            cidx_local = (cidx_local + num_workers) %q_size;
+            tasks[cidx_local].task_type = UCC_EE_EXECUTOR_TASK_LAST;
+            cidx_local = (cidx_local + num_workers) % q_size;
         }
     }
 }


### PR DESCRIPTION
## What
Optimize copy_multi and reduce_multi_dst operations for persistent executor in TL CUDA

## How ?
Multi operations are split into smaller subtasks to utilize multiple workers (blcoks) in persistent kernel