### PR TITLE
TL/CUDA: use pci bdf to build topo

### DIFF
--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -124,7 +124,6 @@ typedef struct ucc_tl_cuda_mem_info {
 } ucc_tl_cuda_mem_info_t;
 
 typedef struct ucc_tl_cuda_rank_id {
-    int                         device;
     ucc_tl_cuda_device_pci_id_t pci_id;
     ucc_tl_cuda_mem_info_t      scratch_info;
     int                         shm;

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -106,7 +106,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
         }
     }
 ids_exchange:
-    self->ids[UCC_TL_TEAM_SIZE(self)].device = ctx->device;
     self->ids[UCC_TL_TEAM_SIZE(self)].pci_id = ctx->device_id;
     self->ids[UCC_TL_TEAM_SIZE(self)].shm    = shm_id;
     status = self->oob.allgather(&self->ids[UCC_TL_TEAM_SIZE(self)], self->ids,

--- a/src/components/tl/cuda/tl_cuda_topo.h
+++ b/src/components/tl/cuda/tl_cuda_topo.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -9,6 +9,8 @@
 
 #include "components/tl/ucc_tl_log.h"
 #include "utils/khash.h"
+
+#define MAX_PCI_BUS_ID_STR 16
 
 typedef struct ucc_tl_cuda_device_id {
     uint16_t domain;   /* range: 0 to ffff */
@@ -67,4 +69,6 @@ ucc_status_t ucc_tl_cuda_topo_num_links(const ucc_tl_cuda_topo_t *topo,
                                         const ucc_tl_cuda_device_pci_id_t *dev2,
                                         ucc_rank_t *num_links);
 
+void ucc_tl_cuda_topo_pci_id_to_str(const ucc_tl_cuda_device_pci_id_t *pci_id,
+                                    char *str, size_t max);
 #endif


### PR DESCRIPTION
## What
Use GPU PCI address instead of GPU ID to collect topology information in TL/CUDA

## Why ?
GPU ID (from cudaGetDevice() )  is not guaranteed to be unique within single node, for instance if user sets CUDA_VISIBLE_DEVICES=$OMPI_COMM_WORLD_LOCAL_RANK every rank will see one GPU with ID 0. 
