### PR TITLE
EC/CUDA: memops supported by default in cuda 12.0

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -17,6 +17,8 @@ ARCH110="-gencode=arch=compute_80,code=sm_80 \
 -gencode=arch=compute_80,code=compute_80"
 ARCH111="-gencode=arch=compute_86,code=sm_86 \
 -gencode=arch=compute_86,code=compute_86"
+ARCH120="-gencode=arch=compute_90,code=sm_90 \
+-gencode=arch=compute_90,code=compute_90"
 
 AC_DEFUN([CHECK_CUDA],[
 AS_IF([test "x$cuda_checked" != "xyes"],
@@ -106,10 +108,12 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                [NVCC_CFLAGS="$NVCC_CFLAGS -O3 -g -DNDEBUG"])
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AS_IF([test "x$with_nvcc_gencode" = "xdefault"],
-                      [AS_IF([test $CUDA_MAJOR_VERSION -eq 11],
-			     [AS_IF([test $CUDA_MINOR_VERSION -lt 1],
-                                    [NVCC_ARCH="${ARCH7} ${ARCH8} ${ARCH9} ${ARCH10} ${ARCH110}"],
-                                    [NVCC_ARCH="${ARCH7} ${ARCH8} ${ARCH9} ${ARCH10} ${ARCH110} ${ARCH111}"])])],
+                      [AS_IF([test $CUDA_MAJOR_VERSION -eq 12],
+                             [NVCC_ARCH="${ARCH7} ${ARCH8} ${ARCH9} ${ARCH10} ${ARCH110} ${ARCH111} ${ARCH120}"],
+                             [AS_IF([test $CUDA_MAJOR_VERSION -eq 11],
+                                   [AS_IF([test $CUDA_MINOR_VERSION -lt 1],
+                                           [NVCC_ARCH="${ARCH7} ${ARCH8} ${ARCH9} ${ARCH10} ${ARCH110}"],
+                                           [NVCC_ARCH="${ARCH7} ${ARCH8} ${ARCH9} ${ARCH10} ${ARCH110} ${ARCH111}"])])])],
                       [NVCC_ARCH="$with_nvcc_gencode"])
                 AC_SUBST([NVCC_ARCH], ["$NVCC_ARCH"])])
          LDFLAGS="$save_LDFLAGS"


### PR DESCRIPTION
## Why ?
CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS removed in cuda-12.0 and memops supported by default.

