### PR TITLE
BUILD: fix compilation on clang-16 with hip

### DIFF
--- a/cuda_lt.sh
+++ b/cuda_lt.sh
@@ -26,7 +26,12 @@ local_npic_filepath="${local_npic_dir}${o_filename}"
 
 mkdir -p $pic_dir
 
-cmd="${@:3} -Xcompiler -fPIC -o ${pic_filepath}"
+tmpcmd="${@:3}"
+if [[ "$tmpcmd" == *"hipcc"* ]]; then
+  cmd="${@:3} -fPIC -o ${pic_filepath}"
+else
+  cmd="${@:3} -Xcompiler -fPIC -o ${pic_filepath}"
+fi
 echo $cmd
 $cmd
 


### PR DESCRIPTION
## What
The upcoming rocm release switched from clang-15 to clang-16, and we observer a compilation failure of the ec/rocm/kernel code. 

## Why ?
This commit fixes the compilation problem by omitting the `-Xcompile` flag in cuda_lt.sh if the compiler is hipcc. 
(Previously, the flag generated a warning, now its an error).
