### PR TITLE
API: moving get version to ucc.h

### DIFF
--- a/src/core/ucc_lib.h
+++ b/src/core/ucc_lib.h
@@ -36,9 +36,6 @@ typedef struct ucc_lib_info {
     ucc_cl_lib_attr_t *cl_attrs;
 } ucc_lib_info_t;
 
-void ucc_get_version(unsigned *major_version, unsigned *minor_version,
-                     unsigned *release_number);
-
 int ucc_tl_is_required(ucc_lib_info_t *lib, ucc_tl_iface_t *tl_iface,
                        int forced);
 #endif

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -704,6 +704,27 @@ void ucc_lib_config_print(const ucc_lib_config_h config, FILE *stream,
 ucc_status_t ucc_lib_config_modify(ucc_lib_config_h config, const char *name,
                                    const char *value);
 
+/**
+ * @ingroup UCC_LIB
+ * @brief Get UCC library version.
+ *
+ * This routine returns the UCC library version.
+ *
+ * @param [out] major_version       Filled with library major version.
+ * @param [out] minor_version       Filled with library minor version.
+ * @param [out] release_number      Filled with library release number.
+ */
+void ucc_get_version(unsigned *major_version, unsigned *minor_version,
+                     unsigned *release_number);
+
+/**
+ * @ingroup UCC_LIB
+ * @brief Get UCC library version as a string.
+ *
+ * This routine returns the UCC library version as a string which consists of:
+ * "major.minor.release".
+ */
+const char *ucc_get_version_string(void);
 
 /**
  * @ingroup UCC_LIB


### PR DESCRIPTION
## What
Revealing UCC version get function as part of UCC API

## How ?
Moving ucc_get_version from ucc_lib.h to ucc.h
