### PR TITLE
TL/UCP: fix config clone and destroy

### DIFF
--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -80,6 +80,7 @@ err:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_lib_t)
 {
+    ucc_config_parser_release_opts(&self->cfg, ucc_tl_ucp_lib_config_table);
     tl_info(&self->super, "finalizing lib object: %p", self);
 }
 

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -64,9 +64,11 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     self->status          = UCC_INPROGRESS;
     self->tuning_str      = "";
 
-    memcpy(&self->cfg, &UCC_TL_UCP_TEAM_LIB(self)->cfg,
-           sizeof(ucc_tl_ucp_team_config_t));
-
+    status = ucc_config_clone_table(&UCC_TL_UCP_TEAM_LIB(self)->cfg, &self->cfg,
+                                    ucc_tl_ucp_lib_config_table);
+    if (UCC_OK != status) {
+        return status;
+    }
     if (ctx->topo_required) {
         status = ucc_tl_ucp_get_topo(self);
         if (UCC_OK != status) {
@@ -92,6 +94,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_team_t)
 {
+    ucc_config_parser_release_opts(&self->cfg, ucc_tl_ucp_lib_config_table);
     tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
 }
 

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -194,7 +194,7 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
     }
     /* Check if the combination of the selected CLs provides all the
        requested coll_types: not an error, just print a message if not
-       all the colls are supproted */
+       all the colls are supported */
     if (params.mask & UCC_LIB_PARAM_FIELD_COLL_TYPES &&
         ((params.coll_types & supported_coll_types) != params.coll_types)) {
         ucc_debug("selected set of CLs does not provide all the requested "

--- a/src/utils/ucc_datastruct.c
+++ b/src/utils/ucc_datastruct.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 


### PR DESCRIPTION
## What
Fixing config clone and destroy in TL/UCP after adding mrange config field

## How ?
team config should be cloned instead of copied since it now includes list field
team config and lib config should be proper destroyed with ucc_config_parser_release_opts