### PR TITLE
EC/CUDA: fix build with gcc 4.8.5

### DIFF
--- a/src/components/ec/cuda/kernel/ec_cuda_executor.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_executor.cu
@@ -4,9 +4,13 @@
  * See file LICENSE for terms.
  */
 
+#ifndef UINT32_MAX
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#endif
+
 extern "C" {
 #include "../ec_cuda.h"
-#include <inttypes.h>
 }
 #include "ec_cuda_reduce_ops.h"
 #include <cooperative_groups.h>

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce.cu
@@ -4,10 +4,13 @@
  * See file LICENSE for terms.
  */
 
+#ifndef UINT32_MAX
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#endif
 
 extern "C" {
 #include "../ec_cuda.h"
-#include <inttypes.h>
 }
 #include "ec_cuda_reduce_ops.h"
 

--- a/src/components/ec/cuda/kernel/ec_cuda_wait_kernel.cu
+++ b/src/components/ec/cuda/kernel/ec_cuda_wait_kernel.cu
@@ -1,13 +1,17 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
 
+#ifndef UINT32_MAX
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 #include "../ec_cuda.h"
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## What
Fixes
```
[2022-12-08T22:13:16.385Z] /build-result/src/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-redhat7-cuda11-gdrcopy2-nccl2.12-x86_64/ucc-master/src/utils/ucc_coll_utils.h(183): error: identifier "UINT32_MAX" is undefined
```
