### PR TITLE
CORE: fix kn loop coverity

### DIFF
--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -239,7 +239,8 @@ static inline ucc_rank_t ucc_kn_get_opt_radix(ucc_rank_t team_size,
     ucc_rank_t     n_extra = 0, min_val = team_size;
     ucc_kn_radix_t min_i   = UCC_KN_MIN_RADIX;
     ucc_kn_radix_t max_r   = ucc_max(max_radix, UCC_KN_MIN_RADIX);
-    ucc_kn_radix_t r, fs;
+    ucc_kn_radix_t r;
+    ucc_rank_t     fs;
 
     for (r = UCC_KN_MIN_RADIX; r <= max_r; r++) {
         fs = r;


### PR DESCRIPTION
## What
Coverity "medium" issue - infinite loop fix.

## Why ?
fs can exceed type ucc_kn_radix_t since it is continuously multiplied by radix r.

## How ?
make fs of type ucc_rank_t similar to team_size which while loop is blocked by.
