### PR TITLE
TEST: return error if all tests skipped

### DIFF
--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) Advanced Micro Devices, Inc. 2023. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
 #include <getopt.h>
 #include <sstream>
 #include "test_mpi.h"
@@ -626,6 +633,12 @@ int main(int argc, char *argv[])
             "   elapsed     : " <<
             std::chrono::duration_cast<std::chrono::seconds>(end - begin).count()
                   << "s" << std::endl;
+
+	if (skipped == test->results.size()) {
+            std::cout << "\n All tests have been skipped, indicating most likely "
+                         "a problem\n";
+            failed = 1;
+	}
     }
 test_exit:
     delete test;


### PR DESCRIPTION
## What
return an error if all tests have been skipped, this is most likely not the expected behavior and indicates a problem.

## Why ?
This issue came up when analyzing how the dlopen error with rccl tl has been missed by our CI. The reason turned out to be that the CI still returned SUCCESS despite of the rccl tl not being able to dlopen and execute correctly, but since no test formally 'failed' but all were skipped, no error code was returned.