### PR TITLE
TL/UCP: bcast opt

### DIFF
--- a/.azure/azure-pipelines-pr.yml
+++ b/.azure/azure-pipelines-pr.yml
@@ -96,7 +96,7 @@ stages:
                             --prefix=$(Build.Repository.LocalPath)/install --enable-gtest
               make -j install
             displayName: Build ucc artifact
-            timeoutInMinutes: 50
+            timeoutInMinutes: 60
           - bash: |
               cd build
               make gtest

--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -211,6 +211,25 @@ ucc_knomial_pattern_get_min_radix(ucc_kn_radix_t cfg_radix,
     return radix;
 }
 
+/* Calculates for each rank at which distance it should recieve */
+static inline ucc_rank_t
+ucc_knomial_calc_recv_dist(ucc_rank_t team_size, ucc_rank_t rank,
+                           ucc_rank_t radix, ucc_rank_t root)
+{
+    if (rank == root) {
+        return 0;
+    }
+    ucc_rank_t root_base = 0 ;
+    ucc_rank_t dist = 1;
+    while (dist <= team_size) {
+        if (rank < root_base + radix * dist) {
+            break;
+        }
+        dist *= radix;
+    }
+    return dist;
+}
+
 /* A set of convenience macros used to implement sw based progress
    of the algorithms that use kn pattern */
 enum {

--- a/src/components/tl/ucp/bcast/bcast.h
+++ b/src/components/tl/ucp/bcast/bcast.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -17,8 +17,9 @@ enum {
 extern ucc_base_coll_alg_info_t
              ucc_tl_ucp_bcast_algs[UCC_TL_UCP_BCAST_ALG_LAST + 1];
 
+/* SAG bcast supports team size 2, but Knomial is always better in this case */
 #define UCC_TL_UCP_BCAST_DEFAULT_ALG_SELECT_STR \
-    "bcast:0-32k:@0#bcast:32k-inf:@1"
+    "bcast:0-inf:[2-2]:@0#bcast:0-32k:[3-inf]:@0#bcast:32k-inf:[3-inf]:@1"
 
 static inline int ucc_tl_ucp_bcast_alg_from_str(const char *str)
 {

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -57,10 +57,14 @@ void ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
             }
         }
         dist /= radix;
-        if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+        if (UCC_INPROGRESS == ucc_tl_ucp_test_recv(task)) {
             task->bcast_kn.dist = dist;
             return;
         }
+    }
+    if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+        task->bcast_kn.dist = dist;
+        return;
     }
 
     ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));

--- a/src/components/tl/ucp/scatter/scatter_knomial.c
+++ b/src/components/tl/ucp/scatter/scatter_knomial.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -55,7 +55,6 @@ void ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_coll_args_t       *args = &TASK_ARGS(task);
     ucc_tl_ucp_team_t     *team = TASK_TEAM(task);
     ucc_kn_radix_t         radix     = task->scatter_kn.p.radix;
-    uint8_t                node_type = task->scatter_kn.p.node_type;
     ucc_knomial_pattern_t *p         = &task->scatter_kn.p;
     void                  *rbuf      = args->dst.info.buffer;
     ucc_memory_type_t      mem_type  = args->src.info.mem_type;
@@ -80,7 +79,7 @@ void ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
         goto UCC_SCATTER_KN_PHASE_LOOP;
     }
 
-    if (KN_NODE_EXTRA == node_type) {
+    if (KN_NODE_EXTRA == p->node_type) {
         goto out;
     }
 
@@ -101,8 +100,8 @@ void ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
          Receive will only occur in the following iteration to that of
          it's parent's send.
         */
-        if (rank != root && task->scatter_kn.recv_dist == p->radix_pow &&
-            task->tagged.recv_posted == 0) {
+        if ((rank != root) && (task->scatter_kn.recv_dist == p->radix_pow)) {
+            ucc_assert(task->tagged.recv_posted == 0);
             for (loop_step = 1; loop_step < radix; loop_step++) {
                 peer = ucc_knomial_pattern_get_loop_peer(p, rank, loop_step);
                 if (peer == UCC_KN_PEER_NULL)
@@ -111,6 +110,7 @@ void ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
                 vroot = ucc_knomial_pattern_loop_rank(p, root);
                 peer_recv_dist =
                     calc_recv_dist(team_size, vpeer, radix, vroot);
+                task->scatter_kn.recv_size = local_seg_count * dt_size;
                 if (peer_recv_dist < task->scatter_kn.recv_dist) {
                     UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(rbuf,
                                   local_seg_count * dt_size, mem_type,
@@ -128,9 +128,8 @@ void ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
          Each rank's send (besides leaf ranks) happens only after it's recieve
          from previous iteration has completed.
         */
-        if (root == rank ||
-            (task->tagged.recv_posted > 0 &&
-             task->tagged.recv_posted == task->tagged.recv_completed)) {
+        if ((root == rank) || (task->tagged.recv_posted > 0)) {
+            ucc_assert(task->tagged.recv_posted == task->tagged.recv_completed);
             for (loop_step = 1; loop_step < radix; loop_step++) {
                 peer = ucc_knomial_pattern_get_loop_peer(p, rank, loop_step);
                 if (peer == UCC_KN_PEER_NULL)
@@ -146,6 +145,7 @@ void ucc_tl_ucp_scatter_knomial_progress(ucc_coll_task_t *coll_task)
                     peer_seg_count * dt_size, mem_type, INV_VRANK(peer,
                     (ucc_rank_t)args->root, size), team, task), task, out);
             }
+            /*TODO: local_seg_index is always zero since rank that sends is base root? */
             local_seg_index =
                 ucc_kn_compute_seg_index(rank, p->radix_pow, p);
             offset = ucc_sra_kn_compute_seg_offset(
@@ -165,8 +165,8 @@ UCC_SCATTER_KN_PHASE_LOOP:
                                      &offset, &local_seg_count);
     if (offset != 0) {
         status = ucc_mc_memcpy(PTR_OFFSET(args->dst.info.buffer, offset),
-                               PTR_OFFSET(rbuf, task->scatter_kn.send_offset),
-                               local_seg_count * dt_size, mem_type, mem_type);
+                               rbuf, task->scatter_kn.recv_size, mem_type,
+                               mem_type);
         if (ucc_unlikely(UCC_OK != status)) {
             task->super.status = status;
             return;
@@ -202,8 +202,7 @@ ucc_status_t ucc_tl_ucp_scatter_knomial_start(ucc_coll_task_t *coll_task)
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
-ucc_status_t
-ucc_tl_ucp_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
+ucc_status_t ucc_tl_ucp_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
 {
     return ucc_tl_ucp_coll_finalize(coll_task);
 }
@@ -212,29 +211,24 @@ ucc_status_t ucc_tl_ucp_scatter_knomial_init_r(
     ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
     ucc_coll_task_t **task_h, ucc_kn_radix_t radix)
 {
-    ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_rank_t         size    = UCC_TL_TEAM_SIZE(tl_team);
-    ucc_rank_t         rank    = UCC_TL_TEAM_RANK(tl_team);
     ucc_tl_ucp_task_t *task;
-
-    task                 = ucc_tl_ucp_init_task(coll_args, team);
-    task->super.post     = ucc_tl_ucp_scatter_knomial_start;
-    task->super.progress = ucc_tl_ucp_scatter_knomial_progress;
-    task->super.finalize = ucc_tl_ucp_scatter_knomial_finalize;
 
     ucc_assert(coll_args->args.src.info.mem_type ==
                coll_args->args.dst.info.mem_type);
 
-    ucc_knomial_pattern_init(size, rank, radix, &task->scatter_kn.p);
+    task                     = ucc_tl_ucp_init_task(coll_args, team);
+    task->super.post         = ucc_tl_ucp_scatter_knomial_start;
+    task->super.progress     = ucc_tl_ucp_scatter_knomial_progress;
+    task->super.finalize     = ucc_tl_ucp_scatter_knomial_finalize;
+    task->scatter_kn.p.radix = radix;
 
     *task_h = &task->super;
     return UCC_OK;
 }
 
-ucc_status_t
-ucc_tl_ucp_scatter_knomial_init(ucc_base_coll_args_t *coll_args,
-                                       ucc_base_team_t *     team,
-                                       ucc_coll_task_t **    task_h)
+ucc_status_t ucc_tl_ucp_scatter_knomial_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t *team,
+                                             ucc_coll_task_t **task_h)
 {
     ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     size_t             count   = coll_args->args.src.info.count;


### PR DESCRIPTION
## What
Pull request contains multiple optimizations for TL/UCP broadcast

## How ?

- Use knomial bcast for team size 2 for all message sizes. It doesn't make sense to use SAG bcast for 2 ranks since we can directly send whole message to single rank
- Knomial bcast
1. Wait for recv completion only to continue to the next iteration
- SAG bcast
1. Don’t send message to base root rank on each iteration in knomial allgather
2.Wait for recv completion only to continue to the next iteration
