### PR TITLE
TEST: add linter for TL CUDA

### DIFF
--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -1,0 +1,50 @@
+name: Linter-NVIDIA
+
+on: [push, pull_request]
+
+env:
+  OPEN_UCX_LINK: https://github.com/openucx/ucx
+  OPEN_UCX_BRANCH: master
+  CLANG_VER: 12
+  CUDA_VER: 11-4
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
+        sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VER} main"
+        sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear
+    - name: Install extra dependencies
+      run: |
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+        sudo dpkg -i cuda-keyring_1.0-1_all.deb
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends  cuda-cudart-dev-${CUDA_VER} cuda-nvcc-${CUDA_VER} cuda-nvml-dev-${CUDA_VER}
+    - name: Get UCX
+      run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
+    - name: Build UCX
+      run: |
+        cd /tmp/ucx && ./autogen.sh
+        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./contrib/configure-release --without-java --without-go --disable-numa --prefix $PWD/install
+        make -j install
+    - uses: actions/checkout@v1
+    - name: Build UCC
+      run: |
+        ./autogen.sh
+        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-cuda=/usr/local/cuda --with-nvcc-gencode="-gencode=arch=compute_80,code=sm_80" --enable-assert
+        bear --exclude ${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/ --exclude ${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/ --cdb /tmp/compile_commands.json make
+    - name: Run clang-tidy
+      run: |
+        echo "Workspace: ${GITHUB_WORKSPACE}"
+        cd ${GITHUB_WORKSPACE}
+        run-clang-tidy-${CLANG_VER} -p /tmp/ 2>&1 | tee /tmp/clang_tidy.log
+        nerrors=$(grep 'error:' /tmp/clang_tidy.log | wc -l)
+        if [ $nerrors -ne 0 ]; then
+            exit 125;
+        fi
+        make clean
+        rm -rf /tmp/ucc

--- a/config/m4/configure.m4
+++ b/config/m4/configure.m4
@@ -83,3 +83,11 @@ AS_IF([test "x$enable_debug" = xyes],
     CXXFLAGS="$CXXFLAGS -O3 -g -DNDEBUG"
     AC_DEFINE([UCS_MAX_LOG_LEVEL], [UCS_LOG_LEVEL_DEBUG], [Highest log level])
     ])
+
+#
+# Enables additional checks
+#
+AC_ARG_ENABLE([assert],
+    AS_HELP_STRING([--enable-assert], [Enable extra correctness checks (default is NO).]),
+    [AC_DEFINE([UCC_ENABLE_ASSERT], [1], [Enable asserts])],
+    [enable_assert=no])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
+# See file LICENSE for terms.
 
 cl_dirs = components/cl/basic \
 		  components/cl/hier
@@ -73,6 +74,7 @@ noinst_HEADERS =                      \
 	utils/profile/ucc_profile_off.h   \
 	utils/ucc_time.h                  \
 	utils/ucc_sys.h                   \
+	utils/ucc_assert.h                \
 	components/base/ucc_base_iface.h  \
 	components/cl/ucc_cl.h            \
 	components/cl/ucc_cl_log.h        \
@@ -121,6 +123,7 @@ libucc_la_SOURCES =                   \
 	utils/ucc_sys.c                   \
 	utils/arch/x86_64/cpu.c           \
 	utils/arch/aarch64/cpu.c          \
+	utils/ucc_assert.c                \
 	components/base/ucc_base_iface.c  \
 	components/cl/ucc_cl.c            \
 	components/tl/ucc_tl.c            \

--- a/src/components/ec/cuda/ec_cuda_executor_interruptible.c
+++ b/src/components/ec/cuda/ec_cuda_executor_interruptible.c
@@ -16,6 +16,7 @@ ucc_status_t ucc_cuda_executor_interruptible_get_stream(cudaStream_t *stream)
     int             i, j;
     uint32_t        id;
 
+    ucc_assert(num_streams > 0);
     if (ucc_unlikely(!ucc_ec_cuda.exec_streams_initialized)) {
         ucc_spin_lock(&ucc_ec_cuda.init_spinlock);
         if (ucc_ec_cuda.exec_streams_initialized) {

--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -147,7 +147,7 @@ __device__ ucc_status_t executor_reduce(ucc_ee_executor_task_args_t *task)
         s2      = task->reduce.srcs[1];
         d       = task->reduce.dst;
     } else {
-        ucc_assert(task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED);
+        ucc_assert_system(task->task_type == UCC_EE_EXECUTOR_TASK_REDUCE_STRIDED);
         dt      = task->reduce_strided.dt;
         count   = task->reduce_strided.count;
         op      = task->reduce_strided.op;
@@ -225,7 +225,7 @@ __device__ ucc_status_t executor_reduce(ucc_ee_executor_task_args_t *task)
         return UCC_ERR_NOT_SUPPORTED;
 #endif
     case UCC_DT_BFLOAT16:
-        ucc_assert(2 == sizeof(__nv_bfloat16));
+        ucc_assert_system(2 == sizeof(__nv_bfloat16));
         DT_REDUCE_FLOAT(__nv_bfloat16, task, op);
         break;
     default:
@@ -395,4 +395,3 @@ ucc_status_t ucc_ec_cuda_copy_multi_kernel(const ucc_ee_executor_task_args_t *ar
 }
 
 }
-

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
@@ -177,7 +177,7 @@ ucc_status_t ucc_ec_cuda_reduce(ucc_ee_executor_task_args_t *task,
         return UCC_ERR_NOT_SUPPORTED;
 #endif
     case UCC_DT_BFLOAT16:
-        ucc_assert(2 == sizeof(__nv_bfloat16));
+        ucc_assert_system(2 == sizeof(__nv_bfloat16));
         DT_REDUCE_FLOAT(__nv_bfloat16, task, op, stream, bk, th);
         break;
     default:

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -53,112 +53,114 @@ cuFloatComplex operator* (const cuFloatComplex & first,
                                cuCimagf(first) * second);
 }
 
-#define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                      \
-    template <typename _Type, typename _AlphaType, bool triggered>                  \
-    __device__ ucc_status_t ucc_reduce_cuda_default_##NAME(                         \
-        ucc_eee_task_reduce_t task, uint16_t flags)                                 \
-    {                                                                               \
-        size_t        count  = task.count;                                          \
-        int           n_srcs = task.n_srcs;                                         \
-        const _Type **s      = (const _Type **)task.srcs;                           \
-        _Type *       d      = (_Type *)task.dst;                                   \
-        size_t        start =                                                       \
-            triggered ? threadIdx.x : threadIdx.x + blockIdx.x * blockDim.x; \
-        size_t step = triggered ? blockDim.x : blockDim.x * gridDim.x;              \
-        size_t i, j;                                                                \
-        switch (n_srcs) {                                                           \
-        case 2:                                                                     \
-            for (i = start; i < count; i += step) {                                 \
-                d[i] = _OP##_2(s[0][i], s[1][i]);                                   \
-            }                                                                       \
-            break;                                                                  \
-        case 3:                                                                     \
-            for (i = start; i < count; i += step) {                                 \
-                d[i] = _OP##_3(s[0][i], s[1][i], s[2][i]);                          \
-            }                                                                       \
-            break;                                                                  \
-        case 4:                                                                     \
-            for (i = start; i < count; i += step) {                                 \
-                d[i] = _OP##_4(s[0][i], s[1][i], s[2][i], s[3][i]);                 \
-            }                                                                       \
-            break;                                                                  \
-        default:                                                                    \
-            for (i = start; i < count; i += step) {                                 \
-                d[i] = _OP(s[0][i], s[1][i]);                                       \
-                for (j = 2; j < n_srcs; j++) {                                      \
-                    d[i] = _OP(d[i], s[j][i]);                                      \
-                }                                                                   \
-            }                                                                       \
-            break;                                                                  \
-        }                                                                           \
-        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                          \
-            for (i = start; i < count; i += step) {                                 \
-                d[i] = d[i] * (_AlphaType)task.alpha;                               \
-            }                                                                       \
-        }                                                                           \
-    }                                                                               \
-    template <typename _Type, typename _AlphaType, bool triggered>                  \
-    __global__ void UCC_REDUCE_CUDA_DEFAULT_##NAME(ucc_eee_task_reduce_t task,      \
-                                                   uint16_t              flags)     \
-    {                                                                               \
-        ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, triggered>(task,          \
-                                                                     flags);        \
+#define CUDA_REDUCE_WITH_OP_DEFAULT(NAME, _OP)                                 \
+    template <typename _Type, typename _AlphaType, bool triggered>             \
+    __device__ ucc_status_t ucc_reduce_cuda_default_##NAME(                    \
+        ucc_eee_task_reduce_t task, uint16_t flags)                            \
+    {                                                                          \
+        size_t        count  = task.count;                                     \
+        int           n_srcs = task.n_srcs;                                    \
+        const _Type **s      = (const _Type **)task.srcs;                      \
+        _Type *       d      = (_Type *)task.dst;                              \
+        size_t        start =                                                  \
+            triggered ? threadIdx.x : threadIdx.x + blockIdx.x * blockDim.x;   \
+        size_t step = triggered ? blockDim.x : blockDim.x * gridDim.x;         \
+        size_t i, j;                                                           \
+        switch (n_srcs) {                                                      \
+        case 2:                                                                \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP##_2(s[0][i], s[1][i]);                              \
+            }                                                                  \
+            break;                                                             \
+        case 3:                                                                \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP##_3(s[0][i], s[1][i], s[2][i]);                     \
+            }                                                                  \
+            break;                                                             \
+        case 4:                                                                \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP##_4(s[0][i], s[1][i], s[2][i], s[3][i]);            \
+            }                                                                  \
+            break;                                                             \
+        default:                                                               \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP(s[0][i], s[1][i]);                                  \
+                for (j = 2; j < n_srcs; j++) {                                 \
+                    d[i] = _OP(d[i], s[j][i]);                                 \
+                }                                                              \
+            }                                                                  \
+            break;                                                             \
+        }                                                                      \
+        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                     \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = d[i] * (_AlphaType)task.alpha;                          \
+            }                                                                  \
+        }                                                                      \
+        return UCC_OK;                                                         \
+    }                                                                          \
+    template <typename _Type, typename _AlphaType, bool triggered>             \
+    __global__ void UCC_REDUCE_CUDA_DEFAULT_##NAME(ucc_eee_task_reduce_t task, \
+                                                   uint16_t flags)             \
+    {                                                                          \
+        ucc_reduce_cuda_default_##NAME<_Type, _AlphaType, triggered>(task,     \
+                                                                     flags);   \
     }
 
-#define CUDA_REDUCE_WITH_OP_STRIDED(NAME, _OP)                                     \
-    template <typename _Type, typename _AlphaType, bool triggered>                 \
-    __device__ ucc_status_t ucc_reduce_cuda_strided_##NAME(                        \
-        ucc_eee_task_reduce_strided_t task, uint16_t flags)                        \
-    {                                                                              \
-        uint16_t     n_src2 = task.n_src2;                                         \
-        size_t       count  = task.count;                                          \
-        size_t       stride = task.stride;                                         \
-        size_t       ld     = stride / sizeof(_Type);                              \
-        const _Type *s1     = (const _Type *)task.src1;                            \
-        const _Type *s2     = (const _Type *)task.src2;                            \
-        _Type *      d      = (_Type *)task.dst;                                   \
-        size_t       start =                                                       \
-            triggered ? threadIdx.x : threadIdx.x + blockIdx.x * blockDim.x; \
-        size_t step = triggered ? blockDim.x : blockDim.x * gridDim.x;             \
-        size_t i, j;                                                               \
-        ucc_assert(stride % sizeof(_Type) == 0);                                   \
-        switch (n_src2) {                                                          \
-        case 1:                                                                    \
-            for (i = start; i < count; i += step) {                                \
-                d[i] = _OP##_2(s1[i], s2[i]);                                      \
-            }                                                                      \
-            break;                                                                 \
-        case 2:                                                                    \
-            for (i = start; i < count; i += step) {                                \
-                d[i] = _OP##_3(s1[i], s2[i], s2[i + ld]);                          \
-            }                                                                      \
-            break;                                                                 \
-        case 3:                                                                    \
-            for (i = start; i < count; i += step) {                                \
-                d[i] = _OP##_4(s1[i], s2[i], s2[i + ld], s2[i + 2 * ld]);          \
-            }                                                                      \
-            break;                                                                 \
-        default:                                                                   \
-            for (i = start; i < count; i += step) {                                \
-                d[i] = _OP(s1[i], s2[i]);                                          \
-                for (j = 1; j < n_src2; j++) {                                     \
-                    d[i] = _OP(d[i], s2[i + j * ld]);                              \
-                }                                                                  \
-            }                                                                      \
-            break;                                                                 \
-        }                                                                          \
-        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                         \
-            for (i = start; i < count; i += step) {                                \
-                d[i] = d[i] * (_AlphaType)task.alpha;                              \
-            }                                                                      \
-        }                                                                          \
-    }                                                                              \
-    template <typename _Type, typename _AlphaType, bool triggered>                 \
-    __global__ void UCC_REDUCE_CUDA_STRIDED_##NAME(                                \
-        ucc_eee_task_reduce_strided_t task, uint16_t flags)                        \
-    {                                                                              \
-        ucc_reduce_cuda_strided_##NAME<_Type, _AlphaType, triggered>(task,         \
-                                                                     flags);       \
+#define CUDA_REDUCE_WITH_OP_STRIDED(NAME, _OP)                                 \
+    template <typename _Type, typename _AlphaType, bool triggered>             \
+    __device__ ucc_status_t ucc_reduce_cuda_strided_##NAME(                    \
+        ucc_eee_task_reduce_strided_t task, uint16_t flags)                    \
+    {                                                                          \
+        uint16_t     n_src2 = task.n_src2;                                     \
+        size_t       count  = task.count;                                      \
+        size_t       stride = task.stride;                                     \
+        size_t       ld     = stride / sizeof(_Type);                          \
+        const _Type *s1     = (const _Type *)task.src1;                        \
+        const _Type *s2     = (const _Type *)task.src2;                        \
+        _Type *      d      = (_Type *)task.dst;                               \
+        size_t       start =                                                   \
+            triggered ? threadIdx.x : threadIdx.x + blockIdx.x * blockDim.x;   \
+        size_t step = triggered ? blockDim.x : blockDim.x * gridDim.x;         \
+        size_t i, j;                                                           \
+        ucc_assert_system(stride % sizeof(_Type) == 0);                        \
+        switch (n_src2) {                                                      \
+        case 1:                                                                \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP##_2(s1[i], s2[i]);                                  \
+            }                                                                  \
+            break;                                                             \
+        case 2:                                                                \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP##_3(s1[i], s2[i], s2[i + ld]);                      \
+            }                                                                  \
+            break;                                                             \
+        case 3:                                                                \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP##_4(s1[i], s2[i], s2[i + ld], s2[i + 2 * ld]);      \
+            }                                                                  \
+            break;                                                             \
+        default:                                                               \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = _OP(s1[i], s2[i]);                                      \
+                for (j = 1; j < n_src2; j++) {                                 \
+                    d[i] = _OP(d[i], s2[i + j * ld]);                          \
+                }                                                              \
+            }                                                                  \
+            break;                                                             \
+        }                                                                      \
+        if (flags & UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA) {                     \
+            for (i = start; i < count; i += step) {                            \
+                d[i] = d[i] * (_AlphaType)task.alpha;                          \
+            }                                                                  \
+        }                                                                      \
+        return UCC_OK;                                                         \
+    }                                                                          \
+    template <typename _Type, typename _AlphaType, bool triggered>             \
+    __global__ void UCC_REDUCE_CUDA_STRIDED_##NAME(                            \
+        ucc_eee_task_reduce_strided_t task, uint16_t flags)                    \
+    {                                                                          \
+        ucc_reduce_cuda_strided_##NAME<_Type, _AlphaType, triggered>(task,     \
+                                                                     flags);   \
     }
 
 #define CUDA_REDUCE_WITH_OP_MULTI_DST(NAME, _OP)                               \
@@ -213,79 +215,79 @@ CUDA_REDUCE_WITH_OP_MULTI_DST(BAND, DO_OP_BAND);
 CUDA_REDUCE_WITH_OP_MULTI_DST(BOR,  DO_OP_BOR);
 CUDA_REDUCE_WITH_OP_MULTI_DST(BXOR, DO_OP_BXOR);
 
-#define DT_REDUCE_INT(_Type, _task, _op, ...)               \
-    do {                                                    \
-        switch (_op) {                                      \
-        case UCC_OP_AVG:                                    \
-        case UCC_OP_SUM:                                    \
-            LAUNCH_REDUCE(SUM, _Type, _task, __VA_ARGS__);  \
-            break;                                          \
-        case UCC_OP_PROD:                                   \
-            LAUNCH_REDUCE(PROD, _Type, _task, __VA_ARGS__); \
-            break;                                          \
-        case UCC_OP_MIN:                                    \
-            LAUNCH_REDUCE(MIN, _Type, _task, __VA_ARGS__);  \
-            break;                                          \
-        case UCC_OP_MAX:                                    \
-            LAUNCH_REDUCE(MAX, _Type, _task, __VA_ARGS__);  \
-            break;                                          \
-        case UCC_OP_LAND:                                   \
-            LAUNCH_REDUCE(LAND, _Type, _task, __VA_ARGS__); \
-            break;                                          \
-        case UCC_OP_BAND:                                   \
-            LAUNCH_REDUCE(BAND, _Type, _task, __VA_ARGS__); \
-            break;                                          \
-        case UCC_OP_LOR:                                    \
-            LAUNCH_REDUCE(LOR, _Type, _task, __VA_ARGS__);  \
-            break;                                          \
-        case UCC_OP_BOR:                                    \
-            LAUNCH_REDUCE(BOR, _Type, _task, __VA_ARGS__);  \
-            break;                                          \
-        case UCC_OP_LXOR:                                   \
-            LAUNCH_REDUCE(LXOR, _Type, _task, __VA_ARGS__); \
-            break;                                          \
-        case UCC_OP_BXOR:                                   \
-            LAUNCH_REDUCE(BXOR, _Type, _task, __VA_ARGS__); \
-            break;                                          \
-        default:                                            \
-            return UCC_ERR_NOT_SUPPORTED;                   \
-        }                                                   \
+#define DT_REDUCE_INT(_Type, _task, _op, ...)                                  \
+    do {                                                                       \
+        switch (_op) {                                                         \
+        case UCC_OP_AVG:                                                       \
+        case UCC_OP_SUM:                                                       \
+            LAUNCH_REDUCE(SUM, _Type, _task, __VA_ARGS__);                     \
+            break;                                                             \
+        case UCC_OP_PROD:                                                      \
+            LAUNCH_REDUCE(PROD, _Type, _task, __VA_ARGS__);                    \
+            break;                                                             \
+        case UCC_OP_MIN:                                                       \
+            LAUNCH_REDUCE(MIN, _Type, _task, __VA_ARGS__);                     \
+            break;                                                             \
+        case UCC_OP_MAX:                                                       \
+            LAUNCH_REDUCE(MAX, _Type, _task, __VA_ARGS__);                     \
+            break;                                                             \
+        case UCC_OP_LAND:                                                      \
+            LAUNCH_REDUCE(LAND, _Type, _task, __VA_ARGS__);                    \
+            break;                                                             \
+        case UCC_OP_BAND:                                                      \
+            LAUNCH_REDUCE(BAND, _Type, _task, __VA_ARGS__);                    \
+            break;                                                             \
+        case UCC_OP_LOR:                                                       \
+            LAUNCH_REDUCE(LOR, _Type, _task, __VA_ARGS__);                     \
+            break;                                                             \
+        case UCC_OP_BOR:                                                       \
+            LAUNCH_REDUCE(BOR, _Type, _task, __VA_ARGS__);                     \
+            break;                                                             \
+        case UCC_OP_LXOR:                                                      \
+            LAUNCH_REDUCE(LXOR, _Type, _task, __VA_ARGS__);                    \
+            break;                                                             \
+        case UCC_OP_BXOR:                                                      \
+            LAUNCH_REDUCE(BXOR, _Type, _task, __VA_ARGS__);                    \
+            break;                                                             \
+        default:                                                               \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
     } while (0)
 
-#define DT_REDUCE_FLOAT_COMPLEX(_Type, _alphaType, _task, _op, ...)       \
-    do {                                                                  \
-        switch (_op) {                                                    \
-        case UCC_OP_AVG:                                                  \
-        case UCC_OP_SUM:                                                  \
-            LAUNCH_REDUCE_A(SUM, _Type, _alphaType, _task, __VA_ARGS__);  \
-            break;                                                        \
-        case UCC_OP_PROD:                                                 \
-            LAUNCH_REDUCE_A(PROD, _Type, _alphaType, _task, __VA_ARGS__); \
-            break;                                                        \
-        default:                                                          \
-            return UCC_ERR_NOT_SUPPORTED;                                 \
-        }                                                                 \
+#define DT_REDUCE_FLOAT_COMPLEX(_Type, _alphaType, _task, _op, ...)            \
+    do {                                                                       \
+        switch (_op) {                                                         \
+        case UCC_OP_AVG:                                                       \
+        case UCC_OP_SUM:                                                       \
+            LAUNCH_REDUCE_A(SUM, _Type, _alphaType, _task, __VA_ARGS__);       \
+            break;                                                             \
+        case UCC_OP_PROD:                                                      \
+            LAUNCH_REDUCE_A(PROD, _Type, _alphaType, _task, __VA_ARGS__);      \
+            break;                                                             \
+        default:                                                               \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
     } while (0)
 
-#define DT_REDUCE_FLOAT(_Type, _task, _op, ...)             \
-    do {                                                    \
-        switch (_op) {                                      \
-        case UCC_OP_AVG:                                    \
-        case UCC_OP_SUM:                                    \
-            LAUNCH_REDUCE(SUM, _Type, _task, __VA_ARGS__);  \
-            break;                                          \
-        case UCC_OP_PROD:                                   \
-            LAUNCH_REDUCE(PROD, _Type, _task, __VA_ARGS__); \
-            break;                                          \
-        case UCC_OP_MIN:                                    \
-            LAUNCH_REDUCE(MIN, _Type, _task, __VA_ARGS__);  \
-            break;                                          \
-        case UCC_OP_MAX:                                    \
-            LAUNCH_REDUCE(MAX, _Type, _task, __VA_ARGS__);  \
-            break;                                          \
-        default:                                            \
-            return UCC_ERR_NOT_SUPPORTED;                   \
-        }                                                   \
+#define DT_REDUCE_FLOAT(_Type, _task, _op, ...)                                \
+    do {                                                                       \
+        switch (_op) {                                                         \
+        case UCC_OP_AVG:                                                       \
+        case UCC_OP_SUM:                                                       \
+            LAUNCH_REDUCE(SUM, _Type, _task, __VA_ARGS__);                     \
+            break;                                                             \
+        case UCC_OP_PROD:                                                      \
+            LAUNCH_REDUCE(PROD, _Type, _task, __VA_ARGS__);                    \
+            break;                                                             \
+        case UCC_OP_MIN:                                                       \
+            LAUNCH_REDUCE(MIN, _Type, _task, __VA_ARGS__);                     \
+            break;                                                             \
+        case UCC_OP_MAX:                                                       \
+            LAUNCH_REDUCE(MAX, _Type, _task, __VA_ARGS__);                     \
+            break;                                                             \
+        default:                                                               \
+            return UCC_ERR_NOT_SUPPORTED;                                      \
+        }                                                                      \
     } while (0)
 
 #endif

--- a/src/components/ec/rocm/kernel/ec_rocm_reduce.cu
+++ b/src/components/ec/rocm/kernel/ec_rocm_reduce.cu
@@ -66,7 +66,7 @@
         size_t ld    = stride / sizeof(_Type);                                 \
         size_t i;                                                              \
                                                                                \
-        ucc_assert(stride % sizeof(_Type) == 0);                               \
+        ucc_assert_system(stride % sizeof(_Type) == 0);                        \
         switch (n_src2) {                                                      \
         case 1:                                                                \
             for (i = start; i < count; i += step) {                            \

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -193,12 +193,12 @@ static void ucc_mc_cuda_chunk_init(ucc_mpool_t *mp, //NOLINT
     h->mt        = UCC_MEMORY_TYPE_CUDA;
 }
 
-static void ucc_mc_cuda_chunk_release(ucc_mpool_t *mp, void *chunk) //NOLINT
+static void ucc_mc_cuda_chunk_release(ucc_mpool_t *mp, void *chunk) //NOLINT: mp is unused
 {
     ucc_free(chunk);
 }
 
-static void ucc_mc_cuda_chunk_cleanup(ucc_mpool_t *mp, void *obj)
+static void ucc_mc_cuda_chunk_cleanup(ucc_mpool_t *mp, void *obj) //NOLINT: mp is unused
 {
     ucc_mc_buffer_header_t *h = (ucc_mc_buffer_header_t *)obj;
     cudaError_t             st;

--- a/src/components/tl/cuda/allgather/allgather.c
+++ b/src/components/tl/cuda/allgather/allgather.c
@@ -25,13 +25,13 @@ ucc_base_coll_alg_info_t
             .id = 0, .name = NULL, .desc = NULL}};
 
 size_t ucc_tl_cuda_allgather_get_count(const ucc_tl_cuda_task_t *task,
-                                       ucc_rank_t                block)
+                                       ucc_rank_t block) //NOLINT: block is unused
 {
     return TASK_ARGS(task).dst.info.count / UCC_TL_TEAM_SIZE(TASK_TEAM(task));
 }
 
 size_t ucc_tl_cuda_allgather_get_offset(const ucc_tl_cuda_task_t *task,
-                                        ucc_rank_t                block)
+                                        ucc_rank_t block)
 {
     return (TASK_ARGS(task).dst.info.count /
             UCC_TL_TEAM_SIZE(TASK_TEAM(task))) *

--- a/src/components/tl/cuda/allgatherv/allgatherv_linear.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv_linear.c
@@ -110,8 +110,11 @@ static inline size_t get_scratch_size(ucc_tl_cuda_team_t *team,
 {
     size_t     dt_size = ucc_dt_size(dt);
     ucc_rank_t tsize   = UCC_TL_TEAM_SIZE(team);
-    size_t     div     = 2 * dt_size * tsize;
+    size_t     div;
 
+    ucc_assert((dt_size > 0) && (tsize > 0));
+
+    div = 2 * dt_size * tsize;
     return (UCC_TL_CUDA_TEAM_LIB(team)->cfg.scratch_size / div) * div;
 }
 
@@ -286,8 +289,6 @@ ucc_tl_cuda_allgatherv_linear_progress_frag(ucc_tl_cuda_task_t *task)
                 if (i == trank) {
                     continue;
                 }
-                rank_offset =
-                    task->allgatherv_linear.get_offset(task, i) * dt_size;
                 dbuf = PTR_OFFSET(TASK_SCRATCH(task, i),
                                   remote_offset + scratch_offset);
 

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -14,14 +14,14 @@
 
 //NOLINTNEXTLINE
 size_t ucc_tl_cuda_alltoall_get_size(const ucc_tl_cuda_task_t *task,
-                                     size_t *cnts, ucc_rank_t block)
+                                     size_t *cnts, ucc_rank_t block) //NOLINT: cnts is unused
 {
     return ucc_dt_size(TASK_ARGS(task).dst.info.datatype) *
            (TASK_ARGS(task).dst.info.count / UCC_TL_TEAM_SIZE(TASK_TEAM(task)));
 }
 
 size_t ucc_tl_cuda_alltoall_get_offset(const ucc_tl_cuda_task_t *task,
-                                       size_t *displ, ucc_rank_t block)
+                                       size_t *displ, ucc_rank_t block) //NOLINT: displ is unused
 {
     return ucc_dt_size(TASK_ARGS(task).dst.info.datatype) *
            (TASK_ARGS(task).dst.info.count /

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -395,13 +395,14 @@ ucc_tl_cuda_alltoallv_ce_triggered_post_setup(ucc_coll_task_t *coll_task)
     return UCC_OK;
 }
 
-//NOLINTNEXTLINE
+//NOLINTNEXTLINE: task is unused
 size_t ucc_tl_cuda_alltoallv_get_size(const ucc_tl_cuda_task_t *task,
                                       size_t *sizes, ucc_rank_t block)
 {
     return sizes[block];
 }
 
+//NOLINTNEXTLINE: task is unused
 size_t ucc_tl_cuda_alltoallv_get_offset(const ucc_tl_cuda_task_t *task,
                                         size_t *displ, ucc_rank_t block)
 {

--- a/src/components/tl/cuda/tl_cuda_cache.c
+++ b/src/components/tl/cuda/tl_cuda_cache.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -17,7 +17,7 @@
 #define ENABLE_CACHE 1
 
 static ucs_pgt_dir_t*
-ucc_tl_cuda_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
+ucc_tl_cuda_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable) //NOLINT: pgtable is unused
 {
     void *ptr;
     int ret;
@@ -27,14 +27,14 @@ ucc_tl_cuda_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
     return (ret == 0) ? ptr : NULL;
 }
 
-static void ucc_tl_cuda_cache_pgt_dir_release(const ucs_pgtable_t *pgtable,
+static void ucc_tl_cuda_cache_pgt_dir_release(const ucs_pgtable_t *pgtable, //NOLINT: pgtable is unused
                                               ucs_pgt_dir_t *dir)
 {
     free(dir);
 }
 
 static void
-ucc_tl_cuda_cache_region_collect_callback(const ucs_pgtable_t *pgtable,
+ucc_tl_cuda_cache_region_collect_callback(const ucs_pgtable_t *pgtable, //NOLINT: pgtable is unused
                                           ucs_pgt_region_t *pgt_region,
                                           void *arg)
 {

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -61,8 +61,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
                  "failed to initialize tl_cuda_topo");
         goto free_mpool;
     }
-    status = ucc_tl_cuda_topo_get_pci_id(self->super.super.lib, self->device,
-                                         &self->device_id);
+    status = ucc_tl_cuda_topo_get_pci_id(self->device, &self->device_id);
     if (status != UCC_OK) {
         tl_error(self->super.super.lib, "failed to get pci id");
         goto free_mpool;

--- a/src/components/tl/cuda/tl_cuda_team_topo.c
+++ b/src/components/tl/cuda/tl_cuda_team_topo.c
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
 #include "tl_cuda_team_topo.h"
 #include "tl_cuda.h"
 
@@ -14,6 +20,7 @@ ucc_tl_cuda_team_topo_add_ring(const ucc_tl_cuda_team_t *team,
     ucc_status_t status;
     int i, j;
 
+    ucc_assert(size > 1);
     for (i = 0; i < num_dups; i++) {
         topo->rings[topo->num_rings + i].ring  = NULL;
         topo->rings[topo->num_rings + i].iring = NULL;
@@ -117,6 +124,7 @@ ucc_tl_cuda_team_topo_init_rings(const ucc_tl_cuda_team_t *team,
     ucc_status_t status;
     int *graph;
 
+    ucc_assert(size > 1);
     topo->num_rings = 0;
     ring.ring = (ucc_rank_t*) ucc_malloc(size * sizeof(ucc_rank_t),
                                          "cuda_topo_ring");
@@ -125,17 +133,14 @@ ucc_tl_cuda_team_topo_init_rings(const ucc_tl_cuda_team_t *team,
         return UCC_ERR_NO_MEMORY;
     }
 
-    graph = (ucc_rank_t*) ucc_malloc(size * size * sizeof(int),
-                                     "cuda_topo_graph");
+    graph = (int*) ucc_malloc(size * size * sizeof(int), "cuda_topo_graph");
     if (!graph) {
         status = UCC_ERR_NO_MEMORY;
         tl_error(UCC_TL_TEAM_LIB(team), "failed to allocate topo graph");
         goto free_ring;
     }
 
-    for (i = 0; i < size * size; i++) {
-        graph[i] = topo->matrix[i];
-    }
+    memcpy(graph, topo->matrix, size * size * sizeof(int));
 
     num_rings = 0;
     min_width = 4;

--- a/src/components/tl/cuda/tl_cuda_topo.c
+++ b/src/components/tl/cuda/tl_cuda_topo.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -48,8 +48,7 @@ static void ucc_tl_cuda_topo_pci_id_to_str(const ucc_tl_cuda_device_pci_id_t *pc
                       pci_id->bus, pci_id->device, pci_id->function);
 }
 
-ucc_status_t ucc_tl_cuda_topo_get_pci_id(const ucc_base_lib_t *lib,
-                                         int device,
+ucc_status_t ucc_tl_cuda_topo_get_pci_id(int device,
                                          ucc_tl_cuda_device_pci_id_t *pci_id)
 {
     char pci_bus_id[MAX_PCI_BUS_ID_STR];
@@ -149,9 +148,8 @@ ucc_tl_cuda_topo_graph_add_link(ucc_tl_cuda_topo_t *topo,
     return UCC_OK;
 }
 
-static void ucc_tl_cuda_topo_free_link(ucc_tl_cuda_topo_link_t *link) {
-    return;
-}
+static void ucc_tl_cuda_topo_free_link(ucc_tl_cuda_topo_link_t *link) //NOLINT: link is unused
+{}
 
 static void ucc_tl_cuda_topo_graph_destroy(ucc_tl_cuda_topo_t *topo)
 {

--- a/src/components/tl/cuda/tl_cuda_topo.h
+++ b/src/components/tl/cuda/tl_cuda_topo.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -54,8 +54,7 @@ typedef struct ucc_tl_cuda_topo {
     ucc_tl_cuda_topo_node_t *graph;
 } ucc_tl_cuda_topo_t;
 
-ucc_status_t ucc_tl_cuda_topo_get_pci_id(const ucc_base_lib_t *lib,
-                                         int device,
+ucc_status_t ucc_tl_cuda_topo_get_pci_id(int device,
                                          ucc_tl_cuda_device_pci_id_t *pci_id);
 
 ucc_status_t ucc_tl_cuda_topo_create(const ucc_base_lib_t *lib,

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -310,7 +310,7 @@ static void ucc_tl_ucp_context_barrier(ucc_tl_ucp_context_t *ctx,
     }
     if (UCC_OK == oob->allgather(&sbuf, rbuf, sizeof(char), oob->coll_info,
                                  &req)) {
-        ucc_assert(req);
+        ucc_assert(req != NULL);
         while (UCC_OK != (status = oob->req_test(req))) {
             ucp_worker_progress(ctx->worker.ucp_worker);
             if (ctx->cfg.service_worker != 0) {

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -240,7 +240,7 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
 
     *segment  = -1;
     core_rank = ucc_ep_map_eval(UCC_TL_TEAM_MAP(team), peer);
-    ucc_assert(UCC_TL_CORE_TEAM(team));
+    ucc_assert(UCC_TL_CORE_TEAM(team) != NULL);
     peer = ucc_get_ctx_rank(UCC_TL_CORE_TEAM(team), core_rank);
 
     offset = ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), UCC_TL_CORE_TEAM(team),

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -495,7 +495,7 @@ poll:
             goto poll;
         }
         addr_lens = (size_t *)addr_storage->storage;
-        ucc_assert(addr_storage->storage);
+        ucc_assert(addr_storage->storage != NULL);
         for (i = 0; i < addr_storage->size; i++) {
             if (addr_lens[i] > addr_storage->addr_len) {
                 addr_storage->addr_len = addr_lens[i];

--- a/src/core/ucc_dt.h
+++ b/src/core/ucc_dt.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -7,7 +8,7 @@
 #define UCC_DT_H_
 #include "config.h"
 #include "ucc/api/ucc.h"
-#include "utils/ucc_compiler_def.h"
+#include "utils/ucc_assert.h"
 
 typedef struct ucc_dt_generic {
     void                     *context;

--- a/src/core/ucc_ee.c
+++ b/src/core/ucc_ee.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -67,7 +68,7 @@ ucc_status_t ucc_ee_get_event_internal(ucc_ee_h ee, ucc_ev_t **ev, ucc_queue_hea
     elem = ucc_queue_pull(queue);
     ucc_spin_unlock(&ee->lock);
 
-    ucc_assert(elem);
+    ucc_assert(elem != NULL);
 
     event_desc = ucc_container_of(elem, ucc_event_desc_t, queue);
     *ev = &event_desc->ev;

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -467,7 +467,7 @@ ucc_status_t ucc_finalize(ucc_lib_info_t *lib)
 
     gl_status = UCC_OK;
     ucc_assert(lib->n_cl_libs_opened > 0);
-    ucc_assert(lib->cl_libs);
+    ucc_assert(lib->cl_libs != NULL);
     for (i = 0; i < lib->n_tl_libs_opened; i++) {
         lib->tl_libs[i]->iface->lib.finalize(&lib->tl_libs[i]->super);
     }

--- a/src/core/ucc_service_coll.c
+++ b/src/core/ucc_service_coll.c
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -40,7 +41,7 @@ ucc_service_coll_req_init(ucc_team_t *team, ucc_subset_t *subset,
         subset->map.cb.cb     = ucc_service_coll_map_cb;
         subset->map.cb.cb_ctx = req;
     } else {
-        ucc_assert(team->service_team);
+        ucc_assert(team->service_team != NULL);
         *service_team = team->service_team;
     }
 

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -1,6 +1,7 @@
 /**
- * Copyright (c) 2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
+ *
  * See file LICENSE for terms.
  */
 
@@ -332,7 +333,7 @@ static inline ucc_status_t ucc_team_exchange(ucc_context_t *context,
         return ucc_core_addr_exchange(context, NULL, &oob, &team->addr_storage);
     }
     /* We only need to exchange ctx_ranks and build map to ctx array */
-    ucc_assert(context->addr_storage.storage);
+    ucc_assert(context->addr_storage.storage != NULL);
     if (team->bp.params.mask & UCC_TEAM_PARAM_FIELD_EP_MAP) {
         team->ctx_map = team->bp.params.ep_map;
     } else {

--- a/src/utils/ucc_assert.c
+++ b/src/utils/ucc_assert.c
@@ -1,0 +1,57 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2022. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include "ucc_assert.h"
+#include "ucc_log.h"
+#include <stdio.h>
+
+/**
+ * Get pointer to file name in path, same as basename but do not
+ * modify source string.
+ *
+ * @param path Path to parse.
+ *
+ * @return file name
+ */
+static const char* ucc_basename(const char *path)
+{
+    const char *name = strrchr(path, '/');
+
+    return (name == NULL) ? path : name + 1;
+}
+
+void ucc_fatal_error_message(const char *file, unsigned line,
+                             const char *function, char *message_buf) //NOLINT: function is unused
+{
+    char *message_line, *save_ptr = NULL;
+
+    ucc_log_flush();
+
+    message_line = (message_buf == NULL) ? NULL :
+                   strtok_r(message_buf, "\n", &save_ptr);
+    while (message_line != NULL) {
+        ucc_log_fatal_error("%13s:%-4u %s", ucc_basename(file), line, message_line);
+        message_line = strtok_r(NULL, "\n", &save_ptr);
+    }
+
+    abort();
+}
+
+void ucc_fatal_error_format(const char *file, unsigned line,
+                            const char *function, const char *format, ...)
+{
+    const size_t buffer_size = ucc_log_get_buffer_size();
+    char *buffer;
+    va_list ap;
+
+    buffer = alloca(buffer_size);
+    va_start(ap, format);
+    //NOLINTNEXTLINE
+    vsnprintf(buffer, buffer_size, format, ap);
+    va_end(ap);
+
+    ucc_fatal_error_message(file, line, function, buffer);
+}

--- a/src/utils/ucc_assert.h
+++ b/src/utils/ucc_assert.h
@@ -1,0 +1,64 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2022. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCC_ASSERT_H
+#define UCC_ASSERT_H
+
+#include "ucc_compiler_def.h"
+
+#if ENABLE_DEBUG == 1 || UCC_ENABLE_ASSERT == 1
+#include <assert.h>
+#define ucc_assert(_cond) ucc_assert_always(_cond)
+#define ucc_assert_system(_cond) assert(_cond)
+#else
+#define ucc_assert(_cond)
+#define ucc_assert_system(_cond)
+#endif
+
+BEGIN_C_DECLS
+
+/**
+ * Fail if _expression evaluates to 0
+ */
+#define ucc_assert_always(_expression)                                         \
+    do {                                                                       \
+        if (!ucc_likely(_expression)) {                                        \
+            ucc_fatal_error_format(__FILE__, __LINE__, __FUNCTION__,           \
+                                   "Assertion `%s' failed", #_expression);     \
+        }                                                                      \
+    } while (0)
+
+/**
+ * Generate a fatal error and stop the program.
+ *
+ * @param [in] file        Source file name
+ * @param [in] line        Source line number
+ * @param [in] function    Calling function name
+ * @param [in] message_buf Error message buffer. Multi-line message is
+ *                         supported.
+ *
+ * IMPORTANT NOTE: message_buf could be overridden by this function
+ */
+void ucc_fatal_error_message(const char *file, unsigned line,
+                             const char *function, char *message_buf)
+    UCS_F_NORETURN;
+
+/**
+ * Generate a fatal error and stop the program.
+ *
+ * @param [in] file        Source file name
+ * @param [in] line        Source line number
+ * @param [in] function    Calling function name
+ * @param [in] format      Error message format string. Multi-line message is
+ *                         supported.
+ */
+void ucc_fatal_error_format(const char *file, unsigned line,
+                            const char *function, const char *format, ...)
+    UCC_F_NORETURN;
+
+END_C_DECLS
+
+#endif

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -11,6 +11,7 @@
 #include "ucc_datastruct.h"
 #include "ucc_math.h"
 #include "utils/ucc_time.h"
+#include "utils/ucc_assert.h"
 #include <string.h>
 
 #define UCC_COLL_TYPE_NUM (ucc_ilog2(UCC_COLL_TYPE_LAST - 1) + 1)
@@ -179,7 +180,7 @@ static inline ucc_rank_t ucc_ep_map_eval(ucc_ep_map_t map, ucc_rank_t rank)
         r = (ucc_rank_t)map.cb.cb(rank, map.cb.cb_ctx);
         break;
     default:
-        r = -1;
+        r = UCC_RANK_INVALID;
     }
     return r;
 }

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -13,9 +14,6 @@
 #include <ucs/sys/preprocessor.h>
 #include <ucs/sys/compiler_def.h>
 #include <ucs/debug/log_def.h>
-#if ENABLE_DEBUG == 1
-#include <assert.h>
-#endif
 
 #ifndef SIZE_MAX
 #define SIZE_MAX ((size_t) -1)
@@ -56,6 +54,9 @@ typedef int                        ucc_score_t;
 #else
 #define UCC_F_NOOPTIMIZE
 #endif
+
+/* A function which does not return */
+#define UCC_F_NORETURN __attribute__((noreturn))
 
 #define UCC_COPY_PARAM_BY_FIELD(_dst, _src, _FIELD, _field)                    \
     do {                                                                       \
@@ -101,12 +102,6 @@ static inline ucs_status_t ucc_status_to_ucs_status(ucc_status_t status)
     }
     return UCS_ERR_NO_MESSAGE;
 }
-
-#if ENABLE_DEBUG == 1
-#define ucc_assert(_cond) assert(_cond)
-#else
-#define ucc_assert(_cond)
-#endif
 
 #define ucc_for_each_bit ucs_for_each_bit
 

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -16,6 +17,10 @@
 #define UCC_LOG_LEVEL_INFO  UCS_LOG_LEVEL_INFO
 #define UCC_LOG_LEVEL_DEBUG UCS_LOG_LEVEL_DEBUG
 #define UCC_LOG_LEVEL_TRACE UCS_LOG_LEVEL_TRACE
+
+#define ucc_log_get_buffer_size ucs_log_get_buffer_size
+#define ucc_log_fatal_error ucs_log_fatal_error
+#define ucc_log_flush ucs_log_flush
 
 /* Generic wrapper macro to invoke ucs logging backend */
 #define ucc_log_component(_level, _component, _fmt, ...)                       \


### PR DESCRIPTION
## What
Add new GH actions tests for CUDA. New workflow will run clang-tidy linter for all CUDA components in UCC including TL/CUDA, EC/CUDA, MC/CUDA. Also fixed found warning and errors.
New implementation of ucc_assert is needed to suppress false positive warnings, i.e. telling compiler that variable value within certain range.