### PR TITLE
TEST: add linter for ROCm/RCCL

### DIFF
--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -1,0 +1,52 @@
+name: Linter-ROCM
+
+on: [push, pull_request]
+
+env:
+  OPEN_UCX_LINK: https://github.com/openucx/ucx
+  OPEN_UCX_BRANCH: master
+  CLANG_VER: 12
+  ROCM_VER: 5-4
+  LIBRARY_PATH: /tmp/ucx/install/lib
+  LD_LIBRARY_PATH: /tmp/ucx/install/lib
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common gpg curl
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
+        sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VER} main"
+        sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear
+    - name: Install extra dependencies
+      run: |
+        curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/rocm-keyring.gpg
+        echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg]  https://repo.radeon.com/rocm/apt/debian focal main' | sudo tee /etc/apt/sources.list.d/rocm.list
+        sudo apt-get update
+        sudo apt-get install -y rocm-hip-sdk
+    - name: Get UCX
+      run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
+    - name: Build UCX
+      run: |
+        cd /tmp/ucx && ./autogen.sh
+        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./contrib/configure-release --without-java --without-go --disable-numa --prefix $PWD/install --with-rocm=/opt/rocm
+        make -j install
+    - uses: actions/checkout@v1
+    - name: Build UCC
+      run: |
+        ./autogen.sh
+        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-rocm=/opt/rocm --with-rccl=/opt/rocm --enable-assert
+        bear --exclude ${GITHUB_WORKSPACE}/src/components/ec/rocm/kernel/ --exclude ${GITHUB_WORKSPACE}/src/components/mc/rocm/kernel/ --cdb /tmp/compile_commands.json make
+    - name: Run clang-tidy
+      run: |
+        echo "Workspace: ${GITHUB_WORKSPACE}"
+        cd ${GITHUB_WORKSPACE}
+        run-clang-tidy-${CLANG_VER} -p /tmp/ 2>&1 | tee /tmp/clang_tidy.log
+        nerrors=$(grep 'error:' /tmp/clang_tidy.log | wc -l)
+        if [ $nerrors -ne 0 ]; then
+            exit 125;
+        fi
+        make clean
+        rm -rf /tmp/ucc

--- a/src/components/ec/rocm/ec_rocm_executor_interruptible.c
+++ b/src/components/ec/rocm/ec_rocm_executor_interruptible.c
@@ -87,6 +87,7 @@ ucc_status_t ucc_rocm_executor_interruptible_get_stream(hipStream_t *stream)
     int             i, j;
     uint32_t        id;
 
+    ucc_assert(num_streams > 0);
     if (ucc_unlikely(!ucc_ec_rocm.exec_streams_initialized)) {
         ucc_spin_lock(&ucc_ec_rocm.init_spinlock);
         if (ucc_ec_rocm.exec_streams_initialized) {

--- a/src/components/ec/rocm/ec_rocm_executor_persistent.c
+++ b/src/components/ec/rocm/ec_rocm_executor_persistent.c
@@ -68,7 +68,7 @@ ucc_rocm_executor_persistent_task_test(const ucc_ee_executor_task_t *task)
 }
 
 ucc_status_t
-ucc_rocm_executor_persistent_task_finalize(ucc_ee_executor_task_t *task)
+ucc_rocm_executor_persistent_task_finalize(ucc_ee_executor_task_t *task) //NOLINT: task is unused
 {
     return UCC_OK;
 }

--- a/src/components/mc/rocm/mc_rocm.c
+++ b/src/components/mc/rocm/mc_rocm.c
@@ -106,7 +106,7 @@ static ucc_status_t ucc_mc_rocm_mem_pool_alloc(ucc_mc_buffer_header_t **h_ptr,
     return UCC_OK;
 }
 
-static ucc_status_t ucc_mc_rocm_chunk_alloc(ucc_mpool_t *mp,
+static ucc_status_t ucc_mc_rocm_chunk_alloc(ucc_mpool_t *mp, //NOLINT
                                             size_t *size_p,
                                             void **chunk_p)
 {
@@ -119,8 +119,8 @@ static ucc_status_t ucc_mc_rocm_chunk_alloc(ucc_mpool_t *mp,
     return UCC_OK;
 }
 
-static void ucc_mc_rocm_chunk_init(ucc_mpool_t *mp,
-                                   void *obj, void *chunk)
+static void ucc_mc_rocm_chunk_init(ucc_mpool_t *mp, //NOLINT
+                                   void *obj, void *chunk) //NOLINT
 {
     ucc_mc_buffer_header_t *h = (ucc_mc_buffer_header_t *)obj;
     hipError_t st             = hipMalloc(&h->addr, MC_ROCM_CONFIG->mpool_elem_size);
@@ -138,12 +138,12 @@ static void ucc_mc_rocm_chunk_init(ucc_mpool_t *mp,
     h->mt        = UCC_MEMORY_TYPE_ROCM;
 }
 
-static void ucc_mc_rocm_chunk_release(ucc_mpool_t *mp, void *chunk)
+static void ucc_mc_rocm_chunk_release(ucc_mpool_t *mp, void *chunk) //NOLINT: mp is unused
 {
     ucc_free(chunk);
 }
 
-static void ucc_mc_rocm_chunk_cleanup(ucc_mpool_t *mp, void *obj)
+static void ucc_mc_rocm_chunk_cleanup(ucc_mpool_t *mp, void *obj) //NOLINT: mp is unused
 {
     ucc_mc_buffer_header_t *h = (ucc_mc_buffer_header_t *)obj;
     hipError_t st;

--- a/src/components/tl/rccl/tl_rccl_coll.c
+++ b/src/components/tl/rccl/tl_rccl_coll.c
@@ -91,7 +91,7 @@ ucc_tl_rccl_task_t * ucc_tl_rccl_init_task(ucc_base_coll_args_t *coll_args,
 
     task = ucc_mpool_get(&rccl_ctx->req_mp);
     if (ucc_unlikely(!task)) {
-	tl_error(UCC_TASK_LIB(task),"Failed to allocate task");
+	tl_error(team->context->lib,"Failed to allocate task");
 	return NULL;
     }
     ucc_coll_task_init(&task->super, coll_args, team);
@@ -118,7 +118,7 @@ void ucc_tl_rccl_free_task(ucc_tl_rccl_task_t *task)
     ucc_mpool_put(task);
 }
 
-ucc_status_t ucc_tl_rccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
+ucc_status_t ucc_tl_rccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev, //NOLINT: ev is unused
                                         ucc_coll_task_t *coll_task)
 {
     ucc_tl_rccl_task_t *task  = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);

--- a/src/components/tl/rccl/tl_rccl_context.c
+++ b/src/components/tl/rccl/tl_rccl_context.c
@@ -38,8 +38,8 @@ void ucc_tl_rccl_driver_collective_progress(ucc_coll_task_t *coll_task)
 #endif
 }
 
-static void ucc_tl_rccl_req_mpool_obj_init(ucc_mpool_t *mp, void *obj,
-                                           void *chunk)
+static void ucc_tl_rccl_req_mpool_obj_init(ucc_mpool_t *mp, void *obj, //NOLINT: mp is unused
+                                           void *chunk) //NOLINT: chunk is unused
 {
     ucc_tl_rccl_task_t *req = (ucc_tl_rccl_task_t*) obj;
 
@@ -47,7 +47,7 @@ static void ucc_tl_rccl_req_mpool_obj_init(ucc_mpool_t *mp, void *obj,
     req->super.progress = ucc_tl_rccl_event_collective_progress;
 }
 
-static void ucc_tl_rccl_req_mpool_obj_cleanup(ucc_mpool_t *mp, void *obj)
+static void ucc_tl_rccl_req_mpool_obj_cleanup(ucc_mpool_t *mp, void *obj) //NOLINT: mp is unused
 {
     ucc_coll_task_destruct(obj);
 }


### PR DESCRIPTION
## What
add github actions to compile UCC with ROCm and RCCL support and run clang-tidy linter on those components.