### PR TITLE
TEST: add configurable dt for non-reduction colls

### DIFF
--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -10,10 +10,12 @@
 TestAllgather::TestAllgather(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_ALLGATHER, params)
 {
-    dt                       = params.dt;
-    size_t dt_size           = ucc_dt_size(dt);
-    size_t single_rank_count = msgsize / dt_size;
     int    rank, size;
+    size_t dt_size, single_rank_count;
+
+    dt                = params.dt;
+    dt_size           = ucc_dt_size(dt);
+    single_rank_count = msgsize / dt_size;
 
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);

--- a/test/mpi/test_allgather.cc
+++ b/test/mpi/test_allgather.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -7,12 +7,11 @@
 #include "test_mpi.h"
 #include "mpi_util.h"
 
-#define TEST_DT UCC_DT_UINT32
-
 TestAllgather::TestAllgather(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_ALLGATHER, params)
 {
-    size_t dt_size           = ucc_dt_size(TEST_DT);
+    dt                       = params.dt;
+    size_t dt_size           = ucc_dt_size(dt);
     size_t single_rank_count = msgsize / dt_size;
     int    rank, size;
 
@@ -33,12 +32,12 @@ TestAllgather::TestAllgather(ucc_test_team_t &_team, TestCaseParams &params) :
         sbuf                   = sbuf_mc_header->addr;
         args.src.info.buffer   = sbuf;
         args.src.info.count    = single_rank_count;
-        args.src.info.datatype = TEST_DT;
+        args.src.info.datatype = dt;
         args.src.info.mem_type = mem_type;
     }
     args.dst.info.buffer   = rbuf;
     args.dst.info.count    = single_rank_count * size;
-    args.dst.info.datatype = TEST_DT;
+    args.dst.info.datatype = dt;
     args.dst.info.mem_type = mem_type;
     UCC_CHECK(set_input());
     UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
@@ -46,7 +45,7 @@ TestAllgather::TestAllgather(ucc_test_team_t &_team, TestCaseParams &params) :
 
 ucc_status_t TestAllgather::set_input(int iter_persistent)
 {
-    size_t dt_size           = ucc_dt_size(TEST_DT);
+    size_t dt_size           = ucc_dt_size(dt);
     size_t single_rank_count = msgsize / dt_size;
     size_t single_rank_size  = single_rank_count * dt_size;
     int    rank;
@@ -60,7 +59,7 @@ ucc_status_t TestAllgather::set_input(int iter_persistent)
     }
     check = PTR_OFFSET(check_buf, rank * single_rank_size);
 
-    init_buffer(buf, single_rank_count, TEST_DT, mem_type,
+    init_buffer(buf, single_rank_count, dt, mem_type,
                 rank * (iter_persistent + 1));
     UCC_CHECK(ucc_mc_memcpy(check, buf, single_rank_size,
                             UCC_MEMORY_TYPE_HOST, mem_type));
@@ -72,16 +71,16 @@ ucc_status_t TestAllgather::check()
     int size, completed;
     MPI_Comm_size(team.comm, &size);
     size_t       single_rank_count = args.dst.info.count / size;
-    MPI_Datatype dt    = ucc_dt_to_mpi(TEST_DT);
+    MPI_Datatype mpi_dt            = ucc_dt_to_mpi(dt);
     MPI_Request  req;
 
-    MPI_Iallgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                   check_buf, single_rank_count, dt, team.comm, &req);
+    MPI_Iallgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, check_buf,
+                   single_rank_count, mpi_dt, team.comm, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
     } while(!completed);
 
-    return compare_buffers(rbuf, check_buf, single_rank_count * size, TEST_DT,
+    return compare_buffers(rbuf, check_buf, single_rank_count * size, dt,
                            mem_type);
 }

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -34,13 +34,15 @@ static void fill_counts_and_displacements(int size, int count,
 TestAllgatherv::TestAllgatherv(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_ALLGATHERV, params)
 {
-    dt             = params.dt;
-    size_t dt_size = ucc_dt_size(dt);
-    size_t count   = msgsize / dt_size;
     int    rank, size;
+    size_t dt_size, count;
 
+    dt            = params.dt;
+    dt_size       = ucc_dt_size(dt);
+    count         = msgsize / dt_size;
     counts        = NULL;
     displacements = NULL;
+
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
 

--- a/test/mpi/test_alltoall.cc
+++ b/test/mpi/test_alltoall.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -10,14 +10,15 @@
 TestAlltoall::TestAlltoall(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_ALLTOALL, params)
 {
-    dt                       = params.dt;
-    size_t dt_size           = ucc_dt_size(dt);
-    size_t single_rank_count = msgsize / dt_size;
-    void  *work_buf          = nullptr;
-    int    rank;
-    int    nprocs;
+    void*  work_buf = nullptr;
+    int    rank, nprocs;
+    size_t dt_size, single_rank_count;
 
-    is_onesided = (params.buffers != nullptr);
+    dt                = params.dt;
+    dt_size           = ucc_dt_size(dt);
+    single_rank_count = msgsize / dt_size;
+    is_onesided       = (params.buffers != nullptr);
+
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &nprocs);
 
@@ -68,7 +69,7 @@ TestAlltoall::TestAlltoall(ucc_test_team_t &_team, TestCaseParams &params) :
 ucc_status_t TestAlltoall::set_input(int iter_persistent)
 {
     size_t      dt_size           = ucc_dt_size(dt);
-    size_t single_rank_count = msgsize / dt_size;
+    size_t      single_rank_count = msgsize / dt_size;
     MPI_Request req;
     void *      buf;
     int         rank, nprocs, completed;

--- a/test/mpi/test_alltoall.cc
+++ b/test/mpi/test_alltoall.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -7,12 +7,11 @@
 #include "test_mpi.h"
 #include "mpi_util.h"
 
-#define TEST_DT UCC_DT_UINT32
-
 TestAlltoall::TestAlltoall(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_ALLTOALL, params)
 {
-    size_t dt_size           = ucc_dt_size(TEST_DT);
+    dt                       = params.dt;
+    size_t dt_size           = ucc_dt_size(dt);
     size_t single_rank_count = msgsize / dt_size;
     void  *work_buf          = nullptr;
     int    rank;
@@ -54,13 +53,13 @@ TestAlltoall::TestAlltoall(ucc_test_team_t &_team, TestCaseParams &params) :
     if (!inplace) {
         args.src.info.buffer      = sbuf;
         args.src.info.count       = single_rank_count * nprocs;
-        args.src.info.datatype    = TEST_DT;
+        args.src.info.datatype    = dt;
         args.src.info.mem_type    = mem_type;
     }
 
     args.dst.info.buffer      = rbuf;
     args.dst.info.count       = single_rank_count * nprocs;
-    args.dst.info.datatype    = TEST_DT;
+    args.dst.info.datatype    = dt;
     args.dst.info.mem_type    = mem_type;
     UCC_CHECK(set_input());
     UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
@@ -68,7 +67,7 @@ TestAlltoall::TestAlltoall(ucc_test_team_t &_team, TestCaseParams &params) :
 
 ucc_status_t TestAlltoall::set_input(int iter_persistent)
 {
-    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t      dt_size           = ucc_dt_size(dt);
     size_t single_rank_count = msgsize / dt_size;
     MPI_Request req;
     void *      buf;
@@ -81,7 +80,7 @@ ucc_status_t TestAlltoall::set_input(int iter_persistent)
     } else {
         buf = sbuf;
     }
-    init_buffer(buf, single_rank_count * nprocs, TEST_DT, mem_type,
+    init_buffer(buf, single_rank_count * nprocs, dt, mem_type,
                 rank * (iter_persistent + 1));
     UCC_CHECK(ucc_mc_memcpy(check_buf, buf,
                             single_rank_count * nprocs * dt_size,
@@ -106,14 +105,13 @@ ucc_status_t TestAlltoall::check()
     MPI_Comm_size(team.comm, &size);
     single_rank_count = args.src.info.count / size;
 
-    MPI_Ialltoall(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                  check_buf, single_rank_count, ucc_dt_to_mpi(TEST_DT),
-                  team.comm, &req);
+    MPI_Ialltoall(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, check_buf,
+                  single_rank_count, ucc_dt_to_mpi(dt), team.comm, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
     } while(!completed);
 
-    return compare_buffers(rbuf, check_buf, single_rank_count * size, TEST_DT,
+    return compare_buffers(rbuf, check_buf, single_rank_count * size, dt,
                            mem_type);
 }

--- a/test/mpi/test_alltoallv.cc
+++ b/test/mpi/test_alltoallv.cc
@@ -22,11 +22,11 @@ void * TestAlltoallv::mpi_counts_to_ucc(int *mpi_counts, size_t _ncount)
 TestAlltoallv::TestAlltoallv(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_ALLTOALLV, params)
 {
-    dt                                         = params.dt;
-    size_t                             dt_size = ucc_dt_size(dt);
+    dt             = params.dt;
+    size_t dt_size = ucc_dt_size(dt);
     size_t count   = msgsize/dt_size;
     std::uniform_int_distribution<int> urd(count/2, count);
-    std::default_random_engine         eng;
+    std::default_random_engine eng;
     int rank;
     int nprocs;
     int rank_count;
@@ -110,6 +110,20 @@ TestAlltoallv::TestAlltoallv(ucc_test_team_t &_team, TestCaseParams &params) :
     args.dst.info_v.buffer = rbuf;
     args.dst.info_v.datatype = dt;
     args.dst.info_v.mem_type = mem_type;
+
+    if (TEST_FLAG_VSIZE_64BIT == count_bits ||
+        TEST_FLAG_VSIZE_64BIT == displ_bits) {
+        if (msgsize % 64 != 0) {
+            test_skip = TEST_SKIP_NOT_SUPPORTED;
+        }
+    } else {
+        if (msgsize % 32 != 0) {
+            test_skip = TEST_SKIP_NOT_SUPPORTED;
+        }
+    }
+    if (TEST_SKIP_NONE != skip_reduce(test_skip, team.comm)) {
+        return;
+    }
 
     if (TEST_FLAG_VSIZE_64BIT == count_bits) {
         args.src.info_v.counts = scounts64 =

--- a/test/mpi/test_alltoallv.cc
+++ b/test/mpi/test_alltoallv.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -22,19 +22,13 @@ void * TestAlltoallv::mpi_counts_to_ucc(int *mpi_counts, size_t _ncount)
 TestAlltoallv::TestAlltoallv(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_ALLTOALLV, params)
 {
-    dt             = params.dt;
-    size_t dt_size = ucc_dt_size(dt);
-    size_t count   = msgsize/dt_size;
-    std::uniform_int_distribution<int> urd(count/2, count);
     std::default_random_engine eng;
-    int rank;
-    int nprocs;
-    int rank_count;
+    size_t                     dt_size, count;
+    int                        rank, nprocs, rank_count;
 
-    eng.seed(test_rand_seed);
-    MPI_Comm_rank(team.comm, &rank);
-    MPI_Comm_size(team.comm, &nprocs);
-
+    dt         = params.dt;
+    dt_size    = ucc_dt_size(dt);
+    count      = msgsize / dt_size;
     sncounts   = 0;
     rncounts   = 0;
     scounts    = NULL;
@@ -47,6 +41,9 @@ TestAlltoallv::TestAlltoallv(ucc_test_team_t &_team, TestCaseParams &params) :
     rdispls64  = NULL;
     count_bits = params.count_bits;
     displ_bits = params.displ_bits;
+
+    std::uniform_int_distribution<int> urd(count / 2, count);
+    eng.seed(test_rand_seed);
 
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &nprocs);

--- a/test/mpi/test_bcast.cc
+++ b/test/mpi/test_bcast.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -10,14 +10,16 @@
 TestBcast::TestBcast(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_BCAST, params)
 {
-    dt             = params.dt;
-    size_t dt_size = ucc_dt_size(dt);
-    size_t count   = msgsize / dt_size;
     int rank, size;
+    size_t dt_size, count;
+
+    dt      = params.dt;
+    dt_size = ucc_dt_size(dt);
+    count   = msgsize / dt_size;
+    root    = params.root;
 
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
-    root = params.root;
 
     if (skip_reduce(test_max_size < msgsize, TEST_SKIP_MEM_LIMIT, team.comm)) {
         return;

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -137,6 +137,10 @@ std::string TestCase::str() {
     if (ucc_coll_is_rooted(args.coll_type)) {
         _str += std::string(" root=") + std::to_string(root);
     }
+    if (ucc_coll_has_datatype(args.coll_type)) {
+        _str += std::string(" dt=") + ucc_datatype_str(dt);
+    }
+
     return _str;
 }
 
@@ -161,10 +165,10 @@ void TestCase::tc_progress_ctx()
 }
 
 TestCase::TestCase(ucc_test_team_t &_team, ucc_coll_type_t ct,
-                   TestCaseParams params) :
-    team(_team), mem_type(params.mt), msgsize(params.msgsize),
-    inplace(params.inplace), persistent(params.persistent),
-    test_max_size(params.max_size)
+                   TestCaseParams params):
+      team(_team), mem_type(params.mt), msgsize(params.msgsize),
+      inplace(params.inplace), persistent(params.persistent),
+      test_max_size(params.max_size), dt(params.dt)
 {
     int rank;
 

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -165,10 +165,10 @@ void TestCase::tc_progress_ctx()
 }
 
 TestCase::TestCase(ucc_test_team_t &_team, ucc_coll_type_t ct,
-                   TestCaseParams params):
-      team(_team), mem_type(params.mt), msgsize(params.msgsize),
-      inplace(params.inplace), persistent(params.persistent),
-      test_max_size(params.max_size), dt(params.dt)
+                   TestCaseParams params) :
+    team(_team), mem_type(params.mt), msgsize(params.msgsize),
+    inplace(params.inplace), persistent(params.persistent),
+    test_max_size(params.max_size), dt(params.dt)
 {
     int rank;
 

--- a/test/mpi/test_gather.cc
+++ b/test/mpi/test_gather.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -10,12 +10,14 @@
 TestGather::TestGather(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_GATHER, params)
 {
-    dt                       = params.dt;
-    size_t dt_size           = ucc_dt_size(dt);
-    size_t single_rank_count = msgsize / dt_size;
     int    rank, size;
+    size_t dt_size, single_rank_count;
 
-    root = params.root;
+    dt                = params.dt;
+    dt_size           = ucc_dt_size(dt);
+    single_rank_count = msgsize / dt_size;
+    root              = params.root;
+
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
 

--- a/test/mpi/test_gather.cc
+++ b/test/mpi/test_gather.cc
@@ -7,12 +7,11 @@
 #include "test_mpi.h"
 #include "mpi_util.h"
 
-#define TEST_DT UCC_DT_UINT32
-
 TestGather::TestGather(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_GATHER, params)
 {
-    size_t dt_size           = ucc_dt_size(TEST_DT);
+    dt                       = params.dt;
+    size_t dt_size           = ucc_dt_size(dt);
     size_t single_rank_count = msgsize / dt_size;
     int    rank, size;
 
@@ -49,18 +48,18 @@ TestGather::TestGather(ucc_test_team_t &_team, TestCaseParams &params) :
     if (rank == root) {
         args.dst.info.buffer   = rbuf;
         args.dst.info.count    = single_rank_count * size;
-        args.dst.info.datatype = TEST_DT;
+        args.dst.info.datatype = dt;
         args.dst.info.mem_type = mem_type;
         if (!inplace) {
             args.src.info.buffer   = sbuf;
             args.src.info.count    = single_rank_count;
-            args.src.info.datatype = TEST_DT;
+            args.src.info.datatype = dt;
             args.src.info.mem_type = mem_type;
         }
     } else {
         args.src.info.buffer   = sbuf;
         args.src.info.count    = single_rank_count;
-        args.src.info.datatype = TEST_DT;
+        args.src.info.datatype = dt;
         args.src.info.mem_type = mem_type;
     }
 
@@ -70,7 +69,7 @@ TestGather::TestGather(ucc_test_team_t &_team, TestCaseParams &params) :
 
 ucc_status_t TestGather::set_input(int iter_persistent)
 {
-    size_t dt_size           = ucc_dt_size(TEST_DT);
+    size_t dt_size           = ucc_dt_size(dt);
     size_t single_rank_count = msgsize / dt_size;
     size_t single_rank_size  = single_rank_count * dt_size;
     int    rank;
@@ -88,7 +87,7 @@ ucc_status_t TestGather::set_input(int iter_persistent)
     }
     check = PTR_OFFSET(check_buf, rank * single_rank_size);
 
-    init_buffer(buf, single_rank_count, TEST_DT, mem_type,
+    init_buffer(buf, single_rank_count, dt, mem_type,
                 rank * (iter_persistent + 1));
     UCC_CHECK(ucc_mc_memcpy(check, buf, single_rank_size,
                             UCC_MEMORY_TYPE_HOST, mem_type));
@@ -97,22 +96,23 @@ ucc_status_t TestGather::set_input(int iter_persistent)
 
 ucc_status_t TestGather::check()
 {
-    size_t       single_rank_count = msgsize / ucc_dt_size(TEST_DT);
-    MPI_Datatype dt                = ucc_dt_to_mpi(TEST_DT);
+    size_t       single_rank_count = msgsize / ucc_dt_size(dt);
+    MPI_Datatype mpi_dt            = ucc_dt_to_mpi(dt);
     MPI_Request req;
     int size, rank, completed;
 
     MPI_Comm_size(team.comm, &size);
     MPI_Comm_rank(team.comm, &rank);
 
-    MPI_Iallgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                   check_buf, single_rank_count, dt, team.comm, &req);
+    MPI_Iallgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, check_buf,
+                   single_rank_count, mpi_dt, team.comm, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
     } while(!completed);
 
-    return (rank != root) ? UCC_OK :
-        compare_buffers(rbuf, check_buf, single_rank_count * size, TEST_DT,
-                        mem_type);
+    return (rank != root)
+               ? UCC_OK
+               : compare_buffers(rbuf, check_buf, single_rank_count * size, dt,
+                                 mem_type);
 }

--- a/test/mpi/test_gatherv.cc
+++ b/test/mpi/test_gatherv.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -34,14 +34,16 @@ static void fill_counts_and_displacements(int size, int count,
 TestGatherv::TestGatherv(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_GATHERV, params)
 {
-    dt             = params.dt;
-    size_t dt_size = ucc_dt_size(dt);
-    size_t count   = msgsize / dt_size;
     int    rank, size;
+    size_t dt_size, count;
 
+    dt            = params.dt;
+    dt_size       = ucc_dt_size(dt);
+    count         = msgsize / dt_size;
     root          = params.root;
     counts        = NULL;
     displacements = NULL;
+
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
 

--- a/test/mpi/test_gatherv.cc
+++ b/test/mpi/test_gatherv.cc
@@ -7,8 +7,6 @@
 #include "test_mpi.h"
 #include "mpi_util.h"
 
-#define TEST_DT UCC_DT_UINT32
-
 static void fill_counts_and_displacements(int size, int count,
                                           uint32_t *counts, uint32_t *displs)
 {
@@ -36,7 +34,8 @@ static void fill_counts_and_displacements(int size, int count,
 TestGatherv::TestGatherv(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_GATHERV, params)
 {
-    size_t dt_size = ucc_dt_size(TEST_DT);
+    dt             = params.dt;
+    size_t dt_size = ucc_dt_size(dt);
     size_t count   = msgsize / dt_size;
     int    rank, size;
 
@@ -82,18 +81,18 @@ TestGatherv::TestGatherv(ucc_test_team_t &_team, TestCaseParams &params) :
         args.dst.info_v.buffer        = rbuf;
         args.dst.info_v.counts        = (ucc_count_t*)counts;
         args.dst.info_v.displacements = (ucc_aint_t*)displacements;
-        args.dst.info_v.datatype      = TEST_DT;
+        args.dst.info_v.datatype      = dt;
         args.dst.info_v.mem_type      = mem_type;
         if (!inplace) {
             args.src.info.buffer   = sbuf;
             args.src.info.count    = counts[rank];
-            args.src.info.datatype = TEST_DT;
+            args.src.info.datatype = dt;
             args.src.info.mem_type = mem_type;
         }
     } else {
         args.src.info.buffer   = sbuf;
         args.src.info.count    = counts[rank];
-        args.src.info.datatype = TEST_DT;
+        args.src.info.datatype = dt;
         args.src.info.mem_type = mem_type;
     }
 
@@ -103,7 +102,7 @@ TestGatherv::TestGatherv(ucc_test_team_t &_team, TestCaseParams &params) :
 
 ucc_status_t TestGatherv::set_input(int iter_persistent)
 {
-    size_t dt_size = ucc_dt_size(TEST_DT);
+    size_t dt_size = ucc_dt_size(dt);
     int    rank;
     void  *buf, *check;
 
@@ -119,8 +118,7 @@ ucc_status_t TestGatherv::set_input(int iter_persistent)
     }
     check = PTR_OFFSET(check_buf, displacements[rank] * dt_size);
 
-    init_buffer(buf, counts[rank], TEST_DT, mem_type,
-                rank * (iter_persistent + 1));
+    init_buffer(buf, counts[rank], dt, mem_type, rank * (iter_persistent + 1));
     UCC_CHECK(ucc_mc_memcpy(check, buf, counts[rank] * dt_size,
                             UCC_MEMORY_TYPE_HOST, mem_type));
     return UCC_OK;
@@ -138,22 +136,23 @@ TestGatherv::~TestGatherv()
 
 ucc_status_t TestGatherv::check()
 {
-    size_t       count = msgsize / ucc_dt_size(TEST_DT);
-    MPI_Datatype dt    = ucc_dt_to_mpi(TEST_DT);
+    size_t       count  = msgsize / ucc_dt_size(dt);
+    MPI_Datatype mpi_dt = ucc_dt_to_mpi(dt);
     MPI_Request  req;
     int          size, rank, completed;
 
     MPI_Comm_size(team.comm, &size);
     MPI_Comm_rank(team.comm, &rank);
 
-    MPI_Iallgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                    check_buf, (int*)counts, (int*)displacements, dt,
-                    team.comm, &req);
+    MPI_Iallgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, check_buf,
+                    (int *)counts, (int *)displacements, mpi_dt, team.comm,
+                    &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
     } while(!completed);
 
-    return (rank != root) ? UCC_OK :
-        compare_buffers(rbuf, check_buf, count * size, TEST_DT, mem_type);
+    return (rank != root)
+               ? UCC_OK
+               : compare_buffers(rbuf, check_buf, count * size, dt, mem_type);
 }

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -358,13 +358,12 @@ bool ucc_coll_has_msgrange(ucc_coll_type_t c)
 bool ucc_coll_has_datatype(ucc_coll_type_t c)
 {
     switch(c) {
-    case UCC_COLL_TYPE_ALLREDUCE:
-    case UCC_COLL_TYPE_REDUCE:
-    case UCC_COLL_TYPE_REDUCE_SCATTER:
-    case UCC_COLL_TYPE_REDUCE_SCATTERV:
-        return true;
-    default:
+    case UCC_COLL_TYPE_BARRIER:
+    case UCC_COLL_TYPE_FANIN:
+    case UCC_COLL_TYPE_FANOUT:
         return false;
+    default:
+        return true;
     }
 }
 

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -279,7 +279,7 @@ protected:
     size_t test_max_size;
     ucc_datatype_t dt;
 
-  public:
+public:
     void mpi_progress(void);
     test_skip_cause_t test_skip;
     static std::shared_ptr<TestCase> init_single(
@@ -383,16 +383,13 @@ public:
 };
 
 class TestAllgather : public TestCase {
-    ucc_datatype_t dt;
-
-  public:
+public:
     TestAllgather(ucc_test_team_t &team, TestCaseParams &params);
     ucc_status_t set_input(int iter_persistent = 0) override;
     ucc_status_t check();
 };
 
 class TestAllgatherv : public TestCase {
-    ucc_datatype_t dt;
     int *counts;
     int *displacements;
 public:
@@ -403,7 +400,6 @@ public:
 };
 
 class TestAllreduce : public TestCase {
-    ucc_datatype_t dt;
     ucc_reduction_op_t op;
 public:
     TestAllreduce(ucc_test_team_t &team, TestCaseParams &params);
@@ -413,7 +409,6 @@ public:
 };
 
 class TestAlltoall : public TestCase {
-    ucc_datatype_t dt;
     bool is_onesided;
 public:
     TestAlltoall(ucc_test_team_t &team, TestCaseParams &params);
@@ -422,7 +417,6 @@ public:
 };
 
 class TestAlltoallv : public TestCase {
-    ucc_datatype_t dt;
     size_t sncounts;
     size_t rncounts;
     int *scounts;
@@ -458,25 +452,20 @@ public:
 };
 
 class TestBcast : public TestCase {
-    ucc_datatype_t dt;
-
-  public:
+public:
     TestBcast(ucc_test_team_t &team, TestCaseParams &params);
     ucc_status_t set_input(int iter_persistent = 0) override;
     ucc_status_t check();
 };
 
 class TestGather : public TestCase {
-    ucc_datatype_t dt;
-
-  public:
+public:
     TestGather(ucc_test_team_t &team, TestCaseParams &params);
     ucc_status_t set_input(int iter_persistent = 0) override;
     ucc_status_t check();
 };
 
 class TestGatherv : public TestCase {
-    ucc_datatype_t dt;
     uint32_t *counts;
     uint32_t *displacements;
 public:
@@ -487,7 +476,6 @@ public:
 };
 
 class TestReduce : public TestCase {
-	ucc_datatype_t dt;
 	ucc_reduction_op_t op;
 public:
     TestReduce(ucc_test_team_t &team, TestCaseParams &params);
@@ -497,7 +485,6 @@ public:
 };
 
 class TestReduceScatter : public TestCase {
-    ucc_datatype_t dt;
     ucc_reduction_op_t op;
 public:
     TestReduceScatter(ucc_test_team_t &team, TestCaseParams &params);
@@ -508,7 +495,6 @@ public:
 };
 
 class TestReduceScatterv : public TestCase {
-    ucc_datatype_t     dt;
     ucc_reduction_op_t op;
     int *              counts;
   public:
@@ -520,16 +506,13 @@ class TestReduceScatterv : public TestCase {
 };
 
 class TestScatter : public TestCase {
-    ucc_datatype_t dt;
-
-  public:
+public:
     TestScatter(ucc_test_team_t &team, TestCaseParams &params);
     ucc_status_t set_input(int iter_persistent = 0) override;
     ucc_status_t check();
 };
 
 class TestScatterv : public TestCase {
-    ucc_datatype_t dt;
     uint32_t *counts;
     uint32_t *displacements;
 public:

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -176,6 +176,7 @@ void set_gpu_device(test_set_gpu_device_t set_device);
 #endif
 int ucc_coll_inplace_supported(ucc_coll_type_t c);
 int ucc_coll_is_rooted(ucc_coll_type_t c);
+bool ucc_coll_has_datatype(ucc_coll_type_t c);
 
 typedef struct ucc_test_team {
 #ifdef HAVE_CUDA
@@ -276,7 +277,9 @@ protected:
     MPI_Request progress_request;
     uint8_t     progress_buf[1];
     size_t test_max_size;
-public:
+    ucc_datatype_t dt;
+
+  public:
     void mpi_progress(void);
     test_skip_cause_t test_skip;
     static std::shared_ptr<TestCase> init_single(
@@ -380,13 +383,16 @@ public:
 };
 
 class TestAllgather : public TestCase {
-public:
+    ucc_datatype_t dt;
+
+  public:
     TestAllgather(ucc_test_team_t &team, TestCaseParams &params);
     ucc_status_t set_input(int iter_persistent = 0) override;
     ucc_status_t check();
 };
 
 class TestAllgatherv : public TestCase {
+    ucc_datatype_t dt;
     int *counts;
     int *displacements;
 public:
@@ -407,6 +413,7 @@ public:
 };
 
 class TestAlltoall : public TestCase {
+    ucc_datatype_t dt;
     bool is_onesided;
 public:
     TestAlltoall(ucc_test_team_t &team, TestCaseParams &params);
@@ -415,6 +422,7 @@ public:
 };
 
 class TestAlltoallv : public TestCase {
+    ucc_datatype_t dt;
     size_t sncounts;
     size_t rncounts;
     int *scounts;
@@ -450,20 +458,25 @@ public:
 };
 
 class TestBcast : public TestCase {
-public:
+    ucc_datatype_t dt;
+
+  public:
     TestBcast(ucc_test_team_t &team, TestCaseParams &params);
     ucc_status_t set_input(int iter_persistent = 0) override;
     ucc_status_t check();
 };
 
 class TestGather : public TestCase {
-public:
+    ucc_datatype_t dt;
+
+  public:
     TestGather(ucc_test_team_t &team, TestCaseParams &params);
     ucc_status_t set_input(int iter_persistent = 0) override;
     ucc_status_t check();
 };
 
 class TestGatherv : public TestCase {
+    ucc_datatype_t dt;
     uint32_t *counts;
     uint32_t *displacements;
 public:
@@ -507,13 +520,16 @@ class TestReduceScatterv : public TestCase {
 };
 
 class TestScatter : public TestCase {
-public:
+    ucc_datatype_t dt;
+
+  public:
     TestScatter(ucc_test_team_t &team, TestCaseParams &params);
     ucc_status_t set_input(int iter_persistent = 0) override;
     ucc_status_t check();
 };
 
 class TestScatterv : public TestCase {
+    ucc_datatype_t dt;
     uint32_t *counts;
     uint32_t *displacements;
 public:

--- a/test/mpi/test_scatter.cc
+++ b/test/mpi/test_scatter.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -10,12 +10,14 @@
 TestScatter::TestScatter(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_SCATTER, params)
 {
-    dt                       = params.dt;
-    size_t dt_size           = ucc_dt_size(dt);
-    size_t single_rank_count = msgsize / dt_size;
     int    rank, size;
+    size_t dt_size, single_rank_count;
 
-    root = params.root;
+    dt                = params.dt;
+    dt_size           = ucc_dt_size(dt);
+    single_rank_count = msgsize / dt_size;
+    root              = params.root;
+
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
 

--- a/test/mpi/test_scatter.cc
+++ b/test/mpi/test_scatter.cc
@@ -7,12 +7,11 @@
 #include "test_mpi.h"
 #include "mpi_util.h"
 
-#define TEST_DT UCC_DT_UINT32
-
 TestScatter::TestScatter(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_SCATTER, params)
 {
-    size_t dt_size           = ucc_dt_size(TEST_DT);
+    dt                       = params.dt;
+    size_t dt_size           = ucc_dt_size(dt);
     size_t single_rank_count = msgsize / dt_size;
     int    rank, size;
 
@@ -48,18 +47,18 @@ TestScatter::TestScatter(ucc_test_team_t &_team, TestCaseParams &params) :
     if (rank == root) {
         args.src.info.buffer   = sbuf;
         args.src.info.count    = single_rank_count * size;
-        args.src.info.datatype = TEST_DT;
+        args.src.info.datatype = dt;
         args.src.info.mem_type = mem_type;
         if (!inplace) {
             args.dst.info.buffer   = rbuf;
             args.dst.info.count    = single_rank_count;
-            args.dst.info.datatype = TEST_DT;
+            args.dst.info.datatype = dt;
             args.dst.info.mem_type = mem_type;
         }
     } else {
         args.dst.info.buffer   = rbuf;
         args.dst.info.count    = single_rank_count;
-        args.dst.info.datatype = TEST_DT;
+        args.dst.info.datatype = dt;
         args.dst.info.mem_type = mem_type;
     }
 
@@ -69,7 +68,7 @@ TestScatter::TestScatter(ucc_test_team_t &_team, TestCaseParams &params) :
 
 ucc_status_t TestScatter::set_input(int iter_persistent)
 {
-    size_t dt_size           = ucc_dt_size(TEST_DT);
+    size_t dt_size           = ucc_dt_size(dt);
     size_t single_rank_count = msgsize / dt_size;
     size_t single_rank_size  = single_rank_count * dt_size;
     int    rank, size;
@@ -78,7 +77,7 @@ ucc_status_t TestScatter::set_input(int iter_persistent)
     MPI_Comm_size(team.comm, &size);
 
     if (rank == root) {
-        init_buffer(sbuf, single_rank_count * size, TEST_DT, mem_type,
+        init_buffer(sbuf, single_rank_count * size, dt, mem_type,
                     rank * (iter_persistent + 1));
         UCC_CHECK(ucc_mc_memcpy(check_buf, sbuf, single_rank_size * size,
                                 UCC_MEMORY_TYPE_HOST, mem_type));
@@ -88,17 +87,17 @@ ucc_status_t TestScatter::set_input(int iter_persistent)
 
 ucc_status_t TestScatter::check()
 {
-    size_t        single_rank_count = msgsize / ucc_dt_size(TEST_DT);
-    size_t        single_rank_size  = single_rank_count * ucc_dt_size(TEST_DT);
-    MPI_Datatype  dt                = ucc_dt_to_mpi(TEST_DT);
+    size_t        single_rank_count = msgsize / ucc_dt_size(dt);
+    size_t        single_rank_size  = single_rank_count * ucc_dt_size(dt);
+    MPI_Datatype  mpi_dt            = ucc_dt_to_mpi(dt);
     MPI_Request   req;
     int           size, rank, completed;
     MPI_Comm_size(team.comm, &size);
     MPI_Comm_rank(team.comm, &rank);
 
-    MPI_Iscatter(check_buf, single_rank_count, dt,
-                (rank == root) ? MPI_IN_PLACE : check_buf, single_rank_count,
-                 dt, root, team.comm, &req);
+    MPI_Iscatter(check_buf, single_rank_count, mpi_dt,
+                 (rank == root) ? MPI_IN_PLACE : check_buf, single_rank_count,
+                 mpi_dt, root, team.comm, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         ucc_context_progress(team.ctx);
@@ -107,15 +106,14 @@ ucc_status_t TestScatter::check()
     if (rank == root) {
         if (inplace) {
             return compare_buffers(sbuf, check_buf, single_rank_count * size,
-                                   TEST_DT, mem_type);
+                                   dt, mem_type);
         } else {
-            return compare_buffers(rbuf,
-                                   PTR_OFFSET(check_buf, single_rank_size * rank),
-                                   single_rank_count, TEST_DT,
-                                   mem_type);
+            return compare_buffers(
+                rbuf, PTR_OFFSET(check_buf, single_rank_size * rank),
+                single_rank_count, dt, mem_type);
         }
     } else {
-        return compare_buffers(rbuf, check_buf, single_rank_count, TEST_DT,
+        return compare_buffers(rbuf, check_buf, single_rank_count, dt,
                                mem_type);
     }
 }

--- a/test/mpi/test_scatterv.cc
+++ b/test/mpi/test_scatterv.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -34,14 +34,16 @@ static void fill_counts_and_displacements(int size, int count,
 TestScatterv::TestScatterv(ucc_test_team_t &_team, TestCaseParams &params) :
     TestCase(_team, UCC_COLL_TYPE_SCATTERV, params)
 {
-    dt             = params.dt;
-    size_t dt_size = ucc_dt_size(dt);
-    size_t count   = msgsize / dt_size;
     int    rank, size;
+    size_t dt_size, count;
 
+    dt            = params.dt;
+    dt_size       = ucc_dt_size(dt);
+    count         = msgsize / dt_size;
     root          = params.root;
     counts        = NULL;
     displacements = NULL;
+
     MPI_Comm_rank(team.comm, &rank);
     MPI_Comm_size(team.comm, &size);
 


### PR DESCRIPTION
## What
Add datatypes for non-reduction collectives in mpi_test


## Why
This patch is necessary for testing different datatype as the user would do, even if the collectives do not involve reduction