### PR TITLE
CORE: fix triggered persistent coll status

### DIFF
--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -523,7 +523,8 @@ ucc_status_t ucc_triggered_post(ucc_ee_h ee, ucc_ev_t *ev,
         ucc_error("event type %d is not supported", ev->ev_type);
         return UCC_ERR_NOT_IMPLEMENTED;
     }
-    task->ee = ee;
+    task->ee           = ee;
+    task->super.status = UCC_OPERATION_INITIALIZED;
     ev_task = ucc_malloc(sizeof(*ev_task), "ev_task");
     if (!ev_task) {
         ucc_error("failed to allocate %zd bytes for ev_task",

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -174,7 +174,7 @@ static inline ucc_status_t ucc_task_complete(ucc_coll_task_t *task)
 
     ucc_assert((status == UCC_OK) || (status < 0));
 
-    /* If task is part of a  schedule then it can be
+    /* If task is part of a schedule then it can be
        released during ucc_event_manager_notify(EVENT_COMPLETED_SCHEDULE) below.
        Sequence: notify => schedule->n_completed_tasks++ =>
        schedule->super.status = UCC_OK => user releases schedule from another


### PR DESCRIPTION
## What
Fixes incorrect status for triggered tasks when using persistent mode

## Why ?
Running triggered tasks multiple times might result in incorrect status if trigger event is not immediately satisfied for second run and task keeps UCC_OK status from previous run. 

## How ?
Set triggered tasks status to operation initialized in collective post function 
