### PR TITLE
CL/HIER: fix allreduce rab pipeline

### DIFF
--- a/src/components/cl/hier/bcast/bcast_2step.c
+++ b/src/components/cl/hier/bcast/bcast_2step.c
@@ -164,7 +164,8 @@ ucc_cl_hier_bcast_2step_init_schedule(ucc_base_coll_args_t *coll_args,
                                    UCC_EVENT_SCHEDULE_STARTED);
         } else {
             ucc_task_subscribe_dep(tasks[first_task],
-                              tasks[(first_task + 1) % 2], UCC_EVENT_COMPLETED);
+                                   tasks[(first_task + 1) % 2],
+                                   UCC_EVENT_COMPLETED);
         }
         ucc_schedule_add_task(schedule, tasks[(first_task + 1) % 2]);
     }

--- a/src/schedule/ucc_schedule_pipelined.h
+++ b/src/schedule/ucc_schedule_pipelined.h
@@ -1,16 +1,19 @@
 /**
  * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
+
 #ifndef UCC_SCHEDULE_PIPELINED_H_
 #define UCC_SCHEDULE_PIPELINED_H_
+
 #include "components/base/ucc_base_iface.h"
 
 #define UCC_SCHEDULE_FRAG_MAX_TASKS 8
+#define UCC_SCHEDULE_PIPELINED_MAX_FRAGS 4
 
 typedef struct ucc_schedule_pipelined ucc_schedule_pipelined_t;
 
-#define UCC_SCHEDULE_PIPELINED_MAX_FRAGS 4
 
 /* frag_init is the callback provided by the user of pipelined
    framework (e.g., TL that needs to build a pipeline) that is reponsible

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -7,6 +7,8 @@
 #include "ucc_coll_utils.h"
 #include "components/base/ucc_base_iface.h"
 #include "core/ucc_team.h"
+#include "schedule/ucc_schedule_pipelined.h"
+
 #define STR_TYPE_CHECK(_str, _p, _prefix)                                      \
     do {                                                                       \
         if ((0 == strcasecmp(_UCC_PP_MAKE_STRING(_p), _str))) {                \
@@ -511,9 +513,16 @@ void ucc_coll_task_components_str(const ucc_coll_task_t *task, char *str,
                                   size_t *len)
 {
     ucc_schedule_t *schedule;
+    ucc_schedule_pipelined_t *schedule_pipelined;
     int i;
 
-    if (task->flags & UCC_COLL_TASK_FLAG_IS_SCHEDULE) {
+    if (task->flags & UCC_COLL_TASK_FLAG_IS_PIPELINED_SCHEDULE) {
+        schedule_pipelined = ucc_derived_of(task, ucc_schedule_pipelined_t);
+        for (i = 0; i < schedule_pipelined->n_frags; i++) {
+            ucc_coll_task_components_str(&schedule_pipelined->frags[i]->super,
+                                         str, len);
+        }
+    } else if (task->flags & UCC_COLL_TASK_FLAG_IS_SCHEDULE) {
         schedule = ucc_derived_of(task, ucc_schedule_t);
         for (i = 0; i < schedule->n_tasks; i++) {
             ucc_coll_task_components_str(schedule->tasks[i], str, len);

--- a/test/gtest/coll/test_allreduce.cc
+++ b/test/gtest/coll/test_allreduce.cc
@@ -334,6 +334,41 @@ TYPED_TEST(test_allreduce_alg, rab) {
     }
 }
 
+TYPED_TEST(test_allreduce_alg, rab_pipelined) {
+    int           n_procs = 15;
+    ucc_job_env_t env     = {{"UCC_CL_HIER_TUNE", "allreduce:@rab:0-inf:inf"},
+                             {"UCC_CL_HIER_ALLREDUCE_RAB_PIPELINE", "thresh=1024:nfrags=11"},
+                             {"UCC_CLS", "all"}};
+    UccJob        job(n_procs, UccJob::UCC_JOB_CTX_GLOBAL, env);
+    UccTeam_h     team   = job.create_team(n_procs);
+    int           repeat = 3;
+    UccCollCtxVec ctxs;
+    std::vector<ucc_memory_type_t> mt = {UCC_MEMORY_TYPE_HOST};
+
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
+        mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+
+    for (auto count : {65536, 123567}) {
+        for (auto inplace : {TEST_NO_INPLACE, TEST_INPLACE}) {
+            for (auto m : mt) {
+                SET_MEM_TYPE(m);
+                this->set_inplace(inplace);
+                this->data_init(n_procs, TypeParam::dt, count, ctxs, true);
+                UccReq req(team, ctxs);
+
+                for (auto i = 0; i < repeat; i++) {
+                    req.start();
+                    req.wait();
+                    EXPECT_EQ(true, this->data_validate(ctxs));
+                    this->reset(ctxs);
+                }
+                this->data_fini(ctxs);
+            }
+        }
+    }
+}
+
 template <typename T>
 class test_allreduce_avg_order : public test_allreduce<T> {
 };


### PR DESCRIPTION
## What
Fixes segfault in reduce allreduce broadcast hierarchical allreduce algorithm when pipelining is used
Also fixes coll trace print for pipelined schedules 

## How ?
Pipeline fragment start dependency for sequential and ordered pipelines was set to previous fragment only hence completion of one fragment immediately triggers start of another fragment even if schedule is completed. This PR adds dependency on schedule start to prevent this.