### PR TITLE
TL/UCP: add ranks reordering to allgatherv

### DIFF
--- a/src/components/tl/ucp/allgatherv/allgatherv.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv.c
@@ -9,10 +9,6 @@
 #include "allgatherv.h"
 #include "utils/ucc_coll_utils.h"
 
-ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *task);
-
-void ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
-
 ucc_base_coll_alg_info_t
     ucc_tl_ucp_allgatherv_algs[UCC_TL_UCP_ALLGATHERV_ALG_LAST + 1] = {
         [UCC_TL_UCP_ALLGATHERV_ALG_RING] =
@@ -29,8 +25,5 @@ ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task)
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    task->super.post     = ucc_tl_ucp_allgatherv_ring_start;
-    task->super.progress = ucc_tl_ucp_allgatherv_ring_progress;
-
-    return UCC_OK;
+    return ucc_tl_ucp_allgatherv_ring_init_common(task);
 }

--- a/src/components/tl/ucp/allgatherv/allgatherv.h
+++ b/src/components/tl/ucp/allgatherv/allgatherv.h
@@ -18,10 +18,6 @@ enum {
 extern ucc_base_coll_alg_info_t
              ucc_tl_ucp_allgatherv_algs[UCC_TL_UCP_ALLGATHERV_ALG_LAST + 1];
 
-ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *task);
-
-void ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
-
 ucc_status_t ucc_tl_ucp_allgatherv_ring_init_common(ucc_tl_ucp_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task);

--- a/src/components/tl/ucp/allgatherv/allgatherv.h
+++ b/src/components/tl/ucp/allgatherv/allgatherv.h
@@ -18,6 +18,11 @@ enum {
 extern ucc_base_coll_alg_info_t
              ucc_tl_ucp_allgatherv_algs[UCC_TL_UCP_ALLGATHERV_ALG_LAST + 1];
 
-ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task);
+ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *task);
 
+void ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_ucp_allgatherv_ring_init_common(ucc_tl_ucp_task_t *task);
+
+ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task);
 #endif

--- a/src/components/tl/ucp/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv_ring.c
@@ -34,9 +34,9 @@ void ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
 
     while (task->tagged.send_posted < tsize) {
         send_idx   =
-            ucc_ep_map_eval(task->subset.map,(trank -
-                                              task->tagged.send_posted + 1 +
-                                              tsize) % tsize);
+            ucc_ep_map_eval(task->subset.map, (trank -
+                                               task->tagged.send_posted + 1 +
+                                               tsize) % tsize);
         data_displ = ucc_coll_args_get_displacement(
                          args, args->dst.info_v.displacements, send_idx) *
                      rdt_size;
@@ -47,8 +47,9 @@ void ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
                                          rmem, sendto, team, task),
                       task, out);
         recv_idx   =
-            ucc_ep_map_eval(task->subset.map,(trank -
-                            task->tagged.recv_posted + tsize) % tsize);
+            ucc_ep_map_eval(task->subset.map, (trank -
+                                               task->tagged.recv_posted +
+                                               tsize) % tsize);
         data_displ = ucc_coll_args_get_displacement(
                          args, args->dst.info_v.displacements, recv_idx) *
                      rdt_size;


### PR DESCRIPTION
## What
Add ranks reordering to allgatherv ring

## Why ?
Improves performence

## How ?
Sets rank in contiguous manner to exchange as much data as possible between ranks within the same node, minimizing cross node data exchange.
