### PR TITLE
BUILD: fix build with UCX 1.11

### DIFF
--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -728,7 +728,7 @@ int ucc_config_sscanf_pipeline_params(const char *buf, void *dest,
     n_tokens = ucc_str_split_count(tokens);
 
     for (i = 0; i < n_tokens; i++) {
-        if ((order = ucs_string_find_in_list(
+        if ((order = ucc_string_find_in_list(
                  tokens[i], ucc_pipeline_order_names, 0)) >= 0) {
             p->order = (ucc_pipeline_order_t)order;
             continue;

--- a/src/utils/ucc_string.c
+++ b/src/utils/ucc_string.c
@@ -221,3 +221,18 @@ void ucc_mtype_map_to_str(uint32_t mt_map, const char *delim,
     buf -= strlen(delim);
     *buf = '\0';
 }
+
+ssize_t ucc_string_find_in_list(const char *str, const char **string_list,
+                                int case_sensitive)
+{
+    size_t i;
+
+    for (i = 0; string_list[i] != NULL; ++i) {
+        if ((case_sensitive && (strcmp(string_list[i], str) == 0)) ||
+            (!case_sensitive && (strcasecmp(string_list[i], str) == 0))) {
+            return i;
+        }
+    }
+
+    return -1;
+}

--- a/src/utils/ucc_string.h
+++ b/src/utils/ucc_string.h
@@ -1,20 +1,23 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
 #ifndef UCC_STRING_H_
 #define UCC_STRING_H_
+
 #include "config.h"
 #include "ucc/api/ucc_def.h"
+#include <sys/types.h>
 
 #define      ucc_memunits_range_str ucs_memunits_range_str
 
-char**       ucc_str_split(const char *str, const char *delim);
+char** ucc_str_split(const char *str, const char *delim);
 
-unsigned     ucc_str_split_count(char **split);
+unsigned ucc_str_split_count(char **split);
 
-void         ucc_str_split_free(char **split);
+void ucc_str_split_free(char **split);
 
 ucc_status_t ucc_str_is_number(const char *str);
 
@@ -39,6 +42,16 @@ void ucc_mtype_map_to_str(uint32_t mt_map, const char *delim,
 ucc_status_t ucc_str_to_memunits_range(const char *str, size_t *start,
                                        size_t *end);
 
-
+/**
+ * Find a string in a NULL-terminated array of strings.
+ *
+ * @param str          String to search for.
+ * @param string_list  NULL-terminated array of strings.
+ * @param case_sensitive Whether to perform case sensitive search.
+ *
+ * @return Index of the string in the array, or -1 if not found.
+ */
+ssize_t ucc_string_find_in_list(const char *str, const char **string_list,
+                                int case_sensitive);
 
 #endif


### PR DESCRIPTION
## What
ucs_string_find_in_list is not part of UCX 1.11 which breaks UCC build. Declare UCC native function ucc_string_find_in_list
