### PR TITLE
TL/UCP: opt radix alg

### DIFF
--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -236,31 +236,24 @@ ucc_knomial_calc_recv_dist(ucc_rank_t team_size, ucc_rank_t rank,
 static inline ucc_rank_t ucc_kn_get_opt_radix(ucc_rank_t team_size,
                                               ucc_kn_radix_t max_radix)
 {
-    ucc_rank_t     remainder = 0, n_trees = 0, min_val = 0;
-    ucc_kn_radix_t min_i     = UCC_KN_MIN_RADIX;
+    ucc_rank_t     n_extra = 0, min_val = team_size;
+    ucc_kn_radix_t min_i   = UCC_KN_MIN_RADIX;
+    ucc_kn_radix_t max_r   = ucc_max(max_radix, UCC_KN_MIN_RADIX);
     ucc_kn_radix_t r, fs;
-    ucc_rank_t     min_trees;
 
-    max_radix = ucc_max(max_radix, UCC_KN_MIN_RADIX);
-    min_trees = max_radix;
-
-    for (r = UCC_KN_MIN_RADIX; r <= max_radix; r++) {
+    for (r = UCC_KN_MIN_RADIX; r <= max_r; r++) {
         fs = r;
         while (fs < team_size) {
             fs = fs * r;
         }
-        fs        = (fs == team_size) ? fs : fs / r;
-        n_trees   = team_size / fs;
-        remainder = team_size - (team_size / fs) * fs;
-        if (remainder == 0) {
+        fs      = (fs == team_size) ? fs : fs / r;
+        n_extra = team_size - (team_size / fs) * fs;
+        if (n_extra == 0) {
             return r;
         }
-        if (r == UCC_KN_MIN_RADIX || (r > UCC_KN_MIN_RADIX &&
-            (remainder < min_val ||
-            (remainder == min_val && n_trees < min_trees)))) {
-            min_val   = remainder;
-            min_trees = n_trees;
-            min_i     = r;
+        if (n_extra < min_val) {
+            min_val = n_extra;
+            min_i   = r;
         }
     }
     return min_i;

--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -234,13 +234,14 @@ ucc_knomial_calc_recv_dist(ucc_rank_t team_size, ucc_rank_t rank,
 /* Calculates (sub) opt radix for Allreduce SRA and Bcast SAG,
    by minimizing n_extra ranks */
 static inline ucc_rank_t ucc_kn_get_opt_radix(ucc_rank_t team_size,
-                                              ucc_rank_t max_radix)
+                                              ucc_kn_radix_t max_radix)
 {
-    ucc_rank_t remainder = 0, n_trees = 0, min_val = 0,
-               min_i = UCC_KN_MIN_RADIX;
-    ucc_rank_t min_trees, r, fs;
+    ucc_rank_t     remainder = 0, n_trees = 0, min_val = 0;
+    ucc_kn_radix_t min_i     = UCC_KN_MIN_RADIX;
+    ucc_kn_radix_t r, fs;
+    ucc_rank_t     min_trees;
 
-    max_radix = (max_radix >= UCC_KN_MIN_RADIX) ? max_radix : UCC_KN_MIN_RADIX;
+    max_radix = ucc_max(max_radix, UCC_KN_MIN_RADIX);
     min_trees = max_radix;
 
     for (r = UCC_KN_MIN_RADIX; r <= max_radix; r++) {

--- a/src/components/tl/ucp/allreduce/allreduce_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_knomial.c
@@ -198,8 +198,8 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_start(ucc_coll_task_t *coll_task)
     task->allreduce_kn.phase = UCC_KN_PHASE_INIT;
     ucc_assert(UCC_IS_INPLACE(TASK_ARGS(task)) ||
                (TASK_ARGS(task).src.info.mem_type == mem_type));
-    cfg_radix = ucc_tl_ucp_get_radix_from_range(team, data_size,
-                                                mem_type, p);
+    cfg_radix = ucc_tl_ucp_get_radix_from_range(team, data_size, mem_type, p,
+                                                UCC_UUNITS_AUTO_RADIX);
     ucc_knomial_pattern_init(size, rank, ucc_min(cfg_radix, size),
                              &task->allreduce_kn.p);
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
@@ -228,7 +228,7 @@ ucc_status_t ucc_tl_ucp_allreduce_knomial_init_common(ucc_tl_ucp_task_t *task)
     task->super.progress = ucc_tl_ucp_allreduce_knomial_progress;
     task->super.finalize = ucc_tl_ucp_allreduce_knomial_finalize;
     cfg_radix            = ucc_tl_ucp_get_radix_from_range(team, data_size,
-                                                           mem_type, p);
+                               mem_type, p, UCC_UUNITS_AUTO_RADIX);
     radix                = ucc_min(cfg_radix, size);
     status               = ucc_mc_alloc(&task->allreduce_kn.scratch_mc_header,
                           (radix - 1) * data_size,

--- a/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
+++ b/src/components/tl/ucp/allreduce/allreduce_sra_knomial.c
@@ -114,11 +114,11 @@ static ucc_status_t ucc_tl_ucp_allreduce_sra_knomial_frag_init(
 
     cfg_radix = ucc_tl_ucp_get_radix_from_range(tl_team,
                                                 count * ucc_dt_size(dtype),
-                                                mem_type, p);
+                                                mem_type, p,
+                                                tl_team->opt_radix);
     radix     = ucc_knomial_pattern_get_min_radix(cfg_radix,
                                                   UCC_TL_TEAM_SIZE(tl_team),
                                                   count);
-
     /* 1st step of allreduce: knomial reduce_scatter */
     UCC_CHECK_GOTO(
         ucc_tl_ucp_reduce_scatter_knomial_init_r(&args, team, &task, radix),

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -75,7 +75,10 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
 {
     ucc_tl_ucp_team_t   *tl_team  = ucc_derived_of(team, ucc_tl_ucp_team_t);
     size_t               count    = coll_args->args.src.info.count;
+    ucc_datatype_t       dtype    = coll_args->args.src.info.datatype;
+    ucc_memory_type_t    mem_type = coll_args->args.src.info.mem_type;
     ucc_base_coll_args_t args     = *coll_args;
+    ucc_mrange_uint_t   *p        = &tl_team->cfg.bcast_sag_kn_radix;
     ucc_schedule_t      *schedule;
     ucc_coll_task_t     *task, *rs_task;
     ucc_status_t         status;
@@ -86,11 +89,14 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
         return ucc_tl_ucp_bcast_knomial_init(coll_args, team, task_h);
     }
 
-    cfg_radix = UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.bcast_sag_kn_radix;
-    radix = ucc_knomial_pattern_get_min_radix(cfg_radix,
-                                              UCC_TL_TEAM_SIZE(tl_team), count);
-    status = ucc_tl_ucp_get_schedule(tl_team, coll_args,
-                                     (ucc_tl_ucp_schedule_t **)&schedule);
+    cfg_radix = ucc_tl_ucp_get_radix_from_range(tl_team,
+                                                count * ucc_dt_size(dtype),
+                                                mem_type, p);
+    radix     = ucc_knomial_pattern_get_min_radix(cfg_radix,
+                                                  UCC_TL_TEAM_SIZE(tl_team),
+                                                  count);
+    status    = ucc_tl_ucp_get_schedule(tl_team, coll_args,
+                                        (ucc_tl_ucp_schedule_t **)&schedule);
     if (ucc_unlikely(UCC_OK != status)) {
         return status;
     }

--- a/src/components/tl/ucp/bcast/bcast_sag_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_sag_knomial.c
@@ -91,7 +91,8 @@ ucc_tl_ucp_bcast_sag_knomial_init(ucc_base_coll_args_t *coll_args,
 
     cfg_radix = ucc_tl_ucp_get_radix_from_range(tl_team,
                                                 count * ucc_dt_size(dtype),
-                                                mem_type, p);
+                                                mem_type, p,
+                                                tl_team->opt_radix);
     radix     = ucc_knomial_pattern_get_min_radix(cfg_radix,
                                                   UCC_TL_TEAM_SIZE(tl_team),
                                                   count);

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -189,11 +189,6 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, use_reordering),
      UCC_CONFIG_TYPE_BOOL},
 
-    {"CALC_OPT_RADIX", "y",
-     "Opt radix in TL UCP for Bcast SAG and Allreduce SRA. Requires topo info",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, calc_opt_radix),
-     UCC_CONFIG_TYPE_BOOL},
-
     {NULL}};
 
 static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -127,10 +127,10 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, bcast_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
-    {"BCAST_SAG_KN_RADIX", "4",
+    {"BCAST_SAG_KN_RADIX", "auto",
      "Radix of the scatter-allgather (SAG) knomial bcast algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, bcast_sag_kn_radix),
-     UCC_CONFIG_TYPE_UINT},
+     UCC_CONFIG_TYPE_UINT_RANGED},
 
     {"REDUCE_KN_RADIX", "4", "Radix of the knomial tree reduce algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_kn_radix),
@@ -187,6 +187,11 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
     {"RANKS_REORDERING", "y",
      "Use topology information in TL UCP to reorder ranks. Requires topo info",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, use_reordering),
+     UCC_CONFIG_TYPE_BOOL},
+
+    {"CALC_OPT_RADIX", "y",
+     "Opt radix in TL UCP for Bcast SAG and Allreduce SRA. Requires topo info",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, calc_opt_radix),
      UCC_CONFIG_TYPE_BOOL},
 
     {NULL}};

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -14,6 +14,7 @@
 #include "schedule/ucc_schedule_pipelined.h"
 #include <ucp/api/ucp.h>
 #include <ucs/memory/memory_type.h>
+#include "core/ucc_service_coll.h"
 
 #ifndef UCC_TL_UCP_DEFAULT_SCORE
 #define UCC_TL_UCP_DEFAULT_SCORE 10
@@ -52,7 +53,7 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t                 reduce_scatter_kn_radix;
     uint32_t                 allgather_kn_radix;
     uint32_t                 bcast_kn_radix;
-    uint32_t                 bcast_sag_kn_radix;
+    ucc_mrange_uint_t        bcast_sag_kn_radix;
     uint32_t                 reduce_kn_radix;
     uint32_t                 gather_kn_radix;
     uint32_t                 gatherv_linear_num_posts;
@@ -73,6 +74,7 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t                 alltoallv_hybrid_pairwise_num_posts;
     ucc_ternary_auto_value_t use_topo;
     int                      use_reordering;
+    int                      calc_opt_radix;
 } ucc_tl_ucp_lib_config_t;
 
 typedef struct ucc_tl_ucp_context_config {
@@ -142,6 +144,9 @@ typedef struct ucc_tl_ucp_team {
     ucc_topo_t                *topo;
     ucc_ep_map_t               ctx_map;
     ucc_rank_t                 opt_radix;
+    ucc_rank_t                 min_socket_size;
+    ucc_rank_t                 socket_size;
+    ucc_service_coll_req_t    *allreduce_service_req;
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -144,9 +144,6 @@ typedef struct ucc_tl_ucp_team {
     ucc_topo_t                *topo;
     ucc_ep_map_t               ctx_map;
     ucc_rank_t                 opt_radix;
-    ucc_rank_t                 min_socket_size;
-    ucc_rank_t                 socket_size;
-    ucc_service_coll_req_t    *allreduce_service_req;
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -74,7 +74,6 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t                 alltoallv_hybrid_pairwise_num_posts;
     ucc_ternary_auto_value_t use_topo;
     int                      use_reordering;
-    int                      calc_opt_radix;
 } ucc_tl_ucp_lib_config_t;
 
 typedef struct ucc_tl_ucp_context_config {

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -141,6 +141,7 @@ typedef struct ucc_tl_ucp_team {
     const char *               tuning_str;
     ucc_topo_t                *topo;
     ucc_ep_map_t               ctx_map;
+    ucc_rank_t                 opt_radix;
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -409,14 +409,15 @@ static inline unsigned
 ucc_tl_ucp_get_radix_from_range(ucc_tl_ucp_team_t *team,
                                 size_t             msgsize,
                                 ucc_memory_type_t  mem_type,
-                                ucc_mrange_uint_t *p)
+                                ucc_mrange_uint_t *p,
+                                ucc_rank_t         default_value)
 {
     unsigned radix;
 
     radix = ucc_mrange_uint_get(p, msgsize, mem_type);
 
     if (UCC_UUNITS_AUTO == radix) {
-        return team->opt_radix;
+        return default_value;
     }
     return radix;
 }

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -417,6 +417,10 @@ ucc_tl_ucp_get_radix_from_range(ucc_tl_ucp_team_t *team,
 
     if (UCC_UUNITS_AUTO == radix) {
         /* auto selection based on team configuration */
+        if (UCC_TL_UCP_TEAM_CTX(team)->topo_required &&
+            !IS_SERVICE_TEAM(team) && team->cfg.calc_opt_radix) {
+            return team->opt_radix;
+        }
         return UCC_UUNITS_AUTO_RADIX;
     }
     return radix;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -416,12 +416,7 @@ ucc_tl_ucp_get_radix_from_range(ucc_tl_ucp_team_t *team,
     radix = ucc_mrange_uint_get(p, msgsize, mem_type);
 
     if (UCC_UUNITS_AUTO == radix) {
-        /* auto selection based on team configuration */
-        if (team->topo && team->topo->topo->sock_bound &&
-            !IS_SERVICE_TEAM(team)) {
-            return team->opt_radix;
-        }
-        return UCC_UUNITS_AUTO_RADIX;
+        return team->opt_radix;
     }
     return radix;
 }

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -417,8 +417,8 @@ ucc_tl_ucp_get_radix_from_range(ucc_tl_ucp_team_t *team,
 
     if (UCC_UUNITS_AUTO == radix) {
         /* auto selection based on team configuration */
-        if (UCC_TL_UCP_TEAM_CTX(team)->topo_required &&
-            !IS_SERVICE_TEAM(team) && team->cfg.calc_opt_radix) {
+        if (team->topo && team->topo->topo->sock_bound &&
+            !IS_SERVICE_TEAM(team)) {
             return team->opt_radix;
         }
         return UCC_UUNITS_AUTO_RADIX;

--- a/src/components/tl/ucp/tl_ucp_lib.c
+++ b/src/components/tl/ucp/tl_ucp_lib.c
@@ -32,7 +32,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_lib_t, const ucc_base_lib_params_t *params,
         self->cfg.reduce_scatter_kn_radix = tl_ucp_config->kn_radix;
         self->cfg.allgather_kn_radix      = tl_ucp_config->kn_radix;
         self->cfg.bcast_kn_radix          = tl_ucp_config->kn_radix;
-        self->cfg.bcast_sag_kn_radix      = tl_ucp_config->kn_radix;
         self->cfg.reduce_kn_radix         = tl_ucp_config->kn_radix;
         self->cfg.scatter_kn_radix        = tl_ucp_config->kn_radix;
         self->cfg.gather_kn_radix         = tl_ucp_config->kn_radix;

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -46,8 +46,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
 {
     ucc_tl_ucp_context_t *ctx =
         ucc_derived_of(tl_context, ucc_tl_ucp_context_t);
-    ucc_rank_t   max_radix;
-    ucc_status_t status;
+    ucc_kn_radix_t max_radix;
+    ucc_status_t   status;
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
     /* TODO: init based on ctx settings and on params: need to check

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -226,9 +226,7 @@ static ucc_status_t sbgp_create_node_leaders(ucc_topo_t *topo, ucc_sbgp_t *sbgp,
             return UCC_ERR_NO_MEMORY;
         }
 
-        for (i = 0; i < nnodes * max_ctx_sbgp_size; i++) {
-            nl_array_3[i] = 0;
-        }
+        memset(nl_array_3, 0, max_ctx_sbgp_size * nnodes * sizeof(ucc_rank_t));
     }
 
     for (i = 0; i < nnodes; i++) {

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -504,6 +504,9 @@ ucc_status_t ucc_sbgp_create(ucc_topo_t *topo, ucc_sbgp_type_t type)
         sbgp->map = ucc_ep_map_from_array(&sbgp->rank_map, sbgp->group_size,
                                           ucc_subset_size(&topo->set), 1);
     }
+    if (sbgp->rank_map && sbgp->status == UCC_SBGP_NOT_EXISTS) {
+        ucc_free(sbgp->rank_map);
+    }
     return status;
 }
 

--- a/src/components/topo/ucc_sbgp.h
+++ b/src/components/topo/ucc_sbgp.h
@@ -34,7 +34,7 @@ typedef enum ucc_sbgp_type_t
                                     but EXISTS for procs with local_socket_rank != 0 */
     UCC_SBGP_NUMA_LEADERS,       /* Same as SOCKET_LEADERS but for NUMA grouping */
     UCC_SBGP_FULL,               /* Group contains ALL the ranks of the team */
-    UCC_SBGP_FULL_HOST_ORDERED,  /* Group contains All the ranks of the ream ordered
+    UCC_SBGP_FULL_HOST_ORDERED,  /* Group contains ALL the ranks of the team ordered
                                     by host, socket, numa */
     UCC_SBGP_LAST
 } ucc_sbgp_type_t;

--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -178,6 +178,8 @@ ucc_status_t ucc_topo_init(ucc_subset_t set, ucc_context_topo_t *ctx_topo,
     topo->set                 = set;
     topo->min_ppn             = UCC_RANK_MAX;
     topo->max_ppn             = 0;
+    topo->min_socket_size     = UCC_RANK_MAX;
+    topo->max_socket_size     = 0;
     topo->all_sockets         = NULL;
     topo->all_numas           = NULL;
 

--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -180,6 +180,8 @@ ucc_status_t ucc_topo_init(ucc_subset_t set, ucc_context_topo_t *ctx_topo,
     topo->max_ppn             = 0;
     topo->min_socket_size     = UCC_RANK_MAX;
     topo->max_socket_size     = 0;
+    topo->min_numa_size       = UCC_RANK_MAX;
+    topo->max_numa_size       = 0;
     topo->all_sockets         = NULL;
     topo->all_numas           = NULL;
 

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -60,6 +60,10 @@ typedef struct ucc_topo {
                          for ucc_team topo it is team->ctx_map */
     ucc_rank_t   min_ppn; /*< min ppn across the nodes for a team */
     ucc_rank_t   max_ppn; /*< max ppn across the nodes for a team */
+    ucc_rank_t   min_socket_size; /*< min ppn on a socket/numa,
+                                    across the nodes for a team */
+    ucc_rank_t   max_socket_size; /*< max ppn on a socket/numa,
+                                    across the nodes for a team */
 } ucc_topo_t;
 
 /* Initializes ctx level topo structure using addr_storage.

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -60,10 +60,14 @@ typedef struct ucc_topo {
                          for ucc_team topo it is team->ctx_map */
     ucc_rank_t   min_ppn; /*< min ppn across the nodes for a team */
     ucc_rank_t   max_ppn; /*< max ppn across the nodes for a team */
-    ucc_rank_t   min_socket_size; /*< min ppn on a socket/numa,
-                                    across the nodes for a team */
-    ucc_rank_t   max_socket_size; /*< max ppn on a socket/numa,
-                                    across the nodes for a team */
+    ucc_rank_t   min_socket_size; /*< min number of processes on a socket,
+                                      across all nodes of a team */
+    ucc_rank_t   max_socket_size; /*< max number of processes on a socket,
+                                      across all nodes of a team */
+    ucc_rank_t   min_numa_size; /*< min number of processes on a numa,
+                                    across all nodes of a team */
+    ucc_rank_t   max_numa_size; /*< max number of processes on a numa,
+                                    across all nodes of a team */
 } ucc_topo_t;
 
 /* Initializes ctx level topo structure using addr_storage.
@@ -128,6 +132,58 @@ static inline ucc_rank_t ucc_topo_max_ppn(ucc_topo_t *topo)
 static inline int ucc_topo_isoppn(ucc_topo_t *topo)
 {
     return ucc_topo_max_ppn(topo) == ucc_topo_min_ppn(topo);
+}
+
+/* Returns min socket size across the nodes */
+static inline ucc_rank_t ucc_topo_min_socket_size(ucc_topo_t *topo)
+{
+    ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+
+    if (sbgp->status == UCC_SBGP_NOT_INIT) {
+        ucc_assert(topo->topo->sock_bound);
+        return UCC_RANK_INVALID;
+    }
+
+    return topo->min_socket_size;
+}
+
+/* Returns max socket size across the nodes */
+static inline ucc_rank_t ucc_topo_max_socket_size(ucc_topo_t *topo)
+{
+     ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+
+    if (sbgp->status == UCC_SBGP_NOT_INIT) {
+        ucc_assert(topo->topo->sock_bound);
+        return UCC_RANK_INVALID;
+    }
+
+    return topo->max_socket_size;
+}
+
+/* Returns min numa size across the nodes */
+static inline ucc_rank_t ucc_topo_min_numa_size(ucc_topo_t *topo)
+{
+    ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+
+    if (sbgp->status == UCC_SBGP_NOT_INIT) {
+        ucc_assert(topo->topo->numa_bound);
+        return UCC_RANK_INVALID;
+    }
+
+    return topo->min_numa_size;
+}
+
+/* Returns max numa size across the nodes */
+static inline ucc_rank_t ucc_topo_max_numa_size(ucc_topo_t *topo)
+{
+    ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+
+    if (sbgp->status == UCC_SBGP_NOT_INIT) {
+        ucc_assert(topo->topo->numa_bound);
+        return UCC_RANK_INVALID;
+    }
+
+    return topo->max_numa_size;
 }
 
 static inline int ucc_topo_n_sockets(ucc_topo_t *topo)

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -134,52 +134,72 @@ static inline int ucc_topo_isoppn(ucc_topo_t *topo)
     return ucc_topo_max_ppn(topo) == ucc_topo_min_ppn(topo);
 }
 
-/* Returns min socket size across the nodes */
+/* Returns min socket size across the nodes.
+ * If not set will return UCC_RANK_MAX,
+ * in case of error will return UCC_RANK_INVALID.
+ */
 static inline ucc_rank_t ucc_topo_min_socket_size(ucc_topo_t *topo)
 {
-    ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+    ucc_sbgp_t *sbgp;
+
+    ucc_assert(topo->topo->sock_bound);
+    sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
 
     if (sbgp->status == UCC_SBGP_NOT_INIT) {
-        ucc_assert(topo->topo->sock_bound);
         return UCC_RANK_INVALID;
     }
 
     return topo->min_socket_size;
 }
 
-/* Returns max socket size across the nodes */
+/* Returns max socket size across the nodes.
+ * If not set will return 0,
+ * in case of error will return UCC_RANK_INVALID.
+ */
 static inline ucc_rank_t ucc_topo_max_socket_size(ucc_topo_t *topo)
 {
-     ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+    ucc_sbgp_t *sbgp;
+
+    ucc_assert(topo->topo->sock_bound);
+    sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
 
     if (sbgp->status == UCC_SBGP_NOT_INIT) {
-        ucc_assert(topo->topo->sock_bound);
         return UCC_RANK_INVALID;
     }
 
     return topo->max_socket_size;
 }
 
-/* Returns min numa size across the nodes */
+/* Returns min numa size across the nodes.
+ * If not set will return UCC_RANK_MAX,
+ * in case of error will return UCC_RANK_INVALID.
+ */
 static inline ucc_rank_t ucc_topo_min_numa_size(ucc_topo_t *topo)
 {
-    ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+    ucc_sbgp_t *sbgp;
+
+    ucc_assert(topo->topo->numa_bound);
+    sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
 
     if (sbgp->status == UCC_SBGP_NOT_INIT) {
-        ucc_assert(topo->topo->numa_bound);
         return UCC_RANK_INVALID;
     }
 
     return topo->min_numa_size;
 }
 
-/* Returns max numa size across the nodes */
+/* Returns max numa size across the nodes.
+ * If not set will return 0,
+ * in case of error will return UCC_RANK_INVALID.
+ */
 static inline ucc_rank_t ucc_topo_max_numa_size(ucc_topo_t *topo)
 {
-    ucc_sbgp_t *sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
+    ucc_sbgp_t *sbgp;
+
+    ucc_assert(topo->topo->numa_bound);
+    sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_NODE_LEADERS);
 
     if (sbgp->status == UCC_SBGP_NOT_INIT) {
-        ucc_assert(topo->topo->numa_bound);
         return UCC_RANK_INVALID;
     }
 


### PR DESCRIPTION
## What
Adding auto (sub) optimal radix calculation to be used for Allreduce SRA and Bcast SAG inside TL/UCP.

## Why ?
To improve performance when degredation caused by extra ranks.

## How ?
Calculates the radix which minimizes extra ranks per team size.
Additionally makes sure that radix wont be larger then socket size (across all nodes), to also minimize cross socket communication.
