### PR TITLE
CI: fix failure when more than one container stale

### DIFF
--- a/.ci/scripts/run_docker.sh
+++ b/.ci/scripts/run_docker.sh
@@ -58,7 +58,7 @@ for HOST in $(cat "$HOSTFILE"); do
     if [ -n "${STALE_DOCKER_CONTAINER_LIST}" ]; then
         echo "WARNING: stale docker container (name: ${DOCKER_CONTAINER_NAME}) is detected on ${HOST} (to be stopped)"
         echo "INFO: Stopping stale docker container (name: ${DOCKER_CONTAINER_NAME}) on ${HOST}..."
-        ssh "${HOST}" docker stop ${DOCKER_CONTAINER_NAME}
+        ssh "${HOST}" docker stop "$STALE_DOCKER_CONTAINER_LIST"
         echo "INFO: Stopping stale docker container (name: ${DOCKER_CONTAINER_NAME}) on ${HOST}... DONE"
     fi
 done


### PR DESCRIPTION
## What
Fix CI failure when more than one stale container is found. 

## Why?
Failed Jenkins job (NVIDIA internal link)
http://hpc-master.lab.mtl.com:8080/job/ucc/1995/

## How?
Provide a list of container IDs to stop, rather than a single container name.

