### PR TITLE
API: extend mem_map structure

### DIFF
--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -868,13 +868,34 @@ typedef struct ucc_oob_coll {
 typedef ucc_oob_coll_t ucc_context_oob_coll_t;
 typedef ucc_oob_coll_t ucc_team_oob_coll_t;
 
+enum {
+    UCC_MEM_MAP_FIELD_KEY      = UCC_BIT(0),
+    UCC_MEM_MAP_FIELD_MEM_TYPE = UCC_BIT(1),
+};
+
+typedef enum {
+    UCC_KEY_TYPE_MKEY,
+    UCC_KEY_TYPE_MEMH,
+} ucc_key_type_t;
+
+typedef struct ucc_rma_key {
+    void          *key;
+    size_t         key_len;
+    ucc_key_type_t key_type;
+} ucc_rma_key_t;
+
 /**
  *
  *  @ingroup UCC_CONTEXT_DT
  */
 typedef struct ucc_mem_map {
-    void *   address; /*!< the address of a buffer to be attached to a UCC context */
-    size_t   len;     /*!< the length of the buffer */
+    uint64_t mask;
+    void    *address; /*!< The address of a buffer to be attached to a UCC
+                           context */
+    size_t            len; /*!< The length of the buffer */
+    ucc_rma_key_t     key[2]; /*!< Memory keys or handles associated with
+                                   this buffer */
+    ucc_memory_type_t mem_type; /*!< The type of memory */
 } ucc_mem_map_t;
 
 /**


### PR DESCRIPTION
## What
Extends the ucc_mem_map_t structure to add support for associating memory keys/handles and memory types with a particular map. This PR retains backwards compatibility with the previous version.

## Why ?
Enables the ability to potentially remove the required ucp_mem_map operation for one-sided communication, which will improve initialization time.

