### PR TITLE
Mranged params

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -112,6 +112,7 @@ libucc_la_SOURCES =                   \
 	coll_score/ucc_coll_score_map.c   \
 	utils/ini.c                       \
 	utils/ucc_component.c             \
+	utils/ucc_datastruct.c            \
 	utils/ucc_status.c                \
 	utils/ucc_mpool.c                 \
 	utils/ucc_math.c                  \

--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -475,44 +475,6 @@ out:
     return status;
 }
 
-static ucc_status_t str_to_mem_type(const char *str, unsigned *mt_n,
-                                    ucc_memory_type_t **mt)
-{
-    ucc_status_t      status = UCC_OK;
-    char **           tokens;
-    unsigned          i, n_tokens;
-    ucc_memory_type_t t;
-    tokens = ucc_str_split(str, ",");
-    if (!tokens) {
-        status = UCC_ERR_INVALID_PARAM;
-        goto out;
-    }
-    n_tokens = ucc_str_split_count(tokens);
-    *mt = ucc_malloc(n_tokens * sizeof(ucc_memory_type_t), "ucc_mem_types");
-    if (!(*mt)) {
-        ucc_error("failed to allocate %zd bytes for ucc_mem_types",
-                  sizeof(ucc_memory_type_t) * n_tokens);
-        status = UCC_ERR_NO_MEMORY;
-        goto out;
-    }
-    *mt_n = 0;
-    for (i = 0; i < n_tokens; i++) {
-        t = ucc_mem_type_from_str(tokens[i]);
-        if (t == UCC_MEMORY_TYPE_LAST) {
-            /* entry does not match any memory type name */
-            ucc_free(*mt);
-            *mt    = NULL;
-            status = UCC_ERR_NOT_FOUND;
-            goto out;
-        }
-        (*mt)[*mt_n] = t;
-        (*mt_n)++;
-    }
-out:
-    ucc_str_split_free(tokens);
-    return status;
-}
-
 static ucc_status_t str_to_score(const char *str, ucc_score_t *score)
 {
     if (0 == strcasecmp("inf", str)) {
@@ -676,17 +638,18 @@ static ucc_status_t ucc_coll_score_parse_str(const char *str,
 {
     ucc_status_t            status   = UCC_OK;
     ucc_coll_type_t        *ct       = NULL;
-    ucc_memory_type_t      *mt       = NULL;
     size_t                 *msg      = NULL;
     ucc_rank_t             *tsizes   = NULL;
     ucc_base_coll_init_fn_t alg_init = NULL;
     const char*             alg_id   = NULL;
     ucc_score_t             score_v  = UCC_SCORE_INVALID;
     int                     ts_skip  = 0;
+    uint32_t                mtypes   = 0;
     char                  **tokens;
-    unsigned i, n_tokens, ct_n, mt_n, c, m, n_ranges, r, n_tsizes;
+    unsigned i, n_tokens, ct_n, c, m, n_ranges, r, n_tsizes;
 
-    mt_n = ct_n = n_ranges = n_tsizes = 0;
+
+    ct_n = n_ranges = n_tsizes = 0;
     tokens = ucc_str_split(str, ":");
     if (!tokens) {
         status = UCC_ERR_INVALID_PARAM;
@@ -697,7 +660,8 @@ static ucc_status_t ucc_coll_score_parse_str(const char *str,
         if (!ct && UCC_OK == str_to_coll_type(tokens[i], &ct_n, &ct)) {
             continue;
         }
-        if (!mt && UCC_OK == str_to_mem_type(tokens[i], &mt_n, &mt)) {
+        if (!mtypes && UCC_OK == ucc_str_to_mtype_map(tokens[i], ",",
+                                                      &mtypes)) {
             continue;
         }
         if ((UCC_SCORE_INVALID == score_v) &&
@@ -733,18 +697,23 @@ static ucc_status_t ucc_coll_score_parse_str(const char *str,
     if (!ts_skip && (UCC_SCORE_INVALID != score_v || NULL != alg_id)) {
         /* Score provided but not coll_types/mem_types.
            This means: apply score to ALL coll_types/mem_types */
-        if (!ct)
+        if (!ct) {
             ct_n = UCC_COLL_TYPE_NUM;
-        if (!mt)
-            mt_n = UCC_MEMORY_TYPE_LAST;
-        if (!msg)
+        }
+        if (!mtypes) {
+            mtypes = -1;
+        }
+        if (!msg) {
             n_ranges = 1;
+        }
         for (c = 0; c < ct_n; c++) {
-            for (m = 0; m < mt_n; m++) {
+            for (m = 0; m < UCC_MEMORY_TYPE_LAST; m++) {
+                if (!(UCC_BIT(m) & mtypes)) {
+                    continue;
+                }
                 ucc_coll_type_t   coll_type = ct ? ct[c] :
                                                    (ucc_coll_type_t)UCC_BIT(c);
-                ucc_memory_type_t mem_type  = mt ? mt[m] :
-                                                   (ucc_memory_type_t)m;
+                ucc_memory_type_t mem_type  = (ucc_memory_type_t)m;
                 if (alg_id) {
                     if (!alg_fn) {
                         status = UCC_ERR_NOT_SUPPORTED;
@@ -799,7 +768,6 @@ static ucc_status_t ucc_coll_score_parse_str(const char *str,
     }
 out:
     ucc_free(ct);
-    ucc_free(mt);
     ucc_free(msg);
     ucc_free(tsizes);
     ucc_str_split_free(tokens);

--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -648,7 +648,6 @@ static ucc_status_t ucc_coll_score_parse_str(const char *str,
     char                  **tokens;
     unsigned i, n_tokens, ct_n, c, m, n_ranges, r, n_tsizes;
 
-
     ct_n = n_ranges = n_tsizes = 0;
     tokens = ucc_str_split(str, ":");
     if (!tokens) {

--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -700,7 +700,7 @@ static ucc_status_t ucc_coll_score_parse_str(const char *str,
             ct_n = UCC_COLL_TYPE_NUM;
         }
         if (!mtypes) {
-            mtypes = -1;
+            mtypes = UCC_MEM_TYPE_MASK_FULL;
         }
         if (!msg) {
             n_ranges = 1;

--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -164,8 +164,9 @@ static ucc_status_t ucc_cl_hier_allreduce_split_rail_frag_init(
     rs_args.args.dst.info_v.counts   = counts;
     rs_args.args.dst.info_v.mem_type = coll_args->args.dst.info.mem_type;
     rs_args.args.dst.info_v.datatype = coll_args->args.dst.info.datatype;
+    /* linter thinks node_size can be 0 - false positive */
     rs_args.max_frag_count = ucc_buffer_block_count(
-        ucc_buffer_block_count(total_count, n_frags, 0), node_size, 0);
+        ucc_buffer_block_count(total_count, n_frags, 0), node_size, 0); //NOLINT
     rs_args.mask |= UCC_BASE_CARGS_MAX_FRAG_COUNT;
 
 

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -199,7 +199,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allreduce_kn_start", 0);
     task->allreduce_kn.phase = UCC_KN_PHASE_INIT;
     ucc_assert(UCC_IS_INPLACE(TASK_ARGS(task)) ||
-               (TASK_ARGS(task).src.info.mem_type == meme_type));
+               (TASK_ARGS(task).src.info.mem_type == mem_type));
     cfg_radix = ucc_tl_ucp_get_radix_from_range(team, data_size,
                                                 mem_type, p);
     ucc_knomial_pattern_init(size, rank, ucc_min(cfg_radix, size),

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -187,15 +187,22 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
     ucc_rank_t         size      = (ucc_rank_t)task->subset.map.ep_num;
     ucc_rank_t         rank      = task->subset.myrank;
+    ucc_memory_type_t  mem_type  = TASK_ARGS(task).dst.info.mem_type;
+    size_t             count     = TASK_ARGS(task).dst.info.count;
+    ucc_datatype_t     dt        = TASK_ARGS(task).dst.info.datatype;
+    size_t             data_size = count * ucc_dt_size(dt);
+    ucc_mrange_uint_t *p         =
+        &UCC_TL_UCP_TEAM_LIB(team)->cfg.allreduce_kn_radix;
+    ucc_kn_radix_t     cfg_radix;
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allreduce_kn_start", 0);
     task->allreduce_kn.phase = UCC_KN_PHASE_INIT;
     ucc_assert(UCC_IS_INPLACE(TASK_ARGS(task)) ||
-               (TASK_ARGS(task).src.info.mem_type ==
-               TASK_ARGS(task).dst.info.mem_type));
-    ucc_knomial_pattern_init(size, rank,
-                             ucc_min(team->cfg.allreduce_kn_radix, size),
+               (TASK_ARGS(task).src.info.mem_type == meme_type));
+    cfg_radix = ucc_tl_ucp_get_radix_from_range(team, data_size,
+                                                mem_type, p);
+    ucc_knomial_pattern_init(size, rank, ucc_min(cfg_radix, size),
                              &task->allreduce_kn.p);
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
     status =
@@ -209,17 +216,23 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
 ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
 {
     ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
+    ucc_memory_type_t  mem_type  = TASK_ARGS(task).dst.info.mem_type;
     size_t             count     = TASK_ARGS(task).dst.info.count;
     ucc_datatype_t     dt        = TASK_ARGS(task).dst.info.datatype;
     size_t             data_size = count * ucc_dt_size(dt);
     ucc_rank_t         size      = (ucc_rank_t)task->subset.map.ep_num;
-    ucc_kn_radix_t     radix     = ucc_min(team->cfg.allreduce_kn_radix, size);
+    ucc_mrange_uint_t *p         =
+        &UCC_TL_UCP_TEAM_LIB(team)->cfg.allreduce_kn_radix;
+    ucc_kn_radix_t     radix, cfg_radix;
     ucc_status_t       status;
 
     task->super.flags    |= UCC_COLL_TASK_FLAG_EXECUTOR;
     task->super.post     = ucc_tl_ucp_allreduce_knomial_start;
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;
+    cfg_radix            = ucc_tl_ucp_get_radix_from_range(team, data_size,
+                                                           mem_type, p);
+    radix                = ucc_min(cfg_radix, size);
     status               = ucc_mc_alloc(&task->allreduce_kn.scratch_mc_header,
                           (radix - 1) * data_size,
                           TASK_ARGS(task).dst.info.mem_type);

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -93,6 +93,8 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
     ucc_datatype_t       dtype    = coll_args->args.dst.info.datatype;
     ucc_memory_type_t    mem_type = coll_args->args.dst.info.mem_type;
     ucc_base_coll_args_t args     = *coll_args;
+    ucc_mrange_uint_t   *p        =
+        &UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_radix;
     ucc_schedule_t      *schedule;
     ucc_coll_task_t     *task, *rs_task;
     ucc_status_t         status;
@@ -111,10 +113,12 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
         count = coll_args->args.dst.info.count;
     }
 
-    cfg_radix = ucc_tl_ucp_get_sra_kn_radix(tl_team, count *
-                                            ucc_dt_size(dtype), mem_type);
-    radix = ucc_knomial_pattern_get_min_radix(cfg_radix,
-                                              UCC_TL_TEAM_SIZE(tl_team), count);
+    cfg_radix = ucc_tl_ucp_get_radix_from_range(tl_team,
+                                                count * ucc_dt_size(dtype),
+                                                mem_type, p);
+    radix     = ucc_knomial_pattern_get_min_radix(cfg_radix,
+                                                  UCC_TL_TEAM_SIZE(tl_team),
+                                                  count);
 
     /* 1st step of allreduce: knomial reduce_scatter */
     UCC_CHECK_GOTO(

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -90,19 +90,29 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
     ucc_base_team_t *team, ucc_schedule_t **frag_p)
 {
     ucc_tl_ucp_team_t   *tl_team  = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    size_t               count    = coll_args->args.dst.info.count;
+    ucc_datatype_t       dtype    = coll_args->args.dst.info.datatype;
+    ucc_memory_type_t    mem_type = coll_args->args.dst.info.mem_type;
     ucc_base_coll_args_t args     = *coll_args;
     ucc_schedule_t      *schedule;
     ucc_coll_task_t     *task, *rs_task;
     ucc_status_t         status;
     ucc_kn_radix_t       radix, cfg_radix;
+    size_t               count;
 
     status = ucc_tl_ucp_get_schedule(tl_team, coll_args,
                                      (ucc_tl_ucp_schedule_t **)&schedule);
     if (ucc_unlikely(UCC_OK != status)) {
         return status;
     }
-    cfg_radix = tl_team->cfg.allreduce_sra_kn_radix;
+
+    if (coll_args->mask & UCC_BASE_CARGS_MAX_FRAG_COUNT) {
+        count = coll_args->max_frag_count;
+    } else {
+        count = coll_args->args.dst.info.count;
+    }
+
+    cfg_radix = ucc_tl_ucp_get_sra_kn_radix(tl_team, count *
+                                            ucc_dt_size(dtype), mem_type);
     radix = ucc_knomial_pattern_get_min_radix(cfg_radix,
                                               UCC_TL_TEAM_SIZE(tl_team), count);
 

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -69,10 +69,10 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
-    {"ALLREDUCE_SRA_KN_RADIX", "4",
+    {"ALLREDUCE_SRA_KN_RADIX", "auto",
      "Radix of the scatter-reduce-allgather (SRA) knomial allreduce algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_sra_kn_radix),
-     UCC_CONFIG_TYPE_UINT},
+     UCC_CONFIG_TYPE_UINT_RANGED},
 
     {"ALLREDUCE_SRA_KN_PIPELINE", "n",
      "Pipelining settings for SRA Knomial allreduce algorithm",

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -64,10 +64,10 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, fanout_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
-    {"ALLREDUCE_KN_RADIX", "4",
+    {"ALLREDUCE_KN_RADIX", "auto",
      "Radix of the recursive-knomial allreduce algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allreduce_kn_radix),
-     UCC_CONFIG_TYPE_UINT},
+     UCC_CONFIG_TYPE_UINT_RANGED},
 
     {"ALLREDUCE_SRA_KN_RADIX", "auto",
      "Radix of the scatter-reduce-allgather (SRA) knomial allreduce algorithm",

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -48,7 +48,7 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t                 fanout_kn_radix;
     uint32_t                 barrier_kn_radix;
     uint32_t                 allreduce_kn_radix;
-    uint32_t                 allreduce_sra_kn_radix;
+    ucc_mrange_uint_t        allreduce_sra_kn_radix;
     uint32_t                 reduce_scatter_kn_radix;
     uint32_t                 allgather_kn_radix;
     uint32_t                 bcast_kn_radix;

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -47,7 +47,7 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t                 fanin_kn_radix;
     uint32_t                 fanout_kn_radix;
     uint32_t                 barrier_kn_radix;
-    uint32_t                 allreduce_kn_radix;
+    ucc_mrange_uint_t        allreduce_kn_radix;
     ucc_mrange_uint_t        allreduce_sra_kn_radix;
     uint32_t                 reduce_scatter_kn_radix;
     uint32_t                 allgather_kn_radix;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -307,5 +307,20 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
                                        ucc_memory_type_t        mem_type,
                                        ucc_base_coll_init_fn_t *init);
 
+static inline unsigned ucc_tl_ucp_get_sra_kn_radix(ucc_tl_ucp_team_t *team,
+                                                   size_t             msgsize,
+                                                   ucc_memory_type_t  mem_type)
+{
+    ucc_mrange_uint_t *p =
+        &UCC_TL_UCP_TEAM_LIB(team)->cfg.allreduce_sra_kn_radix;
+    unsigned radix;
 
+    radix = ucc_mrange_uint_get(p, msgsize, mem_type);
+
+    if (UCC_UUNITS_AUTO == radix) {
+        /* auto selection based on team configuration */
+        return 4;
+    }
+    return radix;
+}
 #endif

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -15,6 +15,7 @@
 #include "components/ec/ucc_ec.h"
 #include "tl_ucp_tag.h"
 
+#define UCC_UUNITS_AUTO_RADIX 4
 #define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 5
 extern const char
     *ucc_tl_ucp_default_alg_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR];
@@ -307,19 +308,19 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
                                        ucc_memory_type_t        mem_type,
                                        ucc_base_coll_init_fn_t *init);
 
-static inline unsigned ucc_tl_ucp_get_sra_kn_radix(ucc_tl_ucp_team_t *team,
-                                                   size_t             msgsize,
-                                                   ucc_memory_type_t  mem_type)
+static inline unsigned
+ucc_tl_ucp_get_radix_from_range(ucc_tl_ucp_team_t *team,
+                                size_t             msgsize,
+                                ucc_memory_type_t  mem_type,
+                                ucc_mrange_uint_t *p)
 {
-    ucc_mrange_uint_t *p =
-        &UCC_TL_UCP_TEAM_LIB(team)->cfg.allreduce_sra_kn_radix;
     unsigned radix;
 
     radix = ucc_mrange_uint_get(p, msgsize, mem_type);
 
     if (UCC_UUNITS_AUTO == radix) {
         /* auto selection based on team configuration */
-        return 4;
+        return UCC_UUNITS_AUTO_RADIX;
     }
     return radix;
 }

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -21,14 +21,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_ucp.super,
                               &tl_ucp_config->super);
-    memcpy(&self->cfg, tl_ucp_config, sizeof(*tl_ucp_config));
-    status = ucc_mrange_uint_copy(&self->cfg.allreduce_sra_kn_radix,
-                                  &tl_ucp_config->allreduce_sra_kn_radix);
-    if (UCC_OK != status) {
-        return status;
-    }
-    status = ucc_mrange_uint_copy(&self->cfg.allreduce_kn_radix,
-                                  &tl_ucp_config->allreduce_kn_radix);
+    status = ucc_config_clone_table(tl_ucp_config, &self->cfg,
+                                    ucc_tl_ucp_lib_config_table);
     if (UCC_OK != status) {
         return status;
     }

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -27,10 +27,14 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
     if (UCC_OK != status) {
         return status;
     }
+    status = ucc_mrange_uint_copy(&self->cfg.allreduce_kn_radix,
+                                  &tl_ucp_config->allreduce_kn_radix);
+    if (UCC_OK != status) {
+        return status;
+    }
+
     if (tl_ucp_config->kn_radix > 0) {
         self->cfg.barrier_kn_radix        = tl_ucp_config->kn_radix;
-        self->cfg.allreduce_kn_radix      = tl_ucp_config->kn_radix;
-        //self->cfg.allreduce_sra_kn_radix  = tl_ucp_config->kn_radix;
         self->cfg.reduce_scatter_kn_radix = tl_ucp_config->kn_radix;
         self->cfg.allgather_kn_radix      = tl_ucp_config->kn_radix;
         self->cfg.bcast_kn_radix          = tl_ucp_config->kn_radix;

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -22,10 +22,15 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_ucp.super,
                               &tl_ucp_config->super);
     memcpy(&self->cfg, tl_ucp_config, sizeof(*tl_ucp_config));
+    status = ucc_mrange_uint_copy(&self->cfg.allreduce_sra_kn_radix,
+                                  &tl_ucp_config->allreduce_sra_kn_radix);
+    if (UCC_OK != status) {
+        return status;
+    }
     if (tl_ucp_config->kn_radix > 0) {
         self->cfg.barrier_kn_radix        = tl_ucp_config->kn_radix;
         self->cfg.allreduce_kn_radix      = tl_ucp_config->kn_radix;
-        self->cfg.allreduce_sra_kn_radix  = tl_ucp_config->kn_radix;
+        //self->cfg.allreduce_sra_kn_radix  = tl_ucp_config->kn_radix;
         self->cfg.reduce_scatter_kn_radix = tl_ucp_config->kn_radix;
         self->cfg.allgather_kn_radix      = tl_ucp_config->kn_radix;
         self->cfg.bcast_kn_radix          = tl_ucp_config->kn_radix;

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -71,6 +71,8 @@
 #define UCC_COLL_ARGS_ACTIVE_SET(_args)                                        \
     ((_args)->mask & UCC_COLL_ARGS_FIELD_ACTIVE_SET)
 
+#define UCC_MEM_TYPE_MASK_FULL -1
+
 static inline size_t
 ucc_coll_args_get_count(const ucc_coll_args_t *args, const ucc_count_t *counts,
                         ucc_rank_t idx)

--- a/src/utils/ucc_datastruct.c
+++ b/src/utils/ucc_datastruct.c
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_datastruct.h"
+#include "ucc_malloc.h"
+#include "ucc_compiler_def.h"
+#include "ucc_log.h"
+
+ucc_status_t ucc_mrange_uint_copy(ucc_mrange_uint_t       *dst,
+                                  const ucc_mrange_uint_t *src)
+{
+    ucc_mrange_t *r, *r_dup;
+
+    dst->default_value = src->default_value;
+    ucc_list_head_init(&dst->ranges);
+    ucc_list_for_each(r, &src->ranges, list_elem) {
+        r_dup = ucc_malloc(sizeof(*r_dup), "range_dup");
+        if (ucc_unlikely(!r_dup)) {
+            ucc_error("failed to allocate %zd bytes for mrange",
+                      sizeof(*r_dup));
+            goto err;
+        }
+        r_dup->start  = r->start;
+        r_dup->end    = r->end;
+        r_dup->value  = r->value;
+        r_dup->mtypes = r->mtypes;
+        ucc_list_add_tail(&dst->ranges, &r_dup->list_elem);
+    }
+
+    return UCC_OK;
+err:
+    ucc_mrange_uint_destroy(dst);
+    return UCC_ERR_NO_MEMORY;
+}
+
+void ucc_mrange_uint_destroy(ucc_mrange_uint_t *param)
+{
+    ucc_mrange_t *r, *r_tmp;
+
+    ucc_list_for_each_safe(r, r_tmp, &param->ranges, list_elem) {
+        ucc_list_del(&r->list_elem);
+        ucc_free(r);
+    }
+}

--- a/src/utils/ucc_datastruct.h
+++ b/src/utils/ucc_datastruct.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2001-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2001-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * See file LICENSE for terms.
  */
 

--- a/src/utils/ucc_datastruct.h
+++ b/src/utils/ucc_datastruct.h
@@ -6,7 +6,7 @@
 #ifndef UCC_DATASTRUCT_H_
 #define UCC_DATASTRUCT_H_
 #include <ucc/api/ucc.h>
-#include <ucs/datastruct/list.h>
+#include "ucc_list.h"
 #include <stdint.h>
 
 #define UCC_LIST_HEAD UCS_LIST_HEAD
@@ -22,6 +22,39 @@ typedef struct ucc_subset {
 static inline ucc_rank_t ucc_subset_size(ucc_subset_t *set)
 {
     return (ucc_rank_t)set->map.ep_num;
+}
+
+typedef struct ucc_mrange {
+    ucc_list_link_t list_elem;
+    size_t          start;
+    size_t          end;
+    uint32_t        mtypes;
+    unsigned        value;
+} ucc_mrange_t;
+
+typedef struct ucc_mrange_uint {
+    ucc_list_link_t ranges;
+    unsigned        default_value;
+} ucc_mrange_uint_t;
+
+ucc_status_t ucc_mrange_uint_copy(ucc_mrange_uint_t       *dst,
+                                  const ucc_mrange_uint_t *src);
+
+void ucc_mrange_uint_destroy(ucc_mrange_uint_t *param);
+
+static inline unsigned ucc_mrange_uint_get(ucc_mrange_uint_t *param,
+                                           size_t             range_value,
+                                           ucc_memory_type_t  mem_type)
+{
+    ucc_mrange_t *r;
+
+    ucc_list_for_each(r, &param->ranges, list_elem) {
+        if (r->start <= range_value && range_value <= r->end &&
+            (UCC_BIT(mem_type) & r->mtypes)) {
+            return r->value;
+        }
+    }
+    return param->default_value;
 }
 
 #endif

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -797,7 +797,8 @@ void ucc_config_release_pipeline_params(void *ptr, const void *arg)
 {
 }
 
-int ucc_config_sscanf_uint_ranged(const char *buf, void *dest, const void *arg)
+int ucc_config_sscanf_uint_ranged(const char *buf, void *dest,
+                                  const void *arg) //NOLINT
 {
     ucc_mrange_uint_t *p = dest;
     char             **ranges, **tokens;
@@ -875,7 +876,7 @@ err_ranges:
 }
 
 int ucc_config_sprintf_uint_ranged(char *buf, size_t max, const void *src,
-                                   const void *arg)
+                                   const void *arg) // NOLINT
 {
     const ucc_mrange_uint_t *s       = src;
     const size_t             tmp_max = 128;
@@ -918,12 +919,12 @@ int ucc_config_sprintf_uint_ranged(char *buf, size_t max, const void *src,
 }
 
 ucs_status_t ucc_config_clone_uint_ranged(const void *src, void *dest,
-                                          const void *arg)
+                                          const void *arg) //NOLINT
 {
     return ucc_status_to_ucs_status(ucc_mrange_uint_copy(dest, src));
 }
 
-void ucc_config_release_uint_ranged(void *ptr, const void *arg)
+void ucc_config_release_uint_ranged(void *ptr, const void *arg) //NOLINT
 {
     ucc_mrange_uint_destroy(ptr);
 }

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -660,6 +660,12 @@ void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
     }
 }
 
+ucc_status_t ucc_config_clone_table(const void *src, void *dst,
+                                    const void *arg)
+{
+    return ucs_status_to_ucc_status(ucs_config_clone_table(src, dst, arg));
+}
+
 static ucc_pipeline_params_t ucc_pipeline_params_auto = {
     .threshold = 0,
     .n_frags   = 0,

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -660,8 +660,6 @@ void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
     }
 }
 
-#define UCC_UUNITS_AUTO    ((unsigned)-2)
-
 static ucc_pipeline_params_t ucc_pipeline_params_auto = {
     .threshold = 0,
     .n_frags   = 0,
@@ -797,4 +795,135 @@ ucs_status_t ucc_config_clone_pipeline_params(const void *src, void *dest,
 
 void ucc_config_release_pipeline_params(void *ptr, const void *arg)
 {
+}
+
+int ucc_config_sscanf_uint_ranged(const char *buf, void *dest, const void *arg)
+{
+    ucc_mrange_uint_t *p = dest;
+    char             **ranges, **tokens;
+    unsigned           n_ranges, i, j, n_tokens;
+    size_t             start, end;
+    ucc_mrange_t      *r;
+    uint32_t           mt_map;
+
+    ucc_list_head_init(&p->ranges);
+    /* Special value: auto */
+    if (!strcasecmp(buf, UCS_VALUE_AUTO_STR)) {
+        p->default_value = UCC_UUNITS_AUTO;
+        return 1;
+    }
+
+    ranges = ucc_str_split(buf, ",");
+    if (!ranges) {
+        return 0;
+    }
+    n_ranges = ucc_str_split_count(ranges);
+    for (i = 0; i < n_ranges; i++) {
+        tokens = ucc_str_split(ranges[i], ":");
+        if (!tokens) {
+            goto err_ranges;
+        }
+        n_tokens = ucc_str_split_count(tokens);
+        if (n_tokens > 3 || UCC_OK != ucc_str_is_number(tokens[n_tokens - 1])) {
+            goto err_tokens;
+        }
+        if (n_tokens == 1) {
+            /* default value without range */
+            p->default_value = atoi(tokens[0]);
+        } else {
+            r = ucc_malloc(sizeof(*r), "mrange");
+            if (!r) {
+                goto err_tokens;
+            }
+            r->mtypes = -1; //mask all types
+            r->start  = 0;
+            r->end    = SIZE_MAX;
+
+            for (j = 0; j < n_tokens; j++) {
+                if (UCC_OK == ucc_str_is_number(tokens[j])) {
+                    /* value */
+                    r->value = atoi(tokens[j]);
+                    continue;
+                }
+                if (UCC_OK == ucc_str_to_mtype_map(tokens[j], "^", &mt_map)) {
+                    r->mtypes = mt_map;
+                    continue;
+                }
+                if (UCC_OK ==
+                    ucc_str_to_memunits_range(tokens[j], &start, &end)) {
+                    r->start = start;
+                    r->end   = end;
+                    continue;
+                }
+                ucc_free(r);
+                goto err_tokens;
+            }
+
+            ucc_list_add_tail(&p->ranges, &r->list_elem);
+        }
+        ucc_str_split_free(tokens);
+    }
+    ucc_str_split_free(ranges);
+
+    return 1;
+
+err_tokens:
+    ucc_str_split_free(tokens);
+err_ranges:
+    ucc_str_split_free(ranges);
+    return 0;
+}
+
+int ucc_config_sprintf_uint_ranged(char *buf, size_t max, const void *src,
+                                   const void *arg)
+{
+    const ucc_mrange_uint_t *s       = src;
+    const size_t             tmp_max = 128;
+    ucc_mrange_t            *r;
+    char                     tmp_start[tmp_max];
+    char                     tmp_end[tmp_max];
+    char                     tmp_mtypes[tmp_max];
+    size_t                   last;
+
+    ucc_list_for_each(r, &s->ranges, list_elem) {
+        ucs_memunits_to_str(r->start, tmp_start, tmp_max);
+        ucs_memunits_to_str(r->end, tmp_end, tmp_max);
+        if (r->mtypes == -1) {
+            ucc_snprintf_safe(buf, max, "%s-%s:%u", tmp_start, tmp_end,
+                              r->value);
+        } else {
+            ucc_mtype_map_to_str(r->mtypes, "^", tmp_mtypes, tmp_max);
+            ucc_snprintf_safe(buf, max, "%s-%s:%s:%u", tmp_start, tmp_end,
+                              tmp_mtypes, r->value);
+        }
+        last = strlen(buf);
+        if (max - last - 1 <= 0) {
+            /* no more space in buf for next range*/
+            return 1;
+        }
+
+        buf[last]     = ',';
+        buf[last + 1] = '\0';
+        max -= last + 1;
+        buf += last + 1;
+    }
+
+    if (s->default_value == UCC_UUNITS_AUTO) {
+        ucc_snprintf_safe(buf, max, "%s", "auto");
+    } else {
+        ucc_snprintf_safe(buf, max, "%u", s->default_value);
+    }
+
+    return 1;
+}
+
+ucs_status_t ucc_config_clone_uint_ranged(const void *src, void *dest,
+                                          const void *arg)
+{
+    return ucc_status_to_ucs_status(ucc_mrange_uint_copy(dest, src));
+}
+
+void ucc_config_release_uint_ranged(void *ptr, const void *arg)
+{
+    ucc_mrange_uint_destroy(ptr);
 }

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -825,12 +825,19 @@ int ucc_config_sscanf_uint_ranged(const char *buf, void *dest,
             goto err_ranges;
         }
         n_tokens = ucc_str_split_count(tokens);
-        if (n_tokens > 3 || UCC_OK != ucc_str_is_number(tokens[n_tokens - 1])) {
+        if (n_tokens > 3 ||
+            (UCC_OK != ucc_str_is_number(tokens[n_tokens - 1]) &&
+             strcasecmp(tokens[n_tokens - 1], UCS_VALUE_AUTO_STR) != 0)) {
             goto err_tokens;
         }
         if (n_tokens == 1) {
+            if (!strcasecmp(tokens[n_tokens - 1], UCS_VALUE_AUTO_STR)) {
+            /* Special value: auto */
+                p->default_value = UCC_UUNITS_AUTO;
+            } else {
             /* default value without range */
-            p->default_value = atoi(tokens[0]);
+                p->default_value = atoi(tokens[0]);
+            }
         } else {
             r = ucc_malloc(sizeof(*r), "mrange");
             if (!r) {

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -75,6 +75,7 @@ typedef struct ucc_file_config ucc_file_config_t;
 #define UCC_CONFIG_ALLOW_LIST_ALLOW_ALL UCS_CONFIG_ALLOW_LIST_ALLOW_ALL
 #define UCC_CONFIG_ALLOW_LIST_ALLOW     UCS_CONFIG_ALLOW_LIST_ALLOW
 #define UCC_CONFIG_TYPE_TERNARY         UCS_CONFIG_TYPE_TERNARY
+#define UCC_UUNITS_AUTO                 ((unsigned)-2)
 
 typedef enum ucc_ternary_auto_value {
     UCC_NO   = UCS_NO,
@@ -241,6 +242,25 @@ ucs_status_t ucc_config_clone_pipeline_params(const void *src, void *dest,
                                               const void *arg);
 
 void ucc_config_release_pipeline_params(void *ptr, const void *arg);
+
+int ucc_config_sscanf_uint_ranged(const char *buf, void *dest, const void *arg);
+
+int ucc_config_sprintf_uint_ranged(char *buf, size_t max, const void *src,
+                                   const void *arg);
+
+ucs_status_t ucc_config_clone_uint_ranged(const void *src, void *dest,
+                                          const void *arg);
+
+void         ucc_config_release_uint_ranged(void *ptr, const void *arg);
+
+#define UCC_CONFIG_TYPE_UINT_RANGED                                            \
+    {                                                                          \
+        ucc_config_sscanf_uint_ranged, ucc_config_sprintf_uint_ranged,         \
+            ucc_config_clone_uint_ranged, ucc_config_release_uint_ranged,      \
+            ucs_config_help_generic, "[<munit>-<munit>:[mtype]:value,"         \
+            "<munit>-<munit>:[mtype]:value,...,]default_value\n"               \
+            "#            value and default_value can be \"auto\""             \
+    }
 
 #define UCC_CONFIG_TYPE_PIPELINE_PARAMS                                        \
     {                                                                          \

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -230,6 +230,9 @@ void         ucc_release_file_config(ucc_file_config_t *cfg);
 
 typedef struct ucc_pipeline_params ucc_pipeline_params_t;
 
+ucc_status_t ucc_config_clone_table(const void *src, void *dst,
+                                    const void *arg);
+
 int ucc_pipeline_params_is_auto(const ucc_pipeline_params_t *p);
 
 int ucc_config_sscanf_pipeline_params(const char *buf, void *dest,

--- a/src/utils/ucc_string.c
+++ b/src/utils/ucc_string.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -187,7 +187,7 @@ ucc_status_t ucc_str_to_mtype_map(const char *str, const char *delim,
         t = ucc_mem_type_from_str(tokens[i]);
         if (t == UCC_MEMORY_TYPE_LAST) {
             /* entry does not match any memory type name */
-            status = UCC_ERR_NOT_FOUND;
+            status = UCC_ERR_INVALID_PARAM;
             goto out;
         }
         *mt_map |= UCC_BIT(t);
@@ -207,7 +207,7 @@ void ucc_mtype_map_to_str(uint32_t mt_map, const char *delim,
         if (UCC_BIT(i) & mt_map) {
             ucc_snprintf_safe(buf, max, "%s%s", ucc_mem_type_str(i), delim);
             last = strlen(buf);
-            if (max - last <= 0) {
+            if (max - last -1 <= 0) {
                 /* no more space in buf for next range*/
                 return;
             }

--- a/src/utils/ucc_string.h
+++ b/src/utils/ucc_string.h
@@ -6,7 +6,7 @@
 #ifndef UCC_STRING_H_
 #define UCC_STRING_H_
 #include "config.h"
-#include "ucc/api/ucc_status.h"
+#include "ucc/api/ucc_def.h"
 
 #define      ucc_memunits_range_str ucs_memunits_range_str
 
@@ -29,5 +29,16 @@ ucc_status_t ucc_str_concat(const char *str1, const char *str2,
                             char **out);
 
 ucc_status_t ucc_str_concat_n(const char *strs[], int n, char **out);
+
+ucc_status_t ucc_str_to_mtype_map(const char *str, const char* delim,
+                                  uint32_t *mt_map);
+
+void ucc_mtype_map_to_str(uint32_t mt_map, const char *delim,
+                          char *buf, size_t max);
+
+ucc_status_t ucc_str_to_memunits_range(const char *str, size_t *start,
+                                       size_t *end);
+
+
 
 #endif

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -98,6 +98,7 @@ gtest_SOURCES =                     \
 	utils/test_lock_free_queue.cc   \
 	utils/test_math.cc              \
 	utils/test_cfg_file.cc          \
+	utils/test_parser.cc            \
 	coll_score/test_score.cc        \
 	coll_score/test_score_str.cc    \
 	coll_score/test_score_update.cc \

--- a/test/gtest/utils/test_parser.cc
+++ b/test/gtest/utils/test_parser.cc
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include "utils/ucc_parser.h"
+#include "utils/ucc_datastruct.h"
+}
+#include <common/test.h>
+#include <common/test_ucc.h>
+
+class test_parse_mrange : public ucc::test {
+public:
+    ucc_mrange_uint_t *p;
+    test_parse_mrange() {
+        p = (ucc_mrange_uint_t *) ucc_malloc(sizeof(ucc_mrange_uint_t));
+    }
+    ~test_parse_mrange() {
+        ucc_free(p);
+    }
+};
+
+UCC_TEST_F(test_parse_mrange, check_valid) {
+    std::string str = "0-4K:host:8,auto";
+    size_t      msgsize1 = 1024, msgsize2 = 8192;
+
+    EXPECT_EQ(1, ucc_config_sscanf_uint_ranged(str.c_str(), p, NULL));
+    EXPECT_EQ(8, ucc_mrange_uint_get(p, msgsize1, UCC_MEMORY_TYPE_HOST));
+    EXPECT_EQ(UCC_UUNITS_AUTO, ucc_mrange_uint_get(p, msgsize2,
+                                                   UCC_MEMORY_TYPE_HOST));
+    ucc_mrange_uint_destroy(p);
+}
+
+UCC_TEST_F(test_parse_mrange, check_invalid) {
+    std::string       str = "0-4K:host:8:8";
+
+    EXPECT_EQ(0, ucc_config_sscanf_uint_ranged(str.c_str(), p, NULL));
+    ucc_mrange_uint_destroy(p);
+
+    str = "0-4K:host:a";
+    EXPECT_EQ(0, ucc_config_sscanf_uint_ranged(str.c_str(), p, NULL));
+    ucc_mrange_uint_destroy(p);
+
+    str = "0-4K:gpu:8";
+    EXPECT_EQ(0, ucc_config_sscanf_uint_ranged(str.c_str(), p, NULL));
+    ucc_mrange_uint_destroy(p);
+
+    str = "0-f:host:8";
+    EXPECT_EQ(0, ucc_config_sscanf_uint_ranged(str.c_str(), p, NULL));
+    ucc_mrange_uint_destroy(p);
+}
+
+UCC_TEST_F(test_parse_mrange, check_range_multiple) {
+    std::string str = "0-4K:host:8,4k-inf:host:10,0-4k:cuda:7,auto";
+    size_t      msgsize1 = 1024, msgsize2 = 8192;
+
+    EXPECT_EQ(1, ucc_config_sscanf_uint_ranged(str.c_str(), p, NULL));
+    EXPECT_EQ(8, ucc_mrange_uint_get(p, msgsize1, UCC_MEMORY_TYPE_HOST));
+    EXPECT_EQ(10, ucc_mrange_uint_get(p, msgsize2, UCC_MEMORY_TYPE_HOST));
+    EXPECT_EQ(7, ucc_mrange_uint_get(p, msgsize1, UCC_MEMORY_TYPE_CUDA));
+    EXPECT_EQ(UCC_UUNITS_AUTO, ucc_mrange_uint_get(p, msgsize2,
+                                                   UCC_MEMORY_TYPE_CUDA));
+    ucc_mrange_uint_destroy(p);
+}
+


### PR DESCRIPTION
## What
Based on PR #631 
Adds new type of env_var parameter: a value with msg range qualifiers. This represents a parameter that holds different values for different msg sizes/mtypes. For example, in this PR knomia radix of TL/UCP allreduce algorithm is modified to be mragned unsigned parameter. This allows specifying different radix values for different msg ranges/mem_types. E.g.:

UCC_TL_UCP_ALLREDUCE_SRA_KN_RADIX=0-4K:cuda:8,16k-inf:host:4,auto

Parameter can also store a number (single default value applied to the entire msg range 0-inf and for all mtypes). It can be just "auto" as well.

## Why ?
Flexible configuration. Convenient way to specify the value in TUNING section of the config file

## How ?
Internally the parameter is stored as a linked list of ranges with mtype maps.
