### PR TITLE
TL/UCP: fix running with npolls 0

### DIFF
--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -79,20 +79,6 @@ static inline void ucc_ring_frag_block_offset(ucc_tl_ucp_task_t *task,
     *block_offset = ucc_buffer_block_offset(count, size, block);
 }
 
-
-static inline ucc_status_t ucc_tl_ucp_test_ring(ucc_tl_ucp_task_t *task)
-{
-    int polls = 0;
-    while (polls++ < task->n_polls) {
-        if (task->tagged.send_posted - task->tagged.send_completed <= 1 &&
-            task->tagged.recv_posted == task->tagged.recv_completed) {
-            return UCC_OK;
-        }
-        ucp_worker_progress(TASK_CTX(task)->worker.ucp_worker);
-    }
-    return UCC_INPROGRESS;
-}
-
 static void ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t      *task     = ucc_derived_of(coll_task,

--- a/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
@@ -88,19 +88,6 @@ static inline void ucc_ring_frag_block_offset(ucc_tl_ucp_task_t *task,
     *block_offset = get_block_offset(&TASK_ARGS(task), block);
 }
 
-static inline ucc_status_t ucc_tl_ucp_test_ring(ucc_tl_ucp_task_t *task)
-{
-    int polls = 0;
-    while (polls++ < task->n_polls) {
-        if (task->tagged.send_posted - task->tagged.send_completed <= 1 &&
-            task->tagged.recv_posted == task->tagged.recv_completed) {
-            return UCC_OK;
-        }
-        ucp_worker_progress(TASK_CTX(task)->worker.ucp_worker);
-    }
-    return UCC_INPROGRESS;
-}
-
 static void ucc_tl_ucp_reduce_scatterv_ring_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *     task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -124,6 +124,7 @@ static ucc_status_t ucc_tl_ucp_team_preconnect(ucc_tl_ucp_team_t *team)
         team->preconnect_task->super.bargs.args.mask = 0;
     }
     if (UCC_INPROGRESS == ucc_tl_ucp_test(team->preconnect_task)) {
+        ucp_worker_progress(team->worker->ucp_worker);
         return UCC_INPROGRESS;
     }
     for (i = team->preconnect_task->tagged.send_posted; i < size; i++) {


### PR DESCRIPTION
## What
Fixes hangs in following cases when npolls is 0
1. team create with preconnect task
2. reduce scatter ring
3. reduce scatterv ring
