### PR TITLE
UTIL: detect AMD Genoa CPU

### DIFF
--- a/src/utils/arch/cpu.h
+++ b/src/utils/arch/cpu.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2001-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2023. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 *
@@ -30,6 +30,7 @@ typedef enum ucc_cpu_model {
     UCC_CPU_MODEL_AMD_NAPLES,
     UCC_CPU_MODEL_AMD_ROME,
     UCC_CPU_MODEL_AMD_MILAN,
+    UCC_CPU_MODEL_AMD_GENOA,
     UCC_CPU_MODEL_ZHAOXIN_ZHANGJIANG,
     UCC_CPU_MODEL_ZHAOXIN_WUDAOKOU,
     UCC_CPU_MODEL_ZHAOXIN_LUJIAZUI,
@@ -89,6 +90,8 @@ static inline ucc_cpu_model_t ucc_get_model_from_str(const char *m_name)
         return UCC_CPU_MODEL_AMD_ROME;
     if (strcasecmp(m_name, "milan") == 0)
         return UCC_CPU_MODEL_AMD_MILAN;
+    if (strcasecmp(m_name, "genoa") == 0)
+        return UCC_CPU_MODEL_AMD_GENOA;
     if (strcasecmp(m_name, "zhangjiang") == 0)
         return UCC_CPU_MODEL_ZHAOXIN_ZHANGJIANG;
     if (strcasecmp(m_name, "wudaokou") == 0)

--- a/src/utils/arch/x86_64/cpu.c
+++ b/src/utils/arch/x86_64/cpu.c
@@ -1,3 +1,11 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2023. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+* Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
 #if defined(__x86_64__)
 
 #ifdef HAVE_CONFIG_H
@@ -88,7 +96,8 @@ ucc_cpu_model_t ucc_arch_get_cpu_model()
     uint32_t model, family;
 
     /* Get CPU model/family */
-    ucc_x86_cpuid(X86_CPUID_GET_MODEL, ucc_unaligned_ptr(&version.reg), &_ebx, &_ecx, &_edx);
+    ucc_x86_cpuid(X86_CPUID_GET_MODEL, ucc_unaligned_ptr(&version.reg),
+                  &_ebx, &_ecx, &_edx);
 
     model  = version.model;
     family = version.family;
@@ -97,7 +106,8 @@ ucc_cpu_model_t ucc_arch_get_cpu_model()
     if (family == 0xf) {
         family += version.ext_family;
     }
-    if ((family == 0x6) || (family == 0x7) || (family == 0xf) || (family == 0x17)) {
+    if ((family == 0x6) || (family == 0x7) || (family == 0xf) ||
+        (family == 0x17) || (family == 0x19)) {
         model = (version.ext_model << 4) | model;
     }
 
@@ -167,6 +177,8 @@ ucc_cpu_model_t ucc_arch_get_cpu_model()
             case 0x00:
             case 0x01:
                 return UCC_CPU_MODEL_AMD_MILAN;
+            case 0x11:
+                return UCC_CPU_MODEL_AMD_GENOA;
             }
         }
     }


### PR DESCRIPTION
## What
Detect AMD Genoa CPUs.

## Why ?
Required for TL SHM tuning.