### PR TITLE
TL/CUDA: fix pipelining in linear rs

### DIFF
--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -175,8 +175,8 @@ static ucc_status_t ucc_cl_hier_allreduce_split_rail_frag_init(
         rs_args.args.flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
         rs_args.args.src.info.buffer   = coll_args->args.dst.info.buffer;
         rs_args.args.src.info.datatype = coll_args->args.dst.info.datatype;
-        rs_args.args.dst.info_v.buffer = PTR_OFFSET(
-            coll_args->args.dst.info.buffer, displs[node_rank] * dt_size);
+        rs_args.args.dst.info_v.buffer = coll_args->args.dst.info.buffer;
+
     } else {
         rs_args.args.dst.info_v.buffer = PTR_OFFSET(
             coll_args->args.dst.info.buffer, displs[node_rank] * dt_size);

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter_linear.c
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter_linear.c
@@ -34,7 +34,6 @@ ucc_status_t ucc_tl_cuda_reduce_scatter_linear_init(ucc_base_coll_args_t *coll_a
     task->reduce_scatterv_linear.get_offset =
         ucc_tl_cuda_reduce_scatter_get_offset;
     task->reduce_scatterv_linear.dt         = coll_args->args.dst.info.datatype;
-    task->reduce_scatterv_linear.rbuf       = coll_args->args.dst.info.buffer;
     task->super.flags          |= UCC_COLL_TASK_FLAG_EXECUTOR;
     task->super.post           = ucc_tl_cuda_reduce_scatterv_linear_start;
     task->super.progress       = ucc_tl_cuda_reduce_scatterv_linear_progress;


### PR DESCRIPTION
## What
Fix CL HIER Split Rail Allreduce with TL CUDA

## How ?
Fixes several bugs
1. CL HIER split rail algorithm doesn't provide correct buffer for inplace reduce scatter, it passes original rbuf with stairway patter rank offset
2. TL CUDA linear reduce scatter doesn't update rbuf pointer after fragment setup of pipelined schedule 
