### PR TITLE
TL/UCP: hybrid alltoallv

### DIFF
--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 
 if TL_UCP_ENABLED

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -29,7 +29,8 @@ alltoall =                       \
 alltoallv =                        \
 	alltoallv/alltoallv.h          \
 	alltoallv/alltoallv.c          \
-	alltoallv/alltoallv_pairwise.c
+	alltoallv/alltoallv_pairwise.c \
+	alltoallv/alltoallv_hybrid.c
 
 allreduce =                           \
 	allreduce/allreduce.h             \

--- a/src/components/tl/ucp/alltoallv/alltoallv.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -14,7 +14,7 @@ ucc_base_coll_alg_info_t
             {.id   = UCC_TL_UCP_ALLTOALLV_ALG_PAIRWISE,
              .name = "pairwise",
              .desc = "O(N) pairwise exchange with adjustable number "
-             "of outstanding sends/recvs"},
+                     "of outstanding sends/recvs"},
         [UCC_TL_UCP_ALLTOALLV_ALG_HYBRID] =
             {.id   = UCC_TL_UCP_ALLTOALLV_ALG_HYBRID,
              .name = "hybrid",

--- a/src/components/tl/ucp/alltoallv/alltoallv.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -8,9 +8,6 @@
 #include "tl_ucp.h"
 #include "alltoallv.h"
 
-ucc_status_t ucc_tl_ucp_alltoallv_pairwise_start(ucc_coll_task_t *task);
-ucc_status_t ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *task);
-
 ucc_base_coll_alg_info_t
     ucc_tl_ucp_alltoallv_algs[UCC_TL_UCP_ALLTOALLV_ALG_LAST + 1] = {
         [UCC_TL_UCP_ALLTOALLV_ALG_PAIRWISE] =
@@ -18,6 +15,10 @@ ucc_base_coll_alg_info_t
              .name = "pairwise",
              .desc = "O(N) pairwise exchange with adjustable number "
              "of outstanding sends/recvs"},
+        [UCC_TL_UCP_ALLTOALLV_ALG_HYBRID] =
+            {.id   = UCC_TL_UCP_ALLTOALLV_ALG_HYBRID,
+             .name = "hybrid",
+             .desc = "hybrid a2av alg "},
         [UCC_TL_UCP_ALLTOALLV_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 

--- a/src/components/tl/ucp/alltoallv/alltoallv.h
+++ b/src/components/tl/ucp/alltoallv/alltoallv.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/ucp/alltoallv/alltoallv.h
+++ b/src/components/tl/ucp/alltoallv/alltoallv.h
@@ -12,6 +12,7 @@
 
 enum {
     UCC_TL_UCP_ALLTOALLV_ALG_PAIRWISE,
+    UCC_TL_UCP_ALLTOALLV_ALG_HYBRID,
     UCC_TL_UCP_ALLTOALLV_ALG_LAST
 };
 
@@ -23,6 +24,11 @@ ucc_status_t ucc_tl_ucp_alltoallv_init(ucc_tl_ucp_task_t *task);
 ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init(ucc_base_coll_args_t *coll_args,
                                                 ucc_base_team_t      *team,
                                                 ucc_coll_task_t     **task_h);
+
+ucc_status_t ucc_tl_ucp_alltoallv_hybrid_init(ucc_base_coll_args_t *coll_args,
+                                              ucc_base_team_t      *team,
+                                              ucc_coll_task_t     **task_h);
+
 
 ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task);
 
@@ -49,5 +55,17 @@ ucc_status_t ucc_tl_ucp_alltoallv_pairwise_init_common(ucc_tl_ucp_task_t *task);
 #define ALLTOALLV_TASK_CHECK(_args, _team)                                     \
     ALLTOALLV_CHECK_INPLACE((_args), (_team));                                 \
     ALLTOALLV_CHECK_USERDEFINED_DT((_args), (_team));
+
+
+static inline int ucc_tl_ucp_alltoallv_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_TL_UCP_ALLTOALLV_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_tl_ucp_alltoallv_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
 
 #endif

--- a/src/components/tl/ucp/alltoallv/alltoallv_hybrid.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_hybrid.c
@@ -1,0 +1,1065 @@
+/**
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "tl_ucp.h"
+#include "alltoallv.h"
+#include "core/ucc_progress_queue.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
+#include "tl_ucp_sendrecv.h"
+#include "components/mc/ucc_mc.h"
+
+/*
+scratch structure
+buff_size - alltoallv_hybrid_buff_size
+======================================================================================================================================================================================================================
+|sdispls            |scounts            |calc                   |seg                 |lb                                                         |ptrs                                      |buf                     |
+|tsize * sizeof(int)|tsize * sizeof(int)|2 * tsize * sizeof(int)|tsize * sizeof(char)|sizeof(ucc_tl_ucp_alltoallv_hybrid_buf_meta_t) * (radix -1)|ucc_div_round_up(tsize, 2) * sizeof(void*)|(radix - 1) * buff_size |
+======================================================================================================================================================================================================================
+*/
+
+#define NUM_BINS 5
+#define MAX_BRUCK 1250
+#define COUNT_DIRECT UINT_MAX
+#define DENSE_PACK_FORMAT UINT_MAX
+
+enum {
+    UCC_ALLTOALLV_HYBRID_PHASE_START,
+    UCC_ALLTOALLV_HYBRID_PHASE_SENT,
+    UCC_ALLTOALLV_HYBRID_PHASE_RECV
+};
+
+enum {
+    ALLTOALLV_HYBRID_SEG_SEND_DIRECT = 0,
+    ALLTOALLV_HYBRID_SEG_RECV_DIRECT = 1,
+    ALLTOALLV_HYBRID_SEG_DIGIT       = 2
+};
+
+typedef struct ucc_tl_ucp_alltoallv_hybrid_merge_bin {
+    ucc_tl_ucp_task_t *task;
+    int                start;
+    int                len;
+} ucc_tl_ucp_alltoallv_hybrid_merge_bin_t;
+
+typedef struct ucc_tl_ucp_alltoallv_hybrid_buf_meta {
+    ucc_tl_ucp_alltoallv_hybrid_merge_bin_t bins[NUM_BINS];
+    int                                     cur_bin;
+    int                                     offset;
+} ucc_tl_ucp_alltoallv_hybrid_buf_meta_t;
+
+#define TASK_SCRATCH(_task) ({                                                 \
+             (_task)->alltoallv_hybrid.scratch_mc_header->addr;                \
+        })
+
+#define TASK_CALC(_task, _tsize) ({                                            \
+            PTR_OFFSET(TASK_SCRATCH(_task), 2*_tsize*sizeof(int));             \
+        })
+
+#define TASK_SEG(_task, _tsize) ({                                             \
+            PTR_OFFSET(TASK_SCRATCH(_task), 4 * _tsize*sizeof(int));           \
+        })
+
+#define TASK_LB(_task, _tsize) ({                                              \
+            PTR_OFFSET(TASK_SEG(_task, _tsize), _tsize*sizeof(char));          \
+        })
+
+#define TASK_PTRS(_task, _tsize) ({                                                                          \
+            uint32_t _radix  = (_task)->alltoallv_hybrid.radix;                                              \
+            PTR_OFFSET(TASK_LB(_task, _tsize), sizeof(ucc_tl_ucp_alltoallv_hybrid_buf_meta_t)*(_radix - 1)); \
+        })
+
+#define TASK_BUF(_task, _i, _tsize) ({                                                                  \
+            size_t _buff_size  = UCC_TL_UCP_TEAM_LIB(TASK_TEAM(_task))->cfg.alltoallv_hybrid_buff_size; \
+            PTR_OFFSET(TASK_PTRS(_task, _tsize), ucc_div_round_up(_tsize, 2)*sizeof(void*) +            \
+                       (_i) * _buff_size);                                                              \
+        })
+
+#define CEIL(x,y) (((x)%(y))?((x)/(y)+1)*(y):(x))
+
+#define ALIGN(x) CEIL(x, 4)
+
+#define IS_DIRECT_SEND(_seg) ((_seg) & UCC_BIT(ALLTOALLV_HYBRID_SEG_SEND_DIRECT))
+
+#define SET_DIRECT_SEND(_seg) ((_seg) |= UCC_BIT(ALLTOALLV_HYBRID_SEG_SEND_DIRECT))
+
+#define IS_DIRECT_RECV(_seg) ((_seg) & UCC_BIT(ALLTOALLV_HYBRID_SEG_RECV_DIRECT))
+
+#define SET_DIRECT_RECV(_seg) ((_seg) |= UCC_BIT(ALLTOALLV_HYBRID_SEG_RECV_DIRECT))
+
+#define GET_BRUCK_DIGIT(_seg) ((_seg) >> ALLTOALLV_HYBRID_SEG_DIGIT)
+
+#define SET_BRUCK_DIGIT(_seg, _digit) \
+    ((_seg) = (((_digit) << ALLTOALLV_HYBRID_SEG_DIGIT) + ((_seg) & UCC_MASK(ALLTOALLV_HYBRID_SEG_DIGIT))))
+
+#define GET_NEXT_BRUCK_NUM(_num, _radix, _pow) \
+    ((((_num) + 1) % (_pow))?((_num) + 1):(((_num) + 1) + (_pow) * ((_radix) - 1)))
+
+#define GET_PREV_BRUCK_NUM(_num, _radix, _pow) \
+    (((_num) % (_pow))?((_num) - 1):(((_num) - 1) - (_pow) * ((_radix) - 1)))
+
+static inline ucc_rank_t get_bruck_step_start(uint32_t pow, uint32_t d)
+{
+    return pow * d;
+}
+
+static inline ucc_rank_t get_bruck_step_finish(ucc_rank_t n, uint32_t radix,
+                                               uint32_t d, uint32_t pow)
+{
+    return ucc_min(n + pow - 1 - (n - d * pow) % (pow * radix), n);
+}
+
+static inline ucc_rank_t get_bruck_recv_peer(ucc_rank_t trank, ucc_rank_t tsize,
+                                             ucc_rank_t step, uint32_t digit)
+{
+    return (trank - step * digit + tsize * digit ) % tsize;
+}
+
+static inline ucc_rank_t get_bruck_send_peer(ucc_rank_t trank, ucc_rank_t tsize,
+                                             ucc_rank_t step, uint32_t digit)
+{
+    return (trank + step * digit ) % tsize;
+}
+
+static inline ucc_rank_t get_pairwise_send_peer(ucc_rank_t trank, ucc_rank_t tsize,
+                                                ucc_rank_t step)
+{
+    return (trank + step) % tsize;
+}
+
+static inline ucc_rank_t get_pairwise_recv_peer(ucc_rank_t trank, ucc_rank_t tsize,
+                                                ucc_rank_t step)
+{
+    return (trank - step + tsize) % tsize;
+}
+
+static void send_completion(void *request, ucs_status_t status,
+                            void *user_data)
+{
+    ucc_tl_ucp_alltoallv_hybrid_merge_bin_t *bin =
+        (ucc_tl_ucp_alltoallv_hybrid_merge_bin_t*)user_data;
+    if (ucc_unlikely(UCS_OK != status)) {
+        tl_error(UCC_TASK_LIB(bin->task), "failure in alltoallv_hybird completion %s",
+                 ucs_status_string(status));
+        bin->task->super.status = ucs_status_to_ucc_status(status);
+    }
+    if (request) {
+        ucp_request_free(request);
+    }
+    bin->task->tagged.send_completed++;
+    bin->len = 0;
+}
+
+static ucc_status_t ucc_tl_ucp_alltoallv_hybrid_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+
+    if (task->alltoallv_hybrid.scratch_mc_header) {
+        ucc_mc_free(task->alltoallv_hybrid.scratch_mc_header);
+    }
+    return ucc_tl_ucp_coll_finalize(coll_task);
+}
+
+static inline void radix_setup(ucc_tl_ucp_task_t *task, int id, ucc_rank_t tsize,
+                               int merge_buf_size,
+                               ucc_tl_ucp_alltoallv_hybrid_buf_meta_t** meta,
+                               void** merge_buf, void** tmp_buf)
+{
+    ucc_tl_ucp_alltoallv_hybrid_buf_meta_t *bm = TASK_LB(task, tsize);
+
+    (*meta)      = &bm[id];
+    (*merge_buf) = TASK_BUF(task, id, tsize);
+    (*tmp_buf)   = PTR_OFFSET(*merge_buf, merge_buf_size);
+}
+
+/* get the number of blocks of data to be sent for the given step and edge in the algorithm. */
+static inline int get_send_block_count(ucc_rank_t tsize, int radix,
+                                       int node_edge_id, int radix_pow)
+{
+    int send_count, k;
+    k = tsize / radix_pow;
+    send_count = (k / radix) * radix_pow;
+    if ((k % radix) > node_edge_id) {
+        send_count += radix_pow;
+    } else if ((k % radix) == node_edge_id) {
+        send_count += (tsize % radix_pow);
+    }
+    return send_count;
+}
+
+static inline int calculate_head_size(int snd_count, size_t dt_size)
+{
+    int head_num_elements = 0;
+
+    if (dt_size <= sizeof(unsigned int))
+    {
+        head_num_elements = ((snd_count + 1) * sizeof(unsigned int)) / dt_size;
+    } else {
+        /* The size of dtype is greater than unsigned int */
+        if (((snd_count + 1) * sizeof(unsigned int)) % dt_size == 0) {
+            /* The size of head can fit */
+            head_num_elements = ((snd_count + 1) * sizeof(unsigned int)) / dt_size;
+        } else {
+            /* The size of head can not fit*/
+            head_num_elements = ((snd_count + 1) * sizeof(unsigned int)) / dt_size + 1;
+        }
+    }
+    return head_num_elements;
+}
+
+static int fit_in_send_buffer(int num,
+                              ucc_tl_ucp_alltoallv_hybrid_buf_meta_t* meta,
+                              int size_req, int mem_size)
+{
+    int *cur_bin = &meta->cur_bin;
+    int start_ok = 1;
+    int bin_rdy  = -1;
+    int i, k, pos, valid_pos;
+
+    ucc_assert(size_req <= mem_size);
+    for (i = 0; i < num; i++) {
+        if (meta->bins[i].len == 0) {
+            bin_rdy = i;
+            break;
+        }
+    }
+    *cur_bin = bin_rdy;
+
+    if (bin_rdy == -1) {
+        /* no free bins, exit */
+        return -1;
+    }
+
+    for (i = 0; i < num; i++) {
+        if ((meta->bins[i].len > 0) && (meta->bins[i].start < size_req)) {
+            start_ok = 0;
+            break;
+        }
+    }
+
+    if (start_ok == 1) {
+        /* we have enough empty space at the beggining of buffer */
+        return 0;
+    }
+
+    /* at this point at least one bin is not empty */
+    for (k = 0; k < num; k++) {  /* complexity O(num_bins^2) */
+        if (meta->bins[k].len > 0) {
+            /* bin is not empty, check if there is enough space after it*/
+            valid_pos = 1;
+            pos = meta->bins[k].start + meta->bins[k].len;
+            if (pos + size_req < mem_size) {
+                /* there is enough space till the end of the buffer,
+                 * need to check collisions with other bins
+                 */
+                for (i = 0; i < num; i++) {
+                    if ((i == k) || (meta->bins[i].len == 0)) {
+                        /* skip current bin and empty bins */
+                        continue;
+                    }
+                    if (meta->bins[i].start < (pos + size_req) &&
+                        pos < meta->bins[i].start + meta->bins[i].len) {
+                        /* two regions overlap => collision */
+                        valid_pos = 0;
+                        break;
+                    }
+                }
+
+                if (valid_pos) {
+                    /* found a slot, no collisions with other bins */
+                    return pos;
+                }
+            }
+        }
+    }
+    /* no available slots */
+    return -1;
+}
+
+static inline
+ucc_status_t get_send_buffer(void *p_tmp_send_region,
+                             ucc_tl_ucp_alltoallv_hybrid_buf_meta_t* p_scratch_space_meta_data,
+                             int num_bins, int required_buf_size,
+                             ucc_tl_ucp_task_t *task, void **buf)
+{
+    int merge_buf_size = task->alltoallv_hybrid.merge_buf_size;
+    int polls          = 0;
+    int send_buf_offset;
+
+    /* get send buffer pointer */
+    send_buf_offset = fit_in_send_buffer(num_bins, p_scratch_space_meta_data,
+                                         required_buf_size, merge_buf_size);
+    if (send_buf_offset < 0) {
+        do {
+            ucp_worker_progress(TASK_CTX(task)->worker.ucp_worker);
+            send_buf_offset = fit_in_send_buffer(num_bins, p_scratch_space_meta_data,
+                                                 required_buf_size, merge_buf_size);
+        } while ((send_buf_offset < 0) && (polls++ < task->n_polls));
+        if (send_buf_offset < 0) {
+            return UCC_INPROGRESS;
+        }
+    }
+
+    p_scratch_space_meta_data->bins[p_scratch_space_meta_data->cur_bin].start = send_buf_offset;
+    *buf = PTR_OFFSET(p_tmp_send_region, send_buf_offset);
+    return UCC_OK;
+}
+
+/* Pack data for sending
+ * packed_send_buf (output) contains the send buffer that is ready to be sent
+ * returns length of the buffer to be sent
+ */
+static size_t pack_send_data(ucc_tl_ucp_task_t *task, int step, ucc_rank_t tsize,
+                             int send_count, int node_edge_id, size_t dt_size,
+                             int send_limit, int step_header_size,
+                             int *BytesForPacking, void *op_metadata,
+                             char* seg_st, void *packed_send_buf)
+{
+    int           tmp_send_region_size = task->alltoallv_hybrid.merge_buf_size;
+    uint32_t      radix                = task->alltoallv_hybrid.radix;
+    void        **src_iovec            = TASK_PTRS(task, tsize);
+    void         *user_sbuf            = TASK_ARGS(task).src.info_v.buffer;
+    int           sparse_cnt           = 0;
+    int           n                    = send_count;
+    int           logi                 = 1;
+    ucc_rank_t index;
+    int send_len, snd_offset, i, k;
+    unsigned int temp_count;
+    char loc;
+    size_t offset;
+
+    for (i = 0; i < n; i++) {
+        BytesForPacking[i] = send_limit;
+    }
+
+    while (logi < n) {
+        logi = logi* radix;
+    }
+
+    index = get_bruck_step_finish(tsize - 1, radix, node_edge_id, step);
+    while (n > 0) {
+        ucc_assert((index / step) % radix == node_edge_id);
+        n--;
+        if (logi > n) {
+            logi = logi / radix;
+        }
+        temp_count = ((unsigned int *)op_metadata)[index + tsize];
+        if (temp_count == COUNT_DIRECT) {
+            /* data will be directly sent */
+            send_len = 0;
+        } else {
+            loc = GET_BRUCK_DIGIT(seg_st[index]);
+            snd_offset = ((unsigned int *)op_metadata)[index] * dt_size;
+            send_len   = dt_size * temp_count;
+            if (loc) {
+                /* data is in scratch buffer */
+                src_iovec[n] = PTR_OFFSET(TASK_BUF(task, (loc - 1), tsize),
+                                          tmp_send_region_size + snd_offset);
+            } else {
+                /* data is in user buffer */
+                if ((send_len <= BytesForPacking[n]) &&
+                    (send_len < MAX_BRUCK || n < step)) {
+                    src_iovec[n] = PTR_OFFSET(user_sbuf, snd_offset);
+                } else {
+                    /* direct exchange */
+                    temp_count = COUNT_DIRECT;
+                    task->alltoallv_hybrid.num2send++;
+                    /* mark the send as direct */
+                    SET_DIRECT_SEND(seg_st[index]);
+                    send_len = 0;
+                }
+            }
+        }
+        ((unsigned int *)packed_send_buf)[n + 1] = temp_count;
+        if (send_len > 0) {
+            sparse_cnt++;
+        }
+
+        if (logi > 0) {
+            BytesForPacking[n % logi] += BytesForPacking[n] - send_len;
+        }
+        index = GET_PREV_BRUCK_NUM(index, radix, step);
+    }
+    /* if there is data for less than half the destinations, send meta data
+     * in sparse format.
+     */
+    if ((sparse_cnt / 2) < send_count) {
+        /* sparse format */
+        ((unsigned int *)packed_send_buf)[0] = sparse_cnt;
+        /* compute space requirement for sparse data exchange header */
+        offset = calculate_head_size(sparse_cnt*2, dt_size) * dt_size;
+        i = k = 0;
+        while (k < sparse_cnt) {
+            unsigned int cur_len = ((unsigned int *)packed_send_buf)[i + 1];
+            if (cur_len != 0 && cur_len != COUNT_DIRECT) {
+                BytesForPacking[2*k]   = i;
+                BytesForPacking[2*k+1] = cur_len;
+                ++k;
+            }
+            ++i;
+        }
+        for (i = 0; i < sparse_cnt; i++){
+            ((unsigned int *)packed_send_buf)[2*i+1] = BytesForPacking[2*i];
+            ((unsigned int *)packed_send_buf)[2*i+2] = BytesForPacking[2*i+1];
+        }
+        /* pack the send buffer */
+        for (k = 0; k < sparse_cnt; ++k) {
+            i          = ((unsigned int *)packed_send_buf)[2*k+1];
+            temp_count = ((unsigned int *)packed_send_buf)[2*k+2];
+            memcpy(PTR_OFFSET(packed_send_buf, offset), src_iovec[i],
+                   temp_count * dt_size);
+            offset = offset + temp_count * dt_size;
+        }
+    } else {
+        /* dense format */
+        ((unsigned int *)packed_send_buf)[0] = DENSE_PACK_FORMAT;
+        offset = step_header_size;
+        for (i = 0; i < send_count; i++){
+            temp_count = ((unsigned int *)packed_send_buf)[i + 1];
+            if (temp_count != COUNT_DIRECT) {
+                memcpy(PTR_OFFSET(packed_send_buf, offset), src_iovec[i],
+                       temp_count * dt_size);
+                offset = offset + temp_count * dt_size;
+            }
+        }
+    }
+
+    return offset;
+}
+
+static inline
+ucc_status_t send_data(void *buf, int send_size, ucc_rank_t dst,
+                       ucc_tl_ucp_alltoallv_hybrid_buf_meta_t* p_scratch_space_meta_data,
+                       ucc_tl_ucp_task_t *task)
+{
+    ucc_status_t status;
+
+    ucc_assert(p_scratch_space_meta_data->bins[p_scratch_space_meta_data->cur_bin].len != 0);
+    status = ucc_tl_ucp_send_cb(buf, send_size, UCC_MEMORY_TYPE_HOST, dst, TASK_TEAM(task), task,
+                                send_completion,
+                                (void*)&p_scratch_space_meta_data->bins[p_scratch_space_meta_data->cur_bin]);
+    task->alltoallv_hybrid.phase = UCC_ALLTOALLV_HYBRID_PHASE_SENT;
+    return status;
+}
+
+static
+int receive_buffer_recycler(ucc_rank_t tsize, unsigned int* rcv_start, int* rcv_len,
+                            char* seg_st, void* buf, size_t dt_size, int* tmp_buf,
+                            int step, void* rbuf, int* rdisps, int my_group_index,
+                            int radix, int node_edge_id)
+{
+    int cur = 0;
+    int i, k, in_buf, offset, idx;
+
+    for (i = 0; i < tsize; ++i) {
+        if (GET_BRUCK_DIGIT(seg_st[i]) == node_edge_id) {
+            tmp_buf[i+tsize] = 1;
+            ++cur;
+        } else {
+            tmp_buf[i+tsize] = 0;
+        }
+    }
+
+    in_buf = cur;
+    int mstep = step/radix;
+    --cur;
+    while (cur >= 0){
+        for (i = tsize-1; i >= 0; --i){
+              if (tmp_buf[i+tsize] && ((i / mstep)% radix == node_edge_id) ) {
+                tmp_buf[cur] = i;
+                tmp_buf[i+tsize] = 0;
+                --cur;
+              }
+        }
+        mstep = mstep/radix;
+    }
+    k = 0;
+    offset = 0;
+    while (k < in_buf) {
+        cur = tmp_buf[k];
+        if ((rcv_start[cur] == COUNT_DIRECT) || (rcv_len[cur] == 0)){
+            ++k;
+            continue;
+        }
+        if (cur < step) {
+            /* final destination of data */
+            idx = (my_group_index - cur + tsize ) % tsize;
+            memcpy(PTR_OFFSET(rbuf, rdisps[idx] * dt_size),
+                   PTR_OFFSET(buf, rcv_start[cur] * dt_size),
+                   rcv_len[cur] * dt_size);
+            rcv_start[cur] = COUNT_DIRECT;
+            rcv_len[cur] = 0;
+            seg_st[cur] = seg_st[cur] % 4;
+        } else {
+            if (offset < rcv_start[cur]) {
+                memcpy(PTR_OFFSET(buf, offset * dt_size),
+                       PTR_OFFSET(buf, rcv_start[cur] * dt_size),
+                       rcv_len[cur] * dt_size);
+                rcv_start[cur] = offset;
+                offset += rcv_len[cur];
+            } else {
+                assert(offset == rcv_start[cur]);
+                offset += rcv_len[cur];
+            }
+        }
+        ++k;
+    }
+
+    return offset;
+}
+
+static
+ucc_status_t post_recv(ucc_rank_t recvfrom, ucc_rank_t tsize, size_t dt_size,
+                       int node_edge_id, int step, ucc_rank_t trank,
+                       void *op_metadata, int tmp_buf_size, char *seg_st,
+                       ucc_tl_ucp_alltoallv_hybrid_buf_meta_t* p_scratch_space_meta_data,
+                       int step_buf_size, int *BytesForPacking,
+                       void *p_tmp_recv_region, ucc_tl_ucp_task_t *task)
+{
+    int          *rdisps    = (int*)TASK_ARGS(task).dst.info_v.displacements;
+    void         *user_rbuf = TASK_ARGS(task).dst.info_v.buffer;
+    uint32_t      radix     = task->alltoallv_hybrid.radix;
+    ucc_status_t  status    = UCC_OK;
+    int recv_size, new_offset;
+    void* dst_buf;
+
+    if (task->alltoallv_hybrid.phase != UCC_ALLTOALLV_HYBRID_PHASE_SENT) {
+        return UCC_OK;
+    }
+    recv_size = step_buf_size;
+    /* Yaniv: Check if we have space for maximum recieve. If not, recycle */
+    if (p_scratch_space_meta_data->offset*dt_size + recv_size > tmp_buf_size) {
+        new_offset = receive_buffer_recycler(tsize, (int *)op_metadata, (int *)op_metadata + tsize,
+                                             seg_st, p_tmp_recv_region, dt_size, BytesForPacking,
+                                             step, user_rbuf, rdisps, trank, radix, node_edge_id);
+        p_scratch_space_meta_data->offset = new_offset;
+    }
+    ucc_assert(p_scratch_space_meta_data->offset*dt_size + recv_size <= tmp_buf_size);
+    dst_buf = PTR_OFFSET(p_tmp_recv_region, p_scratch_space_meta_data->offset*dt_size);
+
+    status = ucc_tl_ucp_recv_nb(dst_buf, recv_size, UCC_MEMORY_TYPE_HOST,
+                                recvfrom, TASK_TEAM(task), task);
+    if (ucc_unlikely(status != UCC_OK)) {
+        return status;
+    }
+
+    task->alltoallv_hybrid.phase = UCC_ALLTOALLV_HYBRID_PHASE_START;
+    task->alltoallv_hybrid.cur_radix++;
+    if (task->alltoallv_hybrid.cur_radix == radix) {
+        /* setup the contol variables for the next phase of processing */
+        task->alltoallv_hybrid.phase     = UCC_ALLTOALLV_HYBRID_PHASE_RECV;
+        task->alltoallv_hybrid.cur_radix = 1;
+    }
+
+    return UCC_OK;
+}
+
+/* complete all receives in current step */
+static ucc_status_t complete_current_step_receives(ucc_rank_t tsize, int step,
+                                                   size_t dt_size, ucc_rank_t trank,
+                                                   void *op_metadata, char *seg_st,
+                                                   ucc_tl_ucp_task_t *task)
+{
+    size_t    tmp_send_region_size = task->alltoallv_hybrid.merge_buf_size;
+    uint32_t  radix                = task->alltoallv_hybrid.radix;
+    int      *rcounts              = (int*)TASK_ARGS(task).dst.info_v.counts;
+    int       polls                = 0;
+    ucc_tl_ucp_alltoallv_hybrid_buf_meta_t *p_scratch_space_meta_data;
+    unsigned int rcv_sparse, next_p, cur_p;
+    void *p_tmp_recv_region, *p_tmp_send_region, *dst_buf, *temp_offset;
+    int i, k, n, node_edge_id, recv_count, cur_buf_length, recv_size;
+
+    while ((task->tagged.recv_posted != task->tagged.recv_completed) &&
+           (polls++ < task->n_polls))
+    {
+        ucp_worker_progress(TASK_CTX(task)->worker.ucp_worker);
+    }
+
+    if (task->tagged.recv_posted != task->tagged.recv_completed) {
+        return UCC_INPROGRESS;
+    }
+
+    while (task->alltoallv_hybrid.cur_radix < radix) {
+        node_edge_id = task->alltoallv_hybrid.cur_radix;
+        radix_setup(task, node_edge_id - 1, tsize, tmp_send_region_size,
+                    &p_scratch_space_meta_data, &p_tmp_send_region,
+                    &p_tmp_recv_region);
+
+        n = get_send_block_count(tsize, radix, node_edge_id, step);
+        if (!n) {
+            /* nothing to be done here */
+            task->alltoallv_hybrid.cur_radix++;
+            continue;
+        }
+
+        /* fill in the information to be be used in subsequenst aggrgation
+         * steps to extract data received for packing.
+         */
+        dst_buf = PTR_OFFSET(p_tmp_recv_region,
+                             p_scratch_space_meta_data->offset * dt_size);
+        rcv_sparse = ((unsigned int *)dst_buf)[0];
+        i = get_bruck_step_start(step, node_edge_id);
+        if (rcv_sparse == DENSE_PACK_FORMAT) {
+            recv_count = 0;
+            recv_size = calculate_head_size(n, dt_size);
+            temp_offset = PTR_OFFSET(dst_buf, recv_size*dt_size);
+            /* this is where we parse the recieved bruck-like packet and
+             * set the pointers to point on the important data segments.
+             */
+            while (i < tsize) {
+                cur_buf_length = ((unsigned int *)dst_buf)[1 + recv_count];
+                if (cur_buf_length != COUNT_DIRECT) {
+                    ((unsigned int *)op_metadata)[i] =
+                        ((char *)temp_offset-(char *)p_tmp_recv_region) / dt_size;
+                    /* mark data received destined to rank i, and its length */
+                    SET_BRUCK_DIGIT(seg_st[i], node_edge_id);
+                    ((int *)op_metadata)[i + tsize] = cur_buf_length;
+                    recv_size += cur_buf_length;
+                    temp_offset = PTR_OFFSET(temp_offset, cur_buf_length * dt_size);
+                } else {
+                    /* data will be sent pairwise */
+                    ((int *)op_metadata)[i]         = COUNT_DIRECT;
+                    ((int *)op_metadata)[i + tsize] = COUNT_DIRECT;
+                    if (i < (step*radix)) {
+                        int pairwise_src = (trank - i + tsize) % tsize;
+                        if (rcounts[pairwise_src] > 0) {
+                            task->alltoallv_hybrid.num2recv++;
+                            SET_DIRECT_RECV(seg_st[i]);
+                        }
+                    }
+                }
+                ++recv_count;
+                i = GET_NEXT_BRUCK_NUM(i, radix, step);
+            }
+        } else {
+            recv_size = calculate_head_size(2*rcv_sparse, dt_size);
+            temp_offset= PTR_OFFSET(dst_buf, recv_size*dt_size);
+            k = 0;
+            if (rcv_sparse > 0) {
+                next_p = ((unsigned int *)dst_buf)[2*k + 1];
+            } else {
+                next_p = tsize;
+            }
+
+            cur_p = 0;
+            while (i < tsize) {
+                if (cur_p == next_p) {
+                    cur_buf_length = ((unsigned int *)dst_buf)[2*k + 2];
+                    ((int *)op_metadata)[i] =
+                        (((char *)temp_offset - (char *)p_tmp_recv_region) / dt_size);
+                    ((int *)op_metadata)[i + tsize] = cur_buf_length;
+
+                    recv_size+= cur_buf_length;
+                    temp_offset = PTR_OFFSET(temp_offset, cur_buf_length * dt_size);
+                    SET_BRUCK_DIGIT(seg_st[i], node_edge_id);
+                    ++k;
+                    if (k < rcv_sparse){
+                        next_p= ((unsigned int *)dst_buf)[2*k + 1];
+                    } else {
+                        next_p = tsize;
+                    }
+                } else {
+                    ((int *)op_metadata)[i]         = COUNT_DIRECT;
+                    ((int *)op_metadata)[i + tsize] = COUNT_DIRECT;
+                    if (i < (step*radix)) {
+                        int pairwise_src = (trank - i + tsize) % tsize;
+                        if (rcounts[pairwise_src] > 0) {
+                            task->alltoallv_hybrid.num2recv++;
+                            SET_DIRECT_RECV(seg_st[i]);
+                        }
+                    }
+                }
+                ++cur_p;
+                i = GET_NEXT_BRUCK_NUM(i, radix, step);
+            }
+            ucc_assert(next_p == tsize);
+        }
+        p_scratch_space_meta_data->offset += recv_size;
+        task->alltoallv_hybrid.cur_radix++;
+    }
+
+    return UCC_OK;
+}
+
+static inline void hybrid_reverse_rotation(ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t *team           = TASK_TEAM(task);
+    ucc_rank_t         tsize          = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t         trank          = UCC_TL_TEAM_RANK(team);
+    char              *seg_st         = TASK_SEG(task, tsize);
+    size_t             merge_buf_size = task->alltoallv_hybrid.merge_buf_size;
+    void              *user_sbuf      = TASK_ARGS(task).src.info_v.buffer;
+    void              *user_rbuf      = TASK_ARGS(task).dst.info_v.buffer;
+    int               *rdisps         = (int*)TASK_ARGS(task).dst.info_v.displacements;
+    void              *ml_buf_metainfo = task->alltoallv_hybrid.scratch_mc_header->addr;
+    size_t dt_size;
+    int i, idx, cur_buf_index, cur_buf_size;
+    char loc;
+    void *lb;
+
+    dt_size = ucc_dt_size(TASK_ARGS(task).dst.info_v.datatype);
+    for (i = 0; i < tsize; i++ ) {
+        cur_buf_index = ((int *)ml_buf_metainfo)[i];
+        cur_buf_size  = ((int *)ml_buf_metainfo)[i + tsize];
+        if (cur_buf_index != COUNT_DIRECT ){
+            loc = GET_BRUCK_DIGIT(seg_st[i]);
+            idx = (trank - i + tsize ) % tsize;
+            if (loc == 0) {
+                /* This block of data is in user send buffer */
+                memcpy(PTR_OFFSET(user_rbuf, rdisps[idx] * dt_size),
+                       PTR_OFFSET(user_sbuf, cur_buf_index * dt_size),
+                       cur_buf_size * dt_size);
+            } else {
+                /* This block of data is in ml temp buffer */
+                lb = TASK_BUF(task, loc - 1, tsize);
+                memcpy(PTR_OFFSET(user_rbuf, rdisps[idx] * dt_size),
+                       PTR_OFFSET(lb, merge_buf_size + cur_buf_index*dt_size),
+                       cur_buf_size * dt_size);
+            }
+        }
+    }
+}
+
+static
+ucc_status_t pairwise_manager(ucc_rank_t trank, ucc_rank_t tsize,
+                              size_t dt_size, ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t *team             = TASK_TEAM(task);
+    char              *seg_st           = TASK_SEG(task, tsize);
+    void              *user_sbuf        = TASK_ARGS(task).src.info_v.buffer;
+    void              *user_rbuf        = TASK_ARGS(task).dst.info_v.buffer;
+    int               *s_disps          = (int*)TASK_ARGS(task).src.info_v.displacements;
+    int               *r_disps          = (int*)TASK_ARGS(task).dst.info_v.displacements;
+    int               *scounts          = (int*)TASK_ARGS(task).src.info_v.counts;
+    int               *rcounts          = (int*)TASK_ARGS(task).dst.info_v.counts;
+    int*               cur              = &task->alltoallv_hybrid.cur_out;
+    int                chunk_num_limit  = UCC_TL_UCP_TEAM_LIB(team)->cfg.alltoallv_hybrid_pairwise_num_posts;
+    int                chunk_byte_limit = UCC_TL_UCP_TEAM_LIB(team)->cfg.alltoallv_hybrid_chunk_byte_limit;
+    ucc_status_t status;
+    void* mem_dst;
+    int pairwise_dest, msg_size;
+
+    if ((task->alltoallv_hybrid.num_in < chunk_num_limit) &&
+        (task->alltoallv_hybrid.traffic_in <= chunk_byte_limit) &&
+        (task->alltoallv_hybrid.traffic_out <= chunk_byte_limit)) {
+        if ((task->alltoallv_hybrid.num2send == 0) &&
+            (task->alltoallv_hybrid.num2recv == 0)) {
+            return UCC_OK;
+        }
+
+        while (!(IS_DIRECT_SEND(seg_st[*cur]) || IS_DIRECT_RECV(seg_st[*cur]))) {
+            ++(*cur);
+            assert(*cur < tsize);
+        }
+
+        if (IS_DIRECT_SEND(seg_st[*cur])) {
+            pairwise_dest = get_pairwise_send_peer(trank, tsize, *cur);
+            mem_dst = PTR_OFFSET(user_sbuf, s_disps[pairwise_dest] * dt_size);
+            msg_size = scounts[pairwise_dest] * dt_size;
+            task->alltoallv_hybrid.traffic_out += msg_size;
+            if ((task->alltoallv_hybrid.num_in > 0) &&
+                (task->alltoallv_hybrid.traffic_out > chunk_byte_limit)) {
+                /* too much outgoing trafic, exit */
+                return UCC_OK;
+            }
+
+            status = ucc_tl_ucp_send_nb(mem_dst, msg_size, UCC_MEMORY_TYPE_HOST,
+                                        pairwise_dest, team, task);
+            if (ucc_unlikely(UCC_OK != status )) {
+                return status;
+            }
+            seg_st[(*cur)] = seg_st[(*cur)] - 1;
+            task->alltoallv_hybrid.num2send--;
+        }
+
+        if (IS_DIRECT_RECV(seg_st[*cur])) {
+            pairwise_dest = get_pairwise_recv_peer(trank, tsize, *cur);
+            mem_dst = PTR_OFFSET(user_rbuf, r_disps[pairwise_dest] * dt_size);
+            msg_size = rcounts[pairwise_dest] * dt_size;
+            status = ucc_tl_ucp_recv_nb(mem_dst, msg_size, UCC_MEMORY_TYPE_HOST,
+                                        pairwise_dest, team, task);
+            if (ucc_unlikely(UCC_OK != status )) {
+                return status;
+            }
+            task->alltoallv_hybrid.traffic_in += msg_size;
+            seg_st[(*cur)] = seg_st[(*cur)] - 2;
+            task->alltoallv_hybrid.num2recv--;
+        }
+        task->alltoallv_hybrid.num_in++;
+        ++(*cur);
+    } else {
+        if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+            return UCC_OK;
+        }
+        task->alltoallv_hybrid.num_in      = 0;
+        task->alltoallv_hybrid.traffic_in  = 0;
+        task->alltoallv_hybrid.traffic_out = 0;
+    }
+
+    return UCC_OK;
+}
+
+static void ucc_tl_ucp_alltoallv_hybrid_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task            = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team            = TASK_TEAM(task);
+    ucc_rank_t         gsize           = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t         grank           = UCC_TL_TEAM_RANK(team);
+    uint32_t           radix           = task->alltoallv_hybrid.radix;
+    char              *seg_st          = TASK_SEG(task, gsize);
+    void              *op_metadata     = task->alltoallv_hybrid.scratch_mc_header->addr;
+    size_t             merge_buf_size  = task->alltoallv_hybrid.merge_buf_size;
+    size_t             send_limit      = task->alltoallv_hybrid.byte_send_limit;
+    int               *BytesForPacking = TASK_CALC(task, gsize);
+    size_t             buff_size       = UCC_TL_UCP_TEAM_LIB(team)->cfg.alltoallv_hybrid_buff_size;
+    size_t             tmp_buf_size    = buff_size - (merge_buf_size + sizeof(ucc_tl_ucp_alltoallv_hybrid_buf_meta_t));
+    size_t             dt_size         = ucc_dt_size(coll_task->bargs.args.dst.info_v.datatype);
+    ucc_rank_t sendto, recvfrom;
+    int node_edge_id, step, i, istep, step_header_size, step_buf_size;
+    size_t snd_count, send_size;
+    void *p_tmp_recv_region, *p_tmp_send_region, *buf;
+    ucc_tl_ucp_alltoallv_hybrid_buf_meta_t *p_scratch_space_meta_data;
+    ucc_status_t status;
+
+    istep = 1;
+    for (i = 1; i < task->alltoallv_hybrid.iteration; i++) {
+        istep *= radix;
+    }
+
+    /* Loop over algorithm stage - number of stages is ceil(log_k(N)),
+     * where k is algorithm radix and N is communicator size
+     */
+    for (step = istep; step < gsize; step *= radix) {
+        while ((task->alltoallv_hybrid.phase == UCC_ALLTOALLV_HYBRID_PHASE_START) ||
+               (task->alltoallv_hybrid.phase == UCC_ALLTOALLV_HYBRID_PHASE_SENT)) {
+            /* initiate sends
+             * set the current substage index. node_edge_id=1, 2, ..., k-1
+             */
+            node_edge_id = task->alltoallv_hybrid.cur_radix;
+            radix_setup(task, node_edge_id - 1, gsize, merge_buf_size,
+                        &p_scratch_space_meta_data, &p_tmp_send_region,
+                        &p_tmp_recv_region);
+            /* figure out number of desinaiton ranks the will be included in the current send */
+            snd_count = get_send_block_count(gsize, radix, node_edge_id, step);
+            if (!snd_count) {
+                task->alltoallv_hybrid.cur_radix++;
+                if (task->alltoallv_hybrid.cur_radix == radix) {
+                    task->alltoallv_hybrid.phase     = UCC_ALLTOALLV_HYBRID_PHASE_RECV;
+                    task->alltoallv_hybrid.cur_radix = 1;
+                }
+                continue;
+            }
+
+            /* peers to communicate with in the rth exchange of the current stage */
+            sendto   = get_bruck_send_peer(grank, gsize, step, node_edge_id);
+            recvfrom = get_bruck_recv_peer(grank, gsize, step, node_edge_id);
+
+            /* Send aggregated data */
+            step_header_size = calculate_head_size(snd_count, dt_size) * dt_size;
+            step_buf_size    = (send_limit * snd_count) + step_header_size;
+            if (task->alltoallv_hybrid.phase == UCC_ALLTOALLV_HYBRID_PHASE_START) {
+                /* Initialize the space data destined to process i,
+                 * where i is the index in the array. Buddy buffer algorithm may
+                 * increase this value.
+                 */
+                status = get_send_buffer(p_tmp_send_region, p_scratch_space_meta_data,
+                                         NUM_BINS, step_buf_size, task, &buf);
+                if (UCC_OK != status) {
+                    task->super.status = status;
+                    goto out;
+                }
+
+                /* pack the data */
+                send_size = pack_send_data(task, step, gsize, snd_count, node_edge_id,
+                                           dt_size, send_limit,
+                                           step_header_size, BytesForPacking,
+                                           op_metadata, seg_st, buf);
+                ucc_assert(step_buf_size >= send_size);
+                p_scratch_space_meta_data->bins[p_scratch_space_meta_data->cur_bin].len = send_size;
+                status = send_data(buf, send_size, sendto, p_scratch_space_meta_data,
+                                   task);
+                if (ucc_unlikely(UCC_OK != status)) {
+                    task->super.status = status;
+                    goto out;
+                }
+            }
+
+            status = post_recv(recvfrom, gsize, dt_size, node_edge_id,
+                               step, grank, op_metadata,
+                               tmp_buf_size, seg_st, p_scratch_space_meta_data,
+                               step_buf_size, BytesForPacking,
+                               p_tmp_recv_region, task);
+            if (ucc_unlikely(UCC_OK != status)) {
+                task->super.status = status;
+                goto out;
+            }
+        }
+
+        status = complete_current_step_receives(gsize, step, dt_size, grank,
+                                                op_metadata, seg_st, task);
+        if (UCC_OK != status) {
+            task->super.status = status;
+            goto out;
+        }
+        task->alltoallv_hybrid.phase     = UCC_ALLTOALLV_HYBRID_PHASE_START;
+        task->alltoallv_hybrid.cur_radix = 1;
+        task->alltoallv_hybrid.iteration++;
+    }
+    /* The brucks iterations are done. Now we send and recv all the
+     * pairwise we didn't already send and recieve
+     */
+    while ((task->alltoallv_hybrid.num2recv > 0) ||
+           (task->alltoallv_hybrid.num2send > 0)) {
+        status = pairwise_manager(grank, gsize, dt_size, task);
+        if (UCC_OK != status) {
+            task->super.status = status;
+            goto out;
+        }
+    }
+
+    if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+        return;
+    }
+
+    hybrid_reverse_rotation(task);
+    task->super.status = UCC_OK;
+out:
+    if (task->super.status != UCC_INPROGRESS) {
+        UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task,
+                                         "ucp_alltoallv_hybrid_done", 0);
+    }
+}
+
+static inline void meta_init(ucc_tl_ucp_alltoallv_hybrid_buf_meta_t* meta,
+                             ucc_tl_ucp_task_t *task)
+{
+    int i;
+
+    meta->cur_bin = 0;
+    meta->offset  = 0;
+    for (i = 0; i < NUM_BINS; i++) {
+        meta->bins[i].len       = 0;
+        meta->bins[i].task      = task;
+    }
+}
+
+static ucc_status_t ucc_tl_ucp_alltoallv_hybrid_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task   = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team   = TASK_TEAM(task);
+    uint32_t           radix  = task->alltoallv_hybrid.radix;
+    ucc_rank_t         tsize  = UCC_TL_TEAM_SIZE(team);
+    ucc_tl_ucp_alltoallv_hybrid_buf_meta_t *lbm;
+    int i;
+
+    lbm = TASK_LB(task, tsize);
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_alltoallv_hybrid_start",
+                                     0);
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
+
+    task->alltoallv_hybrid.num_in      = 0;
+    task->alltoallv_hybrid.cur_out     = 1;
+    task->alltoallv_hybrid.cur_radix   = 1;
+    task->alltoallv_hybrid.traffic_in  = 0;
+    task->alltoallv_hybrid.traffic_out = 0;
+    task->alltoallv_hybrid.num2send    = 0;
+    task->alltoallv_hybrid.num2recv    = 0;
+    task->alltoallv_hybrid.phase       = UCC_ALLTOALLV_HYBRID_PHASE_START;
+    task->alltoallv_hybrid.iteration   = 1;
+
+    memset(TASK_SEG(task, tsize), 0, tsize*sizeof(char));
+    for (i = 0; i < radix - 1; ++i){
+        meta_init(&lbm[i], task);
+    }
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+}
+
+
+static inline void copy_brucks_rotation(void *scratch,
+                                        void *scounts, void *sdisps,
+                                        ucc_rank_t trank, ucc_rank_t tsize)
+{
+
+    size_t size = sizeof(int); /* currently support for 32 bit counts */
+
+    memcpy(scratch, PTR_OFFSET(sdisps, trank * size), (tsize - trank) * size);
+    memcpy(PTR_OFFSET(scratch, tsize * size), PTR_OFFSET(scounts, trank * size),
+           (tsize - trank) * size);
+    /* Copy the rest part */
+    if (trank != 0) {
+        memcpy(PTR_OFFSET(scratch, (tsize - trank) * size), sdisps, trank * size);
+        memcpy(PTR_OFFSET(scratch, (tsize - trank + tsize) * size), scounts,
+               trank * size);
+    }
+}
+
+
+ucc_status_t ucc_tl_ucp_alltoallv_hybrid_init(ucc_base_coll_args_t *coll_args,
+                                              ucc_base_team_t      *team,
+                                              ucc_coll_task_t     **task_h)
+{
+    ucc_tl_ucp_team_t *tl_team    = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_rank_t         tsize      = UCC_TL_TEAM_SIZE(tl_team);
+    ucc_rank_t         trank      = UCC_TL_TEAM_RANK(tl_team);
+    uint32_t           radix      = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.alltoallv_hybrid_radix;
+    size_t             buff_size  = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.alltoallv_hybrid_buff_size;
+    uint32_t           snd_size   = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.alltoallv_hybrid_send_buffer_size;
+    uint32_t           rcv_size   = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.alltoallv_hybrid_recv_buffer_size;
+    ucc_tl_ucp_task_t *task;
+    size_t             scratch_size, calc_limit, max_snd_count, dt_size;
+    ucc_status_t       status;
+
+    if (UCC_COLL_ARGS_DISPL64(&coll_args->args) ||
+        UCC_COLL_ARGS_COUNT64(&coll_args->args) ||
+        coll_args->args.src.info_v.mem_type != UCC_MEMORY_TYPE_HOST ||
+        coll_args->args.dst.info_v.mem_type != UCC_MEMORY_TYPE_HOST) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    task = ucc_tl_ucp_init_task(coll_args, team);
+    if (ucc_unlikely(!task)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+    task->super.post     = ucc_tl_ucp_alltoallv_hybrid_start;
+    task->super.progress = ucc_tl_ucp_alltoallv_hybrid_progress;
+    task->super.finalize = ucc_tl_ucp_alltoallv_hybrid_finalize;
+
+    dt_size = ucc_dt_size(coll_args->args.dst.info_v.datatype);
+
+    task->alltoallv_hybrid.radix = radix;
+    scratch_size = 2 * tsize * sizeof(int) /* rotated scounts and sdispls */
+        + 2 * tsize * sizeof(int) /* BytesForPacking */
+        + tsize * sizeof(char*) /* seg_st */
+        + (radix - 1) * sizeof(ucc_tl_ucp_alltoallv_hybrid_buf_meta_t)
+        + ucc_div_round_up(tsize, 2) * sizeof(void*)
+        + (radix - 1) * buff_size;
+
+    status = ucc_mc_alloc(&task->alltoallv_hybrid.scratch_mc_header,
+                          scratch_size, UCC_MEMORY_TYPE_HOST);
+    if (ucc_unlikely(UCC_OK != status)) {
+        ucc_tl_ucp_put_task(task);
+        return status;
+    }
+
+    /* TODO: fix for radix > 2 */
+    max_snd_count = CEIL(tsize, radix) / radix;
+
+    calc_limit = ((buff_size - 256) / (snd_size + rcv_size) -
+                  CEIL(sizeof(int) * (max_snd_count + 1), dt_size)) / max_snd_count;
+    calc_limit -= (calc_limit % 4);
+    ucc_assert(calc_limit>0);
+    task->alltoallv_hybrid.byte_send_limit = calc_limit;
+    task->alltoallv_hybrid.merge_buf_size  =
+        ALIGN((calc_limit*max_snd_count + CEIL(sizeof(int) * (max_snd_count + 1), dt_size)) * snd_size);
+
+    copy_brucks_rotation(task->alltoallv_hybrid.scratch_mc_header->addr,
+                         coll_args->args.src.info_v.counts,
+                         coll_args->args.src.info_v.displacements,
+                         trank, tsize);
+
+    *task_h = &task->super;
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-20022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_pairwise.c
@@ -24,7 +24,7 @@ static inline ucc_rank_t get_send_peer(ucc_rank_t rank, ucc_rank_t size,
     return (rank - step + size) % size;
 }
 
-void ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
+static void ucc_tl_ucp_alltoallv_pairwise_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
@@ -94,7 +94,7 @@ out:
     }
 }
 
-ucc_status_t ucc_tl_ucp_alltoallv_pairwise_start(ucc_coll_task_t *coll_task)
+static ucc_status_t ucc_tl_ucp_alltoallv_pairwise_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team = TASK_TEAM(task);

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -166,7 +166,7 @@ static void ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
 
         busy[id] = 1;
         UCPCHECK_GOTO(ucc_tl_ucp_send_cb(reduce_target, frag_count * dt_size,
-                                         mem_type, sendto, team, task, cb[id]),
+                                         mem_type, sendto, team, task, cb[id], (void *)task),
                       task, out);
 
         recv_data_from = (rank - 2 - step + size) % size;

--- a/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
@@ -171,7 +171,7 @@ static void ucc_tl_ucp_reduce_scatterv_ring_progress(ucc_coll_task_t *coll_task)
 
         busy[id] = 1;
         UCPCHECK_GOTO(ucc_tl_ucp_send_cb(reduce_target, frag_count * dt_size,
-                                         mem_type, sendto, team, task, cb[id]),
+                                         mem_type, sendto, team, task, cb[id], (void *)task),
                       task, out);
 
         recv_data_from = (rank - 2 - step + size) % size;

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -45,6 +45,42 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_pairwise_num_posts),
      UCC_CONFIG_TYPE_UINT},
 
+/* TODO: add radix to config once it's fully supported by the algorithm
+    {"ALLTOALLV_HYBRID_RADIX", "2",
+     "Radix of the Hybrid Alltoallv algorithm",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_radix),
+     UCC_CONFIG_TYPE_UINT},
+*/
+    {"ALLTOALLV_HYBRID_SEND_BUFFER_SIZE", "1",
+     "Number of maximum lengthed messages that can fit in the send buffer",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_send_buffer_size),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLTOALLV_HYBRID_RECV_BUFFER_SIZE", "3",
+     "Number of maximum lengthed messages that can fit in the recv buffer",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_recv_buffer_size),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLTOALLV_HYBRID_PAIRWISE_NUM_POSTS", "3",
+     "The maximum number of pairwise messages to send before waiting for completion",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_pairwise_num_posts),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLTOALLV_HYBRID_SEND_LIMIT", "200",
+     "",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_send_limit),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"ALLTOALLV_HYBRID_BUFF_SIZE", "256k",
+     "",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_buff_size),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
+    {"ALLTOALLV_HYBRID_CHUNK_BYTE_LIMIT", "12k",
+     "",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_chunk_byte_limit),
+     UCC_CONFIG_TYPE_MEMUNITS},
+
     {"KN_RADIX", "0",
      "Radix of all algorithms based on knomial pattern. When set to a "
      "positive value it is used as a convinience parameter to set all "

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -51,33 +51,29 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_radix),
      UCC_CONFIG_TYPE_UINT},
 */
-    {"ALLTOALLV_HYBRID_SEND_BUFFER_SIZE", "1",
-     "Number of maximum lengthed messages that can fit in the send buffer",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_send_buffer_size),
+    {"ALLTOALLV_HYBRID_NUM_SCRATCH_SENDS", "1",
+     "Number of send operations issued from scratch buffer per radix step",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_num_scratch_sends),
      UCC_CONFIG_TYPE_UINT},
 
-    {"ALLTOALLV_HYBRID_RECV_BUFFER_SIZE", "3",
-     "Number of maximum lengthed messages that can fit in the recv buffer",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_recv_buffer_size),
+    {"ALLTOALLV_HYBRID_NUM_SCRATCH_RECVS", "3",
+     "Number of recv operations issued from scratch buffer per radix step",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_num_scratch_recvs),
      UCC_CONFIG_TYPE_UINT},
 
     {"ALLTOALLV_HYBRID_PAIRWISE_NUM_POSTS", "3",
-     "The maximum number of pairwise messages to send before waiting for completion",
+     "The maximum number of pairwise messages to send before waiting for "
+     "completion",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_pairwise_num_posts),
      UCC_CONFIG_TYPE_UINT},
 
-    {"ALLTOALLV_HYBRID_SEND_LIMIT", "200",
-     "",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_send_limit),
-     UCC_CONFIG_TYPE_MEMUNITS},
-
     {"ALLTOALLV_HYBRID_BUFF_SIZE", "256k",
-     "",
+     "Total size of scratch buffer, used for sends and receives",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_buff_size),
      UCC_CONFIG_TYPE_MEMUNITS},
 
     {"ALLTOALLV_HYBRID_CHUNK_BYTE_LIMIT", "12k",
-     "",
+     "Max size of data send in pairwise step of hybrid alltoallv algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_chunk_byte_limit),
      UCC_CONFIG_TYPE_MEMUNITS},
 

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -65,11 +65,10 @@ typedef struct ucc_tl_ucp_lib_config {
     int                      reduce_scatter_ring_bidirectional;
     int                      reduce_scatterv_ring_bidirectional;
     uint32_t                 alltoallv_hybrid_radix;
-    size_t                   alltoallv_hybrid_send_limit;
     size_t                   alltoallv_hybrid_buff_size;
     size_t                   alltoallv_hybrid_chunk_byte_limit;
-    uint32_t                 alltoallv_hybrid_send_buffer_size;
-    uint32_t                 alltoallv_hybrid_recv_buffer_size;
+    uint32_t                 alltoallv_hybrid_num_scratch_sends;
+    uint32_t                 alltoallv_hybrid_num_scratch_recvs;
     uint32_t                 alltoallv_hybrid_pairwise_num_posts;
     ucc_ternary_auto_value_t use_topo;
 } ucc_tl_ucp_lib_config_t;

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -64,6 +64,13 @@ typedef struct ucc_tl_ucp_lib_config {
     int                      reduce_avg_pre_op;
     int                      reduce_scatter_ring_bidirectional;
     int                      reduce_scatterv_ring_bidirectional;
+    uint32_t                 alltoallv_hybrid_radix;
+    size_t                   alltoallv_hybrid_send_limit;
+    size_t                   alltoallv_hybrid_buff_size;
+    size_t                   alltoallv_hybrid_chunk_byte_limit;
+    uint32_t                 alltoallv_hybrid_send_buffer_size;
+    uint32_t                 alltoallv_hybrid_recv_buffer_size;
+    uint32_t                 alltoallv_hybrid_pairwise_num_posts;
     ucc_ternary_auto_value_t use_topo;
 } ucc_tl_ucp_lib_config_t;
 

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -162,6 +162,8 @@ static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
         return ucc_tl_ucp_bcast_alg_from_str(str);
     case UCC_COLL_TYPE_ALLTOALL:
         return ucc_tl_ucp_alltoall_alg_from_str(str);
+    case UCC_COLL_TYPE_ALLTOALLV:
+        return ucc_tl_ucp_alltoallv_alg_from_str(str);
     case UCC_COLL_TYPE_REDUCE_SCATTER:
         return ucc_tl_ucp_reduce_scatter_alg_from_str(str);
     case UCC_COLL_TYPE_REDUCE_SCATTERV:
@@ -216,6 +218,19 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
             break;
         case UCC_TL_UCP_ALLTOALL_ALG_ONESIDED:
             *init = ucc_tl_ucp_alltoall_onesided_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    case UCC_COLL_TYPE_ALLTOALLV:
+        switch (alg_id) {
+        case UCC_TL_UCP_ALLTOALLV_ALG_PAIRWISE:
+            *init = ucc_tl_ucp_alltoallv_pairwise_init;
+            break;
+        case UCC_TL_UCP_ALLTOALLV_ALG_HYBRID:
+            *init = ucc_tl_ucp_alltoallv_hybrid_init;
             break;
         default:
             status = UCC_ERR_INVALID_PARAM;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -166,6 +166,21 @@ typedef struct ucc_tl_ucp_task {
             void *                  scratch;
             ucc_mc_buffer_header_t *scratch_mc_header;
         } gather_kn;
+        struct {
+            size_t                  merge_buf_size;
+            ucc_mc_buffer_header_t *scratch_mc_header;
+            size_t                  byte_send_limit;
+            int                     phase;
+            uint32_t                radix;
+            uint32_t                cur_radix;
+            uint32_t                iteration;
+            ucc_rank_t              cur_out;
+            size_t                  traffic_in;
+            size_t                  traffic_out;
+            ucc_rank_t              num_in;
+            ucc_rank_t              num2send;
+            ucc_rank_t              num2recv;
+        } alltoallv_hybrid;
     };
 } ucc_tl_ucp_task_t;
 

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -7,7 +7,7 @@
 #include "tl_ucp.h"
 #include "utils/ucc_malloc.h"
 
-/* NOLINTNEXTLINE  params is not used*/
+/* NOLINTNEXTLINE  params is not used */
 UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
                     const ucc_base_config_t *config)
 {
@@ -37,7 +37,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
         self->cfg.scatter_kn_radix        = tl_ucp_config->kn_radix;
         self->cfg.gather_kn_radix         = tl_ucp_config->kn_radix;
     }
-
+    self->cfg.alltoallv_hybrid_radix = 2;
     self->tlcp_configs = NULL;
     if (n_plugins) {
         self->tlcp_configs = ucc_malloc(sizeof(void*)*n_plugins, "tlcp_configs");

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -11,9 +11,11 @@
 #include "ucc_datastruct.h"
 #include "ucc/api/ucc.h"
 #include "ucc_compiler_def.h"
+
 #define ucc_min(_a, _b) ucs_min((_a), (_b))
 #define ucc_max(_a, _b) ucs_max((_a), (_b))
 #define ucc_ilog2(_v)   ucs_ilog2((_v))
+#define ucc_ceil(_a, _b) (((_a)%(_b))?((_a)/(_b)+1)*(_b):(_a))
 
 #define DO_OP_MAX(_v1, _v2) (_v1 > _v2 ? _v1 : _v2)
 #define DO_OP_MIN(_v1, _v2) (_v1 < _v2 ? _v1 : _v2)

--- a/test/gtest/coll/test_alltoallv.cc
+++ b/test/gtest/coll/test_alltoallv.cc
@@ -277,7 +277,7 @@ UCC_TEST_P(test_alltoallv_alg, hybrid)
 
     ASSERT_NE(inplace, TEST_INPLACE);
     ucc_job_env_t env     = {{"UCC_CL_BASIC_TUNE", "inf"},
-                             {"UCC_TL_UCP_TUNE", "alltoallv:@1:inf"}};
+                             {"UCC_TL_UCP_TUNE", "alltoallv:@hybrid:inf"}};
     UccJob        job(n_procs, UccJob::UCC_JOB_CTX_GLOBAL, env);
     UccTeam_h     team    = job.create_team(n_procs);
     UccCollCtxVec ctxs;

--- a/test/gtest/coll/test_alltoallv.cc
+++ b/test/gtest/coll/test_alltoallv.cc
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -94,7 +95,7 @@ public:
                          0);
         }
     }
-    bool  data_validate(UccCollCtxVec ctxs)
+    bool data_validate(UccCollCtxVec ctxs)
     {
         bool                   ret = true;
         std::vector<uint8_t *> dsts(ctxs.size());
@@ -156,12 +157,12 @@ class test_alltoallv_0 : public test_alltoallv <uint64_t>,
 
 UCC_TEST_P(test_alltoallv_0, single)
 {
-    const int            team_id = std::get<0>(GetParam());
+    const int            team_id  = std::get<0>(GetParam());
     ucc_memory_type_t    mem_type = std::get<1>(GetParam());
-    gtest_ucc_inplace_t  inplace = std::get<2>(GetParam());
-    const ucc_datatype_t dtype   = std::get<3>(GetParam());
-    UccTeam_h            team    = UccJob::getStaticTeams()[team_id];
-    int                  size    = team->procs.size();
+    gtest_ucc_inplace_t  inplace  = std::get<2>(GetParam());
+    const ucc_datatype_t dtype    = std::get<3>(GetParam());
+    UccTeam_h            team     = UccJob::getStaticTeams()[team_id];
+    int                  size     = team->procs.size();
     UccCollCtxVec        ctxs;
 
     coll_mask = UCC_COLL_ARGS_FIELD_FLAGS;
@@ -213,12 +214,12 @@ class test_alltoallv_1 : public test_alltoallv <uint32_t>,
 
 UCC_TEST_P(test_alltoallv_1, single)
 {
-    const int            team_id = std::get<0>(GetParam());
+    const int            team_id  = std::get<0>(GetParam());
     ucc_memory_type_t    mem_type = std::get<1>(GetParam());
-    gtest_ucc_inplace_t  inplace = std::get<2>(GetParam());
-    const ucc_datatype_t dtype   = std::get<3>(GetParam());
-    UccTeam_h            team    = UccJob::getStaticTeams()[team_id];
-    int                  size    = team->procs.size();
+    gtest_ucc_inplace_t  inplace  = std::get<2>(GetParam());
+    const ucc_datatype_t dtype    = std::get<3>(GetParam());
+    UccTeam_h            team     = UccJob::getStaticTeams()[team_id];
+    int                  size     = team->procs.size();
     UccCollCtxVec        ctxs;
 
     set_inplace(inplace);
@@ -264,6 +265,32 @@ class test_alltoallv_2 : public test_alltoallv<uint64_t>,
 class test_alltoallv_3 : public test_alltoallv<uint32_t>,
         public ::testing::WithParamInterface<Param_1> {};
 
+class test_alltoallv_alg : public test_alltoallv<uint32_t>,
+        public ::testing::WithParamInterface<Param_1> {};
+
+UCC_TEST_P(test_alltoallv_alg, hybrid)
+{
+    int                  n_procs  = 15;
+    ucc_memory_type_t    mem_type = std::get<0>(GetParam());
+    gtest_ucc_inplace_t  inplace  = std::get<1>(GetParam());
+    const ucc_datatype_t dtype    = std::get<2>(GetParam());
+
+    ASSERT_NE(inplace, TEST_INPLACE);
+    ucc_job_env_t env     = {{"UCC_CL_BASIC_TUNE", "inf"},
+                             {"UCC_TL_UCP_TUNE", "alltoallv:@1:inf"}};
+    UccJob        job(n_procs, UccJob::UCC_JOB_CTX_GLOBAL, env);
+    UccTeam_h     team    = job.create_team(n_procs);
+    UccCollCtxVec ctxs;
+
+    SET_MEM_TYPE(mem_type);
+    data_init(n_procs, dtype, 16, ctxs, false);
+    UccReq req(team, ctxs);
+    req.start();
+    req.wait();
+
+    EXPECT_EQ(true, data_validate(ctxs));
+    data_fini(ctxs);
+}
 
 UCC_TEST_P(test_alltoallv_2, multiple)
 {
@@ -326,6 +353,13 @@ UCC_TEST_P(test_alltoallv_3, multiple)
         data_fini(ctx);
     }
 }
+
+INSTANTIATE_TEST_CASE_P(
+        alltoallv_algs, test_alltoallv_alg,
+        ::testing::Combine(
+            ::testing::Values(UCC_MEMORY_TYPE_HOST),
+            ::testing::Values(TEST_NO_INPLACE),
+            PREDEFINED_DTYPES));
 
 INSTANTIATE_TEST_CASE_P(
         64, test_alltoallv_2,


### PR DESCRIPTION
## What
Adds new alltoallv algorithms to TL/UCP. It's modified version of SLOAV alltoallv algorithm

C. Xu, M. G. Venkata, R. L. Graham, Y. Wang, Z. Liu and W. Yu, "SLOAVx: Scalable LOgarithmic AlltoallV Algorithm for Hierarchical Multicore Systems," 2013 13th IEEE/ACM International Symposium on Cluster, Cloud, and Grid Computing, 2013, pp. 369-376

## Why ?
Algorithms targes small message alltoallv and outperforms existing algorithm in UCC
Perf data collected on 192 ranks (4 nodes 48 PPN, AMD Milan CPU)
![image](https://user-images.githubusercontent.com/5495223/206145133-a221f566-d554-4585-8111-b3ceb71de36c.png)
