### PR TITLE
TL/UCP: avoid copy in knomial scatter

### DIFF
--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -150,6 +150,11 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, scatter_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
+    {"SCATTER_KN_ENABLE_RECV_ZCOPY", "auto",
+     "Receive scatter data to user buffer with correct offset using zcopy",
+     ucs_offsetof(ucc_tl_ucp_lib_config_t, scatter_kn_enable_recv_zcopy),
+     UCS_CONFIG_TYPE_ON_OFF_AUTO},
+
     {"SCATTERV_LINEAR_NUM_POSTS", "16",
      "Maximum number of outstanding send and receive messages in scatterv "
      "linear algorithm",

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -57,6 +57,7 @@ typedef struct ucc_tl_ucp_lib_config {
     uint32_t                 gather_kn_radix;
     uint32_t                 gatherv_linear_num_posts;
     uint32_t                 scatter_kn_radix;
+    ucc_on_off_auto_value_t  scatter_kn_enable_recv_zcopy;
     uint32_t                 scatterv_linear_num_posts;
     uint32_t                 alltoall_pairwise_num_posts;
     uint32_t                 alltoallv_pairwise_num_posts;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -152,6 +152,7 @@ typedef struct ucc_tl_ucp_task {
             ucc_knomial_pattern_t   p;
             ucc_rank_t              recv_dist;
             ptrdiff_t               send_offset;
+            ptrdiff_t               recv_offset;
             size_t                  recv_size;
         } scatter_kn;
         struct {

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -75,6 +75,7 @@ typedef struct ucc_file_config ucc_file_config_t;
 #define UCC_CONFIG_ALLOW_LIST_ALLOW_ALL UCS_CONFIG_ALLOW_LIST_ALLOW_ALL
 #define UCC_CONFIG_ALLOW_LIST_ALLOW     UCS_CONFIG_ALLOW_LIST_ALLOW
 #define UCC_CONFIG_TYPE_TERNARY         UCS_CONFIG_TYPE_TERNARY
+#define UCC_CONFIG_TYPE_ON_OFF_AUTO     UCS_CONFIG_TYPE_ON_OFF_AUTO
 #define UCC_UUNITS_AUTO                 ((unsigned)-2)
 
 typedef enum ucc_ternary_auto_value {
@@ -84,6 +85,13 @@ typedef enum ucc_ternary_auto_value {
     UCC_AUTO = UCS_AUTO,
     UCC_TERNARY_LAST
 } ucc_ternary_auto_value_t;
+
+typedef enum ucc_on_off_auto_value {
+    UCC_CONFIG_OFF  = UCS_CONFIG_OFF,
+    UCC_CONFIG_ON   = UCS_CONFIG_ON,
+    UCC_CONFIG_AUTO = UCS_CONFIG_AUTO,
+    UCC_CONFIG_ON_OFF_LAST
+} ucc_on_off_auto_value_t;
 
 enum tuning_mask {
     UCC_TUNING_DESC_FIELD_VENDOR    = UCC_BIT(0),


### PR DESCRIPTION
## What
Adding configuration parameter for knomial scatter algorithm (part of scatter allgather broadcast) to receive data directly into destination buffer and avoid memory copy as a last step of the algorithm

## Why ?
Improves performance of large message broadcast. By default enabled only for GPU collective 
