### PR TITLE
TL/UCP: get range from team cfg instead of lib

### DIFF
--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -221,8 +221,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
     ucc_datatype_t     dt        = TASK_ARGS(task).dst.info.datatype;
     size_t             data_size = count * ucc_dt_size(dt);
     ucc_rank_t         size      = (ucc_rank_t)task->subset.map.ep_num;
-    ucc_mrange_uint_t *p         =
-        &UCC_TL_UCP_TEAM_LIB(team)->cfg.allreduce_kn_radix;
+    ucc_mrange_uint_t *p         = &team->cfg.allreduce_kn_radix;
     ucc_kn_radix_t     radix, cfg_radix;
     ucc_status_t       status;
 

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -93,8 +93,7 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
     ucc_datatype_t       dtype    = coll_args->args.dst.info.datatype;
     ucc_memory_type_t    mem_type = coll_args->args.dst.info.mem_type;
     ucc_base_coll_args_t args     = *coll_args;
-    ucc_mrange_uint_t   *p        =
-        &UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.allreduce_sra_kn_radix;
+    ucc_mrange_uint_t   *p        = &tl_team->cfg.allreduce_sra_kn_radix;
     ucc_schedule_t      *schedule;
     ucc_coll_task_t     *task, *rs_task;
     ucc_status_t         status;


### PR DESCRIPTION
## What
Get allreduce radix range from team cfg instead of lib cfg

## Why ?
lib cfg will have either default value or user value from cmd. Team cfg handles config file values to be applied as well.

## How ?
In team creation if config file is available and tuning turned on, team cfg will be updated with config file values.
