### PR TITLE
TOOLS: root and rootshift fix in perftest

### DIFF
--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -31,17 +31,19 @@ ucc_pt_benchmark::ucc_pt_benchmark(ucc_pt_benchmark_config cfg,
         coll = new ucc_pt_coll_barrier(comm);
         break;
     case UCC_PT_OP_TYPE_BCAST:
-        coll = new ucc_pt_coll_bcast(cfg.dt, cfg.mt, comm);
+        coll = new ucc_pt_coll_bcast(cfg.dt, cfg.mt, cfg.root_shift, comm);
         break;
     case UCC_PT_OP_TYPE_GATHER:
-        coll = new ucc_pt_coll_gather(cfg.dt, cfg.mt, cfg.inplace, comm);
+        coll = new ucc_pt_coll_gather(cfg.dt, cfg.mt, cfg.inplace,
+                                      cfg.root_shift, comm);
         break;
     case UCC_PT_OP_TYPE_GATHERV:
-        coll = new ucc_pt_coll_gatherv(cfg.dt, cfg.mt, cfg.inplace, comm);
+        coll = new ucc_pt_coll_gatherv(cfg.dt, cfg.mt, cfg.inplace,
+                                       cfg.root_shift, comm);
         break;
     case UCC_PT_OP_TYPE_REDUCE:
         coll = new ucc_pt_coll_reduce(cfg.dt, cfg.mt, cfg.op, cfg.inplace,
-                                      comm);
+                                      cfg.root_shift, comm);
         break;
     case UCC_PT_OP_TYPE_REDUCE_SCATTER:
         coll = new ucc_pt_coll_reduce_scatter(cfg.dt, cfg.mt, cfg.op,
@@ -52,10 +54,12 @@ ucc_pt_benchmark::ucc_pt_benchmark(ucc_pt_benchmark_config cfg,
                                                cfg.inplace, comm);
         break;
     case UCC_PT_OP_TYPE_SCATTER:
-        coll = new ucc_pt_coll_scatter(cfg.dt, cfg.mt, cfg.inplace, comm);
+        coll = new ucc_pt_coll_scatter(cfg.dt, cfg.mt, cfg.inplace,
+                                       cfg.root_shift, comm);
         break;
     case UCC_PT_OP_TYPE_SCATTERV:
-        coll = new ucc_pt_coll_scatterv(cfg.dt, cfg.mt, cfg.inplace, comm);
+        coll = new ucc_pt_coll_scatterv(cfg.dt, cfg.mt, cfg.inplace,
+                                        cfg.root_shift, comm);
         break;
     case UCC_PT_OP_TYPE_MEMCPY:
         coll = new ucc_pt_op_memcpy(cfg.dt, cfg.mt, comm);
@@ -89,6 +93,7 @@ ucc_status_t ucc_pt_benchmark::run_bench() noexcept
             iter = config.n_iter_large;
             warmup = config.n_warmup_large;
         }
+        args.coll_args.root = config.root;
         UCCCHECK_GOTO(coll->init_args(cnt, args), exit_err, st);
         if ((uint64_t)config.op_type < (uint64_t)UCC_COLL_TYPE_LAST) {
             UCCCHECK_GOTO(run_single_coll_test(args.coll_args, warmup, iter, time),

--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
 #include <iomanip>
 #include "ucc_pt_benchmark.h"
 #include "components/mc/ucc_mc.h"

--- a/tools/perf/ucc_pt_coll.cc
+++ b/tools/perf/ucc_pt_coll.cc
@@ -48,3 +48,8 @@ bool ucc_pt_coll::has_bw()
 {
     return has_bw_;
 }
+
+int ucc_pt_coll::root_shift()
+{
+    return root_shift_;
+}

--- a/tools/perf/ucc_pt_coll.cc
+++ b/tools/perf/ucc_pt_coll.cc
@@ -48,8 +48,3 @@ bool ucc_pt_coll::has_bw()
 {
     return has_bw_;
 }
-
-int ucc_pt_coll::root_shift()
-{
-    return root_shift_;
-}

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -30,7 +30,7 @@ protected:
     bool has_reduction_;
     bool has_range_;
     bool has_bw_;
-    int root_shift_;
+    int  root_shift_;
     ucc_pt_comm *comm;
     ucc_coll_args_t coll_args;
     ucc_ee_executor_task_args_t executor_args;
@@ -52,7 +52,6 @@ public:
     bool has_inplace();
     bool has_range();
     bool has_bw();
-    int  root_shift();
     virtual ~ucc_pt_coll() {};
 };
 

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -30,6 +30,7 @@ protected:
     bool has_reduction_;
     bool has_range_;
     bool has_bw_;
+    int root_shift_;
     ucc_pt_comm *comm;
     ucc_coll_args_t coll_args;
     ucc_ee_executor_task_args_t executor_args;
@@ -51,6 +52,7 @@ public:
     bool has_inplace();
     bool has_range();
     bool has_bw();
+    int  root_shift();
     virtual ~ucc_pt_coll() {};
 };
 
@@ -107,7 +109,7 @@ public:
 
 class ucc_pt_coll_bcast: public ucc_pt_coll {
 public:
-    ucc_pt_coll_bcast(ucc_datatype_t dt, ucc_memory_type mt,
+    ucc_pt_coll_bcast(ucc_datatype_t dt, ucc_memory_type mt, int root_shift,
                       ucc_pt_comm *communicator);
     ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
     void free_args(ucc_pt_test_args_t &args) override;
@@ -117,7 +119,8 @@ public:
 class ucc_pt_coll_gather: public ucc_pt_coll {
 public:
     ucc_pt_coll_gather(ucc_datatype_t dt, ucc_memory_type mt,
-                       bool is_inplace, ucc_pt_comm *communicator);
+                       bool is_inplace, int root_shift,
+                       ucc_pt_comm *communicator);
     ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
     void free_args(ucc_pt_test_args_t &args) override;
     float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
@@ -126,7 +129,8 @@ public:
 class ucc_pt_coll_gatherv: public ucc_pt_coll {
 public:
     ucc_pt_coll_gatherv(ucc_datatype_t dt, ucc_memory_type mt,
-                        bool is_inplace, ucc_pt_comm *communicator);
+                        bool is_inplace, int root_shift,
+                        ucc_pt_comm *communicator);
     ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
     void free_args(ucc_pt_test_args_t &args) override;
 };
@@ -134,7 +138,7 @@ public:
 class ucc_pt_coll_reduce: public ucc_pt_coll {
 public:
     ucc_pt_coll_reduce(ucc_datatype_t dt, ucc_memory_type mt,
-                       ucc_reduction_op_t op, bool is_inplace,
+                       ucc_reduction_op_t op, bool is_inplace, int root_shift,
                        ucc_pt_comm *communicator);
     ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
     void free_args(ucc_pt_test_args_t &args) override;
@@ -163,7 +167,8 @@ public:
 class ucc_pt_coll_scatter: public ucc_pt_coll {
 public:
     ucc_pt_coll_scatter(ucc_datatype_t dt, ucc_memory_type mt,
-                        bool is_inplace, ucc_pt_comm *communicator);
+                        bool is_inplace, int root_shift,
+                        ucc_pt_comm *communicator);
     ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
     void free_args(ucc_pt_test_args_t &args) override;
     float get_bw(float time_ms, int grsize, ucc_pt_test_args_t args) override;
@@ -172,7 +177,8 @@ public:
 class ucc_pt_coll_scatterv: public ucc_pt_coll {
 public:
     ucc_pt_coll_scatterv(ucc_datatype_t dt, ucc_memory_type mt,
-                         bool is_inplace, ucc_pt_comm *communicator);
+                         bool is_inplace, int root_shift,
+                         ucc_pt_comm *communicator);
     ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
     void free_args(ucc_pt_test_args_t &args) override;
 };

--- a/tools/perf/ucc_pt_coll_allgather.cc
+++ b/tools/perf/ucc_pt_coll_allgather.cc
@@ -19,6 +19,7 @@ ucc_pt_coll_allgather::ucc_pt_coll_allgather(ucc_datatype_t dt,
     has_reduction_ = false;
     has_range_     = true;
     has_bw_        = true;
+    root_shift_    = 0;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_ALLGATHER;

--- a/tools/perf/ucc_pt_coll_allgatherv.cc
+++ b/tools/perf/ucc_pt_coll_allgatherv.cc
@@ -18,6 +18,7 @@ ucc_pt_coll_allgatherv::ucc_pt_coll_allgatherv(ucc_datatype_t dt,
     has_reduction_ = false;
     has_range_     = true;
     has_bw_        = false;
+    root_shift_    = 0;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_ALLGATHERV;

--- a/tools/perf/ucc_pt_coll_allreduce.cc
+++ b/tools/perf/ucc_pt_coll_allreduce.cc
@@ -19,6 +19,7 @@ ucc_pt_coll_allreduce::ucc_pt_coll_allreduce(ucc_datatype_t dt,
     has_reduction_ = true;
     has_range_     = true;
     has_bw_        = true;
+    root_shift_    = 0;
 
     coll_args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
     coll_args.mask = 0;

--- a/tools/perf/ucc_pt_coll_alltoall.cc
+++ b/tools/perf/ucc_pt_coll_alltoall.cc
@@ -18,6 +18,7 @@ ucc_pt_coll_alltoall::ucc_pt_coll_alltoall(ucc_datatype_t dt,
     has_reduction_ = false;
     has_range_     = true;
     has_bw_        = true;
+    root_shift_    = 0;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_ALLTOALL;

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -18,6 +18,7 @@ ucc_pt_coll_alltoallv::ucc_pt_coll_alltoallv(ucc_datatype_t dt,
     has_reduction_ = false;
     has_range_     = true;
     has_bw_        = false;
+    root_shift_    = 0;
 
     coll_args.mask                = UCC_COLL_ARGS_FIELD_FLAGS;
     coll_args.coll_type           = UCC_COLL_TYPE_ALLTOALLV;

--- a/tools/perf/ucc_pt_coll_barrier.cc
+++ b/tools/perf/ucc_pt_coll_barrier.cc
@@ -11,6 +11,7 @@ ucc_pt_coll_barrier::ucc_pt_coll_barrier(ucc_pt_comm *communicator) :
     has_reduction_ = false;
     has_range_     = false;
     has_bw_        = false;
+    root_shift_    = 0;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_BARRIER;

--- a/tools/perf/ucc_pt_coll_barrier.cc
+++ b/tools/perf/ucc_pt_coll_barrier.cc
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
 #include "ucc_pt_coll.h"
 #include "ucc_perftest.h"
 #include <ucc/api/ucc.h>

--- a/tools/perf/ucc_pt_coll_bcast.cc
+++ b/tools/perf/ucc_pt_coll_bcast.cc
@@ -11,16 +11,17 @@
 #include <utils/ucc_coll_utils.h>
 
 ucc_pt_coll_bcast::ucc_pt_coll_bcast(ucc_datatype_t dt, ucc_memory_type mt,
-                       ucc_pt_comm *communicator) : ucc_pt_coll(communicator)
+                                     int root_shift, ucc_pt_comm *communicator)
+                   : ucc_pt_coll(communicator)
 {
     has_inplace_   = false;
     has_reduction_ = false;
     has_range_     = true;
     has_bw_        = true;
+    root_shift_    = root_shift;
 
     coll_args.mask = 0;
     coll_args.coll_type = UCC_COLL_TYPE_BCAST;
-    coll_args.root = 0;
     coll_args.src.info.datatype = dt;
     coll_args.src.info.mem_type = mt;
 }
@@ -33,7 +34,8 @@ ucc_status_t ucc_pt_coll_bcast::init_args(size_t count,
     size_t           size     = count * dt_size;
     ucc_status_t     st;
 
-    args = coll_args;
+    coll_args.root      = test_args.coll_args.root;
+    args                = coll_args;
     args.src.info.count = count;
     UCCCHECK_GOTO(ucc_pt_alloc(&src_header, size, args.src.info.mem_type), exit,
                   st);

--- a/tools/perf/ucc_pt_coll_gatherv.cc
+++ b/tools/perf/ucc_pt_coll_gatherv.cc
@@ -11,16 +11,16 @@
 #include <utils/ucc_coll_utils.h>
 
 ucc_pt_coll_gatherv::ucc_pt_coll_gatherv(ucc_datatype_t dt,
-                         ucc_memory_type mt, bool is_inplace,
+                         ucc_memory_type mt, bool is_inplace, int root_shift,
                          ucc_pt_comm *communicator) : ucc_pt_coll(communicator)
 {
     has_inplace_   = true;
     has_reduction_ = false;
     has_range_     = true;
     has_bw_        = false;
+    root_shift_    = root_shift;
 
     coll_args.mask                = 0;
-    coll_args.root                = 0;
     coll_args.coll_type           = UCC_COLL_TYPE_GATHERV;
     coll_args.src.info.datatype   = dt;
     coll_args.src.info.mem_type   = mt;
@@ -43,9 +43,10 @@ ucc_status_t ucc_pt_coll_gatherv::init_args(size_t count,
     ucc_status_t st;
     bool         is_root;
 
-    args    = coll_args;
-    is_root = (comm->get_rank() == args.root);
-    if (is_root) {
+    coll_args.root = test_args.coll_args.root;
+    args           = coll_args;
+    is_root        = (comm->get_rank() == args.root);
+    if (is_root || root_shift_) {
         args.dst.info_v.counts = (ucc_count_t *)
             ucc_malloc(comm_size * sizeof(uint32_t), "counts buf");
         UCC_MALLOC_CHECK_GOTO(args.dst.info_v.counts, exit, st);
@@ -61,13 +62,13 @@ ucc_status_t ucc_pt_coll_gatherv::init_args(size_t count,
         }
     }
 
-    if (!is_root || !UCC_IS_INPLACE(args)) {
+    if (!is_root || !UCC_IS_INPLACE(args) || root_shift_) {
         args.src.info.count = count;
         st = ucc_pt_alloc(&src_header, size_src, args.src.info.mem_type);
         if (UCC_OK != st) {
             std::cerr << "UCC perftest error: " << ucc_status_string(st)
                       << " in " << STR(_call) << "\n";
-            if (is_root) {
+            if (is_root || root_shift_) {
                 goto free_dst;
             } else  {
                 goto exit;
@@ -91,10 +92,10 @@ void ucc_pt_coll_gatherv::free_args(ucc_pt_test_args_t &test_args)
     ucc_coll_args_t &args    = test_args.coll_args;
     bool             is_root = (comm->get_rank() == args.root);
 
-    if (!is_root || !UCC_IS_INPLACE(args)) {
+    if (!is_root || !UCC_IS_INPLACE(args) || root_shift_) {
         ucc_pt_free(src_header);
     }
-    if (is_root) {
+    if (is_root || root_shift_) {
         ucc_pt_free(dst_header);
         ucc_free(args.dst.info_v.displacements);
         ucc_free(args.dst.info_v.counts);

--- a/tools/perf/ucc_pt_coll_gatherv.cc
+++ b/tools/perf/ucc_pt_coll_gatherv.cc
@@ -70,7 +70,7 @@ ucc_status_t ucc_pt_coll_gatherv::init_args(size_t count,
                       << " in " << STR(_call) << "\n";
             if (is_root || root_shift_) {
                 goto free_dst;
-            } else  {
+            } else {
                 goto exit;
             }
         }

--- a/tools/perf/ucc_pt_coll_reduce.cc
+++ b/tools/perf/ucc_pt_coll_reduce.cc
@@ -11,13 +11,14 @@
 #include <utils/ucc_coll_utils.h>
 
 ucc_pt_coll_reduce::ucc_pt_coll_reduce(ucc_datatype_t dt, ucc_memory_type mt,
-                        ucc_reduction_op_t op, bool is_inplace,
+                        ucc_reduction_op_t op, bool is_inplace, int root_shift,
                         ucc_pt_comm *communicator) : ucc_pt_coll(communicator)
 {
     has_inplace_   = true;
     has_reduction_ = true;
     has_range_     = true;
     has_bw_        = true;
+    root_shift_    = root_shift;
 
     coll_args.coll_type = UCC_COLL_TYPE_REDUCE;
     coll_args.mask = 0;
@@ -27,7 +28,6 @@ ucc_pt_coll_reduce::ucc_pt_coll_reduce(ucc_datatype_t dt, ucc_memory_type mt,
     }
 
     coll_args.op   = op;
-    coll_args.root = 0;
     coll_args.src.info.datatype = dt;
     coll_args.src.info.mem_type = mt;
     coll_args.dst.info.datatype = dt;
@@ -42,23 +42,24 @@ ucc_status_t ucc_pt_coll_reduce::init_args(size_t count,
     size_t           size    = count * dt_size;
     ucc_status_t st_src, st_dst;
 
-    args = coll_args;
+    coll_args.root      = test_args.coll_args.root;
+    args                = coll_args;
     args.src.info.count = count;
     args.dst.info.count = count;
     bool is_root = (comm->get_rank() == args.root);
-    if (is_root) {
+    if (is_root || root_shift_) {
         UCCCHECK_GOTO(ucc_pt_alloc(&dst_header, size, args.dst.info.mem_type),
                       exit, st_dst);
         args.dst.info.buffer = dst_header->addr;
     }
-    if (!is_root || !UCC_IS_INPLACE(args)) {
+    if (!is_root || !UCC_IS_INPLACE(args) || root_shift_) {
         UCCCHECK_GOTO(ucc_pt_alloc(&src_header, size, args.src.info.mem_type),
                       free_dst, st_src);
         args.src.info.buffer = src_header->addr;
     }
     return UCC_OK;
 free_dst:
-    if (is_root && st_dst == UCC_OK) {
+    if ((is_root || root_shift_) && st_dst == UCC_OK) {
         ucc_pt_free(dst_header);
     }
     return st_src;
@@ -71,10 +72,10 @@ void ucc_pt_coll_reduce::free_args(ucc_pt_test_args_t &test_args)
     ucc_coll_args_t &args    = test_args.coll_args;
     bool             is_root = (comm->get_rank() == args.root);
 
-    if (!is_root || !UCC_IS_INPLACE(args)) {
+    if (!is_root || !UCC_IS_INPLACE(args) || root_shift_) {
         ucc_pt_free(src_header);
     }
-    if (is_root) {
+    if (is_root || root_shift_) {
         ucc_pt_free(dst_header);
     }
 }

--- a/tools/perf/ucc_pt_coll_reduce_scatter.cc
+++ b/tools/perf/ucc_pt_coll_reduce_scatter.cc
@@ -19,6 +19,7 @@ ucc_pt_coll_reduce_scatter::ucc_pt_coll_reduce_scatter(ucc_datatype_t dt,
     has_reduction_ = true;
     has_range_     = true;
     has_bw_        = true;
+    root_shift_    = 0;
 
     coll_args.coll_type = UCC_COLL_TYPE_REDUCE_SCATTER;
     coll_args.mask = 0;

--- a/tools/perf/ucc_pt_coll_reduce_scatterv.cc
+++ b/tools/perf/ucc_pt_coll_reduce_scatterv.cc
@@ -19,6 +19,7 @@ ucc_pt_coll_reduce_scatterv::ucc_pt_coll_reduce_scatterv(ucc_datatype_t dt,
     has_reduction_ = true;
     has_range_     = true;
     has_bw_        = false;
+    root_shift_    = 0;
 
     coll_args.coll_type = UCC_COLL_TYPE_REDUCE_SCATTERV;
     coll_args.mask = 0;

--- a/tools/perf/ucc_pt_coll_scatterv.cc
+++ b/tools/perf/ucc_pt_coll_scatterv.cc
@@ -11,17 +11,17 @@
 #include <utils/ucc_coll_utils.h>
 
 ucc_pt_coll_scatterv::ucc_pt_coll_scatterv(ucc_datatype_t dt,
-                         ucc_memory_type mt, bool is_inplace,
+                         ucc_memory_type mt, bool is_inplace, int root_shift,
                          ucc_pt_comm *communicator) : ucc_pt_coll(communicator)
 {
     has_inplace_   = true;
     has_reduction_ = false;
     has_range_     = true;
     has_bw_        = false;
+    root_shift_    = root_shift;
 
     coll_args.mask                = 0;
-    coll_args.root                = 0;
-    coll_args.coll_type            = UCC_COLL_TYPE_SCATTERV;
+    coll_args.coll_type           = UCC_COLL_TYPE_SCATTERV;
     coll_args.src.info_v.datatype = dt;
     coll_args.src.info_v.mem_type = mt;
     coll_args.dst.info.datatype   = dt;
@@ -43,9 +43,10 @@ ucc_status_t ucc_pt_coll_scatterv::init_args(size_t count,
     ucc_status_t st;
     bool is_root;
 
-    args    = coll_args;
-    is_root = (comm->get_rank() == args.root);
-    if (is_root) {
+    coll_args.root = test_args.coll_args.root;
+    args           = coll_args;
+    is_root        = (comm->get_rank() == args.root);
+    if (is_root || root_shift_) {
         args.src.info_v.counts = (ucc_count_t *)
             ucc_malloc(comm_size * sizeof(uint32_t), "counts buf");
         UCC_MALLOC_CHECK_GOTO(args.src.info_v.counts, exit, st);
@@ -61,13 +62,13 @@ ucc_status_t ucc_pt_coll_scatterv::init_args(size_t count,
             ((uint32_t*)args.src.info_v.displacements)[i] = count * i;
         }
     }
-    if (!is_root || !UCC_IS_INPLACE(args)) {
+    if (!is_root || !UCC_IS_INPLACE(args) || root_shift_) {
         args.dst.info.count = count;
         st = ucc_pt_alloc(&dst_header, size_dst, args.dst.info.mem_type);
         if (UCC_OK != st) {
             std::cerr << "UCC perftest error: " << ucc_status_string(st)
                       << " in " << STR(_call) << "\n";
-            if (is_root) {
+            if (is_root || root_shift_) {
                 goto free_src;
             } else  {
                 goto exit;
@@ -91,10 +92,10 @@ void ucc_pt_coll_scatterv::free_args(ucc_pt_test_args_t &test_args)
     ucc_coll_args_t &args    = test_args.coll_args;
     bool             is_root = (comm->get_rank() == args.root);
 
-    if (!is_root || !UCC_IS_INPLACE(args)) {
+    if (!is_root || !UCC_IS_INPLACE(args) || root_shift_) {
         ucc_pt_free(dst_header);
     }
-    if (is_root) {
+    if (is_root || root_shift_) {
         ucc_pt_free(src_header);
         ucc_free(args.src.info_v.displacements);
         ucc_free(args.src.info_v.counts);

--- a/tools/perf/ucc_pt_coll_scatterv.cc
+++ b/tools/perf/ucc_pt_coll_scatterv.cc
@@ -70,7 +70,7 @@ ucc_status_t ucc_pt_coll_scatterv::init_args(size_t count,
                       << " in " << STR(_call) << "\n";
             if (is_root || root_shift_) {
                 goto free_src;
-            } else  {
+            } else {
                 goto exit;
             }
         }


### PR DESCRIPTION
## What
Allows non zero root and root shift in perftest of rooted collectives

## Why?
There was a segfault whenever root != 0 (or root shift) since buffers were being allocated only based on root == 0.

## How ?
1. receives root from config instead of predefining as 0.
2. Allocation both src and dst buffers whenever there is a a root shift.
