### PR TITLE
CORE: improve logging

### DIFF
--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -35,8 +35,8 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
         status = ucc_tl_context_get(params->context, tls->names[i],
                                    &self->super.tl_ctxs[self->super.n_tl_ctxs]);
         if (UCC_OK != status) {
-            cl_info(cl_config->cl_lib,
-                    "TL %s context is not available, skipping", tls->names[i]);
+            cl_debug(cl_config->cl_lib,
+                     "TL %s context is not available, skipping", tls->names[i]);
         } else {
             self->super.n_tl_ctxs++;
         }
@@ -47,14 +47,14 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_context_t,
         self->super.tl_ctxs = NULL;
         return UCC_ERR_NOT_FOUND;
     }
-    cl_info(cl_config->cl_lib, "initialized cl context: %p", self);
+    cl_debug(cl_config->cl_lib, "initialized cl context: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_context_t)
 {
     int i;
-    cl_info(self->super.super.lib, "finalizing cl context: %p", self);
+    cl_debug(self->super.super.lib, "finalizing cl context: %p", self);
     for (i = 0; i < self->super.n_tl_ctxs; i++) {
         ucc_tl_context_put(self->super.tl_ctxs[i]);
     }

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -17,13 +17,13 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_lib_t, const ucc_base_lib_params_t *params,
     const ucc_cl_lib_config_t *cl_config =
         ucc_derived_of(config, ucc_cl_lib_config_t);
     UCC_CLASS_CALL_SUPER_INIT(ucc_cl_lib_t, &ucc_cl_basic.super, cl_config);
-    cl_info(&self->super, "initialized lib object: %p", self);
+    cl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 {
-    cl_info(&self->super, "finalizing lib object: %p", self);
+    cl_debug(&self->super, "finalizing lib object: %p", self);
 }
 
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);

--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -49,7 +49,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_basic_team_t, ucc_base_context_t *cl_context,
                  status);
         goto err;
     }
-    cl_info(cl_context->lib, "posted cl team: %p", self);
+    cl_debug(cl_context->lib, "posted cl team: %p", self);
     return UCC_OK;
 err:
     ucc_free(self->tl_teams);
@@ -58,7 +58,7 @@ err:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_team_t)
 {
-    cl_info(self->super.super.context->lib, "finalizing cl team: %p", self);
+    cl_debug(self->super.super.context->lib, "finalizing cl team: %p", self);
 }
 
 UCC_CLASS_DEFINE_DELETE_FUNC(ucc_cl_basic_team_t, ucc_base_team_t);
@@ -117,13 +117,13 @@ ucc_status_t ucc_cl_basic_team_create_test(ucc_base_team_t *cl_team)
             if (team->team_create_req->descs[i].status == UCC_OK) {
                 team->tl_teams[team->n_tl_teams++] =
                     team->team_create_req->descs[i].team;
-                cl_info(ctx->super.super.lib, "initialized tl %s team",
-                        UCC_TL_CTX_IFACE(team->team_create_req->descs[i].ctx)->
-                        super.name);
+                cl_debug(ctx->super.super.lib, "initialized tl %s team",
+                         UCC_TL_CTX_IFACE(team->team_create_req->descs[i].ctx)->
+                         super.name);
             } else {
-                cl_info(ctx->super.super.lib, "failed to create tl %s team: (%d)",
-                        UCC_TL_CTX_IFACE(team->team_create_req->descs[i].ctx)->
-                        super.name, team->team_create_req->descs[i].status);
+                cl_debug(ctx->super.super.lib, "failed to create tl %s team: (%d)",
+                         UCC_TL_CTX_IFACE(team->team_create_req->descs[i].ctx)->
+                         super.name, team->team_create_req->descs[i].status);
             }
         }
         ucc_team_multiple_req_free(team->team_create_req);

--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -264,7 +264,7 @@ ucc_cl_hier_split_rail_allreduce_start(ucc_coll_task_t *task)
     ucc_schedule_pipelined_t *schedule =
         ucc_derived_of(task, ucc_schedule_pipelined_t);
 
-    cl_info(task->team->context->lib,
+    cl_debug(task->team->context->lib,
             "posting split_rail ar, sbuf %p, rbuf %p, count %zd, dt %s, op %s, "
             "inplace %d, pdepth %d, frags_total %d",
             task->bargs.args.src.info.buffer, task->bargs.args.dst.info.buffer,

--- a/src/components/cl/hier/cl_hier_context.c
+++ b/src/components/cl/hier/cl_hier_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -39,8 +39,8 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_context_t,
         status = ucc_tl_context_get(params->context, tls->names[i],
                                     &self->super.tl_ctxs[self->super.n_tl_ctxs]);
         if (UCC_OK != status) {
-            cl_info(cl_config->cl_lib,
-                    "TL %s context is not available, skipping", tls->names[i]);
+            cl_debug(cl_config->cl_lib,
+                     "TL %s context is not available, skipping", tls->names[i]);
         } else {
             self->super.n_tl_ctxs++;
         }
@@ -61,7 +61,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_context_t,
         goto out;
     }
 
-    cl_info(cl_config->cl_lib, "initialized cl context: %p", self);
+    cl_debug(cl_config->cl_lib, "initialized cl context: %p", self);
     return UCC_OK;
 
 out:
@@ -72,7 +72,7 @@ out:
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_hier_context_t)
 {
     int i;
-    cl_info(self->super.super.lib, "finalizing cl context: %p", self);
+    cl_debug(self->super.super.lib, "finalizing cl context: %p", self);
 
     ucc_mpool_cleanup(&self->sched_mp, 1);
     for (i = 0; i < self->super.n_tl_ctxs; i++) {

--- a/src/components/cl/hier/cl_hier_lib.c
+++ b/src/components/cl/hier/cl_hier_lib.c
@@ -50,7 +50,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_lib_t, const ucc_base_lib_params_t *params,
     self->tls.array.count = requested_sbgp_tls.count;
     self->tls.array.names = requested_sbgp_tls.names;
 
-    cl_info(&self->super, "initialized lib object: %p", self);
+    cl_debug(&self->super, "initialized lib object: %p", self);
     return status;
 }
 
@@ -58,7 +58,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_hier_lib_t)
 {
     int i;
 
-    cl_info(&self->super, "finalizing lib object: %p", self);
+    cl_debug(&self->super, "finalizing lib object: %p", self);
     for (i = 0; i < UCC_HIER_SBGP_LAST; i++) {
         ucc_config_names_array_free(&self->cfg.sbgp_tls[i].array);
     }

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -42,7 +42,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
     ucc_subset_t               subset;
     struct ucc_team_team_desc *d;
     if (!params->team->topo) {
-        cl_info(cl_context->lib,
+        cl_debug(cl_context->lib,
                 "can't create hier team without topology data");
         return UCC_ERR_INVALID_PARAM;
     }
@@ -139,7 +139,7 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
         cl_error(cl_context->lib, "failed to post tl team create (%d)", status);
         goto err;
     }
-    cl_info(cl_context->lib, "posted cl team: %p", self);
+    cl_debug(cl_context->lib, "posted cl team: %p", self);
     return UCC_OK;
 err:
     ucc_team_multiple_req_free(self->team_create_req);
@@ -148,7 +148,7 @@ err:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_cl_hier_team_t)
 {
-    cl_info(self->super.super.context->lib, "finalizing cl team: %p", self);
+    cl_debug(self->super.super.context->lib, "finalizing cl team: %p", self);
 }
 
 UCC_CLASS_DEFINE_DELETE_FUNC(ucc_cl_hier_team_t, ucc_base_team_t);
@@ -256,9 +256,9 @@ ucc_status_t ucc_cl_hier_team_create_test(ucc_base_team_t *cl_team)
                     hs->score = score_merge;
                 }
             }
-            cl_info(ctx->super.super.lib, "initialized tl %s team for sbgp %s",
-                    UCC_TL_CTX_IFACE(d->ctx)->super.name,
-                    ucc_sbgp_str(hs->sbgp_type));
+            cl_debug(ctx->super.super.lib, "initialized tl %s team for sbgp %s",
+                     UCC_TL_CTX_IFACE(d->ctx)->super.name,
+                     ucc_sbgp_str(hs->sbgp_type));
         } else {
             cl_debug(ctx->super.super.lib, "failed to create tl %s team",
                      UCC_TL_CTX_IFACE(d->ctx)->super.name);

--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -185,7 +185,7 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
     ucc_ec_cuda.thread_mode = ec_params->thread_mode;
     cuda_st = cudaGetDeviceCount(&num_devices);
     if ((cuda_st != cudaSuccess) || (num_devices == 0)) {
-        ec_info(&ucc_ec_cuda.super, "CUDA devices are not found");
+        ec_debug(&ucc_ec_cuda.super, "CUDA devices are not found");
         return UCC_ERR_NO_RESOURCE;
     }
     CUDA_CHECK(cudaGetDevice(&device));
@@ -283,8 +283,8 @@ static ucc_status_t ucc_ec_cuda_init(const ucc_ec_params_t *ec_params)
 
         if (cfg->strm_task_mode == UCC_EC_CUDA_TASK_AUTO) {
             if (attr == 0) {
-                ec_info(&ucc_ec_cuda.super,
-                        "CUDA MEM OPS are not supported or disabled");
+                ec_debug(&ucc_ec_cuda.super,
+                         "CUDA MEM OPS are not supported or disabled");
                 ucc_ec_cuda.strm_task_mode = UCC_EC_CUDA_TASK_KERNEL;
             }
         } else if (attr == 0) {

--- a/src/components/ec/rocm/ec_rocm.c
+++ b/src/components/ec/rocm/ec_rocm.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -156,7 +156,7 @@ static ucc_status_t ucc_ec_rocm_init(const ucc_ec_params_t *ec_params)
     ucc_ec_rocm.thread_mode = ec_params->thread_mode;
     rocm_st = hipGetDeviceCount(&num_devices);
     if ((rocm_st != hipSuccess) || (num_devices == 0)) {
-        ec_info(&ucc_ec_rocm.super, "rocm devices are not found");
+        ec_debug(&ucc_ec_rocm.super, "rocm devices are not found");
         return UCC_ERR_NO_RESOURCE;
     }
     ROCMCHECK(hipGetDevice(&device));

--- a/src/components/ec/ucc_ec.c
+++ b/src/components/ec/ucc_ec.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -43,15 +43,15 @@ ucc_status_t ucc_ec_init(const ucc_ec_params_t *ec_params)
             status = ucc_config_parser_fill_opts(
                 ec->config, &ec->config_table, "UCC_", 1);
             if (UCC_OK != status) {
-                ucc_info("failed to parse config for EC component: %s (%d)",
-                         ec->super.name, status);
+                ucc_debug("failed to parse config for EC component: %s (%d)",
+                          ec->super.name, status);
                 ucc_free(ec->config);
                 continue;
             }
             status = ec->init(ec_params);
             if (UCC_OK != status) {
-                ucc_info("ec_init failed for component: %s, skipping (%d)",
-                         ec->super.name, status);
+                ucc_debug("ec_init failed for component: %s, skipping (%d)",
+                          ec->super.name, status);
                 ucc_config_parser_release_opts(ec->config,
                                                ec->config_table.table);
                 ucc_free(ec->config);

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -58,7 +58,7 @@ static ucc_status_t ucc_mc_cuda_init(const ucc_mc_params_t *mc_params)
     ucc_mc_cuda.thread_mode = mc_params->thread_mode;
     cuda_st = cudaGetDeviceCount(&num_devices);
     if ((cuda_st != cudaSuccess) || (num_devices == 0)) {
-        mc_info(&ucc_mc_cuda.super, "cuda devices are not found");
+        mc_debug(&ucc_mc_cuda.super, "cuda devices are not found");
         return UCC_ERR_NO_RESOURCE;
     }
     CUDADRV_FUNC(cuDriverGetVersion(&driver_ver));

--- a/src/components/mc/rocm/mc_rocm.c
+++ b/src/components/mc/rocm/mc_rocm.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -40,7 +40,7 @@ static ucc_status_t ucc_mc_rocm_init(const ucc_mc_params_t *mc_params)
     ucc_mc_rocm.thread_mode = mc_params->thread_mode;
     rocm_st = hipGetDeviceCount(&num_devices);
     if ((rocm_st != hipSuccess) || (num_devices == 0)) {
-        mc_info(&ucc_mc_rocm.super, "rocm devices are not found");
+        mc_debug(&ucc_mc_rocm.super, "rocm devices are not found");
         return hip_error_to_ucc_status(rocm_st);
     }
 

--- a/src/components/mc/ucc_mc.c
+++ b/src/components/mc/ucc_mc.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -50,15 +50,15 @@ ucc_status_t ucc_mc_init(const ucc_mc_params_t *mc_params)
             status = ucc_config_parser_fill_opts(
                 mc->config, &mc->config_table, "UCC_", 1);
             if (UCC_OK != status) {
-                ucc_info("failed to parse config for mc: %s (%d)",
-                         mc->super.name, status);
+                ucc_debug("failed to parse config for mc: %s (%d)",
+                          mc->super.name, status);
                 ucc_free(mc->config);
                 continue;
             }
             status = mc->init(mc_params);
             if (UCC_OK != status) {
-                ucc_info("mc_init failed for component: %s, skipping (%d)",
-                         mc->super.name, status);
+                ucc_debug("mc_init failed for component: %s, skipping (%d)",
+                          mc->super.name, status);
                 ucc_config_parser_release_opts(mc->config,
                                                mc->config_table.table);
                 ucc_free(mc->config);

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -29,18 +29,18 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
 
     cuda_st = cudaGetDeviceCount(&num_devices);
     if (cuda_st != cudaSuccess) {
-        tl_info(self->super.super.lib, "failed to get number of GPU devices"
-                "%d %s", cuda_st, cudaGetErrorName(cuda_st));
-        return UCC_ERR_NO_MESSAGE;
+        tl_debug(self->super.super.lib, "failed to get number of GPU devices"
+                 "%d %s", cuda_st, cudaGetErrorName(cuda_st));
+        return UCC_ERR_NO_RESOURCE;
     } else if (num_devices == 0) {
-        tl_info(self->super.super.lib, "no GPU devices found");
+        tl_debug(self->super.super.lib, "no GPU devices found");
         return UCC_ERR_NO_RESOURCE;
     }
 
     cu_st = cuCtxGetCurrent(&cu_ctx);
     if (cu_ctx == NULL || cu_st != CUDA_SUCCESS) {
-        tl_info(self->super.super.lib,
-                "cannot create CUDA TL context without active CUDA context");
+        tl_debug(self->super.super.lib,
+                 "cannot create CUDA TL context without active CUDA context");
         return UCC_ERR_NO_RESOURCE;
     }
 
@@ -68,7 +68,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
     }
 
     self->ipc_cache = kh_init(tl_cuda_ep_hash);
-    tl_info(self->super.super.lib, "initialized tl context: %p", self);
+    tl_debug(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 
 free_mpool:
@@ -78,7 +78,7 @@ free_mpool:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_context_t)
 {
-    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
     ucc_tl_cuda_topo_destroy(self->topo);
     ucc_mpool_cleanup(&self->req_mp, 1);
 }

--- a/src/components/tl/cuda/tl_cuda_lib.c
+++ b/src/components/tl/cuda/tl_cuda_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -32,13 +32,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *params,
     if (self->cfg.scratch_size < min_scratch_size) {
         self->cfg.scratch_size = min_scratch_size;
     }
-    tl_info(&self->super, "initialized lib object: %p", self);
+    tl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_lib_t)
 {
-    tl_info(&self->super, "finalizing lib object: %p", self);
+    tl_debug(&self->super, "finalizing lib object: %p", self);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_cuda_lib_t, ucc_tl_lib_t);

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -34,7 +34,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
     self->scratch.loc = NULL;
 
     if (!ucc_team_map_is_single_node(params->team, params->map)) {
-        tl_info(tl_context->lib, "multinode team is not supported");
+        tl_debug(tl_context->lib, "multinode team is not supported");
         return UCC_ERR_NOT_SUPPORTED;
     }
 
@@ -106,7 +106,7 @@ ids_exchange:
         tl_error(tl_context->lib, "failed to start oob allgather");
         goto free_devices;
     }
-    tl_info(tl_context->lib, "posted tl team: %p", self);
+    tl_debug(tl_context->lib, "posted tl team: %p", self);
 
     self->seq_num = 1;
     return UCC_OK;
@@ -131,7 +131,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_team_t)
     cudaError_t st;
     int i, j;
 
-    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    tl_debug(self->super.super.context->lib, "finalizing tl team: %p", self);
     if (self->topo) {
         ucc_tl_cuda_team_topo_destroy(self->topo);
     }
@@ -311,7 +311,7 @@ barrier:
         }
     }
     team->oob_req = NULL;
-    tl_info(tl_team->context->lib, "initialized tl team: %p", team);
+    tl_debug(tl_team->context->lib, "initialized tl team: %p", team);
     return UCC_OK;
 
 exit_err:

--- a/src/components/tl/cuda/tl_cuda_team_topo.c
+++ b/src/components/tl/cuda/tl_cuda_team_topo.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -166,7 +166,7 @@ ucc_tl_cuda_team_topo_init_rings(const ucc_tl_cuda_team_t *team,
 
     if (num_rings == 0) {
         status = UCC_ERR_NOT_SUPPORTED;
-        tl_info(UCC_TL_TEAM_LIB(team), "no rings found");
+        tl_debug(UCC_TL_TEAM_LIB(team), "no rings found");
         goto free_graph;
     }
 
@@ -308,9 +308,9 @@ ucc_tl_cuda_team_topo_init_proxies(const ucc_tl_cuda_team_t *team,
                                                 pci_str[0], MAX_PCI_BUS_ID_STR);
                 ucc_tl_cuda_topo_pci_id_to_str(&team->ids[j].pci_id,
                                                 pci_str[1], MAX_PCI_BUS_ID_STR);
-                tl_info(UCC_TL_TEAM_LIB(team), "no proxy found between "
-                        "dev %s (%d) and dev %s (%d), "
-                        "cuda topology is not supported",
+                tl_debug(UCC_TL_TEAM_LIB(team), "no proxy found between "
+                         "dev %s (%d) and dev %s (%d), "
+                         "cuda topology is not supported",
                         pci_str[0], i, pci_str[j], j);
                 status = UCC_ERR_NOT_SUPPORTED;
                 goto free_data;

--- a/src/components/tl/cuda/tl_cuda_topo.c
+++ b/src/components/tl/cuda/tl_cuda_topo.c
@@ -225,20 +225,21 @@ static ucc_status_t ucc_tl_cuda_topo_graph_create(ucc_tl_cuda_topo_t *topo)
 
     nvml_st = nvmlInit_v2();
     if (nvml_st != NVML_SUCCESS) {
-        tl_info(topo->lib, "failed to init NVML: %s", nvmlErrorString(nvml_st));
+        tl_debug(topo->lib, "failed to init NVML: %s",
+                 nvmlErrorString(nvml_st));
         return UCC_ERR_NO_MESSAGE;
     }
 
     nvml_st = nvmlDeviceGetCount(&num_gpus);
     if (nvml_st != NVML_SUCCESS) {
-        tl_info(topo->lib, "nvmlDeviceGetCount failed: %s",
-                nvmlErrorString(nvml_st));
+        tl_debug(topo->lib, "nvmlDeviceGetCount failed: %s",
+                 nvmlErrorString(nvml_st));
         status = UCC_ERR_NO_RESOURCE;
         goto exit_nvml_shutdown;
     }
 
     if (num_gpus == 0) {
-        tl_info(topo->lib, "no GPU devices found");
+        tl_debug(topo->lib, "no GPU devices found");
         status = UCC_ERR_NO_RESOURCE;
         goto exit_nvml_shutdown;
     }
@@ -278,7 +279,7 @@ static ucc_status_t ucc_tl_cuda_topo_graph_create(ucc_tl_cuda_topo_t *topo)
             status = ucc_tl_cuda_topo_get_remote_dev_type(topo, nvml_dev, link,
                                                           &dev_type);
             if (status != UCC_OK) {
-                tl_info(topo->lib, "failed to get remote device type");
+                tl_debug(topo->lib, "failed to get remote device type");
                 goto exit_free_graph;
             }
             if (dev_type == UCC_TL_CUDA_TOPO_DEV_TYPE_LAST) {

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -36,7 +36,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
         goto err_mpool;
     }
 
-    tl_info(self->super.super.lib, "initialized tl context: %p", self);
+    tl_debug(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 
 err_mpool:
@@ -45,7 +45,7 @@ err_mpool:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_context_t)
 {
-    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_mlx5_context_t, ucc_tl_context_t);

--- a/src/components/tl/mlx5/tl_mlx5_lib.c
+++ b/src/components/tl/mlx5/tl_mlx5_lib.c
@@ -16,13 +16,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_lib_t, const ucc_base_lib_params_t *params,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_mlx5.super,
                               &tl_mlx5_config->super);
     memcpy(&self->cfg, tl_mlx5_config, sizeof(*tl_mlx5_config));
-    tl_info(&self->super, "initialized lib object: %p", self);
+    tl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_lib_t)
 {
-    tl_info(&self->super, "finalizing lib object: %p", self);
+    tl_debug(&self->super, "finalizing lib object: %p", self);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_mlx5_lib_t, ucc_tl_lib_t);

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -25,7 +25,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_team_t, ucc_base_context_t *tl_context,
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_team_t)
 {
-    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    tl_debug(self->super.super.context->lib, "finalizing tl team: %p", self);
 }
 
 UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_mlx5_team_t, ucc_base_team_t);

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -183,7 +183,7 @@ ucc_status_t ucc_tl_nccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
 
     ucc_assert(ee->ee_type == UCC_EE_CUDA_STREAM);
     coll_task->ee = ee;
-    tl_info(UCC_TASK_LIB(task), "triggered post. task:%p", coll_task);
+    tl_debug(UCC_TASK_LIB(task), "triggered post. task:%p", coll_task);
     status = coll_task->post(coll_task);
     if (ucc_likely(status == UCC_OK)) {
         post_event.ev_type         = UCC_EVENT_COLLECTIVE_POST;
@@ -205,7 +205,7 @@ ucc_status_t ucc_tl_nccl_coll_finalize(ucc_coll_task_t *coll_task)
     if (ucc_unlikely(task->super.super.status != UCC_OK)) {
         team->comm_state = task->super.super.status;
     }
-    tl_info(UCC_TASK_LIB(task), "finalizing coll task %p", task);
+    tl_debug(UCC_TASK_LIB(task), "finalizing coll task %p", task);
     ucc_tl_nccl_free_task(task);
     return status;
 }

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Facebook, Inc. and its affiliates. 2021.
  *
  * See file LICENSE for terms.
@@ -123,7 +123,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
                                         CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS,
                                         cu_dev);
         } else {
-            tl_info(self->super.super.lib, "failed to get cuda device");
+            tl_debug(self->super.super.lib, "failed to get cuda device");
         }
 #else
         mem_ops_attr = 1;
@@ -133,7 +133,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
                 tl_error(self->super.super.lib, "memops not supported");
                 return UCC_ERR_NOT_SUPPORTED;
             }
-            tl_info(self->super.super.lib, "fallback to event completion sync");
+            tl_debug(self->super.super.lib, "fallback to event completion sync");
             self->cfg.sync_type = UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT;
         } else {
             self->cfg.sync_type = UCC_TL_NCCL_COMPLETION_SYNC_TYPE_MEMOPS;
@@ -142,13 +142,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
     ucc_assert(self->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_MEMOPS ||
                self->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_EVENT);
     if (self->cfg.sync_type == UCC_TL_NCCL_COMPLETION_SYNC_TYPE_MEMOPS) {
-        tl_info(self->super.super.lib, "using memops completion sync");
+        tl_debug(self->super.super.lib, "using memops completion sync");
         status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_nccl_task_t), 0,
                                 UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
                                 &ucc_tl_nccl_req_mapped_mpool_ops,
                                 params->thread_mode, "tl_nccl_req_mp");
     } else {
-        tl_info(self->super.super.lib, "using event completion sync");
+        tl_debug(self->super.super.lib, "using event completion sync");
         status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_nccl_task_t), 0,
                                 UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
                                 &ucc_tl_nccl_req_mpool_ops, params->thread_mode,
@@ -165,13 +165,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
     if (cuda_st != cudaSuccess) {
         return UCC_ERR_NO_MEMORY;
     }
-    tl_info(self->super.super.lib, "initialized tl context: %p", self);
+    tl_debug(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_context_t)
 {
-    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
     ucc_mpool_cleanup(&self->req_mp, 1);
     cudaFree(self->scratch_buf);
     self->scratch_buf = NULL;

--- a/src/components/tl/nccl/tl_nccl_lib.c
+++ b/src/components/tl/nccl/tl_nccl_lib.c
@@ -13,13 +13,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_lib_t, const ucc_base_lib_params_t *params,
     const ucc_tl_lib_config_t *tl_config =
         ucc_derived_of(config, ucc_tl_lib_config_t);
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_nccl.super, tl_config);
-    tl_info(&self->super, "initialized lib object: %p", self);
+    tl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_lib_t)
 {
-    tl_info(&self->super, "finalizing lib object: %p", self);
+    tl_debug(&self->super, "finalizing lib object: %p", self);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_nccl_lib_t, ucc_tl_lib_t);

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Facebook, Inc. and its affiliates. 2021.
  *
  * See file LICENSE for terms.
@@ -56,7 +56,7 @@ free_unique_id:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_team_t)
 {
-    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    tl_debug(self->super.super.context->lib, "finalizing tl team: %p", self);
     if (self->nccl_comm) {
         if (self->comm_state != UCC_OK) {
             /* if communication error was detected ncclCommAbort should be used
@@ -111,13 +111,13 @@ ucc_status_t ucc_tl_nccl_team_create_test(ucc_base_team_t *tl_team)
     nccl_status = ncclCommInitRank(&team->nccl_comm, UCC_TL_TEAM_SIZE(team),
                                    team->unique_id[0], UCC_TL_TEAM_RANK(team));
     if (nccl_status != ncclSuccess) {
-        tl_info(tl_team->context->lib, "NCCL error %d %s",
+        tl_debug(tl_team->context->lib, "NCCL error %d %s",
                 nccl_status, ncclGetErrorString(nccl_status));
         status = UCC_ERR_NO_MESSAGE;
         goto free_stream;
     }
     ucc_free(team->unique_id);
-    tl_info(tl_team->context->lib, "initialized tl team: %p", team);
+    tl_debug(tl_team->context->lib, "initialized tl team: %p", team);
     return UCC_OK;
 
 free_stream:
@@ -189,7 +189,7 @@ ucc_status_t ucc_tl_nccl_coll_init(ucc_base_coll_args_t *coll_args,
     if (ucc_unlikely(status != UCC_OK)) {
         goto free_task;
     }
-    tl_info(UCC_TASK_LIB(task), "init coll task %p", task);
+    tl_debug(UCC_TASK_LIB(task), "init coll task %p", task);
     *task_h = &task->super;
     return status;
 

--- a/src/components/tl/rccl/tl_rccl_coll.c
+++ b/src/components/tl/rccl/tl_rccl_coll.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Facebook, Inc. and its affiliates. 2021.
  # Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
  *
@@ -127,7 +127,7 @@ ucc_status_t ucc_tl_rccl_triggered_post(ucc_ee_h ee, ucc_ev_t *ev, //NOLINT: ev 
 
     ucc_assert(ee->ee_type == UCC_EE_ROCM_STREAM);
     coll_task->ee = ee;
-    tl_info(UCC_TASK_LIB(task), "triggered post. task:%p", coll_task);
+    tl_debug(UCC_TASK_LIB(task), "triggered post. task:%p", coll_task);
 
     status = coll_task->post(coll_task);
     if (ucc_likely(status == UCC_OK)) {
@@ -152,7 +152,7 @@ ucc_status_t ucc_tl_rccl_coll_finalize(ucc_coll_task_t *coll_task)
     ucc_tl_rccl_task_t *task  = ucc_derived_of(coll_task, ucc_tl_rccl_task_t);
     ucc_status_t       status = UCC_OK ;
 
-    tl_info(UCC_TASK_LIB(task), "finalizing coll task %p", task);
+    tl_debug(UCC_TASK_LIB(task), "finalizing coll task %p", task);
     ucc_tl_rccl_free_task(task);
     return status;
 }
@@ -617,7 +617,7 @@ ucc_status_t ucc_tl_rccl_gather_start(ucc_coll_task_t *coll_task)
         ucc_dt = args->dst.info.datatype;
         count  = args->dst.info.count / UCC_TL_TEAM_SIZE(team);
         if (UCC_IS_INPLACE(*args)) {
-            src = PTR_OFFSET(dst, UCC_TL_TEAM_RANK(team) * count 
+            src = PTR_OFFSET(dst, UCC_TL_TEAM_RANK(team) * count
                              * ucc_dt_size(args->dst.info.datatype));
         }
     }

--- a/src/components/tl/rccl/tl_rccl_context.c
+++ b/src/components/tl/rccl/tl_rccl_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Facebook, Inc. and its affiliates. 2021.
  * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
  *
@@ -79,12 +79,12 @@ UCC_CLASS_INIT_FUNC(ucc_tl_rccl_context_t,
     }
 
     if (self->cfg.sync_type != UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT) {
-        tl_info(self->super.super.lib, "fallback to event completion sync");
+        tl_debug(self->super.super.lib, "fallback to event completion sync");
         self->cfg.sync_type = UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT;
     }
 
     ucc_assert(self->cfg.sync_type == UCC_TL_RCCL_COMPLETION_SYNC_TYPE_EVENT);
-    tl_info(self->super.super.lib, "using event completion sync");
+    tl_debug(self->super.super.lib, "using event completion sync");
     status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_rccl_task_t), 0,
                             UCC_CACHE_LINE_SIZE, 8, UINT_MAX,
                             &ucc_tl_rccl_req_mpool_ops, params->thread_mode,
@@ -99,13 +99,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_rccl_context_t,
     if (hip_st != hipSuccess) {
         return UCC_ERR_NO_MEMORY;
     }
-    tl_info(self->super.super.lib, "initialized tl context: %p", self);
+    tl_debug(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_rccl_context_t)
 {
-    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
     ucc_mpool_cleanup(&self->req_mp, 1);
     hipFree(self->scratch_buf);
     self->scratch_buf = NULL;

--- a/src/components/tl/rccl/tl_rccl_lib.c
+++ b/src/components/tl/rccl/tl_rccl_lib.c
@@ -15,13 +15,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_rccl_lib_t, const ucc_base_lib_params_t *params,
         ucc_derived_of(config, ucc_tl_lib_config_t);
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_rccl.super, tl_config);
 
-    tl_info(&self->super, "initialized lib object: %p", self);
+    tl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_rccl_lib_t)
 {
-    tl_info(&self->super, "finalizing lib object: %p", self);
+    tl_debug(&self->super, "finalizing lib object: %p", self);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_rccl_lib_t, ucc_tl_lib_t);

--- a/src/components/tl/rccl/tl_rccl_team.c
+++ b/src/components/tl/rccl/tl_rccl_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Facebook, Inc. and its affiliates. 2021.
  * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
  *
@@ -55,7 +55,7 @@ free_unique_id:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_rccl_team_t)
 {
-    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    tl_debug(self->super.super.context->lib, "finalizing tl team: %p", self);
     if (self->rccl_comm) {
         ncclCommDestroy(self->rccl_comm);
         hipStreamDestroy(self->stream);
@@ -105,13 +105,13 @@ ucc_status_t ucc_tl_rccl_team_create_test(ucc_base_team_t *tl_team)
     rccl_status = ncclCommInitRank(&team->rccl_comm, UCC_TL_TEAM_SIZE(team),
                                    team->unique_id[0], UCC_TL_TEAM_RANK(team));
     if (rccl_status != ncclSuccess) {
-        tl_info(tl_team->context->lib, "RCCL error %d %s",
-                rccl_status, ncclGetErrorString(rccl_status));
+        tl_debug(tl_team->context->lib, "RCCL error %d %s",
+                 rccl_status, ncclGetErrorString(rccl_status));
         status = UCC_ERR_NO_MESSAGE;
         goto free_stream;
     }
     ucc_free(team->unique_id);
-    tl_info(tl_team->context->lib, "initialized tl team: %p", team);
+    tl_debug(tl_team->context->lib, "initialized tl team: %p", team);
     return UCC_OK;
 
 free_stream:
@@ -183,7 +183,7 @@ ucc_status_t ucc_tl_rccl_coll_init(ucc_base_coll_args_t *coll_args,
     if (ucc_unlikely(status != UCC_OK)) {
         goto free_task;
     }
-    tl_info(UCC_TASK_LIB(task), "init coll task %p", task);
+    tl_debug(UCC_TASK_LIB(task), "init coll task %p", task);
     *task_h = &task->super;
     return status;
 

--- a/src/components/tl/self/tl_self_context.c
+++ b/src/components/tl/self/tl_self_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -36,7 +36,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_self_context_t,
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_self_context_t)
 {
-    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
     ucc_mpool_cleanup(&self->req_mp, 1);
 }
 

--- a/src/components/tl/self/tl_self_lib.c
+++ b/src/components/tl/self/tl_self_lib.c
@@ -17,13 +17,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_self_lib_t, const ucc_base_lib_params_t *params,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_self.super,
                               &tl_config->super);
     memcpy(&self->cfg, tl_config, sizeof(*tl_config));
-    tl_info(&self->super, "initialized lib object: %p", self);
+    tl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_self_lib_t)
 {
-    tl_info(&self->super, "finalizing lib object: %p", self);
+    tl_debug(&self->super, "finalizing lib object: %p", self);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_self_lib_t, ucc_tl_lib_t);

--- a/src/components/tl/self/tl_self_team.c
+++ b/src/components/tl/self/tl_self_team.c
@@ -16,13 +16,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_self_team_t, ucc_base_context_t *tl_context,
         ucc_derived_of(tl_context, ucc_tl_self_context_t);
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
-    tl_info(tl_context->lib, "posted tl team: %p", self);
+    tl_debug(tl_context->lib, "posted tl team: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_self_team_t)
 {
-    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    tl_debug(self->super.super.context->lib, "finalizing tl team: %p", self);
 }
 
 UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_self_team_t, ucc_base_team_t);
@@ -39,7 +39,7 @@ ucc_status_t ucc_tl_self_team_create_test(ucc_base_team_t *tl_team)
 {
     ucc_tl_self_team_t *team = ucc_derived_of(tl_team, ucc_tl_self_team_t);
 
-    tl_info(tl_team->context->lib, "initialized tl team: %p", team);
+    tl_debug(tl_team->context->lib, "initialized tl team: %p", team);
     return UCC_OK;
 }
 

--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -306,16 +306,18 @@ ucc_status_t ucc_tl_sharp_context_init(ucc_tl_sharp_context_t *sharp_ctx,
                     (sharp_ctx->tm == UCC_THREAD_MULTIPLE) ? 1 : 0;
 
     if (lib->cfg.use_internal_oob) {
-        tl_info(sharp_ctx->super.super.lib, "using internal oob.  rank:%u size:%lu",
-                                            oob_ctx->subset.myrank, oob_ctx->subset.map.ep_num);
+        tl_debug(sharp_ctx->super.super.lib,
+                 "using internal oob.  rank:%u size:%lu",
+                 oob_ctx->subset.myrank, oob_ctx->subset.map.ep_num);
         init_spec.world_rank                 = oob_ctx->subset.myrank;
         init_spec.world_size                 = oob_ctx->subset.map.ep_num;
         init_spec.oob_colls.barrier          = ucc_tl_sharp_service_barrier;
         init_spec.oob_colls.bcast            = ucc_tl_sharp_service_bcast;
         init_spec.oob_colls.gather           = ucc_tl_sharp_service_gather;
     } else {
-        tl_info(sharp_ctx->super.super.lib, "using user provided oob. rank:%u size:%u",
-                                        oob_ctx->oob->oob_ep, oob_ctx->oob->n_oob_eps);
+        tl_debug(sharp_ctx->super.super.lib,
+                 "using user provided oob. rank:%u size:%u",
+                 oob_ctx->oob->oob_ep, oob_ctx->oob->n_oob_eps);
         init_spec.world_rank        = oob_ctx->oob->oob_ep;
         init_spec.world_size        = oob_ctx->oob->n_oob_eps;
         init_spec.oob_colls.barrier = ucc_tl_sharp_oob_barrier;
@@ -334,7 +336,7 @@ ucc_status_t ucc_tl_sharp_context_init(ucc_tl_sharp_context_t *sharp_ctx,
 
     ret = sharp_coll_init(&init_spec, context);
     if (ret < 0 ) {
-        tl_debug(sharp_ctx->super.super.lib, "Failed to initialize SHARP "
+        tl_debug(sharp_ctx->super.super.lib, "failed to initialize SHARP "
                  "collectives:%s(%d) job ID:%" PRIu64"\n",
                  sharp_coll_strerror(ret), ret, init_spec.job_id);
         return UCC_ERR_NO_RESOURCE;
@@ -383,7 +385,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_context_t,
         goto err;
     }
 
-   tl_info(self->super.super.lib, "initialized tl context: %p", self);
+   tl_debug(self->super.super.lib, "initialized tl context: %p", self);
    return UCC_OK;
 
 err:
@@ -438,7 +440,7 @@ ucc_status_t ucc_tl_sharp_context_create_epilog(ucc_base_context_t *context)
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_sharp_context_t)
 {
-    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
 
     if (self->rcache != NULL) {
         ucc_rcache_destroy(self->rcache);

--- a/src/components/tl/sharp/tl_sharp_lib.c
+++ b/src/components/tl/sharp/tl_sharp_lib.c
@@ -17,13 +17,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_lib_t, const ucc_base_lib_params_t *params,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_lib_t, &ucc_tl_sharp.super,
                               &tl_sharp_config->super);
     memcpy(&self->cfg, tl_sharp_config, sizeof(*tl_sharp_config));
-    tl_info(&self->super, "initialized lib object: %p", self);
+    tl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_sharp_lib_t)
 {
-    tl_info(&self->super, "finalizing lib object: %p", self);
+    tl_debug(&self->super, "finalizing lib object: %p", self);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_sharp_lib_t, ucc_tl_lib_t);

--- a/src/components/tl/sharp/tl_sharp_team.c
+++ b/src/components/tl/sharp/tl_sharp_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -122,7 +122,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_team_t, ucc_base_context_t *tl_context,
         goto cleanup;
     }
 
-    tl_info(self->super.super.context->lib, "initialized tl team: %p", self);
+    tl_debug(self->super.super.context->lib, "initialized tl team: %p", self);
     return UCC_OK;
 cleanup:
     if (ctx->cfg.context_per_team) {
@@ -145,7 +145,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_sharp_team_t)
 {
     ucc_tl_sharp_context_t *ctx = ucc_derived_of(UCC_TL_TEAM_CTX(self), ucc_tl_sharp_context_t);
 
-    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    tl_debug(self->super.super.context->lib, "finalizing tl team: %p", self);
     sharp_coll_comm_destroy(self->sharp_comm);
 
     if (ctx->cfg.context_per_team) {
@@ -182,7 +182,7 @@ static ucc_status_t ucc_tl_sharp_coll_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_sharp_task_t *task = ucc_derived_of(coll_task, ucc_tl_sharp_task_t);
 
-    tl_info(UCC_TASK_LIB(task), "finalizing coll task %p", task);
+    tl_debug(UCC_TASK_LIB(task), "finalizing coll task %p", task);
     UCC_TL_SHARP_PROFILE_REQUEST_FREE(task);
     ucc_mpool_put(task);
     return UCC_OK;
@@ -226,7 +226,7 @@ ucc_status_t ucc_tl_sharp_coll_init(ucc_base_coll_args_t *coll_args,
         goto free_task;
     }
 
-    tl_info(UCC_TASK_LIB(task), "init coll task %p", task);
+    tl_debug(UCC_TASK_LIB(task), "init coll task %p", task);
     *task_h = &task->super;
     return status;
 

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -273,7 +273,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     ucc_free(prefix);
     prefix = NULL;
 
-    tl_info(self->super.super.lib, "initialized tl context: %p", self);
+    tl_debug(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 
 err_thread_mode:
@@ -376,7 +376,7 @@ static inline void ucc_tl_ucp_worker_cleanup(ucc_tl_ucp_worker_t worker)
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_context_t)
 {
-    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
     if (self->remote_info) {
         ucc_tl_ucp_rinfo_destroy(self);
     }

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -67,7 +67,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
             }
         }
     }
-    tl_info(&self->super, "initialized lib object: %p", self);
+    tl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 
 err_cfg:
@@ -81,7 +81,7 @@ err:
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_lib_t)
 {
     ucc_config_parser_release_opts(&self->cfg, ucc_tl_ucp_lib_config_table);
-    tl_info(&self->super, "finalizing lib object: %p", self);
+    tl_debug(&self->super, "finalizing lib object: %p", self);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_ucp_lib_t, ucc_tl_lib_t);

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -80,14 +80,14 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
         }
     }
 
-    tl_info(tl_context->lib, "posted tl team: %p", self);
+    tl_debug(tl_context->lib, "posted tl team: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_ucp_team_t)
 {
     ucc_config_parser_release_opts(&self->cfg, ucc_tl_ucp_lib_config_table);
-    tl_info(self->super.super.context->lib, "finalizing tl team: %p", self);
+    tl_debug(self->super.super.context->lib, "finalizing tl team: %p", self);
 }
 
 UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_ucp_team_t, ucc_base_team_t);
@@ -177,7 +177,7 @@ ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team)
         }
     }
 
-    tl_info(tl_team->context->lib, "initialized tl team: %p", team);
+    tl_debug(tl_team->context->lib, "initialized tl team: %p", team);
     team->status = UCC_OK;
     return UCC_OK;
 

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -246,21 +246,23 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
     }
     task->seq_num = team->seq_num++;
 
-    if (ucc_global_config.log_component.log_level >= UCC_LOG_LEVEL_INFO) {
-        if (ucc_global_config.log_component.log_level >= UCC_LOG_LEVEL_DEBUG ||
-            ucc_global_config.coll_trace) {
-            char coll_str[256];
-            ucc_coll_str(task, coll_str, sizeof(coll_str),
-                        ucc_global_config.log_component.log_level);
-            if (ucc_global_config.log_component.log_level == UCC_LOG_LEVEL_INFO) {
-                if (team->rank == 0) {
-                    ucc_info("coll_init: %s", coll_str);
-                }
-            } else {
-                ucc_debug("coll_init: %s", coll_str);
+    if (ucc_global_config.coll_trace.log_level >= UCC_LOG_LEVEL_DIAG) {
+        char coll_str[256];
+        ucc_coll_str(task, coll_str, sizeof(coll_str),
+                     ucc_global_config.coll_trace.log_level);
+        if (ucc_global_config.coll_trace.log_level <= UCC_LOG_LEVEL_DEBUG) {
+            if (team->rank == 0) {
+                ucc_log_component_collective_trace(
+                    ucc_global_config.coll_trace.log_level, "coll_init: %s",
+                    coll_str);
             }
+        } else {
+            ucc_log_component_collective_trace(
+                ucc_global_config.coll_trace.log_level, "coll_init: %s",
+                coll_str);
         }
     }
+
     ucc_assert(task->super.status == UCC_OPERATION_INITIALIZED);
     *request = &task->super;
 

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -246,10 +246,20 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
     }
     task->seq_num = team->seq_num++;
 
-    if (ucc_global_config.log_component.log_level >= UCC_LOG_LEVEL_DEBUG) {
-        char coll_debug_str[256];
-        ucc_coll_str(task, coll_debug_str, sizeof(coll_debug_str));
-        ucc_debug("coll_init: %s", coll_debug_str);
+    if (ucc_global_config.log_component.log_level >= UCC_LOG_LEVEL_INFO) {
+        if (ucc_global_config.log_component.log_level >= UCC_LOG_LEVEL_DEBUG ||
+            ucc_global_config.coll_trace) {
+            char coll_str[256];
+            ucc_coll_str(task, coll_str, sizeof(coll_str),
+                        ucc_global_config.log_component.log_level);
+            if (ucc_global_config.log_component.log_level == UCC_LOG_LEVEL_INFO) {
+                if (team->rank == 0) {
+                    ucc_info("coll_init: %s", coll_str);
+                }
+            } else {
+                ucc_debug("coll_init: %s", coll_str);
+            }
+        }
     }
     ucc_assert(task->super.status == UCC_OPERATION_INITIALIZED);
     *request = &task->super;

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -295,7 +295,22 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_post, (request),
 {
     ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
     ucc_status_t status;
-    ucc_debug("coll_post: req %p, seq_num %u", task, task->seq_num);
+
+    if (ucc_global_config.coll_trace.log_level >= UCC_LOG_LEVEL_DEBUG) {
+        ucc_rank_t rank = task->team->params.team->rank;
+        if (ucc_global_config.coll_trace.log_level == UCC_LOG_LEVEL_DEBUG) {
+            if (rank == 0) {
+                ucc_log_component_collective_trace(
+                    ucc_global_config.coll_trace.log_level,
+                    "coll post: req %p, seq_num %u", task, task->seq_num);
+            }
+        } else {
+            ucc_log_component_collective_trace(
+                ucc_global_config.coll_trace.log_level,
+                "coll post: rank %d req %p, seq_num %u", rank, task,
+                task->seq_num);
+        }
+    }
 
     COLL_POST_STATUS_CHECK(task);
     if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
@@ -312,6 +327,34 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_post, (request),
     return task->post(task);
 }
 
+ucc_status_t ucc_collective_triggered_post(ucc_ee_h ee, ucc_ev_t *ev)
+{
+    ucc_coll_task_t *task = ucc_derived_of(ev->req, ucc_coll_task_t);
+
+    if (ucc_global_config.coll_trace.log_level >= UCC_LOG_LEVEL_DEBUG) {
+        ucc_rank_t rank = task->team->params.team->rank;
+        if (ucc_global_config.coll_trace.log_level == UCC_LOG_LEVEL_DEBUG) {
+            if (rank == 0) {
+                ucc_log_component_collective_trace(
+                    ucc_global_config.coll_trace.log_level,
+                    "coll triggered_post: req %p, seq_num %u", task,
+                    task->seq_num);
+            }
+        } else {
+            ucc_log_component_collective_trace(
+                ucc_global_config.coll_trace.log_level,
+                "coll triggered_post: rank %d req %p, seq_num %u", rank, task,
+                task->seq_num);
+        }
+    }
+
+    COLL_POST_STATUS_CHECK(task);
+    if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
+        task->start_time = ucc_get_time();
+    }
+    return task->triggered_post(ee, ev, task);
+}
+
 UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init_and_post,
                       (coll_args, request, team), ucc_coll_args_t *coll_args, //NOLINT
                       ucc_coll_req_h *request, ucc_team_h team) //NOLINT
@@ -321,13 +364,10 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init_and_post,
     return UCC_ERR_NOT_IMPLEMENTED;
 }
 
-UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_finalize, (request),
-                      ucc_coll_req_h request)
+ucc_status_t ucc_collective_finalize_internal(ucc_coll_task_t *task)
 {
-    ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
     ucc_status_t st;
 
-    ucc_debug("coll_finalize: req %p, seq_num %u", task, task->seq_num);
     if (ucc_unlikely(task->super.status == UCC_INPROGRESS)) {
         ucc_error("attempt to finalize task with status UCC_INPROGRESS");
         return UCC_ERR_INVALID_PARAM;
@@ -336,11 +376,33 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_finalize, (request),
     if (task->executor) {
         st = ucc_ee_executor_finalize(task->executor);
         if (ucc_unlikely(st != UCC_OK)) {
-            ucc_error("executor finalize error: %s",
-                      ucc_status_string(st));
+            ucc_error("executor finalize error: %s", ucc_status_string(st));
         }
     }
     return task->finalize(task);
+}
+
+UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_finalize, (request),
+                      ucc_coll_req_h request)
+{
+    ucc_coll_task_t *task = ucc_derived_of(request, ucc_coll_task_t);
+
+    if (ucc_global_config.coll_trace.log_level >= UCC_LOG_LEVEL_DEBUG) {
+        ucc_rank_t rank = task->team->params.team->rank;
+        if (ucc_global_config.coll_trace.log_level == UCC_LOG_LEVEL_DEBUG) {
+            if (rank == 0) {
+                ucc_log_component_collective_trace(
+                    ucc_global_config.coll_trace.log_level,
+                    "coll finalize: req %p, seq_num %u", task, task->seq_num);
+            }
+        } else {
+            ucc_log_component_collective_trace(
+                ucc_global_config.coll_trace.log_level,
+                "coll finalize: rank %d req %p, seq_num %u", rank, task,
+                task->seq_num);
+        }
+    }
+    return ucc_collective_finalize_internal(task);
 }
 
 static ucc_status_t ucc_triggered_task_finalize(ucc_coll_task_t *task)
@@ -491,17 +553,4 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
     }
 
     return ucc_progress_queue_enqueue(UCC_TASK_CORE_CTX(ev_task)->pq, ev_task);
-}
-
-ucc_status_t ucc_collective_triggered_post(ucc_ee_h ee, ucc_ev_t *ev)
-{
-    ucc_coll_task_t *task = ucc_derived_of(ev->req, ucc_coll_task_t);
-
-    ucc_debug("triggered_post: task %p, seq_num %u", task, task->seq_num);
-
-    COLL_POST_STATUS_CHECK(task);
-    if (UCC_COLL_TIMEOUT_REQUIRED(task)) {
-        task->start_time = ucc_get_time();
-    }
-    return task->triggered_post(ee, ev, task);
 }

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -814,7 +814,7 @@ ucc_status_t ucc_context_create_proc_info(ucc_lib_h                   lib,
         }
     }
 
-    ucc_info("created ucc context %p for lib %s", ctx, lib->full_prefix);
+    ucc_debug("created ucc context %p for lib %s", ctx, lib->full_prefix);
     *context = ctx;
     return UCC_OK;
 

--- a/src/core/ucc_ee.c
+++ b/src/core/ucc_ee.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -39,15 +39,14 @@ ucc_status_t ucc_ee_create(ucc_team_h team, const ucc_ee_params_t *params,
     ucc_queue_head_init(&ee->event_out_queue);
     *ee_p = ee;
 
-    ucc_info("ee is created: %p ee_context: %p",
-              ee, params->ee_context);
+    ucc_debug("ee is created: %p ee_context: %p", ee, params->ee_context);
 
     return UCC_OK;
 }
 
 ucc_status_t ucc_ee_destroy(ucc_ee_h ee)
 {
-    ucc_info("ee is destroyed: %p", ee);
+    ucc_debug("ee is destroyed: %p", ee);
     ucc_spinlock_destroy(&ee->lock);
     ucc_free(ee);
 
@@ -73,8 +72,8 @@ ucc_status_t ucc_ee_get_event_internal(ucc_ee_h ee, ucc_ev_t **ev, ucc_queue_hea
     event_desc = ucc_container_of(elem, ucc_event_desc_t, queue);
     *ev = &event_desc->ev;
 
-    ucc_info("EE Event Get. ee:%p, queue:%p ev_type:%s ",
-                ee, queue, ucc_ee_ev_names[event_desc->ev.ev_type]);
+    ucc_debug("EE Event Get. ee:%p, queue:%p ev_type:%s ",
+              ee, queue, ucc_ee_ev_names[event_desc->ev.ev_type]);
     return UCC_OK;
 }
 
@@ -109,8 +108,8 @@ ucc_status_t ucc_ee_set_event_internal(ucc_ee_h ee, ucc_ev_t *ev, ucc_queue_head
     ucc_spin_lock(&ee->lock);
     ucc_queue_push(queue, &event_desc->queue);
     ucc_spin_unlock(&ee->lock);
-    ucc_info("EE Event Set. ee:%p, queue:%p ev_type:%s ",
-                ee, queue, ucc_ee_ev_names[ev->ev_type]);
+    ucc_debug("EE Event Set. ee:%p, queue:%p ev_type:%s ",
+              ee, queue, ucc_ee_ev_names[ev->ev_type]);
 
     return UCC_OK;
 }

--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -30,6 +30,13 @@ ucc_config_field_t ucc_global_config_table[] = {
      ucc_offsetof(ucc_global_config_t, log_component),
      UCC_CONFIG_TYPE_LOG_COMP},
 
+    {"COLL_TRACE", "n",
+     "If UCC logging level is INFO or higher UCC will print info message"
+     "on each collective.\n",
+     ucc_offsetof(ucc_global_config_t, coll_trace),
+     UCC_CONFIG_TYPE_BOOL
+    },
+
     {"PROFILE_MODE", "",
      "Profile collection modes. If none is specified, profiling is disabled.\n"
      " - log   - Record all timestamps.\n"

--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -13,6 +13,7 @@ UCC_LIST_HEAD(ucc_config_global_list);
 
 ucc_global_config_t ucc_global_config = {
     .log_component    = {UCC_LOG_LEVEL_WARN, "UCC"},
+    .coll_trace       = {UCC_LOG_LEVEL_WARN, "UCC_COLL"},
     .component_path   = NULL,
     .install_path     = NULL,
     .initialized      = 0,
@@ -30,11 +31,13 @@ ucc_config_field_t ucc_global_config_table[] = {
      ucc_offsetof(ucc_global_config_t, log_component),
      UCC_CONFIG_TYPE_LOG_COMP},
 
-    {"COLL_TRACE", "n",
-     "If UCC logging level is INFO or higher UCC will print info message"
-     "on each collective.\n",
+    {"COLL_TRACE", "warn",
+     "UCC collective logging level. Higher level will result in more verbose "
+     "collective info. \n "
+     "Possible values are: fatal, error, warn, info, debug, trace, data, func, "
+     "poll.",
      ucc_offsetof(ucc_global_config_t, coll_trace),
-     UCC_CONFIG_TYPE_BOOL
+     UCC_CONFIG_TYPE_LOG_COMP
     },
 
     {"PROFILE_MODE", "",

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -15,6 +16,8 @@
 typedef struct ucc_global_config {
     /* Log level above which log messages will be printed*/
     ucc_log_component_config_t log_component;
+    /* Print collective info for each initialized collective */
+    int                        coll_trace;
     ucc_component_framework_t  cl_framework;
     ucc_component_framework_t  tl_framework;
     ucc_component_framework_t  mc_framework;

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -17,7 +17,7 @@ typedef struct ucc_global_config {
     /* Log level above which log messages will be printed*/
     ucc_log_component_config_t log_component;
     /* Print collective info for each initialized collective */
-    int                        coll_trace;
+    ucc_log_component_config_t coll_trace;
     ucc_component_framework_t  cl_framework;
     ucc_component_framework_t  tl_framework;
     ucc_component_framework_t  mc_framework;

--- a/src/core/ucc_lib.c
+++ b/src/core/ucc_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -129,8 +129,8 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
                           cl_iface->super.name);
                 goto error_cl_init;
             } else {
-                ucc_info("lib_init failed for component: %s, skipping",
-                         cl_iface->super.name);
+                ucc_debug("lib_init failed for component: %s, skipping",
+                          cl_iface->super.name);
                 ucc_base_config_release(&cl_config->super.super);
                 continue;
             }
@@ -141,11 +141,13 @@ static ucc_status_t ucc_cl_lib_init(const ucc_lib_params_t *user_params,
         status = cl_iface->lib.get_attr(&cl_lib->super,
                                         &attrs[lib->n_cl_libs_opened].super);
         if (UCC_OK != status) {
-            ucc_error("failed to query cl lib %s attr", cl_lib->iface->super.name);
+            ucc_error("failed to query cl lib %s attr",
+                      cl_lib->iface->super.name);
             return status;
         }
-        ucc_info("lib_prefix \"%s\": initialized component \"%s\" score %d",
-                 config->full_prefix, cl_iface->super.name, cl_iface->super.score);
+        ucc_debug("lib_prefix \"%s\": initialized component \"%s\" score %d",
+                  config->full_prefix, cl_iface->super.name,
+                  cl_iface->super.score);
         if (attrs[lib->n_cl_libs_opened].super.attr.thread_mode > highest_tm) {
             highest_tm = attrs[lib->n_cl_libs_opened].super.attr.thread_mode;
         }
@@ -273,8 +275,8 @@ static ucc_status_t ucc_tl_lib_init(const ucc_lib_params_t *user_params,
                                         &b_lib);
             ucc_base_config_release(&tl_config->super.super);
             if (UCC_OK != status) {
-                ucc_info("lib_init failed for component: %s, skipping",
-                         tl_iface->super.name);
+                ucc_debug("lib_init failed for component: %s, skipping",
+                          tl_iface->super.name);
                 continue;
             }
             tl_lib = ucc_derived_of(b_lib, ucc_tl_lib_t);

--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -37,8 +38,6 @@ typedef struct ucc_lib_info {
 
 void ucc_get_version(unsigned *major_version, unsigned *minor_version,
                      unsigned *release_number);
-
-const char *ucc_get_version_string(void);
 
 int ucc_tl_is_required(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface,
                        int forced);

--- a/src/core/ucc_service_coll.c
+++ b/src/core/ucc_service_coll.c
@@ -139,11 +139,13 @@ ucc_status_t ucc_service_coll_test(ucc_service_coll_req_t *req)
     return status;
 }
 
+ucc_status_t ucc_collective_finalize_internal(ucc_coll_task_t *task);
+
 ucc_status_t ucc_service_coll_finalize(ucc_service_coll_req_t *req)
 {
     ucc_status_t status;
 
-    status = ucc_collective_finalize(&req->task->super);
+    status = ucc_collective_finalize_internal(req->task);
     ucc_free(req);
     return status;
 }

--- a/src/schedule/ucc_schedule.c
+++ b/src/schedule/ucc_schedule.c
@@ -190,9 +190,10 @@ ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule,
 {
     ucc_status_t status;
 
-    status            = ucc_coll_task_init(&schedule->super, bargs, team);
-    schedule->ctx     = team->context->ucc_context;
-    schedule->n_tasks = 0;
+    status                = ucc_coll_task_init(&schedule->super, bargs, team);
+    schedule->super.flags |= UCC_COLL_TASK_FLAG_IS_SCHEDULE;
+    schedule->ctx         = team->context->ucc_context;
+    schedule->n_tasks     = 0;
     return status;
 }
 
@@ -202,8 +203,8 @@ ucc_status_t ucc_schedule_add_task(ucc_schedule_t *schedule,
     ucc_status_t status;
 
     status = ucc_event_manager_subscribe(task, UCC_EVENT_COMPLETED_SCHEDULE,
-                                &schedule->super,
-                                ucc_schedule_completed_handler);
+                                         &schedule->super,
+                                         ucc_schedule_completed_handler);
     task->schedule                       = schedule;
     schedule->tasks[schedule->n_tasks++] = task;
     if (task->flags & UCC_COLL_TASK_FLAG_EXECUTOR) {

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -184,7 +185,8 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
         /* error in task status */
         if (UCC_ERR_TIMED_OUT == status) {
             char coll_str[256];
-            ucc_coll_str(task, coll_str, sizeof(coll_str));
+            ucc_coll_str(task, coll_str, sizeof(coll_str),
+                         UCC_LOG_LEVEL_DEBUG);
             ucc_warn("timeout %g sec. has expired on %s",
                      task->bargs.args.timeout, coll_str);
         } else {

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -45,8 +45,7 @@ typedef ucc_status_t (*ucc_task_event_handler_p)(ucc_coll_task_t *parent,
 /* triggered post setup function will be launched before starting executor */
 typedef ucc_status_t (*ucc_coll_triggered_post_setup_fn_t)(ucc_coll_task_t *task);
 
-typedef ucc_status_t (*ucc_coll_triggered_post_fn_t)(ucc_ee_h ee,
-                                                     ucc_ev_t *ev,
+typedef ucc_status_t (*ucc_coll_triggered_post_fn_t)(ucc_ee_h ee, ucc_ev_t *ev,
                                                      ucc_coll_task_t *task);
 
 typedef struct ucc_em_listener {
@@ -71,6 +70,8 @@ enum {
     UCC_COLL_TASK_FLAG_EXECUTOR_STOP    = UCC_BIT(3),
     /* destroy executor in task complete */
     UCC_COLL_TASK_FLAG_EXECUTOR_DESTROY = UCC_BIT(4),
+    /* if set task can be casted to scheulde */
+    UCC_COLL_TASK_FLAG_IS_SCHEDULE      = UCC_BIT(5),
 };
 
 typedef struct ucc_coll_task {
@@ -146,7 +147,8 @@ ucc_status_t ucc_schedule_init(ucc_schedule_t *schedule,
                                ucc_base_coll_args_t *bargs,
                                ucc_base_team_t *team);
 
-ucc_status_t ucc_schedule_add_task(ucc_schedule_t *schedule, ucc_coll_task_t *task);
+ucc_status_t ucc_schedule_add_task(ucc_schedule_t *schedule,
+                                   ucc_coll_task_t *task);
 
 ucc_status_t ucc_schedule_start(ucc_coll_task_t *task);
 

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1,7 +1,7 @@
 /**
  * @file ucc.h
  * @date 2020
- * @copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * @copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * @copyright Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
  * @copyright Copyright (C) UChicago Argonne, LLC. 2022.  ALL RIGHTS RESERVED.
  *
@@ -703,6 +703,16 @@ void ucc_lib_config_print(const ucc_lib_config_h config, FILE *stream,
 
 ucc_status_t ucc_lib_config_modify(ucc_lib_config_h config, const char *name,
                                    const char *value);
+
+
+/**
+ * @ingroup UCC_LIB
+ * @brief Get UCC library version as a string.
+ *
+ * This routine returns the UCC library version as a string which consists of:
+ * "major.minor.release".
+ */
+const char *ucc_get_version_string(void);
 
 
 /**

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
+
 #include "ucc_coll_utils.h"
 #include "components/base/ucc_base_iface.h"
 #include "core/ucc_team.h"
@@ -198,8 +199,8 @@ ucc_memory_type_t ucc_coll_args_mem_type(const ucc_coll_args_t *args,
     return UCC_MEMORY_TYPE_UNKNOWN;
 }
 
-size_t ucc_coll_args_msgsize(const ucc_coll_args_t *args,
-                             ucc_rank_t rank, ucc_rank_t size)
+size_t ucc_coll_args_msgsize(const ucc_coll_args_t *args, ucc_rank_t rank,
+                             ucc_rank_t size)
 {
     ucc_rank_t             root = args->root;
 
@@ -244,7 +245,7 @@ size_t ucc_coll_args_msgsize(const ucc_coll_args_t *args,
                  : args->dst.info.count * ucc_dt_size(args->dst.info.datatype) *
                    size;
     default:
-        break;
+        ucc_assert(args->coll_type == UCC_COLL_TYPE_LAST);
     }
     return 0;
 }
@@ -317,10 +318,8 @@ ucc_ep_map_t ucc_ep_map_from_array_64(uint64_t **array, ucc_rank_t size,
                                          need_free, 1);
 }
 
-static inline int
-ucc_coll_args_is_rooted(const ucc_base_coll_args_t *bargs)
+static inline int ucc_coll_args_is_rooted(ucc_coll_type_t ct)
 {
-    ucc_coll_type_t ct = bargs->args.coll_type;
     if (ct == UCC_COLL_TYPE_REDUCE || ct == UCC_COLL_TYPE_BCAST ||
         ct == UCC_COLL_TYPE_GATHER || ct == UCC_COLL_TYPE_SCATTER ||
         ct == UCC_COLL_TYPE_FANIN || ct == UCC_COLL_TYPE_FANOUT ||
@@ -330,55 +329,204 @@ ucc_coll_args_is_rooted(const ucc_base_coll_args_t *bargs)
     return 0;
 }
 
-void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len)
+static inline int ucc_coll_args_is_reduction(ucc_coll_type_t ct)
 {
-    const ucc_base_coll_args_t *args  = &task->bargs;
-    ucc_team_t                *team  = args->team;
-    ucc_coll_type_t            ct    = args->args.coll_type;
-    size_t                     left  = len;
-    char                       tmp[64];
+    if (ct == UCC_COLL_TYPE_ALLREDUCE || ct == UCC_COLL_TYPE_REDUCE ||
+        ct == UCC_COLL_TYPE_REDUCE_SCATTER ||
+        ct == UCC_COLL_TYPE_REDUCE_SCATTERV) {
+        return 1;
+    }
+    return 0;
+}
 
-    ucc_snprintf_safe(str, left, "req %p, seq_num %u, %s, team_id %u, size %u, "
-                      "rank %u, ctx_rank %u: %s %s inplace=%u",
-                      task, task->seq_num,
-                      task->team->context->lib->log_component.name,
-                      team->id, team->size, team->rank,
-                      ucc_ep_map_eval(team->ctx_map, team->rank),
-                      ucc_coll_type_str(ct),
-                      ucc_mem_type_str(ucc_coll_args_mem_type(&args->args,
-                                                              team->rank)),
-                      UCC_IS_INPLACE(args->args));
+#define COLL_ARGS_HEADER_STR_MAX_SIZE 32
+void ucc_coll_args_str(const ucc_coll_args_t *args, ucc_rank_t trank,
+                       ucc_rank_t tsize, char *str, size_t len)
+{
+    ucc_coll_type_t        ct                                 = args->coll_type;
+    ucc_rank_t             root                               = args->root;
+    ucc_coll_buffer_info_t src_info                           = {0};
+    ucc_coll_buffer_info_t dst_info                           = {0};
+    char                   hdr[COLL_ARGS_HEADER_STR_MAX_SIZE] = "";
+    char tmp[32];
+    size_t count;
+    int left, has_src, has_dst;
 
-    if (ucc_coll_args_is_rooted(args)) {
-        ucc_snprintf_safe(tmp, sizeof(tmp), " root=%u", (ucc_rank_t)args->args.root);
-        left = len - strlen(str);
-        strncat(str, tmp, left);
+    ucc_snprintf_safe(hdr, COLL_ARGS_HEADER_STR_MAX_SIZE, "%s",
+                      ucc_coll_type_str(ct));
+    if (ucc_coll_args_is_reduction(ct)) {
+        ucc_snprintf_safe(tmp, sizeof(tmp), " %s",
+                          ucc_reduction_op_str(args->op));
+        left = COLL_ARGS_HEADER_STR_MAX_SIZE - strlen(hdr);
+        strncat(hdr, tmp, left);
     }
 
-    if (ct ==  UCC_COLL_TYPE_ALLTOALLV) {
-        size_t sbytes = ucc_coll_args_get_total_count(&args->args,
-                           args->args.src.info_v.counts, team->size ) *
-                           ucc_dt_size(args->args.src.info_v.datatype);
-        size_t rbytes = ucc_coll_args_get_total_count(&args->args,
-                           args->args.dst.info_v.counts, team->size ) *
-                           ucc_dt_size(args->args.dst.info_v.datatype);
-        ucc_snprintf_safe(tmp, sizeof(tmp), " sbytes=%zd rbytes=%zd",
-                          sbytes, rbytes);
+    if (UCC_IS_INPLACE(*args)) {
+        ucc_snprintf_safe(tmp, sizeof(tmp), " inplace");
+        left = COLL_ARGS_HEADER_STR_MAX_SIZE - strlen(hdr);
+        strncat(hdr, tmp, left);
+    }
+
+    if (ucc_coll_args_is_rooted(ct)) {
+        ucc_snprintf_safe(tmp, sizeof(tmp), " root %u", root);
+        left = COLL_ARGS_HEADER_STR_MAX_SIZE - strlen(hdr);
+        strncat(hdr, tmp, left);
+    }
+
+    has_src = has_dst = 0;
+    switch (ct) {
+    case UCC_COLL_TYPE_ALLGATHER:
+    case UCC_COLL_TYPE_ALLREDUCE:
+    case UCC_COLL_TYPE_ALLTOALL:
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        dst_info = args->dst.info;
+        has_dst = 1;
+        if (!UCC_IS_INPLACE(*args)) {
+            src_info = args->src.info;
+            has_src = 1;
+        }
+        break;
+    case UCC_COLL_TYPE_ALLGATHERV:
+    case UCC_COLL_TYPE_REDUCE_SCATTERV:
+        count = ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
+                                              tsize);
+        dst_info.buffer   = args->dst.info_v.buffer;
+        dst_info.count    = count;
+        dst_info.datatype = args->dst.info_v.datatype;
+        dst_info.mem_type = args->dst.info_v.mem_type;
+        has_dst = 1;
+        if (!UCC_IS_INPLACE(*args)) {
+            src_info = args->src.info;
+            has_src = 1;
+        }
+        break;
+    case UCC_COLL_TYPE_ALLTOALLV:
+        count = ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
+                                              tsize);
+        dst_info.buffer   = args->dst.info_v.buffer;
+        dst_info.count    = count;
+        dst_info.datatype = args->dst.info_v.datatype;
+        dst_info.mem_type = args->dst.info_v.mem_type;
+        has_dst = 1;
+        if (!UCC_IS_INPLACE(*args)) {
+            count = ucc_coll_args_get_total_count(args, args->src.info_v.counts,
+                                                  tsize);
+            src_info.buffer   = args->src.info_v.buffer;
+            src_info.count    = count;
+            src_info.datatype = args->src.info_v.datatype;
+            src_info.mem_type = args->src.info_v.mem_type;
+            has_src = 1;
+        }
+    case UCC_COLL_TYPE_BARRIER:
+    case UCC_COLL_TYPE_FANIN:
+    case UCC_COLL_TYPE_FANOUT:
+        break;
+    case UCC_COLL_TYPE_BCAST:
+        src_info = args->src.info;
+        has_src = 1;
+        break;
+    case UCC_COLL_TYPE_GATHER:
+    case UCC_COLL_TYPE_REDUCE:
+        if (UCC_IS_ROOT(*args, trank)) {
+            dst_info = args->dst.info;
+            has_dst = 1;
+        }
+        if (!UCC_IS_ROOT(*args, trank) || !UCC_IS_INPLACE(*args)) {
+            src_info = args->src.info;
+            has_src = 1;
+        }
+        break;
+    case UCC_COLL_TYPE_GATHERV:
+        if (UCC_IS_ROOT(*args, trank)) {
+            count = ucc_coll_args_get_total_count(args, args->dst.info_v.counts,
+                                                  tsize);
+            dst_info.buffer   = args->dst.info_v.buffer;
+            dst_info.count    = count;
+            dst_info.datatype = args->dst.info_v.datatype;
+            dst_info.mem_type = args->dst.info_v.mem_type;
+            has_dst = 1;
+        }
+        if (!UCC_IS_ROOT(*args, trank) || !UCC_IS_INPLACE(*args)) {
+            src_info = args->src.info;
+            has_src = 1;
+        }
+        break;
+    case UCC_COLL_TYPE_SCATTER:
+        if (UCC_IS_ROOT(*args, trank)) {
+            src_info = args->src.info;
+            has_src = 1;
+        }
+        if (!UCC_IS_ROOT(*args, trank) || !UCC_IS_INPLACE(*args)) {
+            dst_info = args->dst.info;
+            has_dst = 1;
+        }
+        break;
+    case UCC_COLL_TYPE_SCATTERV:
+        if (UCC_IS_ROOT(*args, trank)) {
+            count = ucc_coll_args_get_total_count(args, args->src.info_v.counts,
+                                                  tsize);
+            src_info.buffer   = args->src.info_v.buffer;
+            src_info.count    = count;
+            src_info.datatype = args->src.info_v.datatype;
+            src_info.mem_type = args->src.info_v.mem_type;
+            has_src = 1;
+        }
+        if (!UCC_IS_ROOT(*args, trank) || !UCC_IS_INPLACE(*args)) {
+            dst_info = args->dst.info;
+            has_dst = 1;
+        }
+        break;
+    default:
+        ucc_assert(args->coll_type == UCC_COLL_TYPE_LAST);
+        return;
+    }
+
+    if (has_src && has_dst) {
+        ucc_snprintf_safe(str, len,
+                          "%s: src={%p, %zd, %s, %s}, dst={%p, %zd, %s, %s}",
+                          hdr, src_info.buffer, src_info.count,
+                          ucc_datatype_str(src_info.datatype),
+                          ucc_mem_type_str(src_info.mem_type),
+                          dst_info.buffer, dst_info.count,
+                          ucc_datatype_str(dst_info.datatype),
+                          ucc_mem_type_str(dst_info.mem_type));
+    } else if (has_src && !has_dst) {
+        ucc_snprintf_safe(str, len,
+                          "%s: src={%p, %zd, %s, %s}",
+                          hdr, src_info.buffer, src_info.count,
+                          ucc_datatype_str(src_info.datatype),
+                          ucc_mem_type_str(src_info.mem_type));
+    } else if (!has_src && has_dst) {
+        ucc_snprintf_safe(str, len,
+                          "%s: dst={%p, %zd, %s, %s}",
+                          hdr, dst_info.buffer, dst_info.count,
+                          ucc_datatype_str(dst_info.datatype),
+                          ucc_mem_type_str(dst_info.mem_type));
     } else {
-        ucc_snprintf_safe(tmp, sizeof(tmp), " bytes=%zd",
-                          ucc_coll_args_msgsize(&args->args, team->rank,
-                                                team->size));
+        ucc_snprintf_safe(str, len, "%s", hdr);
     }
-    left = len - strlen(str);
-    strncat(str, tmp, left);
+}
 
-    if (ct == UCC_COLL_TYPE_ALLREDUCE ||
-        ct == UCC_COLL_TYPE_REDUCE) {
-        ucc_snprintf_safe(tmp, sizeof(tmp), " %s %s",
-                          ucc_datatype_str(args->args.src.info.datatype),
-                          ucc_reduction_op_str(args->args.op));
-        left = len - strlen(str);
-        strncat(str, tmp, left);
+void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len,
+                  int verbosity)
+{
+    ucc_team_t *team  = task->bargs.team;
+
+    if (verbosity >= UCC_LOG_LEVEL_INFO) {
+        char task_info[64];
+        ucc_coll_args_str(&task->bargs.args, team->rank, team->size, str, len);
+        ucc_snprintf_safe(task_info, sizeof(task_info), "; %s, team_id %d",
+                          task->team->context->lib->log_component.name,
+                          team->id);
+        strncat(str, task_info, len - strlen(str));
+        if (verbosity >= UCC_LOG_LEVEL_DEBUG) {
+            ucc_snprintf_safe(task_info, sizeof(task_info),
+                              " rank %u, ctx_rank %u, seq_num %d, req %p",
+                              team->rank,
+                              ucc_ep_map_eval(team->ctx_map, team->rank),
+                              task->seq_num, task);
+            strncat(str, task_info, len - strlen(str));
+        }
     }
 }
 

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -212,7 +212,8 @@ ucc_ep_map_t ucc_ep_map_from_array_64(uint64_t **array, ucc_rank_t size,
                                       ucc_rank_t full_size, int need_free);
 
 typedef struct ucc_coll_task ucc_coll_task_t;
-void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len);
+void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len,
+                  int verbosity);
 
 /* Creates a rank map that reverses rank order, ie
    rank r -> size - 1 - r */

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -14,6 +14,7 @@
 
 #define UCC_LOG_LEVEL_ERROR UCS_LOG_LEVEL_ERROR
 #define UCC_LOG_LEVEL_WARN  UCS_LOG_LEVEL_WARN
+#define UCC_LOG_LEVEL_DIAG  UCS_LOG_LEVEL_DIAG
 #define UCC_LOG_LEVEL_INFO  UCS_LOG_LEVEL_INFO
 #define UCC_LOG_LEVEL_DEBUG UCS_LOG_LEVEL_DEBUG
 #define UCC_LOG_LEVEL_TRACE UCS_LOG_LEVEL_TRACE
@@ -36,6 +37,8 @@
     ucc_log_component_global(UCS_LOG_LEVEL_ERROR, _fmt, ##__VA_ARGS__)
 #define ucc_warn(_fmt, ...)                                                    \
     ucc_log_component_global(UCS_LOG_LEVEL_WARN, _fmt, ##__VA_ARGS__)
+#define ucc_diag(_fmt, ...)                                                    \
+    ucc_log_component_global(UCS_LOG_LEVEL_DIAG, _fmt, ##__VA_ARGS__)
 #define ucc_info(_fmt, ...)                                                    \
     ucc_log_component_global(UCS_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
 #define ucc_debug(_fmt, ...)                                                   \
@@ -93,7 +96,7 @@ static inline const char* ucc_coll_type_str(ucc_coll_type_t ct)
     default:
         break;
     }
-    return 0;
+    return "";
 }
 
 static inline const char* ucc_datatype_str(ucc_datatype_t dt)

--- a/src/utils/ucc_log.h
+++ b/src/utils/ucc_log.h
@@ -57,6 +57,16 @@
 #define ucc_trace_poll(_fmt, ...)                                              \
     ucc_log_component_global(UCS_LOG_LEVEL_TRACE_POLL, _fmt, ##__VA_ARGS__)
 
+/* Collective trace logger */
+#define ucc_log_component_collective_trace(_level, fmt, ...)                   \
+    ucc_log_component(_level, ucc_global_config.coll_trace, fmt,               \
+                      ##__VA_ARGS__)
+
+#define ucc_coll_trace_info(_fmt, ...)                                         \
+    ucc_log_component_collective_trace(UCS_LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+#define ucc_coll_trace_debug(_fmt, ...)                                        \
+    ucc_log_component_collective_trace(UCS_LOG_LEVEL_DEBUG, _fmt, ##__VA_ARGS__)
+
 
 static inline const char* ucc_coll_type_str(ucc_coll_type_t ct)
 {

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -400,6 +400,7 @@ ucc_status_t ucc_parse_file_config(const char *        filename,
         status = UCC_ERR_INVALID_PARAM;
         goto out;
     }
+    cfg->filename = strdup(filename);
 
     *cfg_p = cfg;
     return UCC_OK;
@@ -416,6 +417,7 @@ void ucc_release_file_config(ucc_file_config_t *cfg)
     ucc_section_wrap_t *sec_wrap;
     int j;
 
+    ucc_free(cfg->filename);
     kh_foreach(&cfg->vars, key, value, {
         ucc_free((void *)key);
         ucc_free(value);

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -116,8 +116,9 @@ KHASH_MAP_INIT_STR(ucc_cfg_file, char *);
 KHASH_MAP_INIT_STR(ucc_sections, ucc_section_wrap_t *);
 
 typedef struct ucc_file_config {
-    khash_t(ucc_cfg_file) vars;
-    khash_t(ucc_sections) sections;
+    char                  *filename;
+    khash_t(ucc_cfg_file)  vars;
+    khash_t(ucc_sections)  sections;
 } ucc_file_config_t;
 
 /* Convenience structure used, for example, to represent TLS list.


### PR DESCRIPTION
## What
Improve logging in different components of UCC

## Why ?
Currently there is no unified rules between TLs, CLs, CORE about what to print and how to print.

## How ?
1. Make LOG_LEVE=info less verbose, print only essential info about UCC runtime including
1.1. UCC version
1.2. UCC runtime path (path to the libucc.so)
1.3. global config path if used or n/a otherwise
1.4. team create log with team id and team size
1.5. score map i.e. what collectives available, what memory types available, what TLs/CLs are used
1.6. team destroy log
2. Added UCC_COLL_TRACE (default is no)
2.1. Leader rank prints collective info on each ucc_collective_init if UCC log level is info
2.2. All ranks from team print collective info on ucc_collective_init if UCC log level is debug or above
2.3. For LOG_LEVEL=info collective info includes, src and dst buffer address, count, datatype, memory type if available; inplace flag if set; root for rooted collectives; operation for reduction collectives; chosen TL/CL; team id. For V collectives (allgatherv, alltoallv, scatterv ...) count is sum of corresponding values in counts buffer.
2.4. For LOG_LEVEL=debug collective info output additionally includes team rank number, context rank number, collective sequence number, pointer to request

All other prints moved from info log level to debug log level.
<details>
<summary>UCC_LOG_LEVEL=info example</summary>
<pre>
ucc_constructor.c:183  UCC  INFO  version: 1.2.0, loaded from: /home/ucc/build-debug/install/lib/libucc.so.1, cfg file: n/a
ucc_constructor.c:183  UCC  INFO  version: 1.2.0, loaded from: /home/ucc/build-debug/install/lib/libucc.so.1, cfg file: n/a
       ucc_team.c:471  UCC  INFO  ===== COLL_SCORE_MAP (team_id 32768, size 2) =====
ucc_coll_score_map.c:201  UCC  INFO  Allgather:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Allgatherv:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Allreduce:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..4095}:TL_UCP:10 {4K..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..4095}:TL_UCP:10 {4K..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..4095}:TL_UCP:10 {4K..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Alltoall:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Alltoallv:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Barrier:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Bcast:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..32767}:TL_UCP:10 {32K..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..32767}:TL_UCP:10 {32K..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..32767}:TL_UCP:10 {32K..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Fanin:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Fanout:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Gather:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Gatherv:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Reduce:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Reduce_scatter:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Reduce_scatterv:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Scatterv:
ucc_coll_score_map.c:201  UCC  INFO     Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     Cuda: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO     CudaManaged: {0..inf}:TL_UCP:10
       ucc_team.c:474  UCC  INFO  ================================================

 OSU MPI All-to-All Personalized Exchange Latency Test v5.8
 Size       Avg Latency(us)
....
ucc_team.c:528  UCC  INFO  team destroyed, team_id 32768
</pre>
</details>

<details>
<summary>UCC_COLL_TRACE=y example</summary>
<pre>
ucc_coll.c:257  UCC  INFO  coll_init: Barrier; TL_UCP, team_id 32768
ucc_coll.c:257  UCC  INFO  coll_init: Alltoall: src={0x7f7f2d789000, 2097152, int8, Host}, dst={0x7f7f2d587000, 2097152, int8, Host}; TL_UCP, team_id 32768
ucc_coll.c:257  UCC  INFO  coll_init: Barrier; TL_UCP, team_id 32768
ucc_coll.c:257  UCC  INFO  coll_init: Reduce min root 0: src={0x7ffd97e4ebd0, 1, float64, Host}, dst={0x7ffd97e4ebe8, 1, float64, Host}; TL_UCP, team_id 32768
ucc_coll.c:257  UCC  INFO  coll_init: Reduce max root 0: src={0x7ffd97e4ebd0, 1, float64, Host}, dst={0x7ffd97e4ebe0, 1, float64, Host}; TL_UCP, team_id 32768
ucc_coll.c:257  UCC  INFO  coll_init: Reduce sum root 0: src={0x7ffd97e4ebd0, 1, float64, Host}, dst={0x7ffd97e4ebd8, 1, float64, Host}; TL_UCP, team_id 32768
</pre>
</details>