### PR TITLE
TL/UCP: ranks reordering

### DIFF
--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -20,42 +20,7 @@ ucc_base_coll_alg_info_t
         [UCC_TL_UCP_ALLGATHER_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 
-static ucc_rank_t ucc_tl_ucp_allgather_ring_get_send_block(ucc_subset_t *subset,
-                                                           ucc_rank_t trank,
-                                                           ucc_rank_t tsize,
-                                                           int step)
-{
-    return ucc_ep_map_eval(subset->map, (trank - step + tsize) % tsize);
-}
-
-static ucc_rank_t ucc_tl_ucp_allgather_ring_get_recv_block(ucc_subset_t *subset,
-                                                           ucc_rank_t trank,
-                                                           ucc_rank_t tsize,
-                                                           int step)
-{
-    return ucc_ep_map_eval(subset->map, (trank - step - 1 + tsize) % tsize);
-}
-
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
 {
-    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
-    ucc_sbgp_t *sbgp;
-
-    if (!ucc_coll_args_is_predefined_dt(&TASK_ARGS(task), UCC_RANK_INVALID)) {
-        tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
-        return UCC_ERR_NOT_SUPPORTED;
-    }
-
-    if (!(task->flags & UCC_TL_UCP_TASK_FLAG_SUBSET)) {
-        if (team->topo) {
-            sbgp = ucc_topo_get_sbgp(team->topo, UCC_SBGP_FULL_HOST_ORDERED);
-            task->subset.myrank = sbgp->group_rank;
-            task->subset.map    = sbgp->map;
-        }
-    }
-    task->allgather_ring.get_send_block = ucc_tl_ucp_allgather_ring_get_send_block;
-    task->allgather_ring.get_recv_block = ucc_tl_ucp_allgather_ring_get_recv_block;
-    task->super.post                    = ucc_tl_ucp_allgather_ring_start;
-    task->super.progress                = ucc_tl_ucp_allgather_ring_progress;
-    return UCC_OK;
+    return ucc_tl_ucp_allgather_ring_init_common(task);
 }

--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -20,14 +20,42 @@ ucc_base_coll_alg_info_t
         [UCC_TL_UCP_ALLGATHER_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 
+static ucc_rank_t ucc_tl_ucp_allgather_ring_get_send_block(ucc_subset_t *subset,
+                                                           ucc_rank_t trank,
+                                                           ucc_rank_t tsize,
+                                                           int step)
+{
+    return ucc_ep_map_eval(subset->map, (trank - step + tsize) % tsize);
+}
+
+static ucc_rank_t ucc_tl_ucp_allgather_ring_get_recv_block(ucc_subset_t *subset,
+                                                           ucc_rank_t trank,
+                                                           ucc_rank_t tsize,
+                                                           int step)
+{
+    return ucc_ep_map_eval(subset->map, (trank - step - 1 + tsize) % tsize);
+}
+
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
 {
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+    ucc_sbgp_t *sbgp;
+
     if (!ucc_coll_args_is_predefined_dt(&TASK_ARGS(task), UCC_RANK_INVALID)) {
         tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    task->super.post     = ucc_tl_ucp_allgather_ring_start;
-    task->super.progress = ucc_tl_ucp_allgather_ring_progress;
+    if (!(task->flags & UCC_TL_UCP_TASK_FLAG_SUBSET)) {
+        if (team->topo) {
+            sbgp = ucc_topo_get_sbgp(team->topo, UCC_SBGP_FULL_HOST_ORDERED);
+            task->subset.myrank = sbgp->group_rank;
+            task->subset.map    = sbgp->map;
+        }
+    }
+    task->allgather_ring.get_send_block = ucc_tl_ucp_allgather_ring_get_send_block;
+    task->allgather_ring.get_recv_block = ucc_tl_ucp_allgather_ring_get_recv_block;
+    task->super.post                    = ucc_tl_ucp_allgather_ring_start;
+    task->super.progress                = ucc_tl_ucp_allgather_ring_progress;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/allgather/allgather.h
+++ b/src/components/tl/ucp/allgather/allgather.h
@@ -37,6 +37,8 @@ ucc_status_t ucc_tl_ucp_allgather_ring_init(ucc_base_coll_args_t *coll_args,
                                             ucc_base_team_t *     team,
                                             ucc_coll_task_t **    task_h);
 
+ucc_status_t ucc_tl_ucp_allgather_ring_init_common(ucc_tl_ucp_task_t *task);
+
 void  ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *task);

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -17,35 +17,34 @@ void ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task       = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_tl_ucp_team_t *team       = TASK_TEAM(task);
-    ucc_rank_t         group_rank = task->subset.myrank;
-    ucc_rank_t         group_size = (ucc_rank_t)task->subset.map.ep_num;
+    ucc_rank_t         trank      = task->subset.myrank;
+    ucc_rank_t         tsize      = (ucc_rank_t)task->subset.map.ep_num;
     void              *rbuf       = TASK_ARGS(task).dst.info.buffer;
     ucc_memory_type_t  rmem       = TASK_ARGS(task).dst.info.mem_type;
     size_t             count      = TASK_ARGS(task).dst.info.count;
     ucc_datatype_t     dt         = TASK_ARGS(task).dst.info.datatype;
-    size_t             data_size  = (count / group_size) * ucc_dt_size(dt);
-    ucc_rank_t         sendto     = (group_rank + 1) % group_size;
-    ucc_rank_t         recvfrom   = (group_rank - 1 + group_size) % group_size;
+    size_t             data_size  = (count / tsize) * ucc_dt_size(dt);
+    ucc_rank_t         sendto, recvfrom, sblock, rblock;
     int                step;
     void              *buf;
 
     if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
         return;
     }
-    sendto   = ucc_ep_map_eval(task->subset.map, sendto);
-    recvfrom = ucc_ep_map_eval(task->subset.map, recvfrom);
+    sendto   = ucc_ep_map_eval(task->subset.map, (trank + 1) % tsize);
+    recvfrom = ucc_ep_map_eval(task->subset.map, (trank - 1 + tsize) % tsize);
 
-    while (task->tagged.send_posted < group_size - 1) {
+    while (task->tagged.send_posted < tsize - 1) {
         step = task->tagged.send_posted;
-        buf  = (void *)((ptrdiff_t)rbuf +
-                       ((group_rank - step + group_size) % group_size) *
-                           data_size);
+        sblock = task->allgather_ring.get_send_block(&task->subset, trank,
+                                                     tsize, step);
+        rblock = task->allgather_ring.get_recv_block(&task->subset, trank,
+                                                     tsize, step);
+        buf = PTR_OFFSET(rbuf, sblock * data_size);
         UCPCHECK_GOTO(
             ucc_tl_ucp_send_nb(buf, data_size, rmem, sendto, team, task),
             task, out);
-        buf = (void *)((ptrdiff_t)rbuf +
-                       ((group_rank - step - 1 + group_size) % group_size) *
-                           data_size);
+        buf = PTR_OFFSET(rbuf, rblock * data_size);
         UCPCHECK_GOTO(
             ucc_tl_ucp_recv_nb(buf, data_size, rmem, recvfrom, team, task),
             task, out);
@@ -69,17 +68,20 @@ ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *coll_task)
     ucc_memory_type_t  smem      = TASK_ARGS(task).src.info.mem_type;
     ucc_memory_type_t  rmem      = TASK_ARGS(task).dst.info.mem_type;
     ucc_datatype_t     dt        = TASK_ARGS(task).dst.info.datatype;
-    size_t             data_size = (count / task->subset.map.ep_num) *
-        ucc_dt_size(dt);
+    ucc_rank_t         trank     = task->subset.myrank;
+    ucc_rank_t         tsize     = (ucc_rank_t)task->subset.map.ep_num;
+    size_t             data_size = (count / tsize) * ucc_dt_size(dt);
     ucc_status_t       status;
+    ucc_rank_t         block;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_ring_start", 0);
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
 
     if (!UCC_IS_INPLACE(TASK_ARGS(task))) {
-        status =
-            ucc_mc_memcpy(PTR_OFFSET(rbuf, data_size * task->subset.myrank),
-                          sbuf, data_size, rmem, smem);
+        block = task->allgather_ring.get_send_block(&task->subset, trank, tsize,
+                                                    0);
+        status = ucc_mc_memcpy(PTR_OFFSET(rbuf, data_size * block),
+                               sbuf, data_size, rmem, smem);
         if (ucc_unlikely(UCC_OK != status)) {
             return status;
         }

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -169,14 +169,20 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      UCC_CONFIG_TYPE_BOOL},
 
     {"REDUCE_SCATTERV_RING_BIDIRECTIONAL", "y",
-     "Launch 2 inverted rings concurrently  during ReduceScatterV Ring "
+     "Launch 2 inverted rings concurrently during ReduceScatterV Ring "
      "algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_scatterv_ring_bidirectional),
      UCC_CONFIG_TYPE_BOOL},
 
-    {"USE_TOPO", "try", "allow usage of tl ucp topo",
+    {"USE_TOPO", "try",
+     "Allow usage of tl ucp topo",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, use_topo),
      UCC_CONFIG_TYPE_TERNARY},
+
+    {"RANKS_REORDERING", "y",
+     "Use topology information in TL UCP to reorder ranks. Requires topo info",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, use_reordering),
+     UCC_CONFIG_TYPE_BOOL},
 
     {NULL}};
 

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -71,6 +71,7 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t                 alltoallv_hybrid_num_scratch_recvs;
     uint32_t                 alltoallv_hybrid_pairwise_num_posts;
     ucc_ternary_auto_value_t use_topo;
+    int                      use_reordering;
 } ucc_tl_ucp_lib_config_t;
 
 typedef struct ucc_tl_ucp_context_config {

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -10,6 +10,24 @@
 #include "allreduce/allreduce.h"
 #include "allgather/allgather.h"
 #include "bcast/bcast.h"
+
+//NOLINTNEXTLINE subset unused
+static ucc_rank_t ucc_tl_ucp_service_ring_get_send_block(ucc_subset_t *subset,
+                                                         ucc_rank_t trank,
+                                                         ucc_rank_t tsize,
+                                                         int step)
+{
+    return (trank - step + tsize) % tsize;
+}
+
+//NOLINTNEXTLINE subset unused
+static ucc_rank_t ucc_tl_ucp_service_ring_get_recv_block(ucc_subset_t *subset,
+                                                         ucc_rank_t trank,
+                                                         ucc_rank_t tsize,
+                                                         int step)
+{
+    return (trank - step - 1 + tsize) % tsize;
+}
 
 static ucc_status_t ucc_tl_ucp_service_coll_start_executor(ucc_coll_task_t *task)
 {
@@ -87,6 +105,7 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
     if (status != UCC_OK) {
         goto free_task;
     }
+    task->flags          = UCC_TL_UCP_TASK_FLAG_SUBSET;
     task->subset         = subset;
     task->tagged.tag     = UCC_TL_UCP_SERVICE_TAG;
     task->n_polls        = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
@@ -126,6 +145,8 @@ ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
 {
     ucc_tl_ucp_team_t   *tl_team  = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_task_t   *task     = ucc_tl_ucp_get_task(tl_team);
+    uint32_t             npolls   =
+        UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
     int                  in_place =
         (sbuf == PTR_OFFSET(rbuf, msgsize * ucc_ep_map_eval(subset.map,
                                                             subset.myrank)));
@@ -149,11 +170,14 @@ ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
     if (status != UCC_OK) {
         goto free_task;
     }
-    task->subset         = subset;
-    task->tagged.tag     = UCC_TL_UCP_SERVICE_TAG;
-    task->n_polls        = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
-    task->super.progress = ucc_tl_ucp_allgather_ring_progress;
-    task->super.finalize = ucc_tl_ucp_coll_finalize;
+    task->allgather_ring.get_send_block = ucc_tl_ucp_service_ring_get_send_block;
+    task->allgather_ring.get_recv_block = ucc_tl_ucp_service_ring_get_recv_block;
+    task->flags                         = UCC_TL_UCP_TASK_FLAG_SUBSET;
+    task->subset                        = subset;
+    task->tagged.tag                    = UCC_TL_UCP_SERVICE_TAG;
+    task->n_polls                       = npolls;
+    task->super.progress                = ucc_tl_ucp_allgather_ring_progress;
+    task->super.finalize                = ucc_tl_ucp_coll_finalize;
 
     status = ucc_tl_ucp_allgather_ring_start(&task->super);
     if (status != UCC_OK) {
@@ -194,6 +218,7 @@ ucc_status_t ucc_tl_ucp_service_bcast(ucc_base_team_t *team, void *buf,
     if (status != UCC_OK) {
         goto free_task;
     }
+    task->flags          = UCC_TL_UCP_TASK_FLAG_SUBSET;
     task->subset         = subset;
     task->tagged.tag     = UCC_TL_UCP_SERVICE_TAG;
     task->n_polls        = UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -55,6 +55,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     self->seq_num         = 0;
     self->status          = UCC_INPROGRESS;
     self->tuning_str      = "";
+    self->topo            = NULL;
 
     status = ucc_config_clone_table(&UCC_TL_UCP_TEAM_LIB(self)->cfg, &self->cfg,
                                     ucc_tl_ucp_lib_config_table);

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -81,6 +81,11 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
         }
     }
 
+    if (!self->topo && self->cfg.use_reordering) {
+        tl_debug(tl_context->lib,
+                 "topo is not available, disabling ranks reordering");
+        self->cfg.use_reordering = 0;
+    }
     tl_debug(tl_context->lib, "posted tl team: %p", self);
     return UCC_OK;
 }

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -370,6 +371,75 @@ static inline ucc_status_t sbgp_create_full(ucc_topo_t *topo, ucc_sbgp_t *sbgp)
     return UCC_OK;
 }
 
+typedef struct proc_info_id {
+    ucc_proc_info_t info;
+    ucc_rank_t      id;
+} proc_info_id_t;
+
+static int ucc_compare_proc_info_id(const void *a, const void *b)
+{
+    const ucc_proc_info_t *d1 = &((const proc_info_id_t *)a)->info;
+    const ucc_proc_info_t *d2 = &((const proc_info_id_t *)b)->info;
+
+    if (d1->host_hash != d2->host_hash) {
+        return d1->host_hash > d2->host_hash ? 1 : -1;
+    } else if (d1->socket_id != d2->socket_id) {
+        return d1->socket_id - d2->socket_id;
+    } else if (d1->numa_id != d2->numa_id) {
+        return d1->numa_id - d2->numa_id;
+    } else {
+        return d1->pid - d2->pid;
+    }
+}
+
+static ucc_status_t sbgp_create_full_ordered(ucc_topo_t *topo, ucc_sbgp_t *sbgp)
+{
+    ucc_rank_t      gsize = ucc_subset_size(&topo->set);
+    proc_info_id_t *sorted;
+    ucc_rank_t      i;
+
+    ucc_assert(gsize > 0);
+    sbgp->status     = UCC_SBGP_ENABLED;
+    sbgp->group_size = gsize;
+    sbgp->group_rank = topo->set.myrank;
+
+    sorted = (proc_info_id_t *)ucc_malloc(gsize * sizeof(proc_info_id_t),
+                                          "proc_sorted");
+    if (ucc_unlikely(!sorted)) {
+        ucc_error("failed to allocate %zd bytes for sorted proc info",
+                  gsize * sizeof(proc_info_id_t));
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    for (i = 0; i < gsize; i++) {
+        sorted[i].info = topo->topo->procs[i];
+        sorted[i].id   = i;
+    }
+
+    sbgp->rank_map = ucc_malloc(sizeof(ucc_rank_t) * gsize, "rank_map");
+    if (ucc_unlikely(!sbgp->rank_map)) {
+        ucc_error("failed to allocate %zd bytes for rank_map",
+                  gsize * sizeof(ucc_rank_t));
+        ucc_free(sorted);
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    qsort(sorted, gsize, sizeof(proc_info_id_t), ucc_compare_proc_info_id);
+    for (i = 0; i < gsize; i++) {
+        if (sorted[i].id == topo->set.myrank) {
+            sbgp->group_rank = i;
+        }
+        sbgp->rank_map[i] = sorted[i].id;
+    }
+
+    /*TODO: try to detect map by numa,socket,node and use UCC_EP_MAP_CB to save
+     *      memory
+     */
+
+    ucc_free(sorted);
+    return UCC_OK;
+}
+
 ucc_status_t ucc_sbgp_create(ucc_topo_t *topo, ucc_sbgp_type_t type)
 {
     ucc_status_t status   = UCC_OK;
@@ -385,6 +455,9 @@ ucc_status_t ucc_sbgp_create(ucc_topo_t *topo, ucc_sbgp_type_t type)
         break;
     case UCC_SBGP_FULL:
         status = sbgp_create_full(topo, sbgp);
+        break;
+    case UCC_SBGP_FULL_HOST_ORDERED:
+        status = sbgp_create_full_ordered(topo, sbgp);
         break;
     case UCC_SBGP_SOCKET:
     case UCC_SBGP_NUMA:

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/topo/ucc_sbgp.h
+++ b/src/components/topo/ucc_sbgp.h
@@ -10,30 +10,32 @@
 
 typedef enum ucc_sbgp_type_t
 {
-    UCC_SBGP_NUMA,           /* Group of ranks on the same NUMA domain.
-                                This group does not exist if processes are
-                                not bound to a single NUMA node. */
-    UCC_SBGP_SOCKET,         /* Group of ranks on the same SOCKET.
-                                This group does not exist if processes are
-                                not bound to a single SOCKET node. */
-    UCC_SBGP_NODE,           /* Group of ranks on the same NODE. */
-    UCC_SBGP_NODE_LEADERS,   /* Group of ranks with local_node_rank = 0.
-                                This group EXISTS when team spans at least 2
-                                nodes. This group is ENABLED for procs with
-                                local_node_rank = 0. This group is DISABLED but
-                                EXISTS for procs with local_node_rank != 0*/
-    UCC_SBGP_NET,            /* Group of ranks with the same local_node_rank.
-                                This group EXISTS when team spans at least 2
-                                nodes AND the team has equal PPN across all the
-                                nodes. If EXISTS this group is ENABLED for all
-                                procs. */
-    UCC_SBGP_SOCKET_LEADERS, /* Group of ranks with local_socket_rank = 0.
-                                This group EXISTS when team spans at least 2
-                                sockets. This group is ENABLED for procs with
-                                local_socket_rank = 0. This group is DISABLED
-                                but EXISTS for procs with local_socket_rank != 0 */
-    UCC_SBGP_NUMA_LEADERS,   /* Same as SOCKET_LEADERS but for NUMA grouping */
-    UCC_SBGP_FULL,           /* Group contains ALL the ranks of the team */
+    UCC_SBGP_NUMA,               /* Group of ranks on the same NUMA domain.
+                                    This group does not exist if processes are
+                                    not bound to a single NUMA node. */
+    UCC_SBGP_SOCKET,             /* Group of ranks on the same SOCKET.
+                                    This group does not exist if processes are
+                                    not bound to a single SOCKET node. */
+    UCC_SBGP_NODE,               /* Group of ranks on the same NODE. */
+    UCC_SBGP_NODE_LEADERS,       /* Group of ranks with local_node_rank = 0.
+                                    This group EXISTS when team spans at least 2
+                                    nodes. This group is ENABLED for procs with
+                                    local_node_rank = 0. This group is DISABLED but
+                                    EXISTS for procs with local_node_rank != 0*/
+    UCC_SBGP_NET,                /* Group of ranks with the same local_node_rank.
+                                    This group EXISTS when team spans at least 2
+                                    nodes AND the team has equal PPN across all the
+                                    nodes. If EXISTS this group is ENABLED for all
+                                    procs. */
+    UCC_SBGP_SOCKET_LEADERS,     /* Group of ranks with local_socket_rank = 0.
+                                    This group EXISTS when team spans at least 2
+                                    sockets. This group is ENABLED for procs with
+                                    local_socket_rank = 0. This group is DISABLED
+                                    but EXISTS for procs with local_socket_rank != 0 */
+    UCC_SBGP_NUMA_LEADERS,       /* Same as SOCKET_LEADERS but for NUMA grouping */
+    UCC_SBGP_FULL,               /* Group contains ALL the ranks of the team */
+    UCC_SBGP_FULL_HOST_ORDERED,  /* Group contains All the ranks of the ream ordered
+                                    by host, socket, numa */
     UCC_SBGP_LAST
 } ucc_sbgp_type_t;
 
@@ -55,7 +57,7 @@ typedef struct ucc_sbgp_t {
     ucc_ep_map_t      map;
 } ucc_sbgp_t;
 
-const char*  ucc_sbgp_str(ucc_sbgp_type_t type);
+const char* ucc_sbgp_str(ucc_sbgp_type_t type);
 
 /* The call creates a required subgroup specified by @in type in
    the topo->sbgps[type]. The created sbgp can be in either of 3 states:

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -759,11 +759,12 @@ ucc_status_t ucc_context_create_proc_info(ucc_lib_h                   lib,
                 t_params.rank            = ctx->rank;
                 t_params.size            = ctx->params.oob.n_oob_eps;
                 /* CORE scope id - never overlaps with CL type */
-                t_params.scope    = UCC_CL_LAST + 1;
-                t_params.scope_id = 0;
-                t_params.id       = 0;
-                t_params.team     = NULL;
-                t_params.map.type = UCC_EP_MAP_FULL;
+                t_params.scope      = UCC_CL_LAST + 1;
+                t_params.scope_id   = 0;
+                t_params.id         = 0;
+                t_params.team       = NULL;
+                t_params.map.type   = UCC_EP_MAP_FULL;
+                t_params.map.ep_num = t_params.size;
                 status            = UCC_TL_CTX_IFACE(ctx->service_ctx)
                              ->team.create_post(&ctx->service_ctx->super,
                                                 &t_params, &b_team);


### PR DESCRIPTION
## What
Use topology information in TL UCP to reorder ranks so that ranks first grouped by node, by socket within node, by numa within socket. 

## Why ?
Permutation is used in TL UCP allgather to form better ring algorithm.
Performance data collected on N2 PPN48 (AMD EPYC 7443: 24 cores, 2 sockets, 8 NUMAs) 
<img width="241" alt="ompi" src="https://user-images.githubusercontent.com/5495223/208600801-d116a079-19c7-44d2-ae07-fef4302d6b80.png">
<img width="240" alt="ucc no topo" src="https://user-images.githubusercontent.com/5495223/208600831-2342edea-8cfe-44bb-ab57-596e98e1e1cf.png">
<img width="241" alt="ucc with topo" src="https://user-images.githubusercontent.com/5495223/208600851-c8109f9e-2a0f-4ccd-a24e-aaa5fe4734a4.png">
