### PR TITLE
CL/HIER: alltoall single proc on node fix

### DIFF
--- a/src/components/cl/hier/alltoall/alltoall.c
+++ b/src/components/cl/hier/alltoall/alltoall.c
@@ -34,8 +34,8 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoall_init,
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    if (!SBGP_ENABLED(cl_team, NODE) || !SBGP_ENABLED(cl_team, FULL)) {
-        cl_debug(team->context->lib, "alltoall requires NODE and FULL sbgps");
+    if (!SBGP_ENABLED(cl_team, FULL)) {
+        cl_debug(team->context->lib, "alltoall requires FULL sbgps");
         return UCC_ERR_NOT_SUPPORTED;
     }
 

--- a/src/components/cl/hier/alltoallv/alltoallv.c
+++ b/src/components/cl/hier/alltoallv/alltoallv.c
@@ -145,13 +145,8 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoallv_init,
     }
 
     if (!SBGP_ENABLED(cl_team, FULL)) {
-        cl_debug(team->context->lib, "alltoallv requires FULL sbgps");
+        cl_debug(team->context->lib, "alltoallv requires FULL sbgp");
         return UCC_ERR_NOT_SUPPORTED;
-    }
-
-    if (!SBGP_ENABLED(cl_team, NODE)) {
-        full_only = 1;
-        task_node = NULL;
     }
 
     c64 = UCC_COLL_ARGS_COUNT64(&coll_args->args);
@@ -175,87 +170,86 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_alltoallv_init,
     node_size = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp->group_size;
     elem_size = c64 ? 8 : 4;
 
-    if (full_only) {
+    if (!SBGP_ENABLED(cl_team, NODE)) {
+        full_only = 1;
         UCC_CHECK_GOTO(ucc_coll_init(
                            cl_team->sbgps[UCC_HIER_SBGP_FULL].score_map,
                            &args, &task_full),
-                       err_init_1, status);
-    } else {
-        status = ucc_mc_alloc(&cl_schedule->scratch,
-                              elem_size * (full_size + node_size) * 4,
-                              UCC_MEMORY_TYPE_HOST);
-        if (ucc_unlikely(UCC_OK != status)) {
-            cl_error(team->context->lib,
-                     "failed to allocate %zd bytes for full counts",
-                     elem_size * (full_size + node_size) * 4);
-            goto error;
-        }
-
-        sc_full = cl_schedule->scratch->addr;
-        sd_full = PTR_OFFSET(sc_full, full_size * elem_size);
-        rc_full = PTR_OFFSET(sc_full, full_size * elem_size * 2);
-        rd_full = PTR_OFFSET(sc_full, full_size * elem_size * 3);
-
-        sc_node = PTR_OFFSET(sc_full, full_size * elem_size * 4);
-        sd_node = PTR_OFFSET(sc_node, node_size * elem_size);
-        rc_node = PTR_OFFSET(sc_node, node_size * elem_size * 2);
-        rd_node = PTR_OFFSET(sc_node, node_size * elem_size * 3);
-
-        /* Duplicate FULL a2av info and alloc task */
-        sbgp = cl_team->sbgps[UCC_HIER_SBGP_FULL].sbgp;
-        ucc_assert(sbgp->group_size == team->params.size);
-        sdt_size = ucc_dt_size(coll_args->args.src.info_v.datatype);
-        rdt_size = ucc_dt_size(coll_args->args.dst.info_v.datatype);
-
-        if (c64) {
-            SET_FULL_COUNTS(uint64_t, sbgp, coll_args, team,
-                            cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
-                            sc_full, sd_full, rc_full, rd_full);
-        } else {
-            SET_FULL_COUNTS(uint32_t, sbgp, coll_args, team,
-                            cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
-                            sc_full, sd_full, rc_full, rd_full);
-        }
-        args.args.src.info_v.counts        = (ucc_aint_t *)sc_full;
-        args.args.dst.info_v.counts        = (ucc_aint_t *)rc_full;
-        args.args.src.info_v.displacements = (ucc_aint_t *)sd_full;
-        args.args.dst.info_v.displacements = (ucc_aint_t *)rd_full;
-
-        UCC_CHECK_GOTO(ucc_coll_init(
-                           cl_team->sbgps[UCC_HIER_SBGP_FULL].score_map,
-                           &args, &task_full),
-                       err_init_1, status);
-
-        /* Setup NODE a2av */
-        sbgp = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp;
-
-        if (c64) {
-            SET_NODE_COUNTS(uint64_t, sbgp, coll_args,
-                            cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
-                            sc_node, sd_node, rc_node, rd_node);
-
-        } else {
-            SET_NODE_COUNTS(uint32_t, sbgp, coll_args,
-                            cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
-                            sc_node, sd_node, rc_node, rd_node);
-        }
-
-        args.args.src.info_v.counts        = (ucc_count_t *)sc_node;
-        args.args.dst.info_v.counts        = (ucc_count_t *)rc_node;
-        args.args.src.info_v.displacements = (ucc_aint_t *)sd_node;
-        args.args.dst.info_v.displacements = (ucc_aint_t *)rd_node;
-        UCC_CHECK_GOTO(ucc_coll_init(
-                           cl_team->sbgps[UCC_HIER_SBGP_NODE].score_map,
-                           &args, &task_node),
-                       err_init_2, status);
-
-        UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, task_node), err_init_3,
-                       status);
-        UCC_CHECK_GOTO(ucc_task_subscribe_dep(&schedule->super, task_node,
-                                              UCC_EVENT_SCHEDULE_STARTED),
-                       err_init_3, status);
+                       error, status);
+        goto full;
     }
 
+    status = ucc_mc_alloc(&cl_schedule->scratch,
+                          elem_size * (full_size + node_size) * 4,
+                          UCC_MEMORY_TYPE_HOST);
+    if (ucc_unlikely(UCC_OK != status)) {
+        cl_error(team->context->lib,
+                 "failed to allocate %zd bytes for full counts",
+                 elem_size * (full_size + node_size) * 4);
+        goto error;
+    }
+
+    sc_full = cl_schedule->scratch->addr;
+    sd_full = PTR_OFFSET(sc_full, full_size * elem_size);
+    rc_full = PTR_OFFSET(sc_full, full_size * elem_size * 2);
+    rd_full = PTR_OFFSET(sc_full, full_size * elem_size * 3);
+
+    sc_node = PTR_OFFSET(sc_full, full_size * elem_size * 4);
+    sd_node = PTR_OFFSET(sc_node, node_size * elem_size);
+    rc_node = PTR_OFFSET(sc_node, node_size * elem_size * 2);
+    rd_node = PTR_OFFSET(sc_node, node_size * elem_size * 3);
+
+    /* Duplicate FULL a2av info and alloc task */
+    sbgp = cl_team->sbgps[UCC_HIER_SBGP_FULL].sbgp;
+    ucc_assert(sbgp->group_size == team->params.size);
+    sdt_size = ucc_dt_size(coll_args->args.src.info_v.datatype);
+    rdt_size = ucc_dt_size(coll_args->args.dst.info_v.datatype);
+
+    if (c64) {
+        SET_FULL_COUNTS(uint64_t, sbgp, coll_args, team,
+                        cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
+                        sc_full, sd_full, rc_full, rd_full);
+    } else {
+        SET_FULL_COUNTS(uint32_t, sbgp, coll_args, team,
+                        cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
+                        sc_full, sd_full, rc_full, rd_full);
+    }
+    args.args.src.info_v.counts        = (ucc_count_t *)sc_full;
+    args.args.dst.info_v.counts        = (ucc_count_t *)rc_full;
+    args.args.src.info_v.displacements = (ucc_aint_t *)sd_full;
+    args.args.dst.info_v.displacements = (ucc_aint_t *)rd_full;
+
+    UCC_CHECK_GOTO(ucc_coll_init(cl_team->sbgps[UCC_HIER_SBGP_FULL].score_map,
+                                 &args, &task_full),
+                   err_init_1, status);
+
+    /* Setup NODE a2av */
+    sbgp = cl_team->sbgps[UCC_HIER_SBGP_NODE].sbgp;
+
+    if (c64) {
+        SET_NODE_COUNTS(uint64_t, sbgp, coll_args,
+                        cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
+                        sc_node, sd_node, rc_node, rd_node);
+    } else {
+        SET_NODE_COUNTS(uint32_t, sbgp, coll_args,
+                        cl_lib->cfg.a2av_node_thresh, sdt_size, rdt_size,
+                        sc_node, sd_node, rc_node, rd_node);
+    }
+
+    args.args.src.info_v.counts        = (ucc_count_t *)sc_node;
+    args.args.dst.info_v.counts        = (ucc_count_t *)rc_node;
+    args.args.src.info_v.displacements = (ucc_aint_t *)sd_node;
+    args.args.dst.info_v.displacements = (ucc_aint_t *)rd_node;
+    UCC_CHECK_GOTO(ucc_coll_init(cl_team->sbgps[UCC_HIER_SBGP_NODE].score_map,
+                                 &args, &task_node),
+                   err_init_2, status);
+
+    UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, task_node), err_init_3,
+                   status);
+    UCC_CHECK_GOTO(ucc_task_subscribe_dep(&schedule->super, task_node,
+                                          UCC_EVENT_SCHEDULE_STARTED),
+                   err_init_3, status);
+full:
     UCC_CHECK_GOTO(ucc_schedule_add_task(schedule, task_full), err_init_3,
                    status);
 


### PR DESCRIPTION
## What
Bug fix [#3213667](https://redmine.mellanox.com/issues/3213667).

## Why ?
CL/HIER alltoall and alltoallv was hanging due to single process on node case being disabled.

## How ?
Enabling single process on node, in which case only "full_task" (aka intra node) sends original args data without overwriting counts and displacements. In this case "node_task" (inter node) will not be initiated nor added to schedule.
