### PR TITLE
EC/CUDA: remove if constexpr

### DIFF
--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -84,7 +84,7 @@ cuFloatComplex operator* (const cuFloatComplex & first,
                 }                                                              \
                 _Pragma("unroll") for (i = 0; i < unroll; i++)                 \
                 {                                                              \
-                    if constexpr (strided) {                                   \
+                    if (strided) {                                             \
                         tmp2[i] = s2[line + warp_size * i + j * ld];           \
                     } else {                                                   \
                         tmp2[i] = s[1 + j][line + warp_size * i];              \
@@ -126,19 +126,24 @@ cuFloatComplex operator* (const cuFloatComplex & first,
         __shared__ uint16_t n_src2;                                              \
         size_t              ld;                                                  \
         size_t              i, j, line;                                          \
-        if constexpr (strided) {                                                 \
-            n_src2 = task.n_src2;                                                \
-            s1     = (_Type *)task.src1;                                         \
-            s2     = (_Type *)task.src2;                                         \
-            ld     = task.stride / sizeof(_Type);                                \
-            ucc_assert_system(task.stride % sizeof(_Type) == 0);                 \
+        if (strided) {                                                           \
+            auto task_strided_p =                                                \
+                    reinterpret_cast<ucc_eee_task_reduce_strided_t*>(&task);     \
+            n_src2 = task_strided_p->n_src2;                                     \
+            s1     = (_Type *)task_strided_p->src1;                              \
+            s2     = (_Type *)task_strided_p->src2;                              \
+            ld     = task_strided_p->stride / sizeof(_Type);                     \
+            ucc_assert_system(task_strided_p->stride % sizeof(_Type) == 0);      \
         } else {                                                                 \
-            memcpy(s, task.srcs, UCC_EE_EXECUTOR_NUM_BUFS * sizeof(_Type *));    \
-            n_src2 = task.n_srcs - 1;                                            \
+            auto task_default_p =                                                \
+                        reinterpret_cast<ucc_eee_task_reduce_t*>(&task);         \
+            memcpy(s, task_default_p->srcs,                                      \
+                                    UCC_EE_EXECUTOR_NUM_BUFS * sizeof(_Type *)); \
+            n_src2 = task_default_p->n_srcs - 1;                                 \
             s1     = s[0];                                                       \
         }                                                                        \
         CUDA_REDUCE_WITH_OP_CHUNK(0, UNROLL, WARP_SIZE, _OP);                    \
-        /* second call for data remainder */\
+        /* second call for data remainder */                                     \
         CUDA_REDUCE_WITH_OP_CHUNK(                                               \
             (count / (WARP_SIZE * UNROLL)) * (WARP_SIZE * UNROLL), 1, 1, _OP);   \
     }                                                                            \

--- a/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_reduce_ops.h
@@ -115,11 +115,11 @@ cuFloatComplex operator* (const cuFloatComplex & first,
     {                                                                            \
         _Type *        d     = (_Type *)task.dst;                                \
         const size_t   count = task.count;                                       \
-        constexpr bool strided =                                                 \
+        const bool strided =                                                     \
             std::is_same<_TaskType, ucc_eee_task_reduce_strided_t>::value;       \
-        constexpr int MAXSRCS =                                                  \
+        const int MAXSRCS =                                                      \
             strided ? USHRT_MAX : UCC_EE_EXECUTOR_NUM_BUFS;                      \
-        constexpr int       ALLOC_SIZE = strided ? 1 : UCC_EE_EXECUTOR_NUM_BUFS; \
+        const int       ALLOC_SIZE = strided ? 1 : UCC_EE_EXECUTOR_NUM_BUFS;     \
         _Type *             s[ALLOC_SIZE];                                       \
         _Type *             s1;                                                  \
         _Type *             s2;                                                  \


### PR DESCRIPTION
## What
remove "if constexpr" statements
No perf degradation, see graphs below

## Why ?
causes a linter warning
```
warning #2912-D: constexpr if statements are a C++17 feature
```

![reducedt_float32_a100_plot](https://user-images.githubusercontent.com/17732757/214555932-faa20c43-8c10-4c96-95ff-e00065a74b47.png)
![reducedt_float32-T_a100_plot](https://user-images.githubusercontent.com/17732757/214555943-9bb1bea5-beba-4eda-bb99-a48a77734d6c.png)
![reducedt_float64_a100_plot](https://user-images.githubusercontent.com/17732757/214555947-669684e0-fb1e-4085-8df4-f12093a9523a.png)
![reducedt_float64-T_a100_plot](https://user-images.githubusercontent.com/17732757/214555948-bef144d3-2ea2-4a39-9156-807022af4d25.png)
![reducedt_int32_a100_plot](https://user-images.githubusercontent.com/17732757/214555950-57cec82a-7d4d-44a2-b085-cacf4d002a0e.png)
![reducedt_int32-T_a100_plot](https://user-images.githubusercontent.com/17732757/214555951-00dd3269-efe8-4a88-89df-1c3b84107045.png)
![reducedt_strided_float32_a100_plot](https://user-images.githubusercontent.com/17732757/214555953-4f4e83aa-81b5-45d0-8f93-c018c84ff9b5.png)
![reducedt_strided_float32-T_a100_plot](https://user-images.githubusercontent.com/17732757/214555958-e4a23a15-a914-4f5d-bc5a-cf105ad4aacb.png)
![reducedt_strided_float64_a100_plot](https://user-images.githubusercontent.com/17732757/214555964-670398ea-6ec1-4b46-a74b-04b464f5922c.png)
![reducedt_strided_float64-T_a100_plot](https://user-images.githubusercontent.com/17732757/214555968-bbd9d9f7-62d0-4b0e-9578-851c05ab1f7f.png)
![reducedt_strided_int32_a100_plot](https://user-images.githubusercontent.com/17732757/214555973-241e0543-9e29-4be1-bc8f-831ffed4fad9.png)
![reducedt_strided_int32-T_a100_plot](https://user-images.githubusercontent.com/17732757/214555978-56c18467-8d34-4ee4-b574-68b34dbea04c.png)
