### PR TITLE
CORE: check tl is reachable

### DIFF
--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -78,7 +78,8 @@ ucc_cl_basic_get_context_attr(const ucc_base_context_t *context,
     }
 
     /* CL BASIC reports topo_required if any of the TL available
-       TL contexts needs it */
+     * TL contexts needs it
+     */
     attr->topo_required = 0;
     for (i = 0; i < ctx->super.n_tl_ctxs; i++) {
         memset(&tl_attr, 0, sizeof(tl_attr));

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -69,8 +69,8 @@ UCC_CLASS_DECLARE(ucc_cl_hier_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);
 
 typedef struct ucc_cl_hier_context {
-    ucc_cl_context_t   super;
-    ucc_mpool_t        sched_mp;
+    ucc_cl_context_t super;
+    ucc_mpool_t      sched_mp;
 } ucc_cl_hier_context_t;
 UCC_CLASS_DECLARE(ucc_cl_hier_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/cl/hier/cl_hier_context.c
+++ b/src/components/cl/hier/cl_hier_context.c
@@ -37,7 +37,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_context_t,
     self->super.n_tl_ctxs = 0;
     for (i = 0; i < tls->count; i++) {
         status = ucc_tl_context_get(params->context, tls->names[i],
-                                  &self->super.tl_ctxs[self->super.n_tl_ctxs]);
+                                    &self->super.tl_ctxs[self->super.n_tl_ctxs]);
         if (UCC_OK != status) {
             cl_info(cl_config->cl_lib,
                     "TL %s context is not available, skipping", tls->names[i]);
@@ -45,6 +45,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_context_t,
             self->super.n_tl_ctxs++;
         }
     }
+
     if (0 == self->super.n_tl_ctxs) {
         cl_error(cl_config->cl_lib, "no TL contexts are available");
         status = UCC_ERR_NOT_FOUND;

--- a/src/components/ec/rocm/ec_rocm.c
+++ b/src/components/ec/rocm/ec_rocm.c
@@ -112,7 +112,7 @@ static ucc_mpool_ops_t ucc_ec_rocm_ee_executor_mpool_ops = {
     .obj_cleanup   = ucc_ec_rocm_executor_chunk_cleanup,
 };
 
-static void ucc_ec_rocm_event_init(ucc_mpool_t *mp, void *obj, void *chunk)
+static void ucc_ec_rocm_event_init(ucc_mpool_t *mp, void *obj, void *chunk) //NOLINT: mp is unused
 {
     ucc_ec_rocm_event_t *base = (ucc_ec_rocm_event_t *) obj;
 
@@ -212,6 +212,10 @@ static ucc_status_t ucc_ec_rocm_init(const ucc_ec_params_t *ec_params)
         sizeof(ucc_ec_rocm_executor_interruptible_task_t), 0, UCC_CACHE_LINE_SIZE,
         16, UINT_MAX, NULL, UCC_THREAD_MULTIPLE,
         "interruptible executor tasks");
+    if (status != UCC_OK) {
+        ec_error(&ucc_ec_rocm.super, "failed to create interruptible tasks pool");
+        return status;
+    }
 
     ucc_spinlock_init(&ucc_ec_rocm.init_spinlock, 0);
     return UCC_OK;

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -168,6 +168,10 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
     ucc_memory_type_t         coll_mem_type;
     ucc_ee_type_t             coll_ee_type;
 
+    if (ucc_unlikely(team->state != UCC_TEAM_ACTIVE)) {
+        ucc_error("team %p is used before team create is completed", team);
+        return UCC_ERR_INVALID_PARAM;
+    }
     /* Global check to reduce the amount of checks throughout
        all TLs */
     if (UCC_COLL_ARGS_ACTIVE_SET(coll_args) &&

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -381,13 +381,15 @@ static ucc_status_t ucc_create_tl_contexts(ucc_context_t *ctx,
         tl_lib = ctx_config->tl_cfgs[i]->tl_lib;
         status = tl_lib->iface->lib.get_attr(&tl_lib->super, &attr);
         if (UCC_OK != status) {
-            ucc_error("failed to query tl lib %s attr", tl_lib->iface->super.name);
+            ucc_error("failed to query tl lib %s attr",
+                       tl_lib->iface->super.name);
             return status;
         }
         if ((attr.flags & UCC_BASE_LIB_FLAG_CTX_SERVICE_TEAM_REQUIRED) &&
             (!ctx_service_team)) {
-            ucc_debug("can not create tl/%s context because context service team "
-                      "is not available for it", tl_lib->iface->super.name);
+            ucc_debug("can not create tl/%s context because context service "
+                      "team is not available for it",
+                      tl_lib->iface->super.name);
             continue;
         }
         status = tl_lib->iface->context.create(
@@ -439,20 +441,15 @@ err:
     return status;
 }
 
-ucc_status_t ucc_core_addr_exchange(ucc_context_t          *context,
-                                    ucc_context_oob_coll_t *c_oob,
-                                    ucc_team_oob_coll_t    *t_oob,
-                                    ucc_addr_storage_t     *addr_storage)
+ucc_status_t ucc_core_addr_exchange(ucc_context_t *context, ucc_oob_coll_t *oob,
+                                    ucc_addr_storage_t *addr_storage)
 {
-    ucc_team_oob_coll_t *oob;
-    ucc_context_attr_t   attr;
-    ucc_status_t         status;
-    int                  i;
-    size_t *             addr_lens;
-    size_t               max_addrlen;
+    size_t             *addr_lens;
+    ucc_context_attr_t  attr;
+    ucc_status_t        status;
+    ucc_rank_t          i;
+    size_t              max_addrlen;
 
-    ucc_assert(c_oob || t_oob);
-    oob = c_oob ? (ucc_team_oob_coll_t *)c_oob : t_oob;
 poll:
     if (addr_storage->oob_req) {
         status = oob->req_test(addr_storage->oob_req);
@@ -470,7 +467,7 @@ poll:
         if (NULL == addr_storage->storage) {
             addr_storage->size = oob->n_oob_eps;
             attr.mask          = UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN |
-                        UCC_CONTEXT_ATTR_FIELD_CTX_ADDR;
+                                 UCC_CONTEXT_ATTR_FIELD_CTX_ADDR;
             status = ucc_context_get_attr(context, &attr);
             if (UCC_OK != status) {
                 ucc_error("failed to query ctx address");
@@ -533,7 +530,7 @@ poll:
     {
         /* Compute storage rank and check proc info uniqeness */
         ucc_rank_t r = UCC_RANK_MAX;
-        ucc_context_addr_header_t *h;
+        ucc_context_addr_header_t *h, *h2;
 
         for (i = 0; i < addr_storage->size; i++) {
             h = UCC_ADDR_STORAGE_RANK_HEADER(addr_storage, i);
@@ -544,10 +541,27 @@ poll:
                     ucc_error("proc info collision: %d %d", r, i);
                     return UCC_ERR_NO_MESSAGE;
                 }
-                r = (ucc_rank_t)i;
+                r = i;
             }
         }
         addr_storage->rank = r;
+        /*check if TLs arrays is symmetric*/
+        addr_storage->flags = UCC_ADDR_STORAGE_FLAG_TLS_SYMMETRIC;
+        h = UCC_ADDR_STORAGE_RANK_HEADER(addr_storage, 0);
+
+        for (r = 1; r < addr_storage->size; r++) {
+            h2 = UCC_ADDR_STORAGE_RANK_HEADER(addr_storage, r);
+            if (h->n_components != h2->n_components) {
+                addr_storage->flags = 0;
+                break;
+            }
+            for (i = 0; i < h->n_components; i++) {
+                if (h->components[i].id != h2->components[i].id) {
+                    addr_storage->flags = 0;
+                    break;
+                }
+            }
+        }
     }
 
     return UCC_OK;
@@ -700,7 +714,7 @@ ucc_status_t ucc_context_create_proc_info(ucc_lib_h                   lib,
         do {
             /* UCC context create is blocking fn, so we can wait here for the
                completion of addr exchange */
-            status = ucc_core_addr_exchange(ctx, &ctx->params.oob, NULL,
+            status = ucc_core_addr_exchange(ctx, &ctx->params.oob,
                                             &ctx->addr_storage);
             if (status < 0) {
                 ucc_error("failed to exchange addresses during context creation");
@@ -969,15 +983,13 @@ static ucc_status_t ucc_context_pack_addr(ucc_context_t             *context,
                       cl_lib->super.log_component.name);
             return status;
         }
-        if (attr.attr.ctx_addr_len > 0) {
-            total_len += attr.attr.ctx_addr_len;
-            packed++;
-            if (h) {
-                h->components[last_packed].id     = cl_lib->iface->super.id;
-                h->components[last_packed].offset = offset;
-                last_packed++;
-                offset += attr.attr.ctx_addr_len;
-            }
+        total_len += attr.attr.ctx_addr_len;
+        packed++;
+        if (h) {
+            h->components[last_packed].id     = cl_lib->iface->super.id;
+            h->components[last_packed].offset = offset;
+            last_packed++;
+            offset += attr.attr.ctx_addr_len;
         }
     }
 
@@ -991,21 +1003,20 @@ static ucc_status_t ucc_context_pack_addr(ucc_context_t             *context,
                       tl_lib->super.log_component.name);
             return status;
         }
-        if (attr.attr.ctx_addr_len > 0) {
-            total_len += attr.attr.ctx_addr_len;
-            packed++;
-            if (h) {
-                h->components[last_packed].id     = tl_lib->iface->super.id;
-                h->components[last_packed].offset = offset;
-                last_packed++;
-                offset += attr.attr.ctx_addr_len;
-            }
+        total_len += attr.attr.ctx_addr_len;
+        packed++;
+        if (h) {
+            h->components[last_packed].id     = tl_lib->iface->super.id;
+            h->components[last_packed].offset = offset;
+            last_packed++;
+            offset += attr.attr.ctx_addr_len;
         }
     }
 
     if (addr_len) {
         *addr_len = total_len + UCC_CONTEXT_ADDR_HEADER_SIZE(packed);
     }
+
     if (n_packed) {
         *n_packed = packed;
     }
@@ -1028,7 +1039,7 @@ ucc_status_t ucc_context_get_attr(ucc_context_t      *context,
                 ucc_error("failed to calc ucc context address length");
                 return status;
             }
-            context->attr.mask        |= UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN;
+            context->attr.mask |= UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN;
         }
         context_attr->ctx_addr_len = context->attr.ctx_addr_len;
     }

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -87,7 +87,6 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
     team->state                   = (team->size > 1) ? UCC_TEAM_ADDR_EXCHANGE
                                                      : UCC_TEAM_CL_CREATE;
     team->last_team_create_posted = -1;
-    team->status                  = UCC_INPROGRESS;
     return UCC_OK;
 }
 
@@ -188,8 +187,8 @@ ucc_status_t ucc_team_create_post(ucc_context_h *contexts, uint32_t num_contexts
     team->size         = (ucc_rank_t)team_size;
     team->rank         = (ucc_rank_t)team_rank;
     team->seq_num      = 0;
-    team->contexts =
-        ucc_malloc(sizeof(ucc_context_t *) * num_contexts, "ucc_team_ctx");
+    team->contexts     = ucc_malloc(sizeof(ucc_context_t *) * num_contexts,
+                                    "ucc_team_ctx");
     if (!team->contexts) {
         ucc_error("failed to allocate %zd bytes for ucc team contexts array",
                   sizeof(ucc_context_t) * num_contexts);
@@ -214,8 +213,8 @@ err_ctx_alloc:
     return status;
 }
 
-static inline ucc_status_t
-ucc_team_create_service_team(ucc_context_t *context, ucc_team_t *team)
+static ucc_status_t ucc_team_create_service_team(ucc_context_t *context,
+                                                 ucc_team_t *team)
 {
     ucc_status_t status;
     if (context->service_team) {
@@ -257,16 +256,16 @@ ucc_team_create_service_team(ucc_context_t *context, ucc_team_t *team)
     return status;
 }
 
-static inline ucc_status_t
-ucc_team_create_cls(ucc_context_t *context, ucc_team_t *team)
+static ucc_status_t ucc_team_create_cls(ucc_context_t *context,
+                                        ucc_team_t *team)
 {
-    int                    i;
-    ucc_cl_iface_t        *cl_iface;
-    ucc_base_team_t       *b_team;
-    ucc_status_t           status;
+    ucc_cl_iface_t  *cl_iface;
+    ucc_base_team_t *b_team;
+    ucc_status_t     status;
+    ucc_subset_t     subset;
+    int              i;
 
     if (context->topo && !team->topo && team->size > 1) {
-        ucc_subset_t subset;
         /* Context->topo is not NULL if any of the enabled CLs
            reported topo_required through the lib_attr */
         subset.map    = team->ctx_map;
@@ -293,7 +292,7 @@ ucc_team_create_cls(ucc_context_t *context, ucc_team_t *team)
     for (i = team->last_team_create_posted + 1; i < context->n_cl_ctx; i++) {
         cl_iface = UCC_CL_CTX_IFACE(context->cl_ctx[i]);
         status   = cl_iface->team.create_post(&context->cl_ctx[i]->super,
-                                            &team->bp, &b_team);
+                                              &team->bp, &b_team);
         if (status != UCC_OK) {
             ucc_info("failed to create CL %s team", cl_iface->super.name);
             continue;
@@ -314,7 +313,7 @@ ucc_team_create_cls(ucc_context_t *context, ucc_team_t *team)
         }
     }
     if (0 == team->n_cl_teams) {
-        ucc_error("No CL teams were created");
+        ucc_error("no CL teams were created");
         return UCC_ERR_NO_MESSAGE;
     }
     return UCC_OK;
@@ -329,8 +328,8 @@ static inline ucc_status_t ucc_team_exchange(ucc_context_t *context,
     if (!context->addr_storage.storage) {
         /* There is no addresses collected on the context
            (can be, e.g., if user did not pass OOB for ctx
-           creation). Need to exchange addresses here*/
-        return ucc_core_addr_exchange(context, NULL, &oob, &team->addr_storage);
+           creation). Need to exchange addresses here */
+        return ucc_core_addr_exchange(context, &oob, &team->addr_storage);
     }
     /* We only need to exchange ctx_ranks and build map to ctx array */
     ucc_assert(context->addr_storage.storage != NULL);
@@ -345,9 +344,9 @@ static inline ucc_status_t ucc_team_exchange(ucc_context_t *context,
                           team->size * sizeof(ucc_rank_t));
                 return UCC_ERR_NO_MEMORY;
             }
-            status =
-                oob.allgather(&context->rank, team->ctx_ranks, sizeof(ucc_rank_t),
-                              oob.coll_info, &team->oob_req);
+            status = oob.allgather(&context->rank, team->ctx_ranks,
+                                   sizeof(ucc_rank_t), oob.coll_info,
+                                   &team->oob_req);
             if (UCC_OK != status) {
                 ucc_error("failed to start oob allgather for proc info exchange");
                 ucc_free(team->ctx_ranks);
@@ -429,8 +428,9 @@ ucc_status_t ucc_team_create_test_single(ucc_context_t *context,
             ((context->cl_flags & UCC_BASE_LIB_FLAG_TEAM_ID_REQUIRED) &&
              (team->id == 0))) {
             /* We need service team either when it is explicitly required
-               by any CL/TL (e.g. CL/HIER) or if TEAM_ID is required but
-               not provided by the user */
+             * by any CL/TL (e.g. CL/HIER) or if TEAM_ID is required but
+             * not provided by the user
+             */
             status = ucc_team_create_service_team(context, team);
             if (UCC_OK != status) {
                 goto out;
@@ -455,10 +455,13 @@ ucc_status_t ucc_team_create_test_single(ucc_context_t *context,
         /* fall through */
     case UCC_TEAM_CL_CREATE:
         status = ucc_team_create_cls(context, team);
+        break;
+    case UCC_TEAM_ACTIVE:
+        return UCC_OK;
     }
 out:
-    team->status = status;
     if (UCC_OK == status) {
+        team->state = UCC_TEAM_ACTIVE;
         status = ucc_team_build_score_map(team);
     }
 
@@ -483,7 +486,7 @@ ucc_status_t ucc_team_create_test(ucc_team_h team)
     }
     /* we don't support multiple contexts per team yet */
     ucc_assert(team->num_contexts == 1);
-    if (team->status == UCC_OK) {
+    if (team->state == UCC_TEAM_ACTIVE) {
         return UCC_OK;
     }
     return ucc_team_create_test_single(team->contexts[0], team);
@@ -536,7 +539,7 @@ ucc_status_t ucc_team_destroy(ucc_team_h team)
         return UCC_ERR_INVALID_PARAM;
     }
 
-    if (team->status != UCC_OK) {
+    if (team->state != UCC_TEAM_ACTIVE) {
         ucc_error("team %p is used before team_create is completed", team);
         return UCC_ERR_INVALID_PARAM;
     }

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -12,21 +13,20 @@
 #include "ucc_context.h"
 #include "utils/ucc_math.h"
 #include "components/base/ucc_base_iface.h"
+#include "components/cl/ucc_cl.h"
+#include "components/tl/ucc_tl.h"
 #include "coll_score/ucc_coll_score.h"
 
-typedef struct ucc_context          ucc_context_t;
-typedef struct ucc_cl_team          ucc_cl_team_t;
-typedef struct ucc_tl_team          ucc_tl_team_t;
 typedef struct ucc_service_coll_req ucc_service_coll_req_t;
 typedef enum {
     UCC_TEAM_ADDR_EXCHANGE,
     UCC_TEAM_SERVICE_TEAM,
     UCC_TEAM_ALLOC_ID,
     UCC_TEAM_CL_CREATE,
+    UCC_TEAM_ACTIVE,
 } ucc_team_state_t;
 
 typedef struct ucc_team {
-    ucc_status_t            status;
     ucc_team_state_t        state;
     ucc_context_t **        contexts;
     uint32_t                num_contexts;


### PR DESCRIPTION
## What
Check if TL context exists in every rank before creating tl team.

## Why ?
Because TL contexts list might not be the same for every rank it's possible to have allgather collision when different ranks trying to create different teams e.g.
```
tl_ucp_coll.c:79   TL_UCP ERROR failure in send completion Message truncated
```

## How ?
During address exchange stage in team create or context create collect list of TLs available for each team rank.