### PR TITLE
TEST: fix barrier test

### DIFF
--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -331,16 +331,6 @@ static inline int ucc_coll_args_is_rooted(ucc_coll_type_t ct)
     return 0;
 }
 
-static inline int ucc_coll_args_is_reduction(ucc_coll_type_t ct)
-{
-    if (ct == UCC_COLL_TYPE_ALLREDUCE || ct == UCC_COLL_TYPE_REDUCE ||
-        ct == UCC_COLL_TYPE_REDUCE_SCATTER ||
-        ct == UCC_COLL_TYPE_REDUCE_SCATTERV) {
-        return 1;
-    }
-    return 0;
-}
-
 #define COLL_ARGS_HEADER_STR_MAX_SIZE 32
 void ucc_coll_args_str(const ucc_coll_args_t *args, ucc_rank_t trank,
                        ucc_rank_t tsize, char *str, size_t len)

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -73,6 +73,16 @@
 
 #define UCC_MEM_TYPE_MASK_FULL -1
 
+static inline int ucc_coll_args_is_reduction(ucc_coll_type_t ct)
+{
+    if (ct == UCC_COLL_TYPE_ALLREDUCE || ct == UCC_COLL_TYPE_REDUCE ||
+        ct == UCC_COLL_TYPE_REDUCE_SCATTER ||
+        ct == UCC_COLL_TYPE_REDUCE_SCATTERV) {
+        return 1;
+    }
+    return 0;
+}
+
 static inline size_t
 ucc_coll_args_get_count(const ucc_coll_args_t *args, const ucc_count_t *counts,
                         ucc_rank_t idx)

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -534,7 +534,7 @@ std::vector<ucc_status_t> UccTestMpi::exec_tests(
     return rst;
 }
 
-void UccTestMpi::run_all_at_team(ucc_test_team_t &          team,
+void UccTestMpi::run_all_at_team(ucc_test_team_t &team,
                                  std::vector<ucc_status_t> &rst)
 {
     TestCaseParams params;
@@ -604,9 +604,11 @@ void UccTestMpi::run_all_at_team(ucc_test_team_t &          team,
                     for (auto m: test_msgsizes) {
                         for (auto dt: test_dtypes) {
                             for (auto op: test_ops) {
-                                if (!ucc_coll_reduce_supported(op, dt)) {
+                                if (ucc_coll_args_is_reduction(c) &&
+                                    !ucc_coll_reduce_supported(op, dt)) {
                                     continue;
                                 }
+
                                 if (mt != UCC_MEMORY_TYPE_HOST &&
                                     (dt == UCC_DT_FLOAT128 ||
                                      dt == UCC_DT_FLOAT128_COMPLEX)) {


### PR DESCRIPTION
## What
Don't check reduction datatype support if collective is not reduction

## Why ?
Barrier tests are skip due to incorrect reduction check
