### PR TITLE
CORE: add min team size option

### DIFF
--- a/src/components/base/ucc_base_iface.c
+++ b/src/components/base/ucc_base_iface.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -14,11 +14,17 @@ ucc_config_field_t ucc_base_lib_config_table[] = {
      "selected will be printed.\n"
      "Possible values are: fatal, error, warn, info, debug, trace, data, func, "
      "poll.",
-     ucc_offsetof(ucc_base_lib_config_t, log_component), UCC_CONFIG_TYPE_LOG_COMP},
+     ucc_offsetof(ucc_base_lib_config_t, log_component),
+     UCC_CONFIG_TYPE_LOG_COMP},
 
     {"USE_TUNING", "y",
      "Use perf tuning",
      ucc_offsetof(ucc_base_lib_config_t, use_tuning), UCC_CONFIG_TYPE_BOOL},
+
+    {"MIN_TEAM_SIZE", "auto",
+     "mininaml team size for which component can be used",
+     ucc_offsetof(ucc_base_lib_config_t, min_team_size),
+     UCC_CONFIG_TYPE_ULUNITS},
 
     {NULL}};
 

--- a/src/components/cl/basic/cl_basic.c
+++ b/src/components/cl/basic/cl_basic.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -10,6 +10,8 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
                                        ucc_base_lib_attr_t  *base_attr);
 ucc_status_t ucc_cl_basic_get_context_attr(const ucc_base_context_t *context,
                                            ucc_base_ctx_attr_t      *base_attr);
+
+ucc_status_t ucc_cl_basic_get_lib_properties(ucc_base_lib_properties_t *prop);
 
 static ucc_config_field_t ucc_cl_basic_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_cl_basic_lib_config_t, super),

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -88,5 +88,13 @@ ucc_status_t ucc_cl_basic_get_lib_attr(const ucc_base_lib_t *lib,
             return status;
         }
     }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cl_basic_get_lib_properties(ucc_base_lib_properties_t *prop)
+{
+    prop->default_team_size = 1;
+    prop->min_team_size     = 1;
+    prop->max_team_size     = UCC_RANK_MAX;
     return UCC_OK;
 }

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -12,6 +12,9 @@
 
 ucc_status_t ucc_cl_hier_get_lib_attr(const ucc_base_lib_t *lib,
                                       ucc_base_lib_attr_t  *base_attr);
+
+ucc_status_t ucc_cl_hier_get_lib_properties(ucc_base_lib_properties_t *prop);
+
 ucc_status_t ucc_cl_hier_get_context_attr(const ucc_base_context_t *context,
                                           ucc_base_ctx_attr_t      *base_attr);
 

--- a/src/components/cl/hier/cl_hier_lib.c
+++ b/src/components/cl/hier/cl_hier_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -128,5 +128,13 @@ ucc_status_t ucc_cl_hier_get_lib_attr(const ucc_base_lib_t *lib,
             return status;
         }
     }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_cl_hier_get_lib_properties(ucc_base_lib_properties_t *prop)
+{
+    prop->default_team_size = 2;
+    prop->min_team_size     = 2;
+    prop->max_team_size     = UCC_RANK_MAX;
     return UCC_OK;
 }

--- a/src/components/tl/cuda/tl_cuda.c
+++ b/src/components/tl/cuda/tl_cuda.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -52,6 +52,8 @@ UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_cuda_lib_t, ucc_base_lib_t);
 
 ucc_status_t ucc_tl_cuda_get_lib_attr(const ucc_base_lib_t *lib,
                                       ucc_base_lib_attr_t *base_attr);
+
+ucc_status_t ucc_tl_cuda_get_lib_properties(ucc_base_lib_properties_t *prop);
 
 static ucs_config_field_t ucc_tl_cuda_context_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_cuda_context_config_t, super),

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -35,15 +35,15 @@
 #define UCC_TL_CUDA_TEAM_CTX(_team)                                            \
     (ucc_derived_of((_team)->super.super.context, ucc_tl_cuda_context_t))
 
-#define UCC_TL_CUDA_TEAM_SYNC(_team, _rank, _id)                                    \
-    ({                                                                              \
-        size_t _ctrl_size_rank =                                                    \
-            (sizeof(ucc_tl_cuda_sync_t) +                                           \
-             sizeof(ucc_tl_cuda_sync_data_t) * (UCC_TL_TEAM_SIZE(_team) - 1));      \
-        size_t _ctrl_size = _ctrl_size_rank * UCC_TL_TEAM_SIZE(_team);              \
-        void  *_sync      = PTR_OFFSET(_team->sync, _ctrl_size * (_id) +            \
-                                                        _ctrl_size_rank * (_rank)); \
-        (ucc_tl_cuda_sync_t *)_sync;                                                \
+#define UCC_TL_CUDA_TEAM_SYNC(_team, _rank, _id)                               \
+    ({                                                                         \
+        size_t _ctrl_size_rank =                                               \
+            (sizeof(ucc_tl_cuda_sync_t) +                                      \
+             sizeof(ucc_tl_cuda_sync_data_t) * (UCC_TL_TEAM_SIZE(_team) - 1)); \
+        size_t _ctrl_size = _ctrl_size_rank * UCC_TL_TEAM_SIZE(_team);         \
+        void  *_sync      = PTR_OFFSET(_team->sync, _ctrl_size * (_id) +       \
+                                       _ctrl_size_rank * (_rank));             \
+        (ucc_tl_cuda_sync_t *)_sync;                                           \
     })
 
 #define UCC_TL_CUDA_TEAM_BARRIER(_team, _id)                                   \

--- a/src/components/tl/cuda/tl_cuda_lib.c
+++ b/src/components/tl/cuda/tl_cuda_lib.c
@@ -52,10 +52,10 @@ ucc_status_t ucc_tl_cuda_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
     attr->super.attr.coll_types  = UCC_TL_CUDA_SUPPORTED_COLLS;
     attr->super.flags            = 0;
     if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE) {
-        attr->super.min_team_size    = lib->min_team_size;
+        attr->super.min_team_size = lib->min_team_size;
     }
     if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
-        attr->super.max_team_size    = UCC_TL_CUDA_MAX_PEERS;
+        attr->super.max_team_size = UCC_TL_CUDA_MAX_PEERS;
     }
     return UCC_OK;
 }

--- a/src/components/tl/cuda/tl_cuda_lib.c
+++ b/src/components/tl/cuda/tl_cuda_lib.c
@@ -10,7 +10,7 @@
 UCC_CLASS_INIT_FUNC(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *params,
                     const ucc_base_config_t *config)
 {
-    const ucc_tl_cuda_lib_config_t *tl_config =
+    const ucc_tl_cuda_lib_config_t *tl_config     =
         ucc_derived_of(config, ucc_tl_cuda_lib_config_t);
     size_t min_scratch_size;
 
@@ -25,9 +25,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *params,
     }
 
     /* min scratch size should be large enough so that
-       ucc_align_down_pow2(scratch_size / nrings / nchunks / dt_size / 2, 64) > 1
+     * ucc_align_down_pow2(scratch_size / nrings / nchunks / dt_size / 2, 64) > 1
      */
-
     min_scratch_size = 128 * 16 * ucc_dt_size(UCC_DT_FLOAT128_COMPLEX) *
                        self->cfg.allgather_ring_num_chunks;
     if (self->cfg.scratch_size < min_scratch_size) {
@@ -49,8 +48,22 @@ ucc_status_t ucc_tl_cuda_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
 {
     ucc_tl_lib_attr_t *attr      = ucc_derived_of(base_attr, ucc_tl_lib_attr_t);
 
-    attr->super.flags            = 0;
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = UCC_TL_CUDA_SUPPORTED_COLLS;
+    attr->super.flags            = 0;
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE) {
+        attr->super.min_team_size    = lib->min_team_size;
+    }
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
+        attr->super.max_team_size    = UCC_TL_CUDA_MAX_PEERS;
+    }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_cuda_get_lib_properties(ucc_base_lib_properties_t *prop)
+{
+    prop->default_team_size = 2;
+    prop->min_team_size     = 2;
+    prop->max_team_size     = UCC_TL_CUDA_MAX_PEERS;
     return UCC_OK;
 }

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -32,15 +32,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
     self->stream      = NULL;
     self->topo        = NULL;
     self->scratch.loc = NULL;
-    if (UCC_TL_TEAM_SIZE(self) < 2) {
-        tl_trace(tl_context->lib, "team size is too small, min supported 2");
-        return UCC_ERR_NOT_SUPPORTED;
-    }
-    if (UCC_TL_TEAM_SIZE(self) > UCC_TL_CUDA_MAX_PEERS) {
-        tl_info(tl_context->lib, "team size is too large, max supported %d",
-                UCC_TL_CUDA_MAX_PEERS);
-        return UCC_ERR_NOT_SUPPORTED;
-    }
 
     if (!ucc_team_map_is_single_node(params->team, params->map)) {
         tl_info(tl_context->lib, "multinode team is not supported");

--- a/src/components/tl/mlx5/tl_mlx5.c
+++ b/src/components/tl/mlx5/tl_mlx5.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -10,6 +10,8 @@ ucc_status_t ucc_tl_mlx5_get_lib_attr(const ucc_base_lib_t *lib,
                                       ucc_base_lib_attr_t * base_attr);
 ucc_status_t ucc_tl_mlx5_get_context_attr(const ucc_base_context_t *context,
                                           ucc_base_ctx_attr_t *     base_attr);
+
+ucc_status_t ucc_tl_mlx5_get_lib_properties(ucc_base_lib_properties_t *prop);
 
 static ucc_config_field_t ucc_tl_mlx5_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_mlx5_lib_config_t, super),

--- a/src/components/tl/mlx5/tl_mlx5_lib.c
+++ b/src/components/tl/mlx5/tl_mlx5_lib.c
@@ -40,7 +40,7 @@ ucc_status_t ucc_tl_mlx5_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
     }
 
     if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
-        attr->super.max_team_size    = UCC_RANK_MAX;
+        attr->super.max_team_size = UCC_RANK_MAX;
     }
 
     return UCC_OK;

--- a/src/components/tl/mlx5/tl_mlx5_lib.c
+++ b/src/components/tl/mlx5/tl_mlx5_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -34,6 +34,22 @@ ucc_status_t ucc_tl_mlx5_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE; //TODO check impacts
     attr->super.attr.coll_types  = UCC_TL_MLX5_SUPPORTED_COLLS;
     attr->super.flags            = UCC_BASE_LIB_FLAG_SERVICE_TEAM_REQUIRED |
-                        UCC_BASE_LIB_FLAG_CTX_SERVICE_TEAM_REQUIRED;
+                                   UCC_BASE_LIB_FLAG_CTX_SERVICE_TEAM_REQUIRED;
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE) {
+        attr->super.min_team_size    = lib->min_team_size;
+    }
+
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
+        attr->super.max_team_size    = UCC_RANK_MAX;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_mlx5_get_lib_properties(ucc_base_lib_properties_t *prop)
+{
+    prop->default_team_size = 2;
+    prop->min_team_size     = 2;
+    prop->max_team_size     = UCC_RANK_MAX;
     return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl.c
+++ b/src/components/tl/nccl/tl_nccl.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -10,6 +10,8 @@
 
 ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib,
                                       ucc_base_lib_attr_t  *base_attr);
+
+ucc_status_t ucc_tl_nccl_get_lib_properties(ucc_base_lib_properties_t *prop);
 
 ucc_status_t ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context,
                                           ucc_base_ctx_attr_t      *base_attr);

--- a/src/components/tl/nccl/tl_nccl_lib.c
+++ b/src/components/tl/nccl/tl_nccl_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -31,5 +31,23 @@ ucc_status_t ucc_tl_nccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = UCC_TL_NCCL_SUPPORTED_COLLS;
     attr->super.flags            = 0;
+    attr->super.min_team_size    = 2;
+    attr->super.max_team_size    = UCC_RANK_MAX;
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE) {
+        attr->super.min_team_size = lib->min_team_size;
+    }
+
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
+        attr->super.max_team_size = UCC_RANK_MAX;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_nccl_get_lib_properties(ucc_base_lib_properties_t *prop)
+{
+    prop->default_team_size = 2;
+    prop->min_team_size     = 2;
+    prop->max_team_size     = UCC_RANK_MAX;
     return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -22,12 +22,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_team_t, ucc_base_context_t *tl_context,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
 
     size = UCC_TL_TEAM_SIZE(self);
-    if (size < 2) {
-        tl_debug(tl_context->lib,
-                 "team size %d is too small, minimal size is 2",
-                 UCC_TL_TEAM_SIZE(self));
-        return UCC_ERR_NOT_SUPPORTED;
-    }
     self->comm_state = UCC_OK;
     self->unique_id  = ucc_malloc(sizeof(ncclUniqueId) * (size + 1),
                                   "tl_nccl_unique_id");

--- a/src/components/tl/rccl/tl_rccl.c
+++ b/src/components/tl/rccl/tl_rccl.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -11,6 +11,8 @@
 
 ucc_status_t ucc_tl_rccl_get_lib_attr(const ucc_base_lib_t *lib,
                                       ucc_base_lib_attr_t  *base_attr);
+
+ucc_status_t ucc_tl_rccl_get_lib_properties(ucc_base_lib_properties_t *prop);
 
 ucc_status_t ucc_tl_rccl_get_context_attr(const ucc_base_context_t *context,
                                           ucc_base_ctx_attr_t      *base_attr);

--- a/src/components/tl/rccl/tl_rccl_lib.c
+++ b/src/components/tl/rccl/tl_rccl_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -34,5 +34,22 @@ ucc_status_t ucc_tl_rccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = UCC_TL_RCCL_SUPPORTED_COLLS;
     attr->super.flags            = 0;
+    attr->super.min_team_size    = 2;
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE) {
+        attr->super.min_team_size    = lib->min_team_size;
+    }
+
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
+        attr->super.max_team_size    = UCC_RANK_MAX;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_cuda_get_lib_properties(ucc_base_lib_properties_t *prop)
+{
+    prop->default_team_size = 2;
+    prop->min_team_size     = 2;
+    prop->max_team_size     = UCC_RANK_MAX;
     return UCC_OK;
 }

--- a/src/components/tl/rccl/tl_rccl_lib.c
+++ b/src/components/tl/rccl/tl_rccl_lib.c
@@ -34,13 +34,12 @@ ucc_status_t ucc_tl_rccl_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = UCC_TL_RCCL_SUPPORTED_COLLS;
     attr->super.flags            = 0;
-    attr->super.min_team_size    = 2;
     if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE) {
-        attr->super.min_team_size    = lib->min_team_size;
+        attr->super.min_team_size = lib->min_team_size;
     }
 
     if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
-        attr->super.max_team_size    = UCC_RANK_MAX;
+        attr->super.max_team_size = UCC_RANK_MAX;
     }
 
     return UCC_OK;

--- a/src/components/tl/self/tl_self.c
+++ b/src/components/tl/self/tl_self.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -12,8 +12,11 @@
 
 ucc_status_t ucc_tl_self_get_lib_attr(const ucc_base_lib_t *lib,
                                       ucc_base_lib_attr_t  *base_attr);
+
 ucc_status_t ucc_tl_self_get_context_attr(const ucc_base_context_t *context,
                                           ucc_base_ctx_attr_t      *base_attr);
+
+ucc_status_t ucc_tl_self_get_lib_properties(ucc_base_lib_properties_t *prop);
 
 static ucc_config_field_t ucc_tl_self_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_self_lib_config_t, super),

--- a/src/components/tl/self/tl_self_lib.c
+++ b/src/components/tl/self/tl_self_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -36,5 +36,19 @@ ucc_status_t ucc_tl_self_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
     attr->super.flags            = 0;
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = UCC_TL_SELF_SUPPORTED_COLLS;
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE) {
+        attr->super.min_team_size = 1;
+    }
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
+        attr->super.max_team_size = 1;
+    }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_self_get_lib_properties(ucc_base_lib_properties_t *prop)
+{
+    prop->default_team_size = 1;
+    prop->min_team_size     = 1;
+    prop->max_team_size     = 1;
     return UCC_OK;
 }

--- a/src/components/tl/self/tl_self_team.c
+++ b/src/components/tl/self/tl_self_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -16,14 +16,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_self_team_t, ucc_base_context_t *tl_context,
         ucc_derived_of(tl_context, ucc_tl_self_context_t);
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
-
-    if (UCC_TL_TEAM_SIZE(self) > 1) {
-        tl_trace(tl_context->lib,
-                 "team size %d is too large, max supported 1, skip",
-                 UCC_TL_TEAM_SIZE(self));
-        return UCC_ERR_NOT_SUPPORTED;
-    }
-
     tl_info(tl_context->lib, "posted tl team: %p", self);
     return UCC_OK;
 }

--- a/src/components/tl/sharp/tl_sharp.c
+++ b/src/components/tl/sharp/tl_sharp.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -9,6 +9,8 @@
 
 ucc_status_t ucc_tl_sharp_get_lib_attr(const ucc_base_lib_t *lib,
                                        ucc_base_lib_attr_t *base_attr);
+
+ucc_status_t ucc_tl_sharp_get_lib_properties(ucc_base_lib_properties_t *prop);
 
 ucc_status_t ucc_tl_sharp_get_context_attr(const ucc_base_context_t *context,
                                            ucc_base_ctx_attr_t *base_attr);

--- a/src/components/tl/sharp/tl_sharp_lib.c
+++ b/src/components/tl/sharp/tl_sharp_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -42,5 +42,27 @@ ucc_status_t ucc_tl_sharp_get_lib_attr(const ucc_base_lib_t *lib,
     }
     attr->super.attr.thread_mode = UCC_THREAD_MULTIPLE;
     attr->super.attr.coll_types  = UCC_TL_SHARP_SUPPORTED_COLLS;
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE) {
+        if (lib == NULL) {
+            return UCC_ERR_INVALID_PARAM;
+        }
+        attr->super.min_team_size = lib->min_team_size;
+    }
+
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
+        if (lib == NULL) {
+            return UCC_ERR_INVALID_PARAM;
+        }
+        attr->super.max_team_size = UCC_RANK_MAX;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_sharp_get_lib_properties(ucc_base_lib_properties_t *prop)
+{
+    prop->default_team_size = 4;
+    prop->min_team_size     = 2;
+    prop->max_team_size     = UCC_RANK_MAX;
     return UCC_OK;
 }

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -7,6 +7,7 @@
 #include "ucc_tl.h"
 #include "utils/ucc_log.h"
 #include "core/ucc_team.h"
+#include "ucc_tl_log.h"
 
 ucc_config_field_t ucc_tl_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_lib_config_t, super),
@@ -26,12 +27,36 @@ UCC_CLASS_INIT_FUNC(ucc_tl_lib_t, ucc_tl_iface_t *tl_iface,
                     const ucc_tl_lib_config_t *tl_config)
 {
     UCC_CLASS_CALL_BASE_INIT();
+    ucc_base_lib_properties_t prop;
+    ucc_status_t status;
+
+    status = tl_iface->lib.get_properties(&prop);
+    if (status != UCC_OK) {
+        return status;
+    }
+
     self->iface               = tl_iface;
     self->super.use_tuning    = tl_config->super.use_tuning;
     self->super.log_component = tl_config->super.log_component;
+    self->super.min_team_size = prop.default_team_size;
     ucc_strncpy_safe(self->super.log_component.name,
                      tl_iface->tl_lib_config.name,
                      sizeof(self->super.log_component.name));
+
+    if (tl_config->super.min_team_size != UCC_ULUNITS_AUTO) {
+        if (tl_config->super.min_team_size < prop.min_team_size) {
+            tl_warn(self, "min supported team size is %d, requested %d",
+                    prop.min_team_size,
+                    (ucc_rank_t)tl_config->super.min_team_size);
+        } else if (tl_config->super.min_team_size > prop.max_team_size) {
+            tl_warn(self, "max supported team size is %d, requested %d",
+                    prop.max_team_size,
+                    (ucc_rank_t)tl_config->super.min_team_size);
+        } else {
+            self->super.min_team_size = tl_config->super.min_team_size;
+        }
+    }
+
     return UCC_OK;
 }
 
@@ -47,7 +72,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_context_t, const ucc_tl_context_config_t *tl_config,
     UCC_CLASS_CALL_BASE_INIT();
     self->super.lib         = &tl_config->tl_lib->super;
     self->super.ucc_context = ucc_context;
-    self->ref_count = 0;
+    self->ref_count         = 0;
     if (0 == strcmp(tl_config->super.score_str, "0")) {
         return UCC_ERR_LAST;
     }
@@ -242,8 +267,34 @@ UCC_CLASS_INIT_FUNC(ucc_tl_team_t, ucc_tl_context_t *tl_context,
                     const ucc_base_team_params_t *params)
 {
     UCC_CLASS_CALL_BASE_INIT();
+    ucc_base_lib_t *lib = tl_context->super.lib;
+    ucc_base_lib_attr_t attr;
+    ucc_tl_iface_t *tl_iface;
+    ucc_status_t status;
+
     self->super.context = &tl_context->super;
     self->super.params  = *params;
+
+    tl_iface = UCC_TL_CTX_IFACE(tl_context);
+    attr.mask = UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE |
+                UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE;
+    status = tl_iface->lib.get_attr(lib, &attr);
+    if (status != UCC_OK) {
+        return status;
+    }
+
+    if (attr.min_team_size > params->size) {
+        tl_debug(lib, "team size %d is too small, min supported %d",
+                 params->size, attr.min_team_size);
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    if (attr.max_team_size < params->size) {
+        tl_debug(lib, "team size %d is too big, max supported %d",
+                 params->size, attr.max_team_size);
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
     return UCC_OK;
 }
 

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -26,6 +26,9 @@
 
 ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib,
                                      ucc_base_lib_attr_t  *base_attr);
+
+ucc_status_t ucc_tl_ucp_get_lib_properties(ucc_base_lib_properties_t *prop);
+
 ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
                                          ucc_base_ctx_attr_t      *base_attr);
 

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -119,5 +119,21 @@ ucc_status_t ucc_tl_ucp_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
     }
     attr->super.attr.coll_types = UCC_TL_UCP_SUPPORTED_COLLS;
     attr->super.flags           = UCC_BASE_LIB_FLAG_TEAM_ID_REQUIRED;
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MIN_TEAM_SIZE) {
+        attr->super.min_team_size = lib->min_team_size;
+    }
+
+    if (base_attr->mask & UCC_BASE_LIB_ATTR_FIELD_MAX_TEAM_SIZE) {
+        attr->super.max_team_size = UCC_RANK_MAX;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_ucp_get_lib_properties(ucc_base_lib_properties_t *prop)
+{
+    prop->default_team_size = 2;
+    prop->min_team_size     = 2;
+    prop->max_team_size     = UCC_RANK_MAX;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -51,14 +51,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
     /* TODO: init based on ctx settings and on params: need to check
              if all the necessary ranks mappings are provided */
-
-    if (UCC_TL_TEAM_SIZE(self) < 2) {
-        tl_trace(tl_context->lib,
-                 "team size %d is too small, minimal size is 2",
-                 UCC_TL_TEAM_SIZE(self));
-        return UCC_ERR_NOT_SUPPORTED;
-    }
-
     self->preconnect_task = NULL;
     self->seq_num         = 0;
     self->status          = UCC_INPROGRESS;

--- a/src/utils/ucc_component.h
+++ b/src/utils/ucc_component.h
@@ -28,7 +28,7 @@ typedef struct ucc_component_framework {
     ucc_config_names_array_t names;
 } ucc_component_framework_t;
 
-/* ucc_components_load searches for all available dynamic components 
+/* ucc_components_load searches for all available dynamic components
    with the name matching the pattern: libucc_<framework_name>_*.so.
    The search is performed in the ucc_global_config.component_path.
    Each dynamic component must have a component interface structure defined.


### PR DESCRIPTION
## What
Add config option to disable TL for team sizes below certain threshold, Adds check for min team and max team sizes in super class init.

## Why ?
Some TLs are known to be used starting from particular communicator size, for example it doesn't make sense to use SHARP for comm size 2. This PR sets following limits for TLs
| TL    | min supported team size | max supported team size | default comm size threshold |
|-------|-------------------------|-------------------------|-----------------------------|
| SELF  | 1                       | 1                       | 1                           |
| UCP   | 2                       | INF                     | 2                           |
| SHARP | 2                       | INF                     | 4                           |
| NCCL  | 2                       | INF                     | 2                           |
| RCCL  | 2                       | INF                     | 2                           |
| CUDA  | 2                       | TL_CUDA_MAX_PEERS       | 2                           |

