### PR TITLE
EC/CUDA: optimize reduce with unrolling

### DIFF
--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -73,7 +73,7 @@ static ucc_config_field_t ucc_ec_cuda_config_table[] = {
      ucc_offsetof(ucc_ec_cuda_config_t, reduce_num_blocks),
      UCC_CONFIG_TYPE_ULUNITS},
 
-    {"USE_COOPERATIVE_LAUNCH", "1",
+    {"USE_COOPERATIVE_LAUNCH", "0",
      "whether to use cooperative launch in persistent kernel executor",
      ucc_offsetof(ucc_ec_cuda_config_t, use_cooperative_launch),
      UCC_CONFIG_TYPE_BOOL},

--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -49,12 +49,12 @@ static ucc_config_field_t ucc_ec_cuda_config_table[] = {
      UCC_CONFIG_TYPE_UINT},
 
     {"EXEC_NUM_WORKERS", "1",
-     "Number of thread blocks to use for cuda executor",
+     "Number of thread blocks to use for cuda persistent executor",
      ucc_offsetof(ucc_ec_cuda_config_t, exec_num_workers),
      UCC_CONFIG_TYPE_ULUNITS},
 
     {"EXEC_NUM_THREADS", "512",
-     "Number of thread per block to use for cuda executor",
+     "Number of threads per block to use for cuda persistent executor",
      ucc_offsetof(ucc_ec_cuda_config_t, exec_num_threads),
      UCC_CONFIG_TYPE_ULUNITS},
 
@@ -71,6 +71,12 @@ static ucc_config_field_t ucc_ec_cuda_config_table[] = {
     {"REDUCE_NUM_BLOCKS", "auto",
      "Number of thread blocks to use for reduction in interruptible mode",
      ucc_offsetof(ucc_ec_cuda_config_t, reduce_num_blocks),
+     UCC_CONFIG_TYPE_ULUNITS},
+
+    {"REDUCE_NUM_THREADS", "auto",
+     "Number of threads per block to use for reduction in interruptible "
+     "executor",
+     ucc_offsetof(ucc_ec_cuda_config_t, reduce_num_threads),
      UCC_CONFIG_TYPE_ULUNITS},
 
     {"USE_COOPERATIVE_LAUNCH", "0",
@@ -212,6 +218,28 @@ static ucc_status_t ucc_ec_cuda_post_driver_stream_task(uint32_t *status,
     return UCC_OK;
 }
 
+static inline void ucc_ec_cuda_set_threads_nbr(int *nt, int maxThreadsPerBlock)
+{
+    if (*nt != UCC_ULUNITS_AUTO) {
+        if (maxThreadsPerBlock < *nt) {
+            ec_warn(
+                &ucc_ec_cuda.super,
+                "number of threads per block is too large, max supported is %d",
+                maxThreadsPerBlock);
+        } else if (*nt % WARP_SIZE != 0) {
+            ec_warn(&ucc_ec_cuda.super,
+                    "number of threads per block must be divisible by "
+                    "WARP_SIZE(=%d)",
+                    WARP_SIZE);
+        } else {
+            return;
+        }
+    }
+
+    *nt = (maxThreadsPerBlock / WARP_SIZE) * WARP_SIZE;
+    return;
+}
+
 static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
 {
     ucc_ec_cuda_config_t *cfg = EC_CUDA_CONFIG;
@@ -239,12 +267,16 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
     CUDA_CHECK(cudaGetDevice(&device));
 
     CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
-    cfg->reduce_num_threads = prop.maxThreadsPerBlock;
+
+    ucc_ec_cuda_set_threads_nbr((int *)&cfg->exec_num_threads,
+                                prop.maxThreadsPerBlock);
+    ucc_ec_cuda_set_threads_nbr(&cfg->reduce_num_threads,
+                                prop.maxThreadsPerBlock);
 
     if (cfg->reduce_num_blocks != UCC_ULUNITS_AUTO) {
         if (prop.maxGridSize[0] < cfg->reduce_num_blocks) {
             ec_warn(&ucc_ec_cuda.super,
-                    "number of blocks is too large, max supported %d",
+                    "number of blocks is too large, max supported is %d",
                     prop.maxGridSize[0]);
             cfg->reduce_num_blocks = prop.maxGridSize[0];
         }

--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -237,7 +237,6 @@ static inline void ucc_ec_cuda_set_threads_nbr(int *nt, int maxThreadsPerBlock)
     }
 
     *nt = (maxThreadsPerBlock / WARP_SIZE) * WARP_SIZE;
-    return;
 }
 
 static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)

--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -226,7 +226,7 @@ static inline void ucc_ec_cuda_set_threads_nbr(int *nt, int maxThreadsPerBlock)
                 &ucc_ec_cuda.super,
                 "number of threads per block is too large, max supported is %d",
                 maxThreadsPerBlock);
-        } else if (*nt % WARP_SIZE != 0) {
+        } else if ((*nt % WARP_SIZE) != 0) {
             ec_warn(&ucc_ec_cuda.super,
                     "number of threads per block must be divisible by "
                     "WARP_SIZE(=%d)",

--- a/src/components/ec/cuda/ec_cuda.h
+++ b/src/components/ec/cuda/ec_cuda.h
@@ -13,6 +13,7 @@
 #include "utils/ucc_mpool.h"
 #include <cuda_runtime.h>
 
+#define WARP_SIZE 32
 typedef enum ucc_ec_cuda_strm_task_mode {
     UCC_EC_CUDA_TASK_KERNEL,
     UCC_EC_CUDA_TASK_MEM_OPS,

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -210,7 +210,7 @@ __device__ ucc_status_t executor_reduce(ucc_ee_executor_task_args_t *task)
     }
 
     if (UCC_DT_FLOAT32 == dt && UCC_OP_SUM == op && aligned && n_src == 2) {
-        executor_reduce_float_sum_aligned_2<REDUCE_LOOP_UNROLL(float)>(
+        executor_reduce_float_sum_aligned_2<REDUCE_LOOP_UNROLL_TRIGGERED(float)>(
             (float *)s1, (float *)s2, (float *)d, count);
         return UCC_OK;
     }

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -11,7 +11,6 @@
 
 extern "C" {
 #include "../ec_cuda.h"
-#include <inttypes.h>
 }
 #include "ec_cuda_reduce_ops.h"
 #include <cooperative_groups.h>
@@ -163,14 +162,15 @@ __device__ void executor_reduce_float_sum_aligned_2(const float *s1,
 #define LAUNCH_REDUCE_A(NAME, _Type, _AlphaType, _task, ...)                   \
     do {                                                                       \
         if (_task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE) {                 \
-            return ucc_reduce_cuda_default_##NAME<                             \
-                _Type, _AlphaType, true, REDUCE_LOOP_UNROLL_TRIGGERED>(        \
+            ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, true,            \
+                                           REDUCE_LOOP_UNROLL_TRIGGERED>(      \
                 _task->reduce, _task->flags);                                  \
         } else {                                                               \
-            return ucc_reduce_cuda_strided_##NAME<                             \
-                _Type, _AlphaType, true, REDUCE_LOOP_UNROLL_TRIGGERED>(        \
+            ucc_reduce_cuda_strided_##NAME<_Type, _AlphaType, true,            \
+                                           REDUCE_LOOP_UNROLL_TRIGGERED>(      \
                 _task->reduce_strided, _task->flags);                          \
         }                                                                      \
+        return UCC_OK;                                                         \
     } while (0)
 
 #define LAUNCH_REDUCE(NAME, _Type, _task, ...)      \

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -11,6 +11,7 @@
 
 extern "C" {
 #include "../ec_cuda.h"
+#include <inttypes.h>
 }
 #include "ec_cuda_reduce_ops.h"
 #include <cooperative_groups.h>

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -16,10 +16,7 @@ extern "C" {
 #include <cooperative_groups.h>
 using namespace cooperative_groups;
 
-#define WARP_SIZE          32
-#define LOOP_UNROLL        8
 #define align_pow2(_n, _p) ((_n) & ((_p) - 1))
-typedef int4 vectype;
 
 __global__ void executor_start(ucc_ec_cuda_executor_state_t *state,
                                int *cidx)
@@ -98,34 +95,79 @@ __device__ inline void add_float4(float4 &d, const float4 &x, const float4 &y)
     d.w = x.w + y.w;
 }
 
+template <int UNROLL>
 __device__ void executor_reduce_float_sum_aligned_2(const float *s1,
                                                     const float *s2, float *d,
                                                     size_t count)
 {
-    const float4 *s14      = (const float4*)s1;
-    const float4 *s24      = (const float4*)s2;
-    float4       *d4       = (float4*)d;
-    const size_t  idx      = threadIdx.x;
-    const size_t  step     = blockDim.x;
-    const int     n        = count / 4;
-    const int     num_iter = n / step + ((idx < n % step) ? 1 : 0);
+    const float4 *s14       = reinterpret_cast<const float4 *>(s1);
+    const float4 *s24       = reinterpret_cast<const float4 *>(s2);
+    float4 *      d4        = reinterpret_cast<float4 *>(d);
+    const int     warp      = threadIdx.x / WARP_SIZE;
+    const int     num_warps = blockDim.x / WARP_SIZE;
+    const int     idx       = threadIdx.x % WARP_SIZE;
+    size_t        num_lines =
+        (count * sizeof(float) / (WARP_SIZE * UNROLL * sizeof(float4))) *
+        (WARP_SIZE * UNROLL);
+    float4 tmp1[UNROLL];
+    float4 tmp2[UNROLL];
 
-    for(int i = 0; i < num_iter; i++) {
-        add_float4(d4[i * step + idx], s14[i * step + idx],
-                   s24[i * step + idx]);
+    for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;
+         line += num_warps * WARP_SIZE * UNROLL) {
+#pragma unroll
+        for (int i = 0; i < UNROLL; i++) {
+            tmp1[i] = s14[line + WARP_SIZE * i];
+        }
+#pragma unroll
+        for (int i = 0; i < UNROLL; i++) {
+            tmp2[i] = s24[line + WARP_SIZE * i];
+        }
+#pragma unroll
+        for (int i = 0; i < UNROLL; i++) {
+            add_float4(tmp1[i], tmp1[i], tmp2[i]);
+        }
+#pragma unroll
+        for (int i = 0; i < UNROLL; i++) {
+            d4[line + WARP_SIZE * i] = tmp1[i];
+        }
     }
-    if (idx < count % 4) {
-        d[count - idx - 1] = s1[count - idx - 1] + s2[count - idx - 1];
+
+    count = count - num_lines * sizeof(vectype) / sizeof(float);
+    if (count == 0) {
+        return;
+    }
+
+    s14       = s14 + num_lines;
+    s24       = s24 + num_lines;
+    d4        = d4 + num_lines;
+    num_lines = count * sizeof(float) / sizeof(vectype);
+    for (int line = threadIdx.x; line < num_lines; line += blockDim.x) {
+        add_float4(d4[line], s14[line], s24[line]);
+    }
+
+    count = count - num_lines * sizeof(vectype) / sizeof(float);
+    if (count == 0) {
+        return;
+    }
+
+    s1 = reinterpret_cast<const float *>(s14 + num_lines);
+    s2 = reinterpret_cast<const float *>(s24 + num_lines);
+    d  = reinterpret_cast<float *>(d4 + num_lines);
+
+    for (size_t line = threadIdx.x; line < count; line += blockDim.x) {
+        d[line] = s1[line] + s2[line];
     }
 }
 
 #define LAUNCH_REDUCE_A(NAME, _Type, _AlphaType, _task, ...)                   \
     do {                                                                       \
         if (_task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE) {                 \
-            return ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, true>(    \
+            return ucc_reduce_cuda_default_##NAME<                             \
+                _Type, _AlphaType, true, REDUCE_LOOP_UNROLL_TRIGGERED(_Type)>( \
                 _task->reduce, _task->flags);                                  \
         } else {                                                               \
-            return ucc_reduce_cuda_strided_##NAME<_Type, _AlphaType, true>(    \
+            return ucc_reduce_cuda_strided_##NAME<                             \
+                _Type, _AlphaType, true, REDUCE_LOOP_UNROLL_TRIGGERED(_Type)>( \
                 _task->reduce_strided, _task->flags);                          \
         }                                                                      \
     } while (0)
@@ -168,9 +210,9 @@ __device__ ucc_status_t executor_reduce(ucc_ee_executor_task_args_t *task)
     }
 
     if (UCC_DT_FLOAT32 == dt && UCC_OP_SUM == op && aligned && n_src == 2) {
-            executor_reduce_float_sum_aligned_2((float *)s1, (float *)s2,
-                                                (float *)d, count);
-            return UCC_OK;
+        executor_reduce_float_sum_aligned_2<REDUCE_LOOP_UNROLL(float)>(
+            (float *)s1, (float *)s2, (float *)d, count);
+        return UCC_OK;
     }
     switch (dt) {
     case UCC_DT_INT8:
@@ -293,7 +335,7 @@ __global__ void executor_kernel(volatile ucc_ec_cuda_executor_t *eee,
         }
         switch (args.task_type) {
         case UCC_EE_EXECUTOR_TASK_COPY:
-            executor_copy_task<LOOP_UNROLL>(args.copy);
+            executor_copy_task<COPY_LOOP_UNROLL>(args.copy);
             break;
         case UCC_EE_EXECUTOR_TASK_REDUCE:
         case UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED:

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -163,11 +163,11 @@ __device__ void executor_reduce_float_sum_aligned_2(const float *s1,
     do {                                                                       \
         if (_task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE) {                 \
             return ucc_reduce_cuda_default_##NAME<                             \
-                _Type, _AlphaType, true, REDUCE_LOOP_UNROLL_TRIGGERED(_Type)>( \
+                _Type, _AlphaType, true, REDUCE_LOOP_UNROLL_TRIGGERED>(        \
                 _task->reduce, _task->flags);                                  \
         } else {                                                               \
             return ucc_reduce_cuda_strided_##NAME<                             \
-                _Type, _AlphaType, true, REDUCE_LOOP_UNROLL_TRIGGERED(_Type)>( \
+                _Type, _AlphaType, true, REDUCE_LOOP_UNROLL_TRIGGERED>(        \
                 _task->reduce_strided, _task->flags);                          \
         }                                                                      \
     } while (0)
@@ -210,7 +210,7 @@ __device__ ucc_status_t executor_reduce(ucc_ee_executor_task_args_t *task)
     }
 
     if (UCC_DT_FLOAT32 == dt && UCC_OP_SUM == op && aligned && n_src == 2) {
-        executor_reduce_float_sum_aligned_2<REDUCE_LOOP_UNROLL_TRIGGERED(float)>(
+        executor_reduce_float_sum_aligned_2<REDUCE_LOOP_UNROLL_TRIGGERED>(
             (float *)s1, (float *)s2, (float *)d, count);
         return UCC_OK;
     }

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
@@ -75,7 +75,7 @@ UCC_REDUCE_CUDA_MULTI_DST_SUM<float, false>(ucc_eee_task_reduce_multi_dst_t arg)
                 <<<b, t, 0, s>>>(_task->reduce, _task->flags);                 \
         } else if (_task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED) {  \
             UCC_REDUCE_CUDA_STRIDED_##NAME<type, _AlphaType, false,            \
-                                           REDUCE_LOOP_UNROLL_INTERRUPTIBLE>           \
+                                           REDUCE_LOOP_UNROLL_INTERRUPTIBLE>   \
                 <<<b, t, 0, s>>>(_task->reduce_strided, _task->flags);         \
         } else {                                                               \
             UCC_REDUCE_CUDA_MULTI_DST_##NAME<type, false>                      \

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
@@ -70,10 +70,12 @@ UCC_REDUCE_CUDA_MULTI_DST_SUM<float, false>(ucc_eee_task_reduce_multi_dst_t arg)
 #define LAUNCH_REDUCE_A(NAME, type, _AlphaType, _task, s, b, t)                \
     do {                                                                       \
         if (_task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE) {                 \
-            UCC_REDUCE_CUDA_DEFAULT_##NAME<type, _AlphaType, false>            \
+            UCC_REDUCE_CUDA_DEFAULT_##NAME<type, _AlphaType, false,            \
+                                           REDUCE_LOOP_UNROLL_INTERRUPTIBLE>   \
                 <<<b, t, 0, s>>>(_task->reduce, _task->flags);                 \
         } else if (_task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED) {  \
-            UCC_REDUCE_CUDA_STRIDED_##NAME<type, _AlphaType, false>            \
+            UCC_REDUCE_CUDA_STRIDED_##NAME<type, _AlphaType, false,            \
+                                           REDUCE_LOOP_UNROLL_INTERRUPTIBLE)>           \
                 <<<b, t, 0, s>>>(_task->reduce_strided, _task->flags);         \
         } else {                                                               \
             UCC_REDUCE_CUDA_MULTI_DST_##NAME<type, false>                      \
@@ -83,7 +85,6 @@ UCC_REDUCE_CUDA_MULTI_DST_SUM<float, false>(ucc_eee_task_reduce_multi_dst_t arg)
 
 #define LAUNCH_REDUCE(NAME, type,  _task, s, b, t)  \
     LAUNCH_REDUCE_A(NAME, type, type, _task, s, b, t)
-
 
 extern "C" {
 ucc_status_t ucc_ec_cuda_reduce(ucc_ee_executor_task_args_t *task,

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
@@ -11,7 +11,6 @@
 
 extern "C" {
 #include "../ec_cuda.h"
-#include <inttypes.h>
 }
 #include "ec_cuda_reduce_ops.h"
 

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
@@ -11,6 +11,7 @@
 
 extern "C" {
 #include "../ec_cuda.h"
+#include <inttypes.h>
 }
 #include "ec_cuda_reduce_ops.h"
 

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
@@ -75,7 +75,7 @@ UCC_REDUCE_CUDA_MULTI_DST_SUM<float, false>(ucc_eee_task_reduce_multi_dst_t arg)
                 <<<b, t, 0, s>>>(_task->reduce, _task->flags);                 \
         } else if (_task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED) {  \
             UCC_REDUCE_CUDA_STRIDED_##NAME<type, _AlphaType, false,            \
-                                           REDUCE_LOOP_UNROLL_INTERRUPTIBLE)>           \
+                                           REDUCE_LOOP_UNROLL_INTERRUPTIBLE>           \
                 <<<b, t, 0, s>>>(_task->reduce_strided, _task->flags);         \
         } else {                                                               \
             UCC_REDUCE_CUDA_MULTI_DST_##NAME<type, false>                      \

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -59,87 +59,87 @@ cuFloatComplex operator* (const cuFloatComplex & first,
                                cuCimagf(first) * second);
 }
 
-#define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                  \
-    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>  \
-    __device__ ucc_status_t ucc_reduce_cuda_default_##NAME(                     \
-        ucc_eee_task_reduce_t task, uint16_t flags)                             \
-    {                                                                           \
-        const size_t count  = task.count;                                       \
-        _Type *      d      = (_Type *)task.dst;                                \
-        const uint16_t    n_srcs = task.n_srcs;                                      \
-        const int    warp =                                                     \
+#define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                    \
+    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>    \
+    __device__ ucc_status_t ucc_reduce_cuda_default_##NAME(                       \
+        ucc_eee_task_reduce_t task, uint16_t flags)                               \
+    {                                                                             \
+        const size_t   count  = task.count;                                       \
+        _Type *        d      = (_Type *)task.dst;                                \
+        const uint16_t n_srcs = task.n_srcs;                                      \
+        const int      warp =                                                     \
             triggered ? threadIdx.x / WARP_SIZE                              \
-                         : (threadIdx.x + blockIdx.x * blockDim.x) / WARP_SIZE; \
-        const int    num_warps = triggered                                      \
-                                     ? blockDim.x / WARP_SIZE                   \
-                                     : (blockDim.x * gridDim.x) / WARP_SIZE;    \
-        const int    idx       = threadIdx.x % WARP_SIZE;                       \
-        const size_t num_lines =                                                \
-            (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);              \
-        const _Type *s[UCC_EE_EXECUTOR_NUM_BUFS];                               \
-        _Type        tmp1[UNROLL];                                              \
-        _Type        tmp2[UNROLL];                                              \
-        size_t       i, j;                                                      \
-        memcpy(s, task.srcs, UCC_EE_EXECUTOR_NUM_BUFS * sizeof(_Type *));       \
-        for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;   \
-             line += num_warps * WARP_SIZE * UNROLL) {                          \
-            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                      \
-            {                                                                   \
-                tmp1[i] = s[0][line + WARP_SIZE * i];                           \
-            }                                                                   \
-            for (j = 1; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                    \
-                if (j >= n_srcs) {                                              \
-                    break;                                                      \
-                }                                                               \
-                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
-                {                                                               \
-                    tmp2[i] = s[j][line + WARP_SIZE * i];                       \
-                }                                                               \
-                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
-                {                                                               \
-                    tmp1[i] = _OP(tmp1[i], tmp2[i]);                            \
-                }                                                               \
-            }                                                                   \
-            if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                  \
-                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
-                {                                                               \
-                    tmp1[i] = tmp1[i] * (_AlphaType)task.alpha;                 \
-                }                                                               \
-            }                                                                   \
-            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                      \
-            {                                                                   \
-                d[line + WARP_SIZE * i] = tmp1[i];                              \
-            }                                                                   \
-        }                                                                       \
-        for (i = triggered                                                      \
-                     ? num_lines + threadIdx.x                                  \
-                     : num_lines + threadIdx.x + blockIdx.x * blockDim.x;       \
-             i < count;                                                         \
-             i += triggered ? blockDim.x : blockDim.x * gridDim.x) {            \
-            d[i] = _OP(s[0][i], s[1][i]);                                       \
-            for (j = 2; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                    \
-                if (j >= n_srcs) {                                              \
-                    break;                                                      \
-                }                                                               \
-                d[i] = _OP(d[i], s[j][i]);                                      \
-            }                                                                   \
-        }                                                                       \
-        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                      \
-            for (i = triggered                                                  \
-                         ? num_lines + threadIdx.x                              \
-                         : num_lines + threadIdx.x + blockIdx.x * blockDim.x;   \
-                 i < count;                                                     \
-                 i += triggered ? blockDim.x : blockDim.x * gridDim.x) {        \
-                d[i] = d[i] * (_AlphaType)task.alpha;                           \
-            }                                                                   \
-        }                                                                       \
-    }                                                                           \
-    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>  \
-    __global__ void UCC_REDUCE_CUDA_DEFAULT_##NAME(ucc_eee_task_reduce_t task,  \
-                                                   uint16_t              flags) \
-    {                                                                           \
-        ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, triggered, UNROLL>(   \
-            task, flags);                                                       \
+                           : (threadIdx.x + blockIdx.x * blockDim.x) / WARP_SIZE; \
+        const int    num_warps = triggered                                        \
+                                     ? blockDim.x / WARP_SIZE                     \
+                                     : (blockDim.x * gridDim.x) / WARP_SIZE;      \
+        const int    idx       = threadIdx.x % WARP_SIZE;                         \
+        const size_t num_lines =                                                  \
+            (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);                \
+        const _Type *s[UCC_EE_EXECUTOR_NUM_BUFS];                                 \
+        _Type        tmp1[UNROLL];                                                \
+        _Type        tmp2[UNROLL];                                                \
+        size_t       i, j;                                                        \
+        memcpy(s, task.srcs, UCC_EE_EXECUTOR_NUM_BUFS * sizeof(_Type *));         \
+        for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;     \
+             line += num_warps * WARP_SIZE * UNROLL) {                            \
+            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                        \
+            {                                                                     \
+                tmp1[i] = s[0][line + WARP_SIZE * i];                             \
+            }                                                                     \
+            for (j = 1; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                      \
+                if (j >= n_srcs) {                                                \
+                    break;                                                        \
+                }                                                                 \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                    \
+                {                                                                 \
+                    tmp2[i] = s[j][line + WARP_SIZE * i];                         \
+                }                                                                 \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                    \
+                {                                                                 \
+                    tmp1[i] = _OP(tmp1[i], tmp2[i]);                              \
+                }                                                                 \
+            }                                                                     \
+            if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                    \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                    \
+                {                                                                 \
+                    tmp1[i] = tmp1[i] * (_AlphaType)task.alpha;                   \
+                }                                                                 \
+            }                                                                     \
+            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                        \
+            {                                                                     \
+                d[line + WARP_SIZE * i] = tmp1[i];                                \
+            }                                                                     \
+        }                                                                         \
+        for (i = triggered                                                        \
+                     ? num_lines + threadIdx.x                                    \
+                     : num_lines + threadIdx.x + blockIdx.x * blockDim.x;         \
+             i < count;                                                           \
+             i += triggered ? blockDim.x : blockDim.x * gridDim.x) {              \
+            d[i] = _OP(s[0][i], s[1][i]);                                         \
+            for (j = 2; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                      \
+                if (j >= n_srcs) {                                                \
+                    break;                                                        \
+                }                                                                 \
+                d[i] = _OP(d[i], s[j][i]);                                        \
+            }                                                                     \
+        }                                                                         \
+        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                        \
+            for (i = triggered                                                    \
+                         ? num_lines + threadIdx.x                                \
+                         : num_lines + threadIdx.x + blockIdx.x * blockDim.x;     \
+                 i < count;                                                       \
+                 i += triggered ? blockDim.x : blockDim.x * gridDim.x) {          \
+                d[i] = d[i] * (_AlphaType)task.alpha;                             \
+            }                                                                     \
+        }                                                                         \
+    }                                                                             \
+    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>    \
+    __global__ void UCC_REDUCE_CUDA_DEFAULT_##NAME(ucc_eee_task_reduce_t task,    \
+                                                   uint16_t              flags)   \
+    {                                                                             \
+        ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, triggered, UNROLL>(     \
+            task, flags);                                                         \
     }
 
 #define CUDA_REDUCE_WITH_OP_STRIDED(NAME, _OP)                                  \
@@ -161,10 +161,10 @@ cuFloatComplex operator* (const cuFloatComplex & first,
         const int    idx       = threadIdx.x % WARP_SIZE;                       \
         const size_t num_lines =                                                \
             (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);              \
-        __shared__ uint16_t n_src2;                                                  \
-        _Type          tmp1[UNROLL];                                            \
-        _Type          tmp2[UNROLL];                                            \
-        size_t         i, j;                                                    \
+        __shared__ uint16_t n_src2;                                             \
+        _Type               tmp1[UNROLL];                                       \
+        _Type               tmp2[UNROLL];                                       \
+        size_t              i, j;                                               \
         n_src2 = task.n_src2;                                                   \
         ucc_assert(task.stride % sizeof(_Type) == 0);                           \
         for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;   \
@@ -173,7 +173,7 @@ cuFloatComplex operator* (const cuFloatComplex & first,
             {                                                                   \
                 tmp1[i] = s1[line + WARP_SIZE * i];                             \
             }                                                                   \
-            for (j = 0; j < USHRT_MAX; j++) {                                     \
+            for (j = 0; j < USHRT_MAX; j++) {                                   \
                 if (j >= n_src2) {                                              \
                     break;                                                      \
                 }                                                               \
@@ -203,7 +203,7 @@ cuFloatComplex operator* (const cuFloatComplex & first,
              i < count;                                                         \
              i += triggered ? blockDim.x : blockDim.x * gridDim.x) {            \
             d[i] = _OP(s1[i], s2[i]);                                           \
-            for (j = 1; j < USHRT_MAX; j++) {                                     \
+            for (j = 1; j < USHRT_MAX; j++) {                                   \
                 if (j >= n_src2) {                                              \
                     break;                                                      \
                 }                                                               \

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -15,6 +15,12 @@ extern "C" {
 #include <cuda_bf16.h>
 #include <cuComplex.h>
 
+#define WARP_SIZE                          32
+#define COPY_LOOP_UNROLL                   8
+#define REDUCE_LOOP_UNROLL_TRIGGERED(TYPE) 32 / sizeof(TYPE)
+#define REDUCE_LOOP_UNROLL_INTERRUPTIBLE   1
+typedef int4 vectype;
+
 __device__ inline
 cuDoubleComplex operator+ (const cuDoubleComplex & first,
                            const cuDoubleComplex & second) {
@@ -53,114 +59,163 @@ cuFloatComplex operator* (const cuFloatComplex & first,
                                cuCimagf(first) * second);
 }
 
-#define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                 \
-    template <typename _Type, typename _AlphaType, bool triggered>             \
-    __device__ ucc_status_t ucc_reduce_cuda_default_##NAME(                    \
-        ucc_eee_task_reduce_t task, uint16_t flags)                            \
-    {                                                                          \
-        size_t        count  = task.count;                                     \
-        int           n_srcs = task.n_srcs;                                    \
-        const _Type **s      = (const _Type **)task.srcs;                      \
-        _Type *       d      = (_Type *)task.dst;                              \
-        size_t        start =                                                  \
-            triggered ? threadIdx.x : threadIdx.x + blockIdx.x * blockDim.x;   \
-        size_t step = triggered ? blockDim.x : blockDim.x * gridDim.x;         \
-        size_t i, j;                                                           \
-        switch (n_srcs) {                                                      \
-        case 2:                                                                \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = _OP##_2(s[0][i], s[1][i]);                              \
-            }                                                                  \
-            break;                                                             \
-        case 3:                                                                \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = _OP##_3(s[0][i], s[1][i], s[2][i]);                     \
-            }                                                                  \
-            break;                                                             \
-        case 4:                                                                \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = _OP##_4(s[0][i], s[1][i], s[2][i], s[3][i]);            \
-            }                                                                  \
-            break;                                                             \
-        default:                                                               \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = _OP(s[0][i], s[1][i]);                                  \
-                for (j = 2; j < n_srcs; j++) {                                 \
-                    d[i] = _OP(d[i], s[j][i]);                                 \
-                }                                                              \
-            }                                                                  \
-            break;                                                             \
-        }                                                                      \
-        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                     \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = d[i] * (_AlphaType)task.alpha;                          \
-            }                                                                  \
-        }                                                                      \
-        return UCC_OK;                                                         \
-    }                                                                          \
-    template <typename _Type, typename _AlphaType, bool triggered>             \
-    __global__ void UCC_REDUCE_CUDA_DEFAULT_##NAME(ucc_eee_task_reduce_t task, \
-                                                   uint16_t flags)             \
-    {                                                                          \
-        ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, triggered>(task,     \
-                                                                     flags);   \
+#define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                   \
+    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>   \
+    __device__ ucc_status_t ucc_reduce_cuda_default_##NAME(                      \
+        ucc_eee_task_reduce_t task, uint16_t flags)                              \
+    {                                                                            \
+        size_t        count  = task.count;                                       \
+        const _Type **s      = (const _Type **)task.srcs;                        \
+        _Type *       d      = (_Type *)task.dst;                                \
+        int           n_srcs = task.n_srcs;                                      \
+        const int     warp =                                                     \
+            triggered ? threadIdx.x / WARP_SIZE                              \
+                          : (threadIdx.x + blockIdx.x * blockDim.x) / WARP_SIZE; \
+        const int num_warps = triggered                                          \
+                                  ? blockDim.x / WARP_SIZE                       \
+                                  : (blockDim.x * gridDim.x) / WARP_SIZE;        \
+        const int idx       = threadIdx.x % WARP_SIZE;                           \
+        size_t    num_lines =                                                    \
+            (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);               \
+        _Type  tmp1[UNROLL];                                                     \
+        _Type  tmp2[UNROLL];                                                     \
+        size_t i, j;                                                             \
+        for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;    \
+             line += num_warps * WARP_SIZE * UNROLL) {                           \
+            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                       \
+            {                                                                    \
+                tmp1[i] = s[0][line + WARP_SIZE * i];                            \
+            }                                                                    \
+            for (j = 1; j < n_srcs; j++) {                                       \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                   \
+                {                                                                \
+                    tmp2[i] = s[j][line + WARP_SIZE * i];                        \
+                }                                                                \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                   \
+                {                                                                \
+                    tmp1[i] = _OP(tmp1[i], tmp2[i]);                             \
+                }                                                                \
+            }                                                                    \
+            if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                   \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                   \
+                {                                                                \
+                    tmp1[i] = tmp1[i] * (_AlphaType)task.alpha;                  \
+                }                                                                \
+            }                                                                    \
+            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                       \
+            {                                                                    \
+                d[line + WARP_SIZE * i] = tmp1[i];                               \
+            }                                                                    \
+        }                                                                        \
+        for (i = triggered                                                       \
+                     ? num_lines + threadIdx.x                                   \
+                     : num_lines + threadIdx.x + blockIdx.x * blockDim.x;        \
+             i < count;                                                          \
+             i += triggered ? blockDim.x : blockDim.x * gridDim.x) {             \
+            d[i] = _OP(s[0][i], s[1][i]);                                        \
+            for (j = 2; j < n_srcs; j++) {                                       \
+                d[i] = _OP(d[i], s[j][i]);                                       \
+            }                                                                    \
+        }                                                                        \
+        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                       \
+            for (i = triggered                                                   \
+                         ? num_lines + threadIdx.x                               \
+                         : num_lines + threadIdx.x + blockIdx.x * blockDim.x;    \
+                 i < count;                                                      \
+                 i += triggered ? blockDim.x : blockDim.x * gridDim.x) {         \
+                d[i] = d[i] * (_AlphaType)task.alpha;                            \
+            }                                                                    \
+        }                                                                        \
+    }                                                                            \
+    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>   \
+    __global__ void UCC_REDUCE_CUDA_DEFAULT_##NAME(ucc_eee_task_reduce_t task,   \
+                                                   uint16_t              flags)  \
+    {                                                                            \
+        ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, triggered, UNROLL>(    \
+            task, flags);                                                        \
     }
 
-#define CUDA_REDUCE_WITH_OP_STRIDED(NAME, _OP)                                 \
-    template <typename _Type, typename _AlphaType, bool triggered>             \
-    __device__ ucc_status_t ucc_reduce_cuda_strided_##NAME(                    \
-        ucc_eee_task_reduce_strided_t task, uint16_t flags)                    \
-    {                                                                          \
-        uint16_t     n_src2 = task.n_src2;                                     \
-        size_t       count  = task.count;                                      \
-        size_t       stride = task.stride;                                     \
-        size_t       ld     = stride / sizeof(_Type);                          \
-        const _Type *s1     = (const _Type *)task.src1;                        \
-        const _Type *s2     = (const _Type *)task.src2;                        \
-        _Type *      d      = (_Type *)task.dst;                               \
-        size_t       start =                                                   \
-            triggered ? threadIdx.x : threadIdx.x + blockIdx.x * blockDim.x;   \
-        size_t step = triggered ? blockDim.x : blockDim.x * gridDim.x;         \
-        size_t i, j;                                                           \
-        ucc_assert_system(stride % sizeof(_Type) == 0);                        \
-        switch (n_src2) {                                                      \
-        case 1:                                                                \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = _OP##_2(s1[i], s2[i]);                                  \
-            }                                                                  \
-            break;                                                             \
-        case 2:                                                                \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = _OP##_3(s1[i], s2[i], s2[i + ld]);                      \
-            }                                                                  \
-            break;                                                             \
-        case 3:                                                                \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = _OP##_4(s1[i], s2[i], s2[i + ld], s2[i + 2 * ld]);      \
-            }                                                                  \
-            break;                                                             \
-        default:                                                               \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = _OP(s1[i], s2[i]);                                      \
-                for (j = 1; j < n_src2; j++) {                                 \
-                    d[i] = _OP(d[i], s2[i + j * ld]);                          \
-                }                                                              \
-            }                                                                  \
-            break;                                                             \
-        }                                                                      \
-        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                     \
-            for (i = start; i < count; i += step) {                            \
-                d[i] = d[i] * (_AlphaType)task.alpha;                          \
-            }                                                                  \
-        }                                                                      \
-        return UCC_OK;                                                         \
-    }                                                                          \
-    template <typename _Type, typename _AlphaType, bool triggered>             \
-    __global__ void UCC_REDUCE_CUDA_STRIDED_##NAME(                            \
-        ucc_eee_task_reduce_strided_t task, uint16_t flags)                    \
-    {                                                                          \
-        ucc_reduce_cuda_strided_##NAME<_Type, _AlphaType, triggered>(task,     \
-                                                                     flags);   \
+#define CUDA_REDUCE_WITH_OP_STRIDED(NAME, _OP)                                  \
+    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>  \
+    __device__ ucc_status_t ucc_reduce_cuda_strided_##NAME(                     \
+        ucc_eee_task_reduce_strided_t task, uint16_t flags)                     \
+    {                                                                           \
+        size_t       count = task.count;                                        \
+        size_t       ld    = task.stride / sizeof(_Type);                       \
+        const _Type *s1    = (const _Type *)task.src1;                          \
+        const _Type *s2    = (const _Type *)task.src2;                          \
+        _Type *      d     = (_Type *)task.dst;                                 \
+        const int    warp =                                                     \
+            triggered ? threadIdx.x / WARP_SIZE                              \
+                         : (threadIdx.x + blockIdx.x * blockDim.x) / WARP_SIZE; \
+        const int num_warps = triggered                                         \
+                                  ? blockDim.x / WARP_SIZE                      \
+                                  : (blockDim.x * gridDim.x) / WARP_SIZE;       \
+        const int idx       = threadIdx.x % WARP_SIZE;                          \
+        size_t    num_lines =                                                   \
+            (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);              \
+        _Type  tmp1[UNROLL];                                                    \
+        _Type  tmp2[UNROLL];                                                    \
+        size_t i, j;                                                            \
+        ucc_assert(task.stride % sizeof(_Type) == 0);                           \
+        for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;   \
+             line += num_warps * WARP_SIZE * UNROLL) {                          \
+            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                      \
+            {                                                                   \
+                tmp1[i] = s1[line + WARP_SIZE * i];                             \
+            }                                                                   \
+            for (j = 0; j < task.n_src2; j++) {                                 \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
+                {                                                               \
+                    tmp2[i] = s2[line + WARP_SIZE * i + j * ld];                \
+                }                                                               \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
+                {                                                               \
+                    tmp1[i] = _OP(tmp1[i], tmp2[i]);                            \
+                }                                                               \
+            }                                                                   \
+            if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                  \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
+                {                                                               \
+                    tmp1[i] = tmp1[i] * (_AlphaType)task.alpha;                 \
+                }                                                               \
+            }                                                                   \
+            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                      \
+            {                                                                   \
+                d[line + WARP_SIZE * i] = tmp1[i];                              \
+            }                                                                   \
+        }                                                                       \
+        count -= num_lines;                                                     \
+        if (!count) {                                                           \
+            return;                                                             \
+        }                                                                       \
+        s1 += num_lines;                                                        \
+        s2 += num_lines;                                                        \
+        d += num_lines;                                                         \
+        for (i = triggered ? threadIdx.x                                        \
+                           : threadIdx.x + blockIdx.x * blockDim.x;             \
+             i < count;                                                         \
+             i += triggered ? blockDim.x : blockDim.x * gridDim.x) {            \
+            d[i] = _OP(s1[i], s2[i]);                                           \
+            for (j = 1; j < task.n_src2; j++) {                                 \
+                d[i] = _OP(d[i], s2[i + j * ld]);                               \
+            }                                                                   \
+        }                                                                       \
+        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                      \
+            for (i = triggered ? threadIdx.x                                    \
+                               : threadIdx.x + blockIdx.x * blockDim.x;         \
+                 i < count;                                                     \
+                 i += triggered ? blockDim.x : blockDim.x * gridDim.x) {        \
+                d[i] = d[i] * (_AlphaType)task.alpha;                           \
+            }                                                                   \
+        }                                                                       \
+    }                                                                           \
+    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>  \
+    __global__ void UCC_REDUCE_CUDA_STRIDED_##NAME(                             \
+        ucc_eee_task_reduce_strided_t task, uint16_t flags)                     \
+    {                                                                           \
+        ucc_reduce_cuda_strided_##NAME<_Type, _AlphaType, triggered, UNROLL>(   \
+            task, flags);                                                       \
     }
 
 #define CUDA_REDUCE_WITH_OP_MULTI_DST(NAME, _OP)                               \

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -143,8 +143,8 @@ cuFloatComplex operator* (const cuFloatComplex & first,
     __device__ ucc_status_t ucc_reduce_cuda_strided_##NAME(                     \
         ucc_eee_task_reduce_strided_t task, uint16_t flags)                     \
     {                                                                           \
-        size_t       count = task.count;                                        \
-        size_t       ld    = task.stride / sizeof(_Type);                       \
+        const size_t       count = task.count;                                        \
+        const size_t       ld    = task.stride / sizeof(_Type);                       \
         const _Type *s1    = (const _Type *)task.src1;                          \
         const _Type *s2    = (const _Type *)task.src2;                          \
         _Type *      d     = (_Type *)task.dst;                                 \
@@ -155,11 +155,13 @@ cuFloatComplex operator* (const cuFloatComplex & first,
                                   ? blockDim.x / WARP_SIZE                      \
                                   : (blockDim.x * gridDim.x) / WARP_SIZE;       \
         const int idx       = threadIdx.x % WARP_SIZE;                          \
-        size_t    num_lines =                                                   \
+        const size_t    num_lines =                                                   \
             (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);              \
+        __shared__ int n_src2;\
         _Type  tmp1[UNROLL];                                                    \
         _Type  tmp2[UNROLL];                                                    \
         size_t i, j;                                                            \
+        n_src2 = task.n_src2;\
         ucc_assert(task.stride % sizeof(_Type) == 0);                           \
         for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;   \
              line += num_warps * WARP_SIZE * UNROLL) {                          \
@@ -167,7 +169,8 @@ cuFloatComplex operator* (const cuFloatComplex & first,
             {                                                                   \
                 tmp1[i] = s1[line + WARP_SIZE * i];                             \
             }                                                                   \
-            for (j = 0; j < task.n_src2; j++) {                                 \
+            for (j = 0; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                                 \
+                if (j >= n_src2){break;}\
                 _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
                 {                                                               \
                     tmp2[i] = s2[line + WARP_SIZE * i + j * ld];                \
@@ -188,25 +191,19 @@ cuFloatComplex operator* (const cuFloatComplex & first,
                 d[line + WARP_SIZE * i] = tmp1[i];                              \
             }                                                                   \
         }                                                                       \
-        count -= num_lines;                                                     \
-        if (!count) {                                                           \
-            return;                                                             \
-        }                                                                       \
-        s1 += num_lines;                                                        \
-        s2 += num_lines;                                                        \
-        d += num_lines;                                                         \
-        for (i = triggered ? threadIdx.x                                        \
-                           : threadIdx.x + blockIdx.x * blockDim.x;             \
+        for (i = triggered ? num_lines + threadIdx.x                                        \
+                           : num_lines + threadIdx.x + blockIdx.x * blockDim.x;             \
              i < count;                                                         \
              i += triggered ? blockDim.x : blockDim.x * gridDim.x) {            \
             d[i] = _OP(s1[i], s2[i]);                                           \
-            for (j = 1; j < task.n_src2; j++) {                                 \
+            for (j = 1; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                                 \
+                if (j >= n_src2){break;}\
                 d[i] = _OP(d[i], s2[i + j * ld]);                               \
             }                                                                   \
         }                                                                       \
         if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                      \
-            for (i = triggered ? threadIdx.x                                    \
-                               : threadIdx.x + blockIdx.x * blockDim.x;         \
+            for (i = triggered ? num_lines + threadIdx.x                                    \
+                               : num_lines + threadIdx.x + blockIdx.x * blockDim.x;         \
                  i < count;                                                     \
                  i += triggered ? blockDim.x : blockDim.x * gridDim.x) {        \
                 d[i] = d[i] * (_AlphaType)task.alpha;                           \

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -15,9 +15,9 @@ extern "C" {
 #include <cuda_bf16.h>
 #include <cuComplex.h>
 
-#define WARP_SIZE                32
-#define COPY_LOOP_UNROLL         8
-#define REDUCE_LOOP_UNROLL_TRIGGERED(TYPE) 16 / sizeof(TYPE)
+#define WARP_SIZE                        32
+#define COPY_LOOP_UNROLL                 8
+#define REDUCE_LOOP_UNROLL_TRIGGERED     7
 #define REDUCE_LOOP_UNROLL_INTERRUPTIBLE 1
 typedef int4 vectype;
 
@@ -59,83 +59,87 @@ cuFloatComplex operator* (const cuFloatComplex & first,
                                cuCimagf(first) * second);
 }
 
-#define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                   \
-    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>   \
-    __device__ ucc_status_t ucc_reduce_cuda_default_##NAME(                      \
-        ucc_eee_task_reduce_t task, uint16_t flags)                              \
-    {                                                                            \
-        const size_t        count  = task.count;                                       \
-        _Type *       d      = (_Type *)task.dst;                                \
-        const int           n_srcs = task.n_srcs;                                      \
-        const int     warp =                                                     \
+#define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                  \
+    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>  \
+    __device__ ucc_status_t ucc_reduce_cuda_default_##NAME(                     \
+        ucc_eee_task_reduce_t task, uint16_t flags)                             \
+    {                                                                           \
+        const size_t count  = task.count;                                       \
+        _Type *      d      = (_Type *)task.dst;                                \
+        const int    n_srcs = task.n_srcs;                                      \
+        const int    warp =                                                     \
             triggered ? threadIdx.x / WARP_SIZE                              \
-                          : (threadIdx.x + blockIdx.x * blockDim.x) / WARP_SIZE; \
-        const int num_warps = triggered                                          \
-                                  ? blockDim.x / WARP_SIZE                       \
-                                  : (blockDim.x * gridDim.x) / WARP_SIZE;        \
-        const int idx       = threadIdx.x % WARP_SIZE;                           \
-        const size_t    num_lines =                                                    \
-            (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);               \
-        const _Type *s[UCC_EE_EXECUTOR_NUM_BUFS];                    \
-        _Type  tmp1[UNROLL];                                                     \
-        _Type  tmp2[UNROLL];                                                     \
-        size_t i, j;                                                             \
-        memcpy(s, task.srcs, UCC_EE_EXECUTOR_NUM_BUFS * sizeof(_Type *));\
-        for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;    \
-             line += num_warps * WARP_SIZE * UNROLL) {                           \
-            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                       \
-            {                                                                    \
-                tmp1[i] = s[0][line + WARP_SIZE * i];                            \
-            }                                                                    \
-            for (j = 1; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                                       \
-                if (j >= n_srcs){break;}\
-                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                   \
-                {                                                                \
-                    tmp2[i] = s[j][line + WARP_SIZE * i];                        \
-                }                                                                \
-                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                   \
-                {                                                                \
-                    tmp1[i] = _OP(tmp1[i], tmp2[i]);                             \
-                }                                                                \
-            }                                                                    \
-            if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                   \
-                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                   \
-                {                                                                \
-                    tmp1[i] = tmp1[i] * (_AlphaType)task.alpha;                  \
-                }                                                                \
-            }                                                                    \
-            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                       \
-            {                                                                    \
-                d[line + WARP_SIZE * i] = tmp1[i];                               \
-            }                                                                    \
-        }                                                                        \
-        for (i = triggered                                                       \
-                     ? num_lines + threadIdx.x                                   \
-                     : num_lines + threadIdx.x + blockIdx.x * blockDim.x;        \
-             i < count;                                                          \
-             i += triggered ? blockDim.x : blockDim.x * gridDim.x) {             \
-            d[i] = _OP(s[0][i], s[1][i]);                                        \
-            for (j = 2; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                                       \
-                if (j >= n_srcs){break;}\
-                d[i] = _OP(d[i], s[j][i]);                                       \
-            }                                                                    \
-        }                                                                        \
-        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                       \
-            for (i = triggered                                                   \
-                         ? num_lines + threadIdx.x                               \
-                         : num_lines + threadIdx.x + blockIdx.x * blockDim.x;    \
-                 i < count;                                                      \
-                 i += triggered ? blockDim.x : blockDim.x * gridDim.x) {         \
-                d[i] = d[i] * (_AlphaType)task.alpha;                            \
-            }                                                                    \
-        }                                                                        \
-    }                                                                            \
-    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>   \
-    __global__ void UCC_REDUCE_CUDA_DEFAULT_##NAME(ucc_eee_task_reduce_t task,   \
-                                                   uint16_t              flags)  \
-    {                                                                            \
-        ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, triggered, UNROLL>(    \
-            task, flags);                                                        \
+                         : (threadIdx.x + blockIdx.x * blockDim.x) / WARP_SIZE; \
+        const int    num_warps = triggered                                      \
+                                     ? blockDim.x / WARP_SIZE                   \
+                                     : (blockDim.x * gridDim.x) / WARP_SIZE;    \
+        const int    idx       = threadIdx.x % WARP_SIZE;                       \
+        const size_t num_lines =                                                \
+            (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);              \
+        const _Type *s[UCC_EE_EXECUTOR_NUM_BUFS];                               \
+        _Type        tmp1[UNROLL];                                              \
+        _Type        tmp2[UNROLL];                                              \
+        size_t       i, j;                                                      \
+        memcpy(s, task.srcs, UCC_EE_EXECUTOR_NUM_BUFS * sizeof(_Type *));       \
+        for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;   \
+             line += num_warps * WARP_SIZE * UNROLL) {                          \
+            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                      \
+            {                                                                   \
+                tmp1[i] = s[0][line + WARP_SIZE * i];                           \
+            }                                                                   \
+            for (j = 1; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                    \
+                if (j >= n_srcs) {                                              \
+                    break;                                                      \
+                }                                                               \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
+                {                                                               \
+                    tmp2[i] = s[j][line + WARP_SIZE * i];                       \
+                }                                                               \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
+                {                                                               \
+                    tmp1[i] = _OP(tmp1[i], tmp2[i]);                            \
+                }                                                               \
+            }                                                                   \
+            if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                  \
+                _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
+                {                                                               \
+                    tmp1[i] = tmp1[i] * (_AlphaType)task.alpha;                 \
+                }                                                               \
+            }                                                                   \
+            _Pragma("unroll") for (i = 0; i < UNROLL; i++)                      \
+            {                                                                   \
+                d[line + WARP_SIZE * i] = tmp1[i];                              \
+            }                                                                   \
+        }                                                                       \
+        for (i = triggered                                                      \
+                     ? num_lines + threadIdx.x                                  \
+                     : num_lines + threadIdx.x + blockIdx.x * blockDim.x;       \
+             i < count;                                                         \
+             i += triggered ? blockDim.x : blockDim.x * gridDim.x) {            \
+            d[i] = _OP(s[0][i], s[1][i]);                                       \
+            for (j = 2; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                    \
+                if (j >= n_srcs) {                                              \
+                    break;                                                      \
+                }                                                               \
+                d[i] = _OP(d[i], s[j][i]);                                      \
+            }                                                                   \
+        }                                                                       \
+        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                      \
+            for (i = triggered                                                  \
+                         ? num_lines + threadIdx.x                              \
+                         : num_lines + threadIdx.x + blockIdx.x * blockDim.x;   \
+                 i < count;                                                     \
+                 i += triggered ? blockDim.x : blockDim.x * gridDim.x) {        \
+                d[i] = d[i] * (_AlphaType)task.alpha;                           \
+            }                                                                   \
+        }                                                                       \
+    }                                                                           \
+    template <typename _Type, typename _AlphaType, bool triggered, int UNROLL>  \
+    __global__ void UCC_REDUCE_CUDA_DEFAULT_##NAME(ucc_eee_task_reduce_t task,  \
+                                                   uint16_t              flags) \
+    {                                                                           \
+        ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, triggered, UNROLL>(   \
+            task, flags);                                                       \
     }
 
 #define CUDA_REDUCE_WITH_OP_STRIDED(NAME, _OP)                                  \
@@ -143,25 +147,25 @@ cuFloatComplex operator* (const cuFloatComplex & first,
     __device__ ucc_status_t ucc_reduce_cuda_strided_##NAME(                     \
         ucc_eee_task_reduce_strided_t task, uint16_t flags)                     \
     {                                                                           \
-        const size_t       count = task.count;                                        \
-        const size_t       ld    = task.stride / sizeof(_Type);                       \
+        const size_t count = task.count;                                        \
+        const size_t ld    = task.stride / sizeof(_Type);                       \
         const _Type *s1    = (const _Type *)task.src1;                          \
         const _Type *s2    = (const _Type *)task.src2;                          \
         _Type *      d     = (_Type *)task.dst;                                 \
         const int    warp =                                                     \
             triggered ? threadIdx.x / WARP_SIZE                              \
                          : (threadIdx.x + blockIdx.x * blockDim.x) / WARP_SIZE; \
-        const int num_warps = triggered                                         \
-                                  ? blockDim.x / WARP_SIZE                      \
-                                  : (blockDim.x * gridDim.x) / WARP_SIZE;       \
-        const int idx       = threadIdx.x % WARP_SIZE;                          \
-        const size_t    num_lines =                                                   \
+        const int    num_warps = triggered                                      \
+                                     ? blockDim.x / WARP_SIZE                   \
+                                     : (blockDim.x * gridDim.x) / WARP_SIZE;    \
+        const int    idx       = threadIdx.x % WARP_SIZE;                       \
+        const size_t num_lines =                                                \
             (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);              \
-        __shared__ int n_src2;\
-        _Type  tmp1[UNROLL];                                                    \
-        _Type  tmp2[UNROLL];                                                    \
-        size_t i, j;                                                            \
-        n_src2 = task.n_src2;\
+        __shared__ int n_src2;                                                  \
+        _Type          tmp1[UNROLL];                                            \
+        _Type          tmp2[UNROLL];                                            \
+        size_t         i, j;                                                    \
+        n_src2 = task.n_src2;                                                   \
         ucc_assert(task.stride % sizeof(_Type) == 0);                           \
         for (size_t line = warp * WARP_SIZE * UNROLL + idx; line < num_lines;   \
              line += num_warps * WARP_SIZE * UNROLL) {                          \
@@ -169,8 +173,10 @@ cuFloatComplex operator* (const cuFloatComplex & first,
             {                                                                   \
                 tmp1[i] = s1[line + WARP_SIZE * i];                             \
             }                                                                   \
-            for (j = 0; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                                 \
-                if (j >= n_src2){break;}\
+            for (j = 0; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                    \
+                if (j >= n_src2) {                                              \
+                    break;                                                      \
+                }                                                               \
                 _Pragma("unroll") for (i = 0; i < UNROLL; i++)                  \
                 {                                                               \
                     tmp2[i] = s2[line + WARP_SIZE * i + j * ld];                \
@@ -191,19 +197,23 @@ cuFloatComplex operator* (const cuFloatComplex & first,
                 d[line + WARP_SIZE * i] = tmp1[i];                              \
             }                                                                   \
         }                                                                       \
-        for (i = triggered ? num_lines + threadIdx.x                                        \
-                           : num_lines + threadIdx.x + blockIdx.x * blockDim.x;             \
+        for (i = triggered                                                      \
+                     ? num_lines + threadIdx.x                                  \
+                     : num_lines + threadIdx.x + blockIdx.x * blockDim.x;       \
              i < count;                                                         \
              i += triggered ? blockDim.x : blockDim.x * gridDim.x) {            \
             d[i] = _OP(s1[i], s2[i]);                                           \
-            for (j = 1; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                                 \
-                if (j >= n_src2){break;}\
+            for (j = 1; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                    \
+                if (j >= n_src2) {                                              \
+                    break;                                                      \
+                }                                                               \
                 d[i] = _OP(d[i], s2[i + j * ld]);                               \
             }                                                                   \
         }                                                                       \
         if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                      \
-            for (i = triggered ? num_lines + threadIdx.x                                    \
-                               : num_lines + threadIdx.x + blockIdx.x * blockDim.x;         \
+            for (i = triggered                                                  \
+                         ? num_lines + threadIdx.x                              \
+                         : num_lines + threadIdx.x + blockIdx.x * blockDim.x;   \
                  i < count;                                                     \
                  i += triggered ? blockDim.x : blockDim.x * gridDim.x) {        \
                 d[i] = d[i] * (_AlphaType)task.alpha;                           \

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -9,13 +9,13 @@
 
 extern "C" {
 #include "utils/ucc_math_op.h"
+#include "../ec_cuda.h"
 }
 
 #include "ec_cuda_half_sm52.h"
 #include <cuda_bf16.h>
 #include <cuComplex.h>
 
-#define WARP_SIZE                        32
 #define COPY_LOOP_UNROLL                 8
 #define REDUCE_LOOP_UNROLL_TRIGGERED     7
 #define REDUCE_LOOP_UNROLL_INTERRUPTIBLE 1

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -66,7 +66,7 @@ cuFloatComplex operator* (const cuFloatComplex & first,
     {                                                                           \
         const size_t count  = task.count;                                       \
         _Type *      d      = (_Type *)task.dst;                                \
-        const int    n_srcs = task.n_srcs;                                      \
+        const uint16_t    n_srcs = task.n_srcs;                                      \
         const int    warp =                                                     \
             triggered ? threadIdx.x / WARP_SIZE                              \
                          : (threadIdx.x + blockIdx.x * blockDim.x) / WARP_SIZE; \
@@ -161,7 +161,7 @@ cuFloatComplex operator* (const cuFloatComplex & first,
         const int    idx       = threadIdx.x % WARP_SIZE;                       \
         const size_t num_lines =                                                \
             (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL);              \
-        __shared__ int n_src2;                                                  \
+        __shared__ uint16_t n_src2;                                                  \
         _Type          tmp1[UNROLL];                                            \
         _Type          tmp2[UNROLL];                                            \
         size_t         i, j;                                                    \
@@ -173,7 +173,7 @@ cuFloatComplex operator* (const cuFloatComplex & first,
             {                                                                   \
                 tmp1[i] = s1[line + WARP_SIZE * i];                             \
             }                                                                   \
-            for (j = 0; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                    \
+            for (j = 0; j < USHRT_MAX; j++) {                                     \
                 if (j >= n_src2) {                                              \
                     break;                                                      \
                 }                                                               \
@@ -203,7 +203,7 @@ cuFloatComplex operator* (const cuFloatComplex & first,
              i < count;                                                         \
              i += triggered ? blockDim.x : blockDim.x * gridDim.x) {            \
             d[i] = _OP(s1[i], s2[i]);                                           \
-            for (j = 1; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                    \
+            for (j = 1; j < USHRT_MAX; j++) {                                     \
                 if (j >= n_src2) {                                              \
                     break;                                                      \
                 }                                                               \


### PR DESCRIPTION
## What
Various optimizations in reduce ad reduce_strided kernels. We get the following improvements on the BW (see also graphs below):
- triggered mode (aka persistent mode): BW improved by a factor of ~2
- interruptible mode, reduce collective: BW improved by a factor of ~10
- interruptible mode, reduce_strided collective: BW roughly unchanged


## How
- To optimize the triggered mode, we split and unroll the loops in the kernel. The Unroll factor has been hand-tuned to 7. Higher value could potentially lead to better performances but with the current default number of threads (=512), the kernel does not fit into the GPU (tested on Tesla V100 32GB)
-  We have to set `UCC_EC_CUDA_USE_COOPERATIVE_LAUNCH` to 0 otherwise the persistent kernel with the unrolled loop with unroll factor 7 is too large to fit in the GPU (tested on Tesla V100 32GB)
- to avoid code duplication, we use the same implementation for triggered and interruptible mode. Only the unrolling constant is tuned independently in the two cases
- For interruptible mode, the Unroll factor is set to 1. We then use a series of non-conventional optimizations which yield surprisingly good results (BW improved by a factor 10 for reduce collective). These optimizations are especially important in the interruptible mode when `UCC_EC_CUDA_REDUCE_NUM_BLOCKS=auto` which sets the number of blocks to the maximum possible. The optimizations can be seen for example on `src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h:90` where we use 
```
            for (j = 1; j < UCC_EE_EXECUTOR_NUM_BUFS; j++) {                    \
                if (j >= n_srcs) {                                              \
                    break;                                                      \
                }                                                               \
```
instead of
```
for (j = 1; j < n_srcs; j++) { 
```
another example of non-conventional optimization is on `src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h:83` where we use 
```
        memcpy(s, task.srcs, UCC_EE_EXECUTOR_NUM_BUFS * sizeof(_Type *));       \
```
instead of
```
        memcpy(s, task.srcs, n_srcs* sizeof(_Type *));       \
```
I personally don't understand the intuition behind these optimizations, I just notice that they lead to significantly improved performance. Any intuition or help to understand this would be much welcome.

Performance on A100 GPU:

![reducedt_UNROLL=8_blocks=80_threads=auto_a100_FINAL](https://user-images.githubusercontent.com/17732757/207554048-6cf0df14-663c-4e23-9c60-b99d22a72aec.png)


Performance on V100GPU:
![reducedt_dt=float32_master_plot](https://user-images.githubusercontent.com/17732757/203542237-1b279718-7ed5-440d-b8b1-552c38754f69.png)
![reducedt_dt=float32_master-T_plot](https://user-images.githubusercontent.com/17732757/203542243-6827244e-9b5d-404b-b126-c2890fc931bd.png)
![reducedt_strided_dt=float32_master_plot](https://user-images.githubusercontent.com/17732757/203542248-c8414857-b411-436e-9fcb-3c37b1d15522.png)
![reducedt_strided_dt=float32_master-T_plot](https://user-images.githubusercontent.com/17732757/203542254-08f3254b-7b24-4577-baa8-c15cbde97dc7.png)
![SUMMARY_reducedt_dt=int32_master_plot](https://user-images.githubusercontent.com/17732757/203542258-0c29e8d3-df9f-42e0-9926-eb1a184c26ea.png)
![SUMMARY_reducedt_dt=int32_master-T_plot](https://user-images.githubusercontent.com/17732757/203542261-48746171-f5b0-4d8e-88db-6bb2d2075ed3.png)
![SUMMARY_reducedt_strided_dt=int32_master_plot](https://user-images.githubusercontent.com/17732757/203542267-f88577a6-e9c1-4d3a-9138-e45d72550044.png)
![SUMMARY_reducedt_strided_dt=int32_master-T_plot](https://user-images.githubusercontent.com/17732757/203542269-81b875af-a629-47b0-986e-c01fc19194c9.png)

