### PR TITLE
TL/MLX5: revise team and ctx init

### DIFF
--- a/src/components/tl/mlx5/alltoall/alltoall.c
+++ b/src/components/tl/mlx5/alltoall/alltoall.c
@@ -75,11 +75,11 @@ ucc_status_t ucc_tl_mlx5_team_alltoall_init_start(ucc_tl_mlx5_team_t *team)
     ucc_topo_t             *topo;
     ucc_status_t            status;
 
-    if (team->dm_status[1] != UCC_OK) {
+    if (team->dm_status.global != UCC_OK) {
         tl_debug(ctx->super.super.lib,
                  "node leader failed during device memory init: %s",
-                 ucc_status_string(team->dm_status[1]));
-        return team->dm_status[1];
+                 ucc_status_string(team->dm_status.global));
+        return team->dm_status.global;
     }
 
     a2a = ucc_calloc(1, sizeof(*a2a), "mlx5_a2a");

--- a/src/components/tl/mlx5/alltoall/alltoall.c
+++ b/src/components/tl/mlx5/alltoall/alltoall.c
@@ -180,7 +180,7 @@ ucc_status_t ucc_tl_mlx5_team_test_alltoall_start(ucc_tl_mlx5_team_t *team)
         a2a->bcast_data.shmid =
             shmget(IPC_PRIVATE, storage_size, IPC_CREAT | 0600);
         if (a2a->bcast_data.shmid == -1) {
-            tl_error(ctx->super.super.lib,
+            tl_debug(ctx->super.super.lib,
                      "failed to allocate sysv shm segment for %zd bytes",
                      storage_size);
         } else {

--- a/src/components/tl/mlx5/alltoall/alltoall.c
+++ b/src/components/tl/mlx5/alltoall/alltoall.c
@@ -162,8 +162,7 @@ ucc_status_t ucc_tl_mlx5_team_test_alltoall_start(ucc_tl_mlx5_team_t *team)
     size_t                  storage_size;
 
     if (team->a2a_status.global != UCC_OK) {
-        tl_debug(ctx->super.super.lib,
-                 "global status in error state: %s",
+        tl_debug(ctx->super.super.lib, "global status in error state: %s",
                  ucc_status_string(team->a2a_status.global));
 
         ucc_tl_mlx5_dm_cleanup(team);
@@ -195,10 +194,10 @@ ucc_status_t ucc_tl_mlx5_team_test_alltoall_start(ucc_tl_mlx5_team_t *team)
     a2a->state = TL_MLX5_ALLTOALL_STATE_SHMID;
 
     team->a2a = a2a;
-    return ucc_service_bcast(UCC_TL_CORE_TEAM(team), &a2a->bcast_data,
-                             sizeof(ucc_tl_mlx5_a2a_bcast_data_t),
-                             a2a->node.asr_rank, ucc_sbgp_to_subset(a2a->node.sbgp),
-                             &team->scoll_req);
+    return ucc_service_bcast(
+        UCC_TL_CORE_TEAM(team), &a2a->bcast_data,
+        sizeof(ucc_tl_mlx5_a2a_bcast_data_t), a2a->node.asr_rank,
+        ucc_sbgp_to_subset(a2a->node.sbgp), &team->scoll_req);
 }
 
 static void ucc_tl_mlx5_alltoall_barrier_free(ucc_tl_mlx5_alltoall_t *a2a)

--- a/src/components/tl/mlx5/alltoall/alltoall.h
+++ b/src/components/tl/mlx5/alltoall/alltoall.h
@@ -9,6 +9,7 @@
 
 #include "tl_mlx5.h"
 #include "tl_mlx5_ib.h"
+#include "tl_mlx5_dm.h"
 
 #define SEQ_INDEX(_seq_num) ((_seq_num) % MAX_OUTSTANDING_OPS)
 
@@ -136,8 +137,10 @@ typedef struct ucc_tl_mlx5_alltoall {
     ucc_tl_mlx5_a2a_bcast_data_t bcast_data;
 } ucc_tl_mlx5_alltoall_t;
 
-ucc_status_t ucc_tl_mlx5_team_alltoall_init_start(ucc_tl_mlx5_team_t *team);
-ucc_status_t ucc_tl_mlx5_team_alltoall_init_progress(ucc_tl_mlx5_team_t *team);
+void ucc_tl_mlx5_topo_cleanup(ucc_tl_mlx5_team_t *team);
+ucc_status_t ucc_tl_mlx5_team_init_alltoall(ucc_tl_mlx5_team_t *team);
+ucc_status_t ucc_tl_mlx5_team_test_alltoall_start(ucc_tl_mlx5_team_t *team);
+ucc_status_t ucc_tl_mlx5_team_test_alltoall_progress(ucc_tl_mlx5_team_t *team);
 ucc_status_t ucc_tl_mlx5_alltoall_init(ucc_base_coll_args_t *coll_args,
                                        ucc_base_team_t *     team,
                                        ucc_coll_task_t **    task_h);

--- a/src/components/tl/mlx5/alltoall/alltoall.h
+++ b/src/components/tl/mlx5/alltoall/alltoall.h
@@ -137,7 +137,7 @@ typedef struct ucc_tl_mlx5_alltoall {
     ucc_tl_mlx5_a2a_bcast_data_t bcast_data;
 } ucc_tl_mlx5_alltoall_t;
 
-void ucc_tl_mlx5_topo_cleanup(ucc_tl_mlx5_team_t *team);
+void         ucc_tl_mlx5_topo_cleanup(ucc_tl_mlx5_team_t *team);
 ucc_status_t ucc_tl_mlx5_team_init_alltoall(ucc_tl_mlx5_team_t *team);
 ucc_status_t ucc_tl_mlx5_team_test_alltoall_start(ucc_tl_mlx5_team_t *team);
 ucc_status_t ucc_tl_mlx5_team_test_alltoall_progress(ucc_tl_mlx5_team_t *team);

--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -108,11 +108,16 @@ typedef enum
     TL_MLX5_TEAM_STATE_ALLTOALL_POSTED
 } ucc_tl_mlx5_team_state_t;
 
+typedef struct ucc_tl_mlx5_team_status {
+    ucc_status_t local;
+    ucc_status_t global;
+} ucc_tl_mlx5_team_status_t;
+
 typedef struct ucc_tl_mlx5_team {
     ucc_tl_team_t             super;
     ucc_service_coll_req_t   *scoll_req;
     ucc_tl_mlx5_team_state_t  state;
-    ucc_status_t              dm_status[2];
+    ucc_tl_mlx5_team_status_t dm_status;
     void                     *dm_offset;
     ucc_mpool_t               dm_pool;
     struct ibv_dm            *dm_ptr;

--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -110,13 +110,14 @@ typedef enum
 
 typedef struct ucc_tl_mlx5_team {
     ucc_tl_team_t             super;
-    ucc_status_t              status[2];
     ucc_service_coll_req_t   *scoll_req;
     ucc_tl_mlx5_team_state_t  state;
+    ucc_status_t              dm_status[2];
     void                     *dm_offset;
     ucc_mpool_t               dm_pool;
     struct ibv_dm            *dm_ptr;
     struct ibv_mr            *dm_mr;
+    ucc_status_t              a2a_status;
     ucc_tl_mlx5_alltoall_t   *a2a;
     ucc_topo_t               *topo;
     ucc_ep_map_t              ctx_map;

--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -84,6 +84,7 @@ typedef struct ucc_tl_mlx5_context {
     ucc_rcache_t                *rcache;
     int                          is_imported;
     int                          ib_port;
+    int                          sock;
     ucc_mpool_t                  req_mp;
     ucc_tl_mlx5_mcast_context_t  mcast;
 } ucc_tl_mlx5_context_t;

--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -117,12 +117,11 @@ typedef struct ucc_tl_mlx5_team {
     ucc_tl_team_t             super;
     ucc_service_coll_req_t   *scoll_req;
     ucc_tl_mlx5_team_state_t  state;
-    ucc_tl_mlx5_team_status_t dm_status;
     void                     *dm_offset;
     ucc_mpool_t               dm_pool;
     struct ibv_dm            *dm_ptr;
     struct ibv_mr            *dm_mr;
-    ucc_status_t              a2a_status;
+    ucc_tl_mlx5_team_status_t a2a_status;
     ucc_tl_mlx5_alltoall_t   *a2a;
     ucc_topo_t               *topo;
     ucc_ep_map_t              ctx_map;

--- a/src/components/tl/mlx5/tl_mlx5_coll.c
+++ b/src/components/tl/mlx5/tl_mlx5_coll.c
@@ -71,10 +71,6 @@ ucc_status_t ucc_tl_mlx5_coll_init(ucc_base_coll_args_t *coll_args,
 
     switch (coll_args->args.coll_type) {
     case UCC_COLL_TYPE_ALLTOALL:
-        status = ucc_derived_of(team, ucc_tl_mlx5_team_t)->a2a_status.local;
-        if (status != UCC_OK) {
-            return UCC_ERR_NOT_SUPPORTED;
-        }
         status = ucc_tl_mlx5_alltoall_init(coll_args, team, task_h);
         break;
     case UCC_COLL_TYPE_BCAST:

--- a/src/components/tl/mlx5/tl_mlx5_coll.c
+++ b/src/components/tl/mlx5/tl_mlx5_coll.c
@@ -31,7 +31,7 @@ ucc_status_t ucc_tl_mlx5_bcast_mcast_init(ucc_base_coll_args_t *coll_args,
     if (ucc_unlikely(UCC_OK != status)) {
         goto free_task;
     }
-       
+
     *task_h = &(task->super);
 
     tl_debug(UCC_TASK_LIB(task), "init coll task %p", task);
@@ -71,6 +71,10 @@ ucc_status_t ucc_tl_mlx5_coll_init(ucc_base_coll_args_t *coll_args,
 
     switch (coll_args->args.coll_type) {
     case UCC_COLL_TYPE_ALLTOALL:
+        status = ucc_derived_of(team, ucc_tl_mlx5_team_t)->a2a_status;
+        if (status != UCC_OK) {
+            return status;
+        }
         status = ucc_tl_mlx5_alltoall_init(coll_args, team, task_h);
         break;
     case UCC_COLL_TYPE_BCAST:

--- a/src/components/tl/mlx5/tl_mlx5_coll.c
+++ b/src/components/tl/mlx5/tl_mlx5_coll.c
@@ -71,9 +71,9 @@ ucc_status_t ucc_tl_mlx5_coll_init(ucc_base_coll_args_t *coll_args,
 
     switch (coll_args->args.coll_type) {
     case UCC_COLL_TYPE_ALLTOALL:
-        status = ucc_derived_of(team, ucc_tl_mlx5_team_t)->a2a_status;
+        status = ucc_derived_of(team, ucc_tl_mlx5_team_t)->a2a_status.local;
         if (status != UCC_OK) {
-            return status;
+            return UCC_ERR_NOT_SUPPORTED;
         }
         status = ucc_tl_mlx5_alltoall_init(coll_args, team, task_h);
         break;

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -74,7 +74,6 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_context_t)
     };
 
     ucc_mpool_cleanup(&self->req_mp, 1);
-
     close(self->sock);
 }
 

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -70,7 +70,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_context_t)
         ucc_rcache_destroy(self->rcache);
     }
 
-    if (ucc_tl_mlx5_remove_shared_ctx_pd(self) != UCC_OK) {
+    if (UCC_OK != ucc_tl_mlx5_remove_shared_ctx_pd(self)) {
         tl_debug(self->super.super.lib, "failed to free ib ctx and pd");
     };
 
@@ -205,11 +205,10 @@ ucc_status_t ucc_tl_mlx5_context_ib_ctx_pd_setup(ucc_base_context_t *context)
 
     if (!ctx->is_imported) {
         status = ucc_tl_mlx5_ib_ctx_pd_init(ctx);
-        if (status != UCC_OK) {
-            tl_debug(context->lib, "failed to init ib_ctx and pd");
+        if (UCC_OK != status) {
             goto err_ib_ctx_pd_init;
         }
-        if (sbgp->status == UCC_SBGP_NOT_EXISTS) {
+        if (UCC_SBGP_NOT_EXISTS == sbgp->status) {
             goto topo_ppn_1;
         }
         ucc_strncpy_safe(sock_path, template, sock_dir_len);
@@ -265,8 +264,7 @@ ucc_status_t ucc_tl_mlx5_context_ib_ctx_pd_setup(ucc_base_context_t *context)
         sock_path[sock_dir_len - 1] = '\0';
         rmdir(sock_path);
     }
-    if (status != UCC_OK) {
-        tl_debug(context->lib, "failed to share ctx and pd");
+    if (UCC_OK != status) {
         goto err;
     }
 

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -49,8 +49,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
 
     status = ucc_tl_mlx5_mcast_context_init(&(self->mcast), &(self->cfg.mcast_ctx_conf));
     if (UCC_OK != status) {
-        tl_debug(self->super.super.lib,
-                 "failed to initialize mcast context");
+        tl_debug(self->super.super.lib, "failed to initialize mcast context");
         goto err_mcast_context;
     }
 

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -106,6 +106,7 @@ ucc_status_t ucc_tl_mlx5_ib_ctx_pd_init(ucc_tl_mlx5_context_t *ctx)
         } else {
             devname_len = (int)(pos - ib_devname);
             pos++;
+            errno = 0;
             port = (int)strtol(pos, &end_pos, 10);
             if (errno != 0 || pos == end_pos) {
                 tl_debug(ctx->super.super.lib, "wrong device's port number");

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -36,20 +36,20 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
         UCC_CACHE_LINE_SIZE, 8, UINT_MAX, &ucc_coll_task_mpool_ops,
         params->thread_mode, "tl_mlx5_req_mp");
     if (UCC_OK != status) {
-        tl_error(self->super.super.lib,
+        tl_debug(self->super.super.lib,
                  "failed to initialize tl_mlx5_req mpool");
         return status;
     }
 
     status = tl_mlx5_rcache_create(self);
     if (UCC_OK != status) {
-        tl_error(self->super.super.lib, "failed to create rcache");
+        tl_debug(self->super.super.lib, "failed to create rcache");
         goto err_rcache;
     }
 
     status = ucc_tl_mlx5_mcast_context_init(&(self->mcast), &(self->cfg.mcast_ctx_conf));
     if (UCC_OK != status) {
-        tl_error(self->super.super.lib,
+        tl_debug(self->super.super.lib,
                  "failed to initialize mcast context");
         goto err_mcast_context;
     }
@@ -109,7 +109,7 @@ ucc_status_t ucc_tl_mlx5_ib_ctx_pd_init(ucc_tl_mlx5_context_t *ctx)
             pos++;
             port = (int)strtol(pos, &end_pos, 10);
             if (errno != 0 || pos == end_pos) {
-                tl_error(ctx->super.super.lib, "wrong device's port number");
+                tl_debug(ctx->super.super.lib, "wrong device's port number");
                 return UCC_ERR_INVALID_PARAM;
             }
         }
@@ -120,7 +120,7 @@ ucc_status_t ucc_tl_mlx5_ib_ctx_pd_init(ucc_tl_mlx5_context_t *ctx)
 
     status = ucc_tl_mlx5_create_ibv_ctx(&ib_devname, &ctx->shared_ctx, ctx->super.super.lib);
     if (UCC_OK != status) {
-        tl_error(ctx->super.super.lib, "failed to allocate ibv_context");
+        tl_debug(ctx->super.super.lib, "failed to allocate ibv_context");
         return status;
     }
     if (port == -1) {
@@ -128,7 +128,7 @@ ucc_status_t ucc_tl_mlx5_ib_ctx_pd_init(ucc_tl_mlx5_context_t *ctx)
     }
     ctx->ib_port = port;
     if (-1 == port || !ucc_tl_mlx5_check_port_active(ctx->shared_ctx, port)) {
-        tl_error(ctx->super.super.lib, "no active ports found on %s",
+        tl_debug(ctx->super.super.lib, "no active ports found on %s",
                  ib_devname);
         goto destroy_context;
     }
@@ -136,7 +136,7 @@ ucc_status_t ucc_tl_mlx5_ib_ctx_pd_init(ucc_tl_mlx5_context_t *ctx)
 
     ctx->shared_pd = ibv_alloc_pd(ctx->shared_ctx);
     if (!ctx->shared_pd) {
-        tl_error(ctx->super.super.lib, "failed to allocate ib_pd");
+        tl_debug(ctx->super.super.lib, "failed to allocate ib_pd");
         goto destroy_context;
     }
 
@@ -181,7 +181,7 @@ ucc_status_t ucc_tl_mlx5_context_ib_ctx_pd_setup(ucc_base_context_t *context)
     sbcast_data = (ucc_tl_mlx5_context_create_sbcast_data_t *)ucc_malloc(
         sbcast_data_length);
     if (!sbcast_data) {
-        tl_error(context->lib,
+        tl_debug(context->lib,
                  "failed to allocate buffer for sharing ib_ctx info");
         return UCC_ERR_NO_MEMORY;
     }
@@ -236,7 +236,7 @@ ucc_status_t ucc_tl_mlx5_context_ib_ctx_pd_setup(ucc_base_context_t *context)
         &steam->super, sbcast_data, sbcast_data_length, PD_OWNER_RANK, s, &req);
 
     if (UCC_OK != status) {
-        tl_error(context->lib, "failed to start mlx5 ctx bcast");
+        tl_debug(context->lib, "failed to start mlx5 ctx bcast");
         goto err;
     }
 
@@ -246,7 +246,7 @@ ucc_status_t ucc_tl_mlx5_context_ib_ctx_pd_setup(ucc_base_context_t *context)
     ucc_collective_finalize(&req->super);
 
     if (UCC_OK != status) {
-        tl_error(context->lib, "failure during mlx5 ctx bcast");
+        tl_debug(context->lib, "failure during mlx5 ctx bcast");
         goto err;
     }
 

--- a/src/components/tl/mlx5/tl_mlx5_dm.c
+++ b/src/components/tl/mlx5/tl_mlx5_dm.c
@@ -61,14 +61,14 @@ ucc_status_t ucc_tl_mlx5_dm_alloc_reg(struct ibv_context *ib_ctx,
         dm_attr.length      = max_chunks_to_alloc * buf_size;
         dm_ptr              = ucc_malloc(dm_attr.length, "memic_host");
         if (!dm_ptr) {
-            tl_error(lib, " memic_host allocation failed");
+            tl_debug(lib, " memic_host allocation failed");
             return UCC_ERR_NO_MEMORY;
         }
 
         dm_mr = ibv_reg_mr(pd, dm_ptr, dm_attr.length,
                            IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
         if (!dm_mr) {
-            tl_error(lib, "failed to reg host memory");
+            tl_debug(lib, "failed to reg host memory");
             ucc_free(dm_ptr);
             return UCC_ERR_NO_MESSAGE;
         }
@@ -76,11 +76,11 @@ ucc_status_t ucc_tl_mlx5_dm_alloc_reg(struct ibv_context *ib_ctx,
     } else {
         attr.comp_mask = 0;
         if (ibv_query_device_ex(ib_ctx, NULL, &attr)) {
-            tl_error(lib, "failed to query device (errno=%d)", errno);
+            tl_debug(lib, "failed to query device (errno=%d)", errno);
             return UCC_ERR_NO_MESSAGE;
         }
         if (!attr.max_dm_size) {
-            tl_error(lib, "device doesn't support dm allocation");
+            tl_debug(lib, "device doesn't support dm allocation");
             return UCC_ERR_NO_RESOURCE;
         }
         max_chunks_to_alloc = min_chunks_to_alloc = *buf_num_p;
@@ -125,7 +125,7 @@ ucc_status_t ucc_tl_mlx5_dm_alloc_reg(struct ibv_context *ib_ctx,
                               IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
                                   IBV_ACCESS_ZERO_BASED);
         if (!dm_mr) {
-            tl_error(lib, "failed to reg memic");
+            tl_debug(lib, "failed to reg memic");
             ibv_free_dm(dm_ptr);
             return UCC_ERR_NO_MESSAGE;
         }
@@ -158,7 +158,7 @@ ucc_status_t ucc_tl_mlx5_dm_init(ucc_tl_mlx5_team_t *team)
         UCC_CACHE_LINE_SIZE, 1, cfg->dm_buf_num, &ucc_tl_mlx5_dm_ops,
         ctx->super.super.ucc_context->thread_mode, "mlx5 dm pool");
     if (status != UCC_OK) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to init dm pool");
+        tl_debug(UCC_TL_TEAM_LIB(team), "failed to init dm pool");
         ucc_tl_mlx5_dm_cleanup(team);
         return status;
     }

--- a/src/components/tl/mlx5/tl_mlx5_ib.c
+++ b/src/components/tl/mlx5/tl_mlx5_ib.c
@@ -74,7 +74,7 @@ ucc_status_t ucc_tl_mlx5_create_ibv_ctx(char               **ib_devname,
             }
         }
         if (!dev_list[i]) {
-            tl_error(lib, "IB device %s not found", *ib_devname);
+            tl_debug(lib, "IB device %s not found", *ib_devname);
             status = UCC_ERR_NOT_FOUND;
             goto out;
         }
@@ -129,7 +129,7 @@ ucc_status_t ucc_tl_mlx5_qp_connect(struct ibv_qp *qp, uint32_t qp_num,
     if (ibv_modify_qp(qp, &qp_attr,
                       IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
                           IBV_QP_ACCESS_FLAGS) != 0) {
-        tl_error(lib, "QP RESET->INIT failed, %m");
+        tl_debug(lib, "QP RESET->INIT failed, %m");
         return UCC_ERR_NO_MESSAGE;
     }
 
@@ -149,7 +149,7 @@ ucc_status_t ucc_tl_mlx5_qp_connect(struct ibv_qp *qp, uint32_t qp_num,
                       IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
                           IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
                           IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER)) {
-        tl_error(lib, "QP INIT->RTR failed, %m");
+        tl_debug(lib, "QP INIT->RTR failed, %m");
         return UCC_ERR_NO_MESSAGE;
     }
 
@@ -165,7 +165,7 @@ ucc_status_t ucc_tl_mlx5_qp_connect(struct ibv_qp *qp, uint32_t qp_num,
                       IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
                           IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
                           IBV_QP_MAX_QP_RD_ATOMIC)) {
-        tl_error(lib, "QP RTR->RTS failed, %m");
+        tl_debug(lib, "QP RTR->RTS failed, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     return UCC_OK;
@@ -213,21 +213,21 @@ ucc_status_t ucc_tl_mlx5_init_dct(struct ibv_pd *pd, struct ibv_context *ctx,
 
     qp = mlx5dv_create_qp(ctx, &attr_ex, &attr_dv);
     if (qp == NULL) {
-        tl_error(lib, "couldn't create DCT QP, %m");
+        tl_debug(lib, "couldn't create DCT QP, %m");
         return UCC_ERR_NO_MESSAGE;
     }
 
     if (ibv_modify_qp(qp, &qp_attr_to_init,
                       IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
                           IBV_QP_ACCESS_FLAGS) != 0) {
-        tl_error(lib, "failed to modify init qp, %m");
+        tl_debug(lib, "failed to modify init qp, %m");
         goto fail;
     }
 
     if (ibv_modify_qp(qp, &qp_attr_to_rtr,
                       IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_AV |
                           IBV_QP_MIN_RNR_TIMER) != 0) {
-        tl_error(lib, "failed to modify init qp, %m");
+        tl_debug(lib, "failed to modify init qp, %m");
         goto fail;
     }
 
@@ -237,7 +237,7 @@ ucc_status_t ucc_tl_mlx5_init_dct(struct ibv_pd *pd, struct ibv_context *ctx,
 
 fail:
     if (ibv_destroy_qp(qp)) {
-        tl_error(lib, "couldn't destroy QP, %m");
+        tl_debug(lib, "couldn't destroy QP, %m");
     }
     return UCC_ERR_NO_MESSAGE;
 }
@@ -299,30 +299,30 @@ ucc_status_t ucc_tl_mlx5_init_dci(ucc_tl_mlx5_dci_t *dci, struct ibv_pd *pd,
 
     dci->dci_qp = mlx5dv_create_qp(ctx, &attr_ex, &attr_dv);
     if (!dci->dci_qp) {
-        tl_error(lib, "couldn't create DCI QP, %m");
+        tl_debug(lib, "couldn't create DCI QP, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     // Turn DCI ibv_qp to ibv_qpex and ibv_mqpex
     dci->dc_qpex = ibv_qp_to_qp_ex(dci->dci_qp);
     if (!dci->dc_qpex) {
-        tl_error(lib, "failed turn ibv_qp to ibv_qp_ex, %m");
+        tl_debug(lib, "failed turn ibv_qp to ibv_qp_ex, %m");
         goto fail;
     }
     dci->dc_mqpex = mlx5dv_qp_ex_from_ibv_qp_ex(dci->dc_qpex);
     if (!dci->dc_mqpex) {
-        tl_error(lib, "failed turn ibv_qp_ex to mlx5dv_qp_ex, %m");
+        tl_debug(lib, "failed turn ibv_qp_ex to mlx5dv_qp_ex, %m");
         goto fail;
     }
 
     if (ibv_modify_qp(dci->dci_qp, &qp_attr_to_init,
                       IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT) != 0) {
-        tl_error(lib, "failed to modify init qp, %m");
+        tl_debug(lib, "failed to modify init qp, %m");
         goto fail;
     }
 
     if (ibv_modify_qp(dci->dci_qp, &qp_attr_to_rtr,
                       IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_AV) != 0) {
-        tl_error(lib, "failed to modify qp to rtr, %m");
+        tl_debug(lib, "failed to modify qp to rtr, %m");
         goto fail;
     }
 
@@ -330,7 +330,7 @@ ucc_status_t ucc_tl_mlx5_init_dci(ucc_tl_mlx5_dci_t *dci, struct ibv_pd *pd,
                       IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
                       IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
                       IBV_QP_MAX_QP_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER) != 0) {
-        tl_error(lib, "failed to modify qp to rts, %m");
+        tl_debug(lib, "failed to modify qp to rts, %m");
         goto fail;
     }
 
@@ -338,7 +338,7 @@ ucc_status_t ucc_tl_mlx5_init_dci(ucc_tl_mlx5_dci_t *dci, struct ibv_pd *pd,
 
 fail:
     if (ibv_destroy_qp(dci->dci_qp)) {
-        tl_error(lib, "couldn't destroy qp, %m");
+        tl_debug(lib, "couldn't destroy qp, %m");
     }
     return UCC_ERR_NO_MESSAGE;
 }
@@ -371,7 +371,7 @@ ucc_status_t ucc_tl_mlx5_create_rc_qp(struct ibv_context *ctx,
 
     qp->qp = mlx5dv_create_qp(ctx, &attr_ex, &attr_dv);
     if (!qp->qp) {
-        tl_error(lib, "failed to create RC QP, %m");
+        tl_debug(lib, "failed to create RC QP, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     qp->qp_ex = ibv_qp_to_qp_ex(qp->qp);
@@ -395,7 +395,7 @@ ucc_status_t ucc_tl_mlx5_create_ah(struct ibv_pd *pd, uint16_t lid,
 
     *ah_ptr = ibv_create_ah(pd, &ah_attr);
     if (!(*ah_ptr)) {
-        tl_error(lib, "failed to create ah, %m");
+        tl_debug(lib, "failed to create ah, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     return UCC_OK;
@@ -448,18 +448,18 @@ ucc_status_t ucc_tl_mlx5_create_umr_qp(struct ibv_context *ctx,
     } while (*qp == NULL && umr_init_attr_ex.cap.max_inline_data > 0);
 
     if (*qp == NULL) {
-        tl_error(lib, "failed to create UMR QP with inline_data, %m");
+        tl_debug(lib, "failed to create UMR QP with inline_data, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     qp_ex = ibv_qp_to_qp_ex(*qp);
     if (qp_ex == NULL) {
-        tl_error(lib, "failed to create UMR qp_ex, %m");
+        tl_debug(lib, "failed to create UMR qp_ex, %m");
         status = UCC_ERR_NO_MESSAGE;
         goto failure;
     }
     qp_ex->wr_flags = IBV_SEND_INLINE | IBV_SEND_SIGNALED;
     if (ibv_query_port(ctx, ib_port, &port_attr)) {
-        tl_error(lib, "failed to get port info, %m");
+        tl_debug(lib, "failed to get port info, %m");
         status = UCC_ERR_NO_MESSAGE;
         goto failure;
     }
@@ -476,7 +476,7 @@ ucc_status_t ucc_tl_mlx5_create_umr_qp(struct ibv_context *ctx,
 
 failure:
     if (ibv_destroy_qp(*qp)) {
-        tl_error(lib, "failed to destroy UMR QP, %m");
+        tl_debug(lib, "failed to destroy UMR QP, %m");
     }
     return status;
 }

--- a/src/components/tl/mlx5/tl_mlx5_pd.c
+++ b/src/components/tl/mlx5/tl_mlx5_pd.c
@@ -159,6 +159,8 @@ static ucc_status_t client_recv_data(int *shared_cmd_fd,
         goto out;
     }
 
+    return status;
+
 out:
     if (close(sock) == -1) {
         tl_debug(lib, "Failed to close client socket errno %d", errno);
@@ -203,6 +205,8 @@ static ucc_status_t server_send_data(int command_fd, uint32_t pd_handle,
         tl_debug(lib, "socket file removal failed");
         status = UCC_ERR_NO_MESSAGE;
     }
+
+    return status;
 
 listen_fail:
     if (close(sock) == -1) {

--- a/src/components/tl/mlx5/tl_mlx5_pd.c
+++ b/src/components/tl/mlx5/tl_mlx5_pd.c
@@ -294,17 +294,15 @@ ucc_status_t ucc_tl_mlx5_remove_shared_ctx_pd(ucc_tl_mlx5_context_t *ctx)
     ucc_status_t    status = UCC_OK;
     int err;
 
-    if (ctx->shared_pd) {
-        if (ctx->is_imported) {
-            ibv_unimport_pd(ctx->shared_pd);
-        }
-        ucc_tl_mlx5_context_barrier(&UCC_TL_CTX_OOB(ctx), lib);
-        if (!ctx->is_imported) {
-            err = ibv_dealloc_pd(ctx->shared_pd);
-            if (err) {
-                tl_debug(lib, "failed to dealloc PD, errno %d", err);
-                status = UCC_ERR_NO_MESSAGE;
-            }
+    if (ctx->shared_pd && ctx->is_imported) {
+        ibv_unimport_pd(ctx->shared_pd);
+    }
+    ucc_tl_mlx5_context_barrier(&UCC_TL_CTX_OOB(ctx), lib);
+    if (ctx->shared_pd && !ctx->is_imported) {
+        err = ibv_dealloc_pd(ctx->shared_pd);
+        if (err) {
+            tl_debug(lib, "failed to dealloc PD, errno %d", err);
+            status = UCC_ERR_NO_MESSAGE;
         }
     }
 

--- a/src/components/tl/mlx5/tl_mlx5_pd.c
+++ b/src/components/tl/mlx5/tl_mlx5_pd.c
@@ -309,7 +309,7 @@ ucc_status_t ucc_tl_mlx5_remove_shared_ctx_pd(ucc_tl_mlx5_context_t *ctx)
     if (ctx->shared_ctx) {
         if (ibv_close_device(ctx->shared_ctx)) {
             tl_debug(lib, "failed to close ib ctx");
-            status |= UCC_ERR_NO_MESSAGE;
+            status = UCC_ERR_NO_MESSAGE;
         }
     }
 

--- a/src/components/tl/mlx5/tl_mlx5_pd.c
+++ b/src/components/tl/mlx5/tl_mlx5_pd.c
@@ -97,7 +97,7 @@ ucc_status_t ucc_tl_mlx5_socket_init(ucc_tl_mlx5_context_t *ctx,
 
     sock = socket(PF_LOCAL, SOCK_STREAM, 0);
     if (sock == -1) {
-        tl_error(ctx->super.super.lib,
+        tl_debug(ctx->super.super.lib,
                  "failed to create server socket errno %d", errno);
         return UCC_ERR_NO_MESSAGE;
     }
@@ -108,12 +108,12 @@ ucc_status_t ucc_tl_mlx5_socket_init(ucc_tl_mlx5_context_t *ctx,
     addr->sun_path[sizeof(addr->sun_path) - 1] = '\0';
 
     if (bind(sock, (struct sockaddr *)addr, sizeof(struct sockaddr_un)) == -1) {
-        tl_error(ctx->super.super.lib, "failed to bind server socket errno %d",
+        tl_debug(ctx->super.super.lib, "failed to bind server socket errno %d",
                  errno);
         goto out;
     }
     if (listen(sock, group_size) == -1) {
-        tl_error(ctx->super.super.lib,
+        tl_debug(ctx->super.super.lib,
                  "failed to listen to server socket errno %d", errno);
         goto out;
     }
@@ -137,7 +137,7 @@ static ucc_status_t client_recv_data(int *shared_cmd_fd,
 
     sock = socket(PF_LOCAL, SOCK_STREAM, 0);
     if (sock == -1) {
-        tl_error(lib, "failed to create client socket errno %d", errno);
+        tl_debug(lib, "failed to create client socket errno %d", errno);
         return UCC_ERR_NO_MESSAGE;
     }
 
@@ -148,20 +148,20 @@ static ucc_status_t client_recv_data(int *shared_cmd_fd,
 
     while (connect(sock, (struct sockaddr *)addr, SUN_LEN(addr)) == -1) {
         if (errno != ENOENT) {
-            tl_error(lib, "failed to connect client socket errno %d", errno);
+            tl_debug(lib, "failed to connect client socket errno %d", errno);
             status = UCC_ERR_NO_MESSAGE;
             goto out;
         }
     }
     if (do_recvmsg(sock, shared_cmd_fd, shared_pd_handle) != UCC_OK) {
-        tl_error(lib, "Failed to recv msg");
+        tl_debug(lib, "Failed to recv msg");
         status = UCC_ERR_NO_MESSAGE;
         goto out;
     }
 
 out:
     if (close(sock) == -1) {
-        tl_error(lib, "Failed to close client socket errno %d", errno);
+        tl_debug(lib, "Failed to close client socket errno %d", errno);
         status = UCC_ERR_NO_MESSAGE;
     }
     return status;
@@ -183,7 +183,7 @@ static ucc_status_t server_send_data(int command_fd, uint32_t pd_handle,
         connection[i].pd_handle = pd_handle;
         connection[i].sock      = accept(sock, NULL, 0);
         if (connection[i].sock == -1) {
-            tl_error(lib,
+            tl_debug(lib,
                      "failed to accept socket connection request %d,"
                      " errno %d",
                      i, errno);
@@ -191,7 +191,7 @@ static ucc_status_t server_send_data(int command_fd, uint32_t pd_handle,
         }
         status = do_sendmsg(&connection[i]);
         if (status != UCC_OK) {
-            tl_error(lib, "failed to send cmd_fd");
+            tl_debug(lib, "failed to send cmd_fd");
             goto listen_fail;
         }
     }
@@ -200,13 +200,13 @@ static ucc_status_t server_send_data(int command_fd, uint32_t pd_handle,
     getsockname(sock, (struct sockaddr *)&addr, &addrlen);
 
     if (remove(addr.sun_path) == -1) {
-        tl_error(lib, "socket file removal failed");
+        tl_debug(lib, "socket file removal failed");
         status = UCC_ERR_NO_MESSAGE;
     }
 
 listen_fail:
     if (close(sock) == -1) {
-        tl_error(lib, "failed to close server socket errno %d", errno);
+        tl_debug(lib, "failed to close server socket errno %d", errno);
         status = UCC_ERR_NO_MESSAGE;
     }
 
@@ -227,19 +227,19 @@ ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
     if (!is_ctx_owner) {
         status = client_recv_data(&ctx_fd, &pd_handle, sock_path, lib);
         if (UCC_OK != status) {
-            tl_error(lib, "failed to share ctx & pd from client side");
+            tl_debug(lib, "failed to share ctx & pd from client side");
             return status;
         }
         ctx->shared_ctx = ibv_import_device(ctx_fd);
         if (!ctx->shared_ctx) {
-            tl_error(lib, "import context failed");
+            tl_debug(lib, "import context failed");
             return UCC_ERR_NO_MESSAGE;
         }
         ctx->shared_pd = ibv_import_pd(ctx->shared_ctx, pd_handle);
         if (!ctx->shared_pd) {
-            tl_error(lib, "import PD failed");
+            tl_debug(lib, "import PD failed");
             if (ibv_close_device(ctx->shared_ctx)) {
-                tl_error(lib, "imported context close failed");
+                tl_debug(lib, "imported context close failed");
             }
             return UCC_ERR_NO_MESSAGE;
         }
@@ -249,7 +249,7 @@ ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
         status = server_send_data(ctx_fd, pd_handle, group_size - 1,
                                   ctx_owner_sock, lib);
         if (UCC_OK != status) {
-            tl_error(lib, "failed to share ctx & pd from server side");
+            tl_debug(lib, "failed to share ctx & pd from server side");
             return status;
         }
     }
@@ -270,7 +270,7 @@ static void ucc_tl_mlx5_context_barrier(ucc_context_oob_coll_t *oob,
 
     rbuf = ucc_malloc(sizeof(char) * oob->n_oob_eps, "tmp_barrier");
     if (!rbuf) {
-        tl_error(lib, "failed to allocate %zd bytes for tmp barrier array",
+        tl_debug(lib, "failed to allocate %zd bytes for tmp barrier array",
                  sizeof(char) * oob->n_oob_eps);
         return;
     }
@@ -279,7 +279,7 @@ static void ucc_tl_mlx5_context_barrier(ucc_context_oob_coll_t *oob,
         ucc_assert(req != NULL);
         while (UCC_OK != (status = oob->req_test(req))) {
             if (status < 0) {
-                tl_error(lib, "failed to test oob req");
+                tl_debug(lib, "failed to test oob req");
                 break;
             }
         }
@@ -310,7 +310,7 @@ ucc_status_t ucc_tl_mlx5_remove_shared_ctx_pd(ucc_tl_mlx5_context_t *ctx)
 
     if (ctx->shared_ctx) {
         if (ibv_close_device(ctx->shared_ctx)) {
-            tl_error(lib, "failed to close ib ctx");
+            tl_debug(lib, "failed to close ib ctx");
             status |= UCC_ERR_NO_MESSAGE;
         }
     }

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -42,7 +42,7 @@ err_topo_init:
 
 void ucc_tl_mlx5_topo_cleanup(ucc_tl_mlx5_team_t *team)
 {
-    if (!team->topo){
+    if (!team->topo) {
         return;
     }
     ucc_ep_map_destroy_nested(&team->ctx_map);
@@ -65,8 +65,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_team_t, ucc_base_context_t *tl_context,
         return status;
     }
 
-    self->a2a    = NULL;
-    status       = ucc_tl_mlx5_team_init_alltoall(self);
+    self->a2a = NULL;
+    status    = ucc_tl_mlx5_team_init_alltoall(self);
     if (ucc_unlikely(UCC_OK != status)) {
         return status;
     }
@@ -135,10 +135,12 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
         ucc_service_coll_finalize(tl_team->scoll_req);
         tl_team->state = TL_MLX5_TEAM_STATE_ALLTOALL_INIT;
     case TL_MLX5_TEAM_STATE_ALLTOALL_INIT:
-        tl_team->a2a_status.local = ucc_tl_mlx5_team_test_alltoall_start(tl_team);
+        tl_team->a2a_status.local =
+            ucc_tl_mlx5_team_test_alltoall_start(tl_team);
         tl_team->state      = TL_MLX5_TEAM_STATE_ALLTOALL_POSTED;
     case TL_MLX5_TEAM_STATE_ALLTOALL_POSTED:
-        tl_team->a2a_status.local = ucc_tl_mlx5_team_test_alltoall_progress(tl_team);
+        tl_team->a2a_status.local =
+            ucc_tl_mlx5_team_test_alltoall_progress(tl_team);
         if (UCC_INPROGRESS == tl_team->a2a_status.local) {
             return UCC_INPROGRESS;
         }

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -171,7 +171,7 @@ ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
     team_info.init                = ucc_tl_mlx5_coll_init;
     team_info.num_mem_types       = 2;
     team_info.supported_mem_types = mt;
-    team_info.supported_colls     = UCC_TL_MLX5_SUPPORTED_COLLS;
+    team_info.supported_colls     = (UCC_COLL_TYPE_ALLTOALL * (team->a2a_status.local == UCC_OK)) | UCC_COLL_TYPE_BCAST;
     team_info.size                = UCC_TL_TEAM_SIZE(team);
 
     status = ucc_coll_score_build_default(

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -22,7 +22,7 @@ static ucc_status_t ucc_tl_mlx5_topo_init(ucc_tl_mlx5_team_t *team)
     status = ucc_ep_map_create_nested(&UCC_TL_CORE_TEAM(team)->ctx_map,
                                       &UCC_TL_TEAM_MAP(team), &team->ctx_map);
     if (UCC_OK != status) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to create ctx map");
+        tl_debug(UCC_TL_TEAM_LIB(team), "failed to create ctx map");
         return status;
     }
     subset.map    = team->ctx_map;
@@ -31,7 +31,7 @@ static ucc_status_t ucc_tl_mlx5_topo_init(ucc_tl_mlx5_team_t *team)
     status = ucc_topo_init(subset, UCC_TL_CORE_CTX(team)->topo, &team->topo);
 
     if (UCC_OK != status) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to init team topo");
+        tl_debug(UCC_TL_TEAM_LIB(team), "failed to init team topo");
         goto err_topo_init;
     }
 
@@ -61,7 +61,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_team_t, ucc_base_context_t *tl_context,
 
     status = ucc_tl_mlx5_topo_init(self);
     if (status != UCC_OK) {
-        tl_error(ctx->super.super.lib, "failed to init team topo");
+        tl_debug(ctx->super.super.lib, "failed to init team topo");
         return status;
     }
 
@@ -120,7 +120,7 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
                                        &tl_team->dm_status[1], UCC_DT_INT32, 1,
                                        UCC_OP_MIN, subset, &tl_team->scoll_req);
         if (status < 0) {
-            tl_error(UCC_TL_TEAM_LIB(tl_team),
+            tl_debug(UCC_TL_TEAM_LIB(tl_team),
                      "failed to collect global status");
             return status;
         }
@@ -128,7 +128,7 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
     case TL_MLX5_TEAM_STATE_POSTED:
         status = ucc_service_coll_test(tl_team->scoll_req);
         if (status < 0) {
-            tl_error(UCC_TL_TEAM_LIB(tl_team),
+            tl_debug(UCC_TL_TEAM_LIB(tl_team),
                      "failure during service coll exchange: %s",
                      ucc_status_string(status));
             return status;
@@ -177,7 +177,7 @@ ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
 
     status = ucc_coll_score_alloc(&score);
     if (UCC_OK != status) {
-        tl_error(lib, "failed to alloc score_t");
+        tl_debug(lib, "failed to alloc score_t");
         return status;
     }
 
@@ -186,7 +186,7 @@ ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
         MAX_MSG_SIZE * UCC_TL_TEAM_SIZE(team), UCC_TL_MLX5_DEFAULT_SCORE,
         ucc_tl_mlx5_coll_init, tl_team);
     if (UCC_OK != status) {
-        tl_error(lib, "failed to add range to score_t");
+        tl_debug(lib, "failed to add range to score_t");
         return status;
     }
 
@@ -195,7 +195,7 @@ ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
         MAX_MSG_SIZE * UCC_TL_TEAM_SIZE(team), UCC_TL_MLX5_DEFAULT_SCORE,
         ucc_tl_mlx5_coll_init, tl_team);
     if (UCC_OK != status) {
-        tl_error(lib, "failed to add range to score_t");
+        tl_debug(lib, "failed to add range to score_t");
         return status;
     }
 

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -171,7 +171,9 @@ ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
     team_info.init                = ucc_tl_mlx5_coll_init;
     team_info.num_mem_types       = 2;
     team_info.supported_mem_types = mt;
-    team_info.supported_colls     = (UCC_COLL_TYPE_ALLTOALL * (team->a2a_status.local == UCC_OK)) | UCC_COLL_TYPE_BCAST;
+    team_info.supported_colls =
+        (UCC_COLL_TYPE_ALLTOALL * (team->a2a_status.local == UCC_OK)) |
+        UCC_COLL_TYPE_BCAST;
     team_info.size                = UCC_TL_TEAM_SIZE(team);
 
     status = ucc_coll_score_build_default(

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -74,7 +74,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_team_t, ucc_base_context_t *tl_context,
     }
 
     self->dm_status.local = status;
-    self->state        = TL_MLX5_TEAM_STATE_INIT;
+    self->state           = TL_MLX5_TEAM_STATE_INIT;
 
     self->mcast  = NULL;
     status = ucc_tl_mlx5_mcast_team_init(tl_context, &(self->mcast), &(ctx->mcast), params,
@@ -116,9 +116,9 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
 
     switch (tl_team->state) {
     case TL_MLX5_TEAM_STATE_INIT:
-        status = ucc_service_allreduce(core_team, &tl_team->dm_status.local,
-                                       &tl_team->dm_status.global, UCC_DT_INT32, 1,
-                                       UCC_OP_MIN, subset, &tl_team->scoll_req);
+        status = ucc_service_allreduce(
+            core_team, &tl_team->dm_status.local, &tl_team->dm_status.global,
+            UCC_DT_INT32, 1, UCC_OP_MIN, subset, &tl_team->scoll_req);
         if (status < 0) {
             tl_debug(UCC_TL_TEAM_LIB(tl_team),
                      "failed to collect global status");

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -137,8 +137,9 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
     case TL_MLX5_TEAM_STATE_ALLTOALL_INIT:
         tl_team->a2a_status.local =
             ucc_tl_mlx5_team_test_alltoall_start(tl_team);
-        tl_team->state      = TL_MLX5_TEAM_STATE_ALLTOALL_POSTED;
+        tl_team->state = TL_MLX5_TEAM_STATE_ALLTOALL_POSTED;
     case TL_MLX5_TEAM_STATE_ALLTOALL_POSTED:
+        // coverity[deref_arg:FALSE]
         tl_team->a2a_status.local =
             ucc_tl_mlx5_team_test_alltoall_progress(tl_team);
         if (UCC_INPROGRESS == tl_team->a2a_status.local) {


### PR DESCRIPTION
## What
Revise TL/MLX5 context and team init.
- Allow other collective to run if a2a setup fails
- Handling device memory allocation error, and other errors happening during team alltoall init
- allocate device memory atomics before device memory pool
- change setup/cleanup error log to debug log

Along the way, we fix two important bugs
- fix pd deallocation https://redmine.mellanox.com/issues/3558239
- fix socket closing https://redmine.mellanox.com/issues/3564403