### PR TITLE
BUILD: remove unnecessary flag

### DIFF
--- a/config/m4/rccl.m4
+++ b/config/m4/rccl.m4
@@ -91,7 +91,7 @@ AS_IF([test "x$rccl_checked" != "xyes"],[
             ])
         ])
 
-        CFLAGS="$save_CFLAGS -D__HIP_PLATFORM_AMD__"
+        CFLAGS="$save_CFLAGS"
         CPPFLAGS="$save_CPPFLAGS"
         LDFLAGS="$save_LDFLAGS"
     ],


### PR DESCRIPTION
## What
Return flags to previous state after exit from RCCL.m4 

## Why ?
Currently flag __HIP_PLATFORM_AMD__ is propagated to almost every component compile command even if component is not related to HIP.
