### PR TITLE
TL/MLX5: share ib_ctx and pd

### DIFF
--- a/src/components/tl/mlx5/Makefile.am
+++ b/src/components/tl/mlx5/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 
 if TL_MLX5_ENABLED

--- a/src/components/tl/mlx5/Makefile.am
+++ b/src/components/tl/mlx5/Makefile.am
@@ -12,9 +12,11 @@ sources =             \
 	tl_mlx5_team.c    \
 	tl_mlx5_coll.h    \
 	tl_mlx5_ib.h	  \
+	tl_mlx5_ib.c      \
 	tl_mlx5_wqe.h	  \
 	tl_mlx5_wqe.c	  \
-	tl_mlx5_ib.c
+	tl_mlx5_pd.h      \
+	tl_mlx5_pd.c
 
 module_LTLIBRARIES = libucc_tl_mlx5.la
 libucc_tl_mlx5_la_SOURCES  = $(sources)

--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -74,8 +74,6 @@ UCC_CLASS_DECLARE(ucc_tl_mlx5_lib_t, const ucc_base_lib_params_t *,
 typedef struct ucc_tl_mlx5_context {
     ucc_tl_context_t             super;
     ucc_tl_mlx5_context_config_t cfg;
-    struct ibv_context *         ib_ctx;
-    struct ibv_pd *              ib_pd;
     struct ibv_context *         shared_ctx;
     struct ibv_pd *              shared_pd;
     ucc_rcache_t *               rcache;

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -107,7 +107,6 @@ ucc_status_t ucc_tl_mlx5_ib_ctx_pd_init(ucc_tl_mlx5_context_t *ctx)
     }
     ctx->ib_port = port;
     if (-1 == port || !ucc_tl_mlx5_check_port_active(ctx->shared_ctx, port)) {
-        status = UCC_ERR_NO_RESOURCE;
         tl_error(ctx->super.super.lib, "no active ports found on %s",
                  ib_devname);
         goto destroy_context;
@@ -116,7 +115,6 @@ ucc_status_t ucc_tl_mlx5_ib_ctx_pd_init(ucc_tl_mlx5_context_t *ctx)
 
     ctx->shared_pd = ibv_alloc_pd(ctx->shared_ctx);
     if (!ctx->shared_pd) {
-        status = UCC_ERR_NO_RESOURCE;
         tl_error(ctx->super.super.lib, "failed to allocate ib_pd");
         goto destroy_context;
     }
@@ -137,6 +135,7 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
     const char *     sockname       = "/sock";
     size_t           sock_dir_len   = strlen(template) + 1;
     size_t           sock_path_len  = sock_dir_len + strlen(sockname);
+    int              sock           = 0;
     char             sock_path[sock_path_len];
     ucc_subset_t     s;
     ucc_status_t     status;
@@ -144,7 +143,6 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
     ucc_sbgp_t *     sbgp;
     ucc_tl_team_t *  steam;
     ucc_coll_task_t *req;
-    int              sock;
 
     ucc_assert(core_ctx->service_team != NULL);
     ucc_assert(core_ctx->params.mask & UCC_CONTEXT_PARAM_FIELD_OOB);

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -41,13 +41,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
         return status;
     }
 
-    tl_info(self->super.super.lib, "initialized tl context: %p", self);
+    tl_debug(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_context_t)
 {
-    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
 
     if (ucc_tl_mlx5_remove_shared_ctx_pd(self) != UCC_OK) {
         tl_error(self->super.super.lib, "failed to free ib ctx and pd");

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -7,9 +7,13 @@
 #include "tl_mlx5.h"
 #include "utils/ucc_math.h"
 #include "schedule/ucc_schedule.h"
+
 #include <limits.h>
 #include "tl_mlx5_coll.h"
 #include "utils/arch/cpu.h"
+#include "tl_mlx5_pd.h"
+
+#define PD_OWNER_RANK 0
 
 UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
                     const ucc_base_context_params_t *params,
@@ -17,7 +21,10 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
 {
     ucc_tl_mlx5_context_config_t *tl_mlx5_config =
         ucc_derived_of(config, ucc_tl_mlx5_context_config_t);
+    int          port       = -1, devname_len;
+    char *       ib_devname = NULL, *pos;
     ucc_status_t status;
+    char         tmp[128];
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_mlx5_config->super,
                               params->context);
@@ -36,8 +43,46 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
         goto err_mpool;
     }
 
-    tl_debug(self->super.super.lib, "initialized tl context: %p", self);
+    if (self->cfg.devices.count > 0) {
+        ib_devname  = self->cfg.devices.names[0];
+        pos         = strstr(ib_devname, ":");
+        devname_len = (int)(pos - ib_devname);
+        strncpy(tmp, ib_devname, devname_len);
+        tmp[devname_len] = '\0';
+        ib_devname       = tmp;
+        port             = atoi(pos + 1);
+    }
+    status = ucc_tl_mlx5_create_ibv_ctx(&ib_devname, &self->ib_ctx,
+                                        self->super.super.lib);
+    if (UCC_OK != status) {
+        tl_error(self->super.super.lib, "failed to allocate ibv_context");
+        goto release_mpool;
+    }
+    if (port == -1) {
+        port = ucc_tl_mlx5_get_active_port(self->ib_ctx);
+    }
+    self->ib_port = port;
+    if (-1 == port || !ucc_tl_mlx5_check_port_active(self->ib_ctx, port)) {
+        status = UCC_ERR_NO_RESOURCE;
+        tl_error(self->super.super.lib, "no active ports found on %s",
+                 ib_devname);
+        goto destroy_context;
+    }
+    tl_debug(self->super.super.lib, "using %s:%d", ib_devname, port);
+
+    self->ib_pd = ibv_alloc_pd(self->ib_ctx);
+    if (!self->ib_pd) {
+        status = UCC_ERR_NO_RESOURCE;
+        tl_error(self->super.super.lib, "failed to allocate ib_pd");
+        goto destroy_context;
+    }
+    tl_info(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
+
+destroy_context:
+    ibv_close_device(self->ib_ctx);
+release_mpool:
+    ucc_mpool_cleanup(&self->req_mp, 1);
 
 err_mpool:
     return status;
@@ -45,7 +90,21 @@ err_mpool:
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_context_t)
 {
-    tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
+    tl_info(self->super.super.lib, "finalizing tl context: %p", self);
+    if (self->rcache) {
+        ucc_rcache_destroy(self->rcache);
+    }
+
+    if (self->shared_pd) {
+        ucc_tl_mlx5_remove_shared_ctx_pd(self);
+    }
+
+    if (ibv_dealloc_pd(self->ib_pd)) {
+        tl_error(self->super.super.lib, "failed to dealloc PD errno %d", errno);
+    }
+
+    ucc_mpool_cleanup(&self->req_mp, 1);
+    ibv_close_device(self->ib_ctx);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_mlx5_context_t, ucc_tl_context_t);
@@ -64,5 +123,94 @@ ucc_tl_mlx5_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
 ucc_status_t
 ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context) /* NOLINT */
 {
-    return UCC_OK;
+    ucc_tl_mlx5_context_t *ctx = ucc_derived_of(context, ucc_tl_mlx5_context_t);
+    ucc_context_t *        core_ctx = context->ucc_context;
+    const char *template            = "/tmp/ucc.mlx5.XXXXXX";
+    const char *     sockname       = "/sock";
+    size_t           sock_dir_len   = strlen(template) + 1;
+    size_t           sock_path_len  = sock_dir_len + strlen(sockname);
+    char             sock_path[sock_path_len];
+    ucc_subset_t     s;
+    ucc_status_t     status;
+    ucc_topo_t *     topo;
+    ucc_sbgp_t *     sbgp;
+    ucc_tl_team_t *  steam;
+    ucc_coll_task_t *req;
+
+    int sock;
+
+    ucc_assert(core_ctx->service_team);
+    ucc_assert(core_ctx->params.mask & UCC_CONTEXT_PARAM_FIELD_OOB);
+
+    s.map.type   = UCC_EP_MAP_FULL;
+    s.map.ep_num = core_ctx->params.oob.n_oob_eps;
+    s.myrank     = core_ctx->rank;
+
+    status = ucc_topo_init(s, core_ctx->topo, &topo);
+    if (UCC_OK != status) {
+        tl_error(context->lib, "failed to init mlx5 ctx topo");
+        return status;
+    }
+
+    sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE);
+    if (sbgp->status != UCC_SBGP_ENABLED) {
+        status = UCC_OK;
+        goto out;
+    }
+
+    if (sbgp->group_rank == PD_OWNER_RANK) {
+        ucc_strncpy_safe(sock_path, template, sock_dir_len);
+        if (NULL == mkdtemp(sock_path)) {
+            tl_error(context->lib, "failed to create tmp file for socket path");
+            sock_path[0] = '\0';
+        } else {
+            strncat(sock_path, sockname, strlen(sockname));
+            status = ucc_tl_mlx5_socket_init(ctx, sbgp->group_size, &sock,
+                                             sock_path);
+            if (UCC_OK != status) {
+                sock_path[0] = '\0';
+                tl_error(context->lib, "failed to init asr socket");
+            }
+        }
+    }
+    steam = core_ctx->service_team;
+
+    s.map    = sbgp->map;
+    s.myrank = sbgp->group_rank;
+    status   = UCC_TL_TEAM_IFACE(steam)->scoll.bcast(
+        &steam->super, sock_path, sizeof(sock_path), PD_OWNER_RANK, s, &req);
+
+    if (UCC_OK != status) {
+        tl_error(context->lib, "failed to start mlx5 ctx bcast");
+        goto out;
+    }
+
+    while (UCC_INPROGRESS == (status = ucc_collective_test(&req->super))) {
+        ucc_context_progress(core_ctx);
+    }
+    ucc_collective_finalize(&req->super);
+
+    if (UCC_OK != status) {
+        tl_error(context->lib, "failure during mlx5 ctx bcast");
+        goto out;
+    }
+    if (strlen(sock_path) == 0) {
+        status = UCC_ERR_NO_MESSAGE;
+        goto out;
+    }
+
+    status = ucc_tl_mlx5_share_ctx_pd(ctx, sock_path, sbgp->group_size,
+                                      sbgp->group_rank == PD_OWNER_RANK, sock);
+    if (sbgp->group_rank == PD_OWNER_RANK) {
+        sock_path[sock_dir_len - 1] = '\0';
+        rmdir(sock_path);
+    }
+    if (status != UCC_OK) {
+        tl_error(context->lib, "failed to share ctx and pd");
+        goto out;
+    }
+
+out:
+    ucc_topo_cleanup(topo);
+    return status;
 }

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -223,7 +223,11 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
     if (status != UCC_OK) {
         tl_error(context->lib, "failed to share ctx and pd");
         goto out;
+    } else {
+        tl_debug(context->lib, "sharing pd and ib_ctx completed successfully");
     }
+
+    return UCC_OK;
 
 out:
     ucc_tl_mlx5_remove_shared_ctx_pd(ctx);

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -96,11 +96,11 @@ ucc_status_t ucc_tl_mlx5_ib_ctx_pd_init(ucc_tl_mlx5_context_t *ctx)
         tmp[devname_len] = '\0';
         ib_devname       = tmp;
     }
-    status = ucc_tl_mlx5_create_ibv_ctx(&ib_devname, &ctx->shared_ctx,
-                                        ctx->super.super.lib);
+
+    status = ucc_tl_mlx5_create_ibv_ctx(&ib_devname, &ctx->shared_ctx, ctx->super.super.lib);
     if (UCC_OK != status) {
         tl_error(ctx->super.super.lib, "failed to allocate ibv_context");
-        return UCC_ERR_NO_RESOURCE;
+        return status;
     }
     if (port == -1) {
         port = ucc_tl_mlx5_get_active_port(ctx->shared_ctx);
@@ -170,7 +170,6 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
         if (mkdtemp(sock_path) != NULL) {
             status = ucc_tl_mlx5_ib_ctx_pd_init(ctx);
             if (status != UCC_OK) {
-                tl_error(context->lib, "failed to create ib ctx and pd");
                 goto out;
             }
 
@@ -221,10 +220,9 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
     if (status != UCC_OK) {
         tl_error(context->lib, "failed to share ctx and pd");
         goto out;
-    } else {
-        tl_debug(context->lib, "sharing pd and ib_ctx completed successfully");
     }
 
+    ucc_topo_cleanup(topo);
     return UCC_OK;
 
 out:

--- a/src/components/tl/mlx5/tl_mlx5_pd.c
+++ b/src/components/tl/mlx5/tl_mlx5_pd.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2022-2023.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -230,8 +230,8 @@ listen_fail:
 
 ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
                                       const char *           sock_path,
-                                      ucc_rank_t group_size, int is_asr,
-                                      int asr_sock)
+                                      ucc_rank_t group_size, int is_ctx_owner,
+                                      int ctx_owner_sock)
 {
     int                ctx_fd    = ctx->ib_ctx->cmd_fd;
     uint32_t           pd_handle = ctx->ib_pd->handle;
@@ -241,7 +241,7 @@ ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
     uint32_t     shared_pd_handle;
     ucc_status_t status;
 
-    if (!is_asr) {
+    if (!is_ctx_owner) {
         status =
             client_recv_data(&shared_ctx_fd, &shared_pd_handle, sock_path, lib);
         if (UCC_OK != status) {
@@ -262,8 +262,8 @@ ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
         }
         ctx->is_imported = 1;
     } else {
-        status =
-            server_send_data(ctx_fd, pd_handle, group_size - 1, asr_sock, lib);
+        status = server_send_data(ctx_fd, pd_handle, group_size - 1,
+                                  ctx_owner_sock, lib);
         if (UCC_OK != status) {
             tl_error(lib, "Failed to Share ctx & pd from server side");
             return status;

--- a/src/components/tl/mlx5/tl_mlx5_pd.c
+++ b/src/components/tl/mlx5/tl_mlx5_pd.c
@@ -1,0 +1,288 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_mlx5.h"
+#include "tl_mlx5_pd.h"
+
+typedef struct {
+    int          sock, fd;
+    uint32_t     pd_handle;
+    ucc_status_t return_val;
+} connection_t;
+
+void *do_sendmsg(void *ptr)
+{
+    connection_t *  conn = (connection_t *)ptr;
+    struct msghdr   msg  = {};
+    struct cmsghdr *cmsghdr;
+    struct iovec    iov[1];
+    ssize_t         nbytes;
+    int *           p;
+    char            buf[CMSG_SPACE(sizeof(int))];
+    uint32_t        handles[1];
+
+    handles[0]      = conn->pd_handle;
+    iov[0].iov_base = handles;
+    iov[0].iov_len  = sizeof(handles);
+    memset(buf, 0x0b, sizeof(buf));
+    cmsghdr             = (struct cmsghdr *)buf;
+    cmsghdr->cmsg_len   = CMSG_LEN(sizeof(int));
+    cmsghdr->cmsg_level = SOL_SOCKET;
+    cmsghdr->cmsg_type  = SCM_RIGHTS;
+    msg.msg_name        = NULL;
+    msg.msg_namelen     = 0;
+    msg.msg_iov         = iov;
+    msg.msg_iovlen      = sizeof(iov) / sizeof(iov[0]);
+    msg.msg_control     = cmsghdr;
+    msg.msg_controllen  = CMSG_LEN(sizeof(int));
+    msg.msg_flags       = 0;
+    p                   = (int *)CMSG_DATA(cmsghdr);
+    *p                  = conn->fd;
+
+    nbytes = sendmsg(conn->sock, &msg, 0);
+    if (nbytes == -1) {
+        conn->return_val = UCC_ERR_NO_MESSAGE;
+    }
+    conn->return_val = UCC_OK;
+    pthread_exit(NULL);
+}
+
+static ucc_status_t do_recvmsg(int sock, int *shared_cmd_fd,
+                               uint32_t *shared_pd_handle)
+{
+    uint32_t        handles[1] = {};
+    struct msghdr   msg;
+    struct cmsghdr *cmsghdr;
+    struct iovec    iov[1];
+    ssize_t         nbytes;
+    int *           p;
+    char            buf[CMSG_SPACE(sizeof(int))];
+
+    iov[0].iov_base = handles;
+    iov[0].iov_len  = sizeof(handles);
+
+    memset(buf, 0x0d, sizeof(buf));
+    cmsghdr             = (struct cmsghdr *)buf;
+    cmsghdr->cmsg_len   = CMSG_LEN(sizeof(int));
+    cmsghdr->cmsg_level = SOL_SOCKET;
+    cmsghdr->cmsg_type  = SCM_RIGHTS;
+    msg.msg_name        = NULL;
+    msg.msg_namelen     = 0;
+    msg.msg_iov         = iov;
+    msg.msg_iovlen      = sizeof(iov) / sizeof(iov[0]);
+    msg.msg_control     = cmsghdr;
+    msg.msg_controllen  = CMSG_LEN(sizeof(int));
+    msg.msg_flags       = 0;
+
+    nbytes = recvmsg(sock, &msg, 0);
+    if (nbytes == -1) {
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    p = (int *)CMSG_DATA(cmsghdr);
+
+    *shared_cmd_fd    = *p;
+    *shared_pd_handle = handles[0];
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_mlx5_socket_init(ucc_tl_mlx5_context_t *ctx,
+                                     ucc_rank_t group_size, int *sock_p,
+                                     const char *sock_path)
+{
+    struct sockaddr_storage storage = {};
+    struct sockaddr_un *    addr;
+    int                     sock;
+
+    sock = socket(PF_LOCAL, SOCK_STREAM, 0);
+    if (sock == -1) {
+        tl_error(ctx->super.super.lib,
+                 "failed to create server socket errno %d", errno);
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    addr             = (struct sockaddr_un *)&storage;
+    addr->sun_family = AF_UNIX;
+    strncpy(addr->sun_path, sock_path, sizeof(addr->sun_path));
+    addr->sun_path[sizeof(addr->sun_path) - 1] = '\0';
+
+    if (bind(sock, (struct sockaddr *)addr, sizeof(struct sockaddr_un)) == -1) {
+        tl_error(ctx->super.super.lib, "failed to bind server socket errno %d",
+                 errno);
+        return UCC_ERR_NO_MESSAGE;
+    }
+    if (listen(sock, group_size) == -1) {
+        tl_error(ctx->super.super.lib,
+                 "failed to listen to server socket errno %d", errno);
+        return UCC_ERR_NO_MESSAGE;
+    }
+    *sock_p = sock;
+    return UCC_OK;
+}
+
+static ucc_status_t client_recv_data(int *              shared_cmd_fd,
+                                     uint32_t *         shared_pd_handle,
+                                     const char *       sock_path,
+                                     ucc_tl_mlx5_lib_t *lib)
+{
+    struct sockaddr_storage sockaddr = {};
+    struct sockaddr_un *    addr;
+    int                     sock;
+    sock = socket(PF_LOCAL, SOCK_STREAM, 0);
+    if (sock == -1) {
+        tl_error(lib, "failed to create client socket errno %d", errno);
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    addr             = (struct sockaddr_un *)&sockaddr;
+    addr->sun_family = AF_UNIX;
+    strncpy(addr->sun_path, sock_path, sizeof(addr->sun_path));
+    addr->sun_path[sizeof(addr->sun_path) - 1] = '\0';
+
+    while (connect(sock, (struct sockaddr *)addr, SUN_LEN(addr)) == -1) {
+        if (errno != ENOENT) {
+            tl_error(lib, "failed to connect client socket errno %d", errno);
+            goto fail;
+        }
+    }
+    if (do_recvmsg(sock, shared_cmd_fd, shared_pd_handle) != UCC_OK) {
+        tl_error(lib, "Failed to recv msg");
+        goto fail;
+    }
+
+    if (close(sock) == -1) {
+        tl_error(lib, "Failed to close client socket errno %d", errno);
+        return UCC_ERR_NO_MESSAGE;
+    }
+    return UCC_OK;
+
+fail:
+    if (close(sock) == -1) {
+        tl_error(lib, "Failed to close client socket errno %d", errno);
+    }
+    return UCC_ERR_NO_MESSAGE;
+}
+
+static ucc_status_t server_send_data(int command_fd, uint32_t pd_handle,
+                                     int group_size, int sock,
+                                     ucc_tl_mlx5_lib_t *lib)
+{
+    int                i = 0;
+    connection_t       connection[group_size];
+    pthread_t          thread[group_size];
+    struct sockaddr_un addr;
+    socklen_t          addrlen;
+
+    while (i < group_size) {
+        /* accept incoming connections */
+        connection[i].sock      = accept(sock, NULL, 0);
+        connection[i].fd        = command_fd;
+        connection[i].pd_handle = pd_handle;
+        if (connection[i].sock != -1) {
+            /* start a new thread but do not wait for it */
+            pthread_create(&thread[i], 0, do_sendmsg, (void *)&connection[i]);
+            i++;
+        }
+    }
+
+    for (i = 0; i < group_size; i++) {
+        pthread_join(thread[i], NULL);
+    }
+
+    addrlen = sizeof(addr);
+    getsockname(sock, (struct sockaddr *)&addr, &addrlen);
+
+    for (i = 0; i < group_size; i++) {
+        if (connection[i].return_val != UCC_OK) {
+            tl_error(lib, "failed to send cmd_fd");
+            goto listen_fail;
+        }
+    }
+
+    if (close(sock) == -1) {
+        tl_error(lib, "failed to close server socket errno %d", errno);
+        if (remove(addr.sun_path) == -1) {
+            tl_error(lib, "socket file removal failed");
+        }
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    if (remove(addr.sun_path) == -1) {
+        tl_error(lib, "socket file removal failed");
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    return UCC_OK;
+
+listen_fail:
+    if (remove(addr.sun_path) == -1) {
+        tl_error(lib, "socket file removal failed");
+    }
+    if (close(sock) == -1) {
+        tl_error(lib, "failed to close server socket errno %d", errno);
+    }
+    return UCC_ERR_NO_MESSAGE;
+}
+
+ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
+                                      const char *           sock_path,
+                                      ucc_rank_t group_size, int is_asr,
+                                      int asr_sock)
+{
+    int                ctx_fd    = ctx->ib_ctx->cmd_fd;
+    uint32_t           pd_handle = ctx->ib_pd->handle;
+    ucc_tl_mlx5_lib_t *lib =
+        ucc_derived_of(ctx->super.super.lib, ucc_tl_mlx5_lib_t);
+    int          shared_ctx_fd;
+    uint32_t     shared_pd_handle;
+    ucc_status_t status;
+
+    if (!is_asr) {
+        status =
+            client_recv_data(&shared_ctx_fd, &shared_pd_handle, sock_path, lib);
+        if (UCC_OK != status) {
+            return status;
+        }
+        ctx->shared_ctx = ibv_import_device(shared_ctx_fd);
+        if (!ctx->shared_ctx) {
+            tl_error(lib, "Import context failed");
+            return UCC_ERR_NO_MESSAGE;
+        }
+        ctx->shared_pd = ibv_import_pd(ctx->shared_ctx, shared_pd_handle);
+        if (!ctx->shared_pd) {
+            tl_error(lib, "Import PD failed");
+            if (ibv_close_device(ctx->shared_ctx)) {
+                tl_error(lib, "imported context close failed");
+            }
+            return UCC_ERR_NO_MESSAGE;
+        }
+        ctx->is_imported = 1;
+    } else {
+        status =
+            server_send_data(ctx_fd, pd_handle, group_size - 1, asr_sock, lib);
+        if (UCC_OK != status) {
+            tl_error(lib, "Failed to Share ctx & pd from server side");
+            return status;
+        }
+        ctx->is_imported = 0;
+        ctx->shared_ctx  = ctx->ib_ctx;
+        ctx->shared_pd   = ctx->ib_pd;
+    }
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_mlx5_remove_shared_ctx_pd(ucc_tl_mlx5_context_t *ctx)
+{
+    if (ctx->is_imported) {
+        ibv_unimport_pd(ctx->shared_pd);
+        if (ibv_close_device(ctx->shared_ctx)) {
+            tl_error(ctx->super.super.lib, "imported context close failed");
+            return UCC_ERR_NO_MESSAGE;
+        }
+    }
+    return UCC_OK;
+}

--- a/src/components/tl/mlx5/tl_mlx5_pd.c
+++ b/src/components/tl/mlx5/tl_mlx5_pd.c
@@ -172,11 +172,11 @@ static ucc_status_t server_send_data(int command_fd, uint32_t pd_handle,
                                      int group_size, int sock,
                                      ucc_tl_mlx5_lib_t *lib)
 {
+    ucc_status_t       status = UCC_OK;
     int                i;
     connection_t       connection[group_size];
     struct sockaddr_un addr;
     socklen_t          addrlen;
-    ucc_status_t       status;
 
     for (i = 0; i < group_size; i++) {
         /* accept incoming connections */

--- a/src/components/tl/mlx5/tl_mlx5_pd.h
+++ b/src/components/tl/mlx5/tl_mlx5_pd.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2022-2023.  ALL RIGHTS RESERVED.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/mlx5/tl_mlx5_pd.h
+++ b/src/components/tl/mlx5/tl_mlx5_pd.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef TL_MLX5_PD_H
+#define TL_MLX5_PD_H
+
+#include <sys/un.h>
+
+typedef struct ucc_tl_mlx5_team ucc_tl_mlx5_team_t;
+
+ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
+                                      const char *           sock_path,
+                                      ucc_rank_t group_size, int is_asr,
+                                      int asr_sock);
+
+ucc_status_t ucc_tl_mlx5_remove_shared_ctx_pd(ucc_tl_mlx5_context_t *ctx);
+
+ucc_status_t ucc_tl_mlx5_socket_init(ucc_tl_mlx5_context_t *ctx,
+                                     ucc_rank_t group_size, int *sock_p,
+                                     const char *sock_path);
+#endif

--- a/src/components/tl/mlx5/tl_mlx5_pd.h
+++ b/src/components/tl/mlx5/tl_mlx5_pd.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Mellanox Technologies Ltd. 2022.  ALL RIGHTS RESERVED.
+ * Copyright (C) Mellanox Technologies Ltd. 2022-2023.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -13,8 +13,8 @@ typedef struct ucc_tl_mlx5_team ucc_tl_mlx5_team_t;
 
 ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
                                       const char *           sock_path,
-                                      ucc_rank_t group_size, int is_asr,
-                                      int asr_sock);
+                                      ucc_rank_t group_size, int is_ctx_owner,
+                                      int ctx_owner_sock);
 
 ucc_status_t ucc_tl_mlx5_remove_shared_ctx_pd(ucc_tl_mlx5_context_t *ctx);
 


### PR DESCRIPTION
[Replaces https://github.com/openucx/ucc/pull/523]
## What
This PR implements 
1. `ib_ctx` and `pd` creation by each rank, during tl/mlx5 context init.
2. One rank per node shares its created `pd` and `ib_ctx` to the other ranks in the node. This is done during `ucc_tl_mlx5_context_create_epilog` (because we need the topo to access the node group `UCC_SBGP_NODE`).

Sharing the `ib_ctx` needs to share a file handle (`cmd_fd`) among the processes. This is done using `SCM_RIGHTS` through a Linux socket. The implementation (technical but standalone and standard) is done in a separate file `tl_mlx5_pd.c`.