### PR TITLE
BUILD: add configure line to ucc info

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,9 +26,15 @@ AC_INIT([ucc], [ucc_ver_major.ucc_ver_minor])
 : ${CPPFLAGS=""}
 : ${CFLAGS=""}
 : ${CXXFLAGS=""}
+config_flags="$*"
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_HEADERS([config.h])
+
+#
+# Save config flags for version dump tool
+#
+AC_DEFINE_UNQUOTED([UCC_CONFIGURE_FLAGS], ["$config_flags"], [UCC configure flags])
 
 UCC_TOP_BUILDDIR="`pwd`"
 AC_SUBST(UCC_TOP_BUILDDIR)

--- a/tools/info/build_info.c
+++ b/tools/info/build_info.c
@@ -12,6 +12,7 @@ void print_version()
 {
     printf("# UCC version=%s revision %s\n", UCC_VERSION_STRING,
            UCC_GIT_REVISION);
+    printf("# Configured with: %s\n", UCC_CONFIGURE_FLAGS);
 }
 
 void print_build_config()


### PR DESCRIPTION
## What
Add information about configure options used to build ucc to ucc_info
example output:
```console
sergeyle@ubuntu:~/ucc/build-debug/install/bin$ ./ucc_info -b | grep UCC_CONFIGURE_FLAGS
#define UCC_CONFIGURE_FLAGS       "--prefix=/home/sergeyle/ucc/build-debug/install --with-ucx=/home/sergeyle/ucx//build-debug/install --with-mpi --without-cuda --without-sharp --enable-debug"
```
and
```console
sergeyle@ubuntu:~/ucc/build-debug/install/bin$ ./ucc_info -v
# UCC version=1.2.0 revision 751c80c2
# Configured with: --prefix=/home/sergeyle/ucc/build-debug/install --with-ucx=/home/sergeyle/ucx//build-debug/install --with-mpi --without-cuda --without-sharp --enable-debug
```
