### PR TITLE
CORE: fix score update when only score given

### DIFF
--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -173,6 +173,7 @@ ucc_status_t ucc_cl_basic_team_get_scores(ucc_base_team_t   *cl_team,
     ucc_cl_basic_team_t *team = ucc_derived_of(cl_team, ucc_cl_basic_team_t);
     ucc_base_context_t  *ctx  = UCC_CL_TEAM_CTX(team);
     ucc_status_t         status;
+    ucc_coll_score_team_info_t team_info;
 
     status = ucc_coll_score_dup(team->score, score);
     if (UCC_OK != status) {
@@ -180,10 +181,16 @@ ucc_status_t ucc_cl_basic_team_get_scores(ucc_base_team_t   *cl_team,
     }
 
     if (strlen(ctx->score_str) > 0) {
-        status = ucc_coll_score_update_from_str(
-            ctx->score_str, *score, UCC_CL_TEAM_SIZE(team), NULL, cl_team,
-            UCC_CL_BASIC_DEFAULT_SCORE, NULL, NULL, 0);
+        team_info.alg_fn              = NULL;
+        team_info.default_score       = UCC_CL_BASIC_DEFAULT_SCORE;
+        team_info.init                = NULL;
+        team_info.num_mem_types       = 0;
+        team_info.supported_mem_types = NULL; /* all memory types supported*/
+        team_info.supported_colls     = UCC_COLL_TYPE_ALL;
+        team_info.size                = UCC_CL_TEAM_SIZE(team);
 
+        status = ucc_coll_score_update_from_str(ctx->score_str, &team_info,
+                                                &team->super.super, *score);
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
             (status != UCC_ERR_NOT_SUPPORTED)) {

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -315,6 +315,15 @@ ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
     ucc_coll_score_t   *score;
     ucc_status_t        status;
     int                 i;
+    ucc_coll_score_team_info_t team_info;
+
+    team_info.alg_fn              = ucc_cl_hier_alg_id_to_init;
+    team_info.default_score       = UCC_CL_HIER_DEFAULT_SCORE;
+    team_info.init                = ucc_cl_hier_coll_init;
+    team_info.num_mem_types       = 0;
+    team_info.supported_mem_types = NULL; /* all memory types supported*/
+    team_info.supported_colls     = UCC_COLL_TYPE_ALL;
+    team_info.size                = UCC_CL_TEAM_SIZE(team);
 
     status = ucc_coll_score_alloc(&score);
     if (UCC_OK != status) {
@@ -353,10 +362,14 @@ ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
     }
 
     for (i = 0; i < UCC_CL_HIER_N_DEFAULT_ALG_SELECT_STR; i++) {
+        // status = ucc_coll_score_update_from_str(
+        //     ucc_cl_hier_default_alg_select_str[i], score,
+        //     UCC_TL_TEAM_SIZE(team), ucc_cl_hier_coll_init, &team->super.super,
+        //     UCC_CL_HIER_DEFAULT_SCORE, ucc_cl_hier_alg_id_to_init, NULL, 0,
+        //     UCC_COLL_TYPE_ALL);
         status = ucc_coll_score_update_from_str(
-            ucc_cl_hier_default_alg_select_str[i], score,
-            UCC_TL_TEAM_SIZE(team), ucc_cl_hier_coll_init, &team->super.super,
-            UCC_CL_HIER_DEFAULT_SCORE, ucc_cl_hier_alg_id_to_init, NULL, 0);
+            ucc_cl_hier_default_alg_select_str[i], &team_info,
+            &team->super.super, score);
         if (UCC_OK != status) {
             cl_error(lib, "failed to apply default coll select setting: %s",
                      ucc_cl_hier_default_alg_select_str[i]);
@@ -365,10 +378,12 @@ ucc_status_t ucc_cl_hier_team_get_scores(ucc_base_team_t   *cl_team,
     }
 
     if (strlen(ctx->score_str) > 0) {
-        status = ucc_coll_score_update_from_str(
-            ctx->score_str, score, UCC_CL_TEAM_SIZE(team), NULL, cl_team,
-            UCC_CL_HIER_DEFAULT_SCORE, ucc_cl_hier_alg_id_to_init, NULL, 0);
-
+        // status = ucc_coll_score_update_from_str(
+        //     ctx->score_str, score, UCC_CL_TEAM_SIZE(team), NULL, cl_team,
+        //     UCC_CL_HIER_DEFAULT_SCORE, ucc_cl_hier_alg_id_to_init, NULL, 0,
+        //     UCC_COLL_TYPE_ALL);
+        status = ucc_coll_score_update_from_str(ctx->score_str, &team_info,
+                                                &team->super.super, score);
         /* if INVALID_PARAM - user provided incorrect input - try to proceed */
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
             (status != UCC_ERR_NOT_SUPPORTED)) {

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -327,6 +327,15 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
     ucc_coll_score_t   *score;
     ucc_status_t        status;
     int                 i;
+    ucc_coll_score_team_info_t team_info;
+
+    team_info.alg_fn              = ucc_tl_cuda_alg_id_to_init;
+    team_info.default_score       = UCC_TL_CUDA_DEFAULT_SCORE;
+    team_info.init                = ucc_tl_cuda_coll_init;
+    team_info.num_mem_types       = 1;
+    team_info.supported_mem_types = &mt;
+    team_info.supported_colls     = UCC_TL_CUDA_SUPPORTED_COLLS;
+    team_info.size                = UCC_TL_TEAM_SIZE(team);
 
     status =
         ucc_coll_score_build_default(tl_team, UCC_TL_CUDA_DEFAULT_SCORE,
@@ -339,9 +348,8 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
 
     for (i = 0; i < UCC_TL_CUDA_N_DEFAULT_ALG_SELECT_STR; i++) {
         status = ucc_coll_score_update_from_str(
-            ucc_tl_cuda_default_alg_select_str[i], score,
-            UCC_TL_TEAM_SIZE(team), ucc_tl_cuda_coll_init, &team->super.super,
-            UCC_TL_CUDA_DEFAULT_SCORE, ucc_tl_cuda_alg_id_to_init, &mt, 1);
+            ucc_tl_cuda_default_alg_select_str[i], &team_info,
+            &team->super.super, score);
         if (UCC_OK != status) {
             tl_error(tl_team->context->lib,
                      "failed to apply default coll select setting: %s",
@@ -351,10 +359,8 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
     }
 
     if (strlen(ctx->score_str) > 0) {
-        status = ucc_coll_score_update_from_str(
-            ctx->score_str, score, UCC_TL_TEAM_SIZE(team),
-            ucc_tl_cuda_coll_init, &team->super.super,
-            UCC_TL_CUDA_DEFAULT_SCORE, ucc_tl_cuda_alg_id_to_init, &mt, 1);
+        status = ucc_coll_score_update_from_str(ctx->score_str, &team_info,
+                                                &team->super.super, score);
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
             (status != UCC_ERR_NOT_SUPPORTED)) {
             goto err;

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -146,6 +146,15 @@ ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
     ucc_memory_type_t   mt   = UCC_MEMORY_TYPE_HOST;
     ucc_coll_score_t *  score;
     ucc_status_t        status;
+    ucc_coll_score_team_info_t team_info;
+
+    team_info.alg_fn              = NULL;
+    team_info.default_score       = UCC_TL_MLX5_DEFAULT_SCORE;
+    team_info.init                = NULL;
+    team_info.num_mem_types       = 1;
+    team_info.supported_mem_types = &mt;
+    team_info.supported_colls     = UCC_TL_MLX5_SUPPORTED_COLLS;
+    team_info.size                = UCC_TL_TEAM_SIZE(team);
 
     status = ucc_coll_score_alloc(&score);
     if (UCC_OK != status) {
@@ -154,10 +163,8 @@ ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
     }
 
     if (strlen(ctx->score_str) > 0) {
-        status = ucc_coll_score_update_from_str(
-            ctx->score_str, score, UCC_TL_TEAM_SIZE(team), NULL, tl_team,
-            UCC_TL_MLX5_DEFAULT_SCORE, NULL, &mt, 1);
-
+        status = ucc_coll_score_update_from_str(ctx->score_str, &team_info,
+                                                &team->super.super, score);
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
             (status != UCC_ERR_NOT_SUPPORTED)) {

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -207,7 +207,15 @@ ucc_status_t ucc_tl_nccl_team_get_scores(ucc_base_team_t   *tl_team,
     ucc_coll_score_t   *score;
     ucc_status_t        status;
     int                 i;
+    ucc_coll_score_team_info_t team_info;
 
+    team_info.alg_fn              = ucc_tl_nccl_alg_id_to_init;
+    team_info.default_score       = UCC_TL_NCCL_DEFAULT_SCORE;
+    team_info.init                = ucc_tl_nccl_coll_init;
+    team_info.num_mem_types       = 1;
+    team_info.supported_mem_types = &mt;
+    team_info.supported_colls     = UCC_TL_NCCL_SUPPORTED_COLLS;
+    team_info.size                = UCC_TL_TEAM_SIZE(team);
     /* There can be a different logic for different coll_type/mem_type.
        Right now just init everything the same way. */
     status =
@@ -220,9 +228,8 @@ ucc_status_t ucc_tl_nccl_team_get_scores(ucc_base_team_t   *tl_team,
 
     for (i = 0; i < UCC_TL_NCCL_N_DEFAULT_ALG_SELECT_STR; i++) {
         status = ucc_coll_score_update_from_str(
-            ucc_tl_nccl_default_alg_select_str[i], score, UCC_TL_TEAM_SIZE(team),
-            ucc_tl_nccl_coll_init, &team->super.super, UCC_TL_NCCL_DEFAULT_SCORE,
-            ucc_tl_nccl_alg_id_to_init, &mt, 1);
+            ucc_tl_nccl_default_alg_select_str[i], &team_info,
+            &team->super.super, score);
         if (ucc_unlikely(UCC_OK != status)) {
             tl_error(tl_team->context->lib,
                      "failed to apply default coll select setting: %s",
@@ -241,10 +248,8 @@ ucc_status_t ucc_tl_nccl_team_get_scores(ucc_base_team_t   *tl_team,
     }
 
     if (strlen(ctx->score_str) > 0) {
-        status = ucc_coll_score_update_from_str(
-            ctx->score_str, score, UCC_TL_TEAM_SIZE(team),
-            ucc_tl_nccl_coll_init, &team->super.super,
-            UCC_TL_NCCL_DEFAULT_SCORE, ucc_tl_nccl_alg_id_to_init, &mt, 1);
+        status = ucc_coll_score_update_from_str(ctx->score_str, &team_info,
+                                                &team->super.super, score);
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
             (status != UCC_ERR_NOT_SUPPORTED)) {

--- a/src/components/tl/rccl/tl_rccl_team.c
+++ b/src/components/tl/rccl/tl_rccl_team.c
@@ -201,7 +201,15 @@ ucc_status_t ucc_tl_rccl_team_get_scores(ucc_base_team_t   *tl_team,
     ucc_coll_score_t   *score;
     ucc_status_t        status;
     int                 i;
+    ucc_coll_score_team_info_t team_info;
 
+    team_info.alg_fn              = ucc_tl_rccl_alg_id_to_init;
+    team_info.default_score       = UCC_TL_RCCL_DEFAULT_SCORE;
+    team_info.init                = ucc_tl_rccl_coll_init;
+    team_info.num_mem_types       = 1;
+    team_info.supported_mem_types = &mt;
+    team_info.supported_colls     = UCC_TL_RCCL_SUPPORTED_COLLS;
+    team_info.size                = UCC_TL_TEAM_SIZE(team);
     /* There can be a different logic for different coll_type/mem_type.
        Right now just init everything the same way. */
     status =
@@ -214,9 +222,8 @@ ucc_status_t ucc_tl_rccl_team_get_scores(ucc_base_team_t   *tl_team,
 
     for (i = 0; i < UCC_TL_RCCL_N_DEFAULT_ALG_SELECT_STR; i++) {
         status = ucc_coll_score_update_from_str(
-            ucc_tl_rccl_default_alg_select_str[i], score, UCC_TL_TEAM_SIZE(team),
-            ucc_tl_rccl_coll_init, &team->super.super, UCC_TL_RCCL_DEFAULT_SCORE,
-            ucc_tl_rccl_alg_id_to_init, &mt, 1);
+            ucc_tl_rccl_default_alg_select_str[i], &team_info,
+            &team->super.super, score);
         if (ucc_unlikely(UCC_OK != status)) {
             tl_error(tl_team->context->lib,
                      "failed to apply default coll select setting: %s",
@@ -235,10 +242,8 @@ ucc_status_t ucc_tl_rccl_team_get_scores(ucc_base_team_t   *tl_team,
     }
 
     if (strlen(ctx->score_str) > 0) {
-        status = ucc_coll_score_update_from_str(
-            ctx->score_str, score, UCC_TL_TEAM_SIZE(team),
-            ucc_tl_rccl_coll_init, &team->super.super,
-            UCC_TL_RCCL_DEFAULT_SCORE, ucc_tl_rccl_alg_id_to_init, &mt, 1);
+        status = ucc_coll_score_update_from_str(ctx->score_str, &team_info,
+                                                &team->super.super, score);
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
             (status != UCC_ERR_NOT_SUPPORTED)) {

--- a/src/components/tl/self/tl_self_team.c
+++ b/src/components/tl/self/tl_self_team.c
@@ -52,10 +52,19 @@ ucc_status_t ucc_tl_self_team_get_scores(ucc_base_team_t   *tl_team,
     ucc_memory_type_t   mem_types[UCC_MEMORY_TYPE_LAST];
     ucc_coll_score_t   *score;
     ucc_status_t        status;
+    ucc_coll_score_team_info_t team_info;
 
     for (i = 0; i < UCC_MEMORY_TYPE_LAST; i++) {
         mem_types[mt_n++] = (ucc_memory_type_t)i;
     }
+
+    team_info.alg_fn              = NULL;
+    team_info.default_score       = UCC_TL_SELF_DEFAULT_SCORE;
+    team_info.init                = ucc_tl_self_coll_init;
+    team_info.num_mem_types       = mt_n;
+    team_info.supported_mem_types = mem_types; /* all memory types supported*/
+    team_info.supported_colls     = UCC_TL_SELF_SUPPORTED_COLLS;
+    team_info.size                = UCC_TL_TEAM_SIZE(team);
 
     status = ucc_coll_score_build_default(
         tl_team, UCC_TL_SELF_DEFAULT_SCORE, ucc_tl_self_coll_init,
@@ -66,10 +75,8 @@ ucc_status_t ucc_tl_self_team_get_scores(ucc_base_team_t   *tl_team,
     }
 
     if (strlen(ctx->score_str) > 0) {
-        status = ucc_coll_score_update_from_str(
-            ctx->score_str, score, UCC_TL_TEAM_SIZE(team),
-            ucc_tl_self_coll_init, &team->super.super,
-            UCC_TL_SELF_DEFAULT_SCORE, NULL, NULL, 0);
+        status = ucc_coll_score_update_from_str(ctx->score_str, &team_info,
+                                                &team->super.super, score);
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
             (status != UCC_ERR_NOT_SUPPORTED)) {
             goto err;

--- a/src/components/tl/sharp/tl_sharp_team.c
+++ b/src/components/tl/sharp/tl_sharp_team.c
@@ -260,7 +260,15 @@ ucc_status_t ucc_tl_sharp_team_get_scores(ucc_base_team_t  *tl_team,
     ucc_base_context_t  *ctx  = UCC_TL_TEAM_CTX(team);
     ucc_coll_score_t    *score;
     ucc_status_t         status;
+    ucc_coll_score_team_info_t team_info;
 
+    team_info.alg_fn              = NULL;
+    team_info.default_score       = UCC_TL_SHARP_DEFAULT_SCORE;
+    team_info.init                = ucc_tl_sharp_coll_init;
+    team_info.num_mem_types       = 0;
+    team_info.supported_mem_types = NULL; /* all memory types supported*/
+    team_info.supported_colls     = UCC_TL_SHARP_SUPPORTED_COLLS;
+    team_info.size                = UCC_TL_TEAM_SIZE(team);
     /* There can be a different logic for different coll_type/mem_type.
        Right now just init everything the same way. */
     status =
@@ -273,10 +281,8 @@ ucc_status_t ucc_tl_sharp_team_get_scores(ucc_base_team_t  *tl_team,
     }
 
     if (strlen(ctx->score_str) > 0) {
-        status = ucc_coll_score_update_from_str(
-            ctx->score_str, score, UCC_TL_TEAM_SIZE(team),
-            ucc_tl_sharp_coll_init, &team->super.super,
-            UCC_TL_SHARP_DEFAULT_SCORE, NULL, NULL, 0);
+        status = ucc_coll_score_update_from_str(ctx->score_str, &team_info,
+                                                &team->super.super, score);
         /* If INVALID_PARAM - User provided incorrect input - try to proceed */
         if ((status < 0) && (status != UCC_ERR_INVALID_PARAM) &&
             (status != UCC_ERR_NOT_SUPPORTED)) {

--- a/test/gtest/coll_score/test_score_update.cc
+++ b/test/gtest/coll_score/test_score_update.cc
@@ -34,7 +34,8 @@ UCC_TEST_F(test_score_update, non_overlap)
                UCC_COLL_TYPE_BARRIER);
     init_score(update, RLIST({RANGE(10, 20, 100), RANGE(30, 35, 1)}),
                UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 10, 10), RANGE(40, 50, 5)})));
@@ -44,7 +45,8 @@ UCC_TEST_F(test_score_update, overlap_single)
 {
     init_score(score, RLIST({RANGE(0, 100, 10)}), UCC_COLL_TYPE_BARRIER);
     init_score(update, RLIST({RANGE(50, 150, 100)}), UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 50, 10), RANGE(50, 100, 100)})));
@@ -52,7 +54,8 @@ UCC_TEST_F(test_score_update, overlap_single)
 
     init_score(score, RLIST({RANGE(0, 100, 100)}), UCC_COLL_TYPE_BARRIER);
     init_score(update, RLIST({RANGE(50, 150, 10)}), UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 50, 100), RANGE(50, 100, 10)})));
@@ -62,7 +65,8 @@ UCC_TEST_F(test_score_update, inclusive)
 {
     init_score(score, RLIST({RANGE(0, 90, 100)}), UCC_COLL_TYPE_BARRIER);
     init_score(update, RLIST({RANGE(30, 60, 10)}), UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 30, 100), RANGE(30, 60, 10),
@@ -71,7 +75,8 @@ UCC_TEST_F(test_score_update, inclusive)
 
     init_score(score, RLIST({RANGE(0, 90, 10)}), UCC_COLL_TYPE_BARRIER);
     init_score(update, RLIST({RANGE(30, 60, 100)}), UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 30, 10), RANGE(30, 60, 100),
@@ -82,7 +87,8 @@ UCC_TEST_F(test_score_update, same_start)
 {
     init_score(score, RLIST({RANGE(0, 100, 100)}), UCC_COLL_TYPE_BARRIER);
     init_score(update, RLIST({RANGE(0, 50, 10)}), UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 50, 10), RANGE(50, 100, 100)})));
@@ -90,7 +96,8 @@ UCC_TEST_F(test_score_update, same_start)
 
     init_score(score, RLIST({RANGE(0, 100, 10)}), UCC_COLL_TYPE_BARRIER);
     init_score(update, RLIST({RANGE(0, 50, 100)}), UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 50, 100), RANGE(50, 100, 10)})));
@@ -98,7 +105,8 @@ UCC_TEST_F(test_score_update, same_start)
 
     init_score(score, RLIST({RANGE(1, 100, 10)}), UCC_COLL_TYPE_BARRIER);
     init_score(update, RLIST({RANGE(1, 50, 100)}), UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(1, 50, 100), RANGE(50, 100, 10)})));
@@ -110,7 +118,8 @@ UCC_TEST_F(test_score_update, 1_overlaps_many)
     init_score(update,
                RLIST({RANGE(10, 20, 10), RANGE(30, 40, 20), RANGE(60, 70, 30)}),
                UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 10, 100), RANGE(10, 20, 10),
@@ -124,7 +133,8 @@ UCC_TEST_F(test_score_update, 1_overlaps_many)
         update,
         RLIST({RANGE(10, 20, 100), RANGE(30, 40, 100), RANGE(60, 70, 5)}),
         UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 10, 10), RANGE(10, 20, 100),
@@ -137,7 +147,8 @@ UCC_TEST_F(test_score_update, same_score)
 {
     init_score(score, RLIST({RANGE(0, 100, 100)}), UCC_COLL_TYPE_BARRIER);
     init_score(update, RLIST({RANGE(100, 200, 100)}), UCC_COLL_TYPE_BARRIER);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 100, 100)})));
@@ -149,7 +160,8 @@ UCC_TEST_F(test_score_update, non_overlap_2)
                0x1);
     init_score(update, RLIST({RANGE(300, 400, 100)}), UCC_COLL_TYPE_BARRIER,
                0x2, 0x2);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 100, 100), RANGE(300, 400, 100)})));
@@ -161,7 +173,8 @@ UCC_TEST_F(test_score_update, init_reset)
                0x1);
     init_score(update, RLIST({RANGE(0, 100, 100)}), UCC_COLL_TYPE_BARRIER, 0x2,
                0x2);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 100, 100)})));
@@ -173,7 +186,8 @@ UCC_TEST_F(test_score_update, init_reset)
                0x1);
     init_score(update, RLIST({RANGE(50, 150, 50)}), UCC_COLL_TYPE_BARRIER, 0x2,
                0x2);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 50, 100), RANGE(50, 100, 50),
@@ -185,7 +199,8 @@ UCC_TEST_F(test_score_update, init_reset)
                0x1);
     init_score(update, RLIST({RANGE(0, 100, 50)}), UCC_COLL_TYPE_BARRIER, 0x2,
                0x2);
-    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0));
+    EXPECT_EQ(UCC_OK, ucc_coll_score_update(score, update, 0, NULL, 0,
+              UCC_COLL_TYPE_ALL));
     EXPECT_EQ(UCC_OK,
               check_range(score, UCC_COLL_TYPE_BARRIER, UCC_MEMORY_TYPE_HOST,
                           RLIST({RANGE(0, 50, 50), RANGE(50, 100, 50),


### PR DESCRIPTION
## What
Fixes ucc score table when user provides score for TL/CL and only total score is given
e.g. UCC_TL_SHARP_TUNE=inf results in scatter, allgather, alltoall collectives (not supported by sharp) in UCC score table

<details>
  <summary>with fix</summary>

```bash
       ucc_team.c:471  UCC  INFO  ===== COLL_SCORE_MAP (team_id 32768, size 2) =====
ucc_coll_score_map.c:201  UCC  INFO  Allgather:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..4095}:TL_UCP:10 {4K..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Allgatherv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Allreduce:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..4095}:TL_SHARP:10 {4K..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Alltoall:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..257}:TL_UCP:10 {258..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Alltoallv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Barrier:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Bcast:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Fanin:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Fanout:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Gather:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Gatherv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Reduce:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Reduce_scatter:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Reduce_scatterv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:201  UCC  INFO  Scatterv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_UCP:10
       ucc_team.c:474  UCC  INFO  ================================================
```
</details>

<details>
  <summary>without fix</summary>

```bash
       ucc_team.c:472  UCC  INFO  ===== COLL_SCORE_MAP (team_id 32771, size 2) =====
ucc_coll_score_map.c:201  UCC  INFO  Allgather:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..4095}:TL_SHARP:10 {4K..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Allgatherv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Allreduce:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..4095}:TL_SHARP:10 {4K..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Alltoall:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..257}:TL_SHARP:10 {258..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Alltoallv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Barrier:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Bcast:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Fanin:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Fanout:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Gather:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Gatherv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Reduce:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Reduce_scatter:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Reduce_scatterv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Scatter:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO  Scatterv:
ucc_coll_score_map.c:201  UCC  INFO        Host: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Cuda: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        CudaManaged: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        Rocm: {0..inf}:TL_SHARP:10
ucc_coll_score_map.c:201  UCC  INFO        RocmManaged: {0..inf}:TL_SHARP:10
       ucc_team.c:474  UCC  INFO  ================================================
```
</details>

## How ?
Pass TL supported collectives to tuning string parser