### PR TITLE
CORE: fix timeout handle for triggered post

### DIFF
--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Facebook, Inc. and its affiliates. 2021.
  *
  * See file LICENSE for terms.
@@ -82,6 +82,7 @@ UCC_CLASS_DECLARE(ucc_tl_nccl_context_t, const ucc_base_context_params_t *,
 
 typedef struct ucc_tl_nccl_team {
     ucc_tl_team_t        super;
+    ucc_status_t         comm_state;
     ncclUniqueId        *unique_id;
     void                *oob_req;
     ncclComm_t           nccl_comm;

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -149,9 +149,13 @@ ucc_status_t ucc_tl_nccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
 
 ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_nccl_task_t *task  = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
-    ucc_status_t       status = UCC_OK ;
+    ucc_tl_nccl_task_t *task   = ucc_derived_of(coll_task, ucc_tl_nccl_task_t);
+    ucc_tl_nccl_team_t *team   = TASK_TEAM(task);
+    ucc_status_t        status = UCC_OK;
 
+    if (ucc_unlikely(task->super.super.status != UCC_OK)) {
+        team->comm_state = task->super.super.status;
+    }
     tl_info(UCC_TASK_LIB(task), "finalizing coll task %p", task);
     ucc_tl_nccl_free_task(task);
     return status;

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -121,9 +121,8 @@ ucc_status_t ucc_coll_task_get_executor(ucc_coll_task_t *task,
     return st;
 }
 
-static ucc_status_t
-ucc_task_error_handler(ucc_coll_task_t *parent_task,
-                       ucc_coll_task_t *task)
+static ucc_status_t ucc_task_error_handler(ucc_coll_task_t *parent_task,
+                                           ucc_coll_task_t *task)
 {
     ucc_event_manager_t *em;
     ucc_coll_task_t     *listener;
@@ -197,7 +196,8 @@ ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule,
     return status;
 }
 
-ucc_status_t ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task)
+ucc_status_t ucc_schedule_add_task(ucc_schedule_t *schedule,
+                                   ucc_coll_task_t *task)
 {
     ucc_status_t status;
 


### PR DESCRIPTION
## What
Correctly handle time out error for triggered task
* For TL NCCL need to use commAbort, otherwise commDestroy could hang
* For other TLs need to destroy executor during finalize
