### PR TITLE
TEST: fix alltoall onesided buf mt

### DIFF
--- a/test/gtest/coll/test_alltoall.cc
+++ b/test/gtest/coll/test_alltoall.cc
@@ -54,9 +54,11 @@ public:
                 work_buf    = (long *)team->procs[i].p->onesided_buf[2];
                 coll->mask  = UCC_COLL_ARGS_FIELD_FLAGS |
                              UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER;
-                coll->src.info.buffer = sbuf;
-                coll->dst.info.buffer = rbuf;
-                coll->flags           = UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS;
+                coll->flags = UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS;
+                coll->src.info.buffer    = sbuf;
+                coll->src.info.mem_type  = UCC_MEMORY_TYPE_HOST;
+                coll->dst.info.buffer    = rbuf;
+                coll->dst.info.mem_type  = UCC_MEMORY_TYPE_HOST;
                 coll->global_work_buffer = work_buf;
             } else {
                 UCC_CHECK(ucc_mc_alloc(


### PR DESCRIPTION
## What
In gtest alltoall onesided test when running with memory type cuda, sbuf and rbuf memory types are set to cuda but in practice use team->procs[i].p->onesided_buf which are allocated as host memory buffers during create_ context().

## Why ?
Bug fix

## How ?
In this onesided case using  onesided buffers from context, set sbuf and rbuf mem type to be host.
