### PR TITLE
TL/UCP: add reorder ranks to reduce_scatter

### DIFF
--- a/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
@@ -270,9 +270,11 @@ static ucc_status_t ucc_tl_ucp_reduce_scatterv_ring_init_subset(
     void *scratch, size_t max_block_count)
 {
     ucc_tl_ucp_task_t *task;
+    ucc_tl_ucp_team_t *tl_team;
     ucc_status_t       status;
 
     task                 = ucc_tl_ucp_init_task(coll_args, team);
+    tl_team              = TASK_TEAM(task);
     task->super.post     = ucc_tl_ucp_reduce_scatterv_ring_start;
     task->super.progress = ucc_tl_ucp_reduce_scatterv_ring_progress;
     task->super.finalize = ucc_tl_ucp_reduce_scatterv_ring_finalize;
@@ -280,7 +282,8 @@ static ucc_status_t ucc_tl_ucp_reduce_scatterv_ring_init_subset(
 
     if (task->subset.map.type != UCC_EP_MAP_FULL) {
         status = ucc_ep_map_create_inverse(task->subset.map,
-                                           &task->reduce_scatterv_ring.inv_map);
+                                           &task->reduce_scatterv_ring.inv_map,
+                                           frag && tl_team->cfg.use_reordering);
         if (UCC_OK != status) {
             return status;
         }

--- a/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
@@ -209,21 +209,21 @@ static ucc_status_t
 ucc_tl_ucp_reduce_scatterv_ring_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task     = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t *  args     = &TASK_ARGS(task);
+    ucc_coll_args_t   *args     = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team     = TASK_TEAM(task);
     ucc_rank_t         size     = task->subset.map.ep_num;
     ucc_rank_t         rank     = task->subset.myrank;
     ucc_datatype_t     dt       = args->dst.info_v.datatype;
     size_t             dt_size  = ucc_dt_size(dt);
     ucc_memory_type_t  mem_type = args->dst.info_v.mem_type;
-    void *             sbuf     = args->src.info.buffer;
+    void              *sbuf     = args->src.info.buffer;
     int                step     = 0;
     ucc_rank_t         sendto   = (rank + 1) % size;
     ucc_rank_t         recvfrom = (rank - 1 + size) % size;
     ucc_rank_t         recv_block = (rank - 2 - step + size) % size;
     ucc_rank_t         send_block = (rank - 1 - step + size) % size;
     size_t             block_offset, frag_count, frag_offset;
-    void *             r_scratch;
+    void              *r_scratch;
     ucc_status_t       status;
 
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
@@ -355,13 +355,13 @@ ucc_tl_ucp_reduce_scatterv_ring_init(ucc_base_coll_args_t *coll_args,
     ucc_datatype_t     dt       = coll_args->args.dst.info_v.datatype;
     size_t             dt_size  = ucc_dt_size(dt);
     ucc_memory_type_t  mem_type = coll_args->args.dst.info_v.mem_type;
-    int                bidir =
+    int                bidir    =
         UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.reduce_scatterv_ring_bidirectional;
     size_t                 to_alloc_per_set, max_segcount, count_per_set, count;
     ucc_tl_ucp_schedule_t *tl_schedule;
-    ucc_schedule_t *       schedule;
-    ucc_coll_task_t *      ctask;
-    ucc_sbgp_t *           sbgp;
+    ucc_schedule_t        *schedule;
+    ucc_coll_task_t       *ctask;
+    ucc_sbgp_t            *sbgp;
     ucc_status_t           status;
     ucc_subset_t           s[2];
     int                    i, n_subsets;
@@ -383,26 +383,22 @@ ucc_tl_ucp_reduce_scatterv_ring_init(ucc_base_coll_args_t *coll_args,
         return status;
     }
 
-    schedule    = &tl_schedule->super.super;
+    schedule  = &tl_schedule->super.super;
     /* if count == size then we have 1 elem per rank, not enough
        to split into 2 sets */
     n_subsets = (bidir && (count > size)) ? 2 : 1;
 
     if (tl_team->cfg.use_reordering) {
         sbgp = ucc_topo_get_sbgp(tl_team->topo, UCC_SBGP_FULL_HOST_ORDERED);
-        s[0].myrank     = sbgp->group_rank;
-        s[0].map        = sbgp->map;
-
-        s[1].map    = ucc_ep_map_create_reverse(UCC_TL_TEAM_SIZE(tl_team));
-        s[1].myrank = ucc_ep_map_eval(s[1].map, s[0].myrank);
+        s[0].myrank = sbgp->group_rank;
+        s[0].map    = sbgp->map;
     } else {
         s[0].myrank     = UCC_TL_TEAM_RANK(tl_team);
         s[0].map.type   = UCC_EP_MAP_FULL;
         s[0].map.ep_num = UCC_TL_TEAM_SIZE(tl_team);
-
-        s[1].map    = ucc_ep_map_create_reverse(UCC_TL_TEAM_SIZE(tl_team));
-        s[1].myrank = ucc_ep_map_eval(s[1].map, UCC_TL_TEAM_RANK(tl_team));
     }
+    s[1].map    = ucc_ep_map_create_reverse(UCC_TL_TEAM_SIZE(tl_team));
+    s[1].myrank = ucc_ep_map_eval(s[1].map, s[0].myrank);
 
     if (coll_args->mask & UCC_BASE_CARGS_MAX_FRAG_COUNT) {
         max_segcount = coll_args->max_frag_count;

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -631,39 +631,6 @@ ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size)
     return map;
 }
 
-ucc_status_t ucc_ep_map_create_reverse_from_reorder(ucc_ep_map_t map,
-                                                    ucc_ep_map_t *new_map)
-{
-    ucc_ep_map_t rev_reord;
-    ucc_rank_t   i, r;
-    ucc_rank_t   max_rank;
-
-    rev_reord.type            = UCC_EP_MAP_ARRAY;
-    rev_reord.ep_num          = map.ep_num;
-    rev_reord.array.elem_size = sizeof(ucc_rank_t);
-    max_rank                  = 0;
-    for (i = 0; i < map.ep_num; i++) {
-        r = (ucc_rank_t)ucc_ep_map_eval(map, i);
-        if (r > max_rank) {
-            max_rank = r;
-        }
-    }
-    rev_reord.array.map =
-        ucc_malloc(sizeof(ucc_rank_t) * (max_rank + 1), "rev_reord_map");
-    if (!rev_reord.array.map) {
-        ucc_error("failed to allocate %zd bytes for rev_reord map\n",
-                    sizeof(ucc_rank_t) * map.ep_num);
-        return UCC_ERR_NO_MEMORY;
-    }
-    for (i = 0; i < map.ep_num; i++) {
-        r = (ucc_rank_t)ucc_ep_map_eval(map, i);
-        *((ucc_rank_t *)PTR_OFFSET(rev_reord.array.map, sizeof(ucc_rank_t) * r)) =
-            max_rank - i;
-    }
-    *new_map = rev_reord;
-    return UCC_OK;
-}
-
 static inline int ucc_ep_map_is_reverse(ucc_ep_map_t *map,
                                         int reversed_reordered_flag)
 {
@@ -705,7 +672,6 @@ ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map,
                 i;
         }
     }
-    // *reversed_reordered_flag = 0;
     *inv_map = inv;
     return UCC_OK;
 }

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -631,20 +631,55 @@ ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size)
     return map;
 }
 
-static inline int ucc_ep_map_is_reverse(ucc_ep_map_t *map)
+ucc_status_t ucc_ep_map_create_reverse_from_reorder(ucc_ep_map_t map,
+                                                    ucc_ep_map_t *new_map)
 {
-    return (map->type == UCC_EP_MAP_STRIDED) &&
-           (map->strided.start == map->ep_num - 1) &&
-           (map->strided.stride == -1);
+    ucc_ep_map_t rev_reord;
+    ucc_rank_t   i, r;
+    ucc_rank_t   max_rank;
+
+    rev_reord.type            = UCC_EP_MAP_ARRAY;
+    rev_reord.ep_num          = map.ep_num;
+    rev_reord.array.elem_size = sizeof(ucc_rank_t);
+    max_rank                  = 0;
+    for (i = 0; i < map.ep_num; i++) {
+        r = (ucc_rank_t)ucc_ep_map_eval(map, i);
+        if (r > max_rank) {
+            max_rank = r;
+        }
+    }
+    rev_reord.array.map =
+        ucc_malloc(sizeof(ucc_rank_t) * (max_rank + 1), "rev_reord_map");
+    if (!rev_reord.array.map) {
+        ucc_error("failed to allocate %zd bytes for rev_reord map\n",
+                    sizeof(ucc_rank_t) * map.ep_num);
+        return UCC_ERR_NO_MEMORY;
+    }
+    for (i = 0; i < map.ep_num; i++) {
+        r = (ucc_rank_t)ucc_ep_map_eval(map, i);
+        *((ucc_rank_t *)PTR_OFFSET(rev_reord.array.map, sizeof(ucc_rank_t) * r)) =
+            max_rank - i;
+    }
+    *new_map = rev_reord;
+    return UCC_OK;
 }
 
-ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map)
+static inline int ucc_ep_map_is_reverse(ucc_ep_map_t *map,
+                                        int reversed_reordered_flag)
+{
+    return (((map->type == UCC_EP_MAP_STRIDED) &&
+           (map->strided.start == map->ep_num - 1) &&
+           (map->strided.stride == -1)) || reversed_reordered_flag);
+}
+
+ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map,
+                                       int reversed_reordered_flag)
 {
     ucc_ep_map_t inv;
     ucc_rank_t   i, r;
     ucc_rank_t   max_rank;
 
-    if (ucc_ep_map_is_reverse(&map)) {
+    if (ucc_ep_map_is_reverse(&map, reversed_reordered_flag)) {
         inv = map;
     } else {
         inv.type            = UCC_EP_MAP_ARRAY;
@@ -670,6 +705,7 @@ ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map)
                 i;
         }
     }
+    // *reversed_reordered_flag = 0;
     *inv_map = inv;
     return UCC_OK;
 }

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -229,10 +229,6 @@ void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len,
    rank r -> size - 1 - r */
 ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size);
 
-/* Creates a rank map that reverses reordered ranks */
-ucc_status_t ucc_ep_map_create_reverse_from_reorder(ucc_ep_map_t map,
-                                                    ucc_ep_map_t *new_map);
-
 /* Creates an inverse mapping for a given map */
 ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map,
                                        int reversed_reordered_flag);

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -229,7 +229,14 @@ void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len,
    rank r -> size - 1 - r */
 ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size);
 
-/* Creates an inverse mapping for a given map */
+/* Creates an inverse mapping for a given map,
+   only if given map is not a reverse map
+   or a reordered map within the reverse direction task.
+   @param [in] map                       given map
+   @param [in] inv_map                   output map
+   @param [in] reversed_reordered_flag   1 if is reverse direction task and
+                                         reorder ranks is configured as yes,
+                                         0 otherwise. */
 ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map,
                                        int reversed_reordered_flag);
 

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -229,8 +229,13 @@ void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len,
    rank r -> size - 1 - r */
 ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size);
 
+/* Creates a rank map that reverses reordered ranks */
+ucc_status_t ucc_ep_map_create_reverse_from_reorder(ucc_ep_map_t map,
+                                                    ucc_ep_map_t *new_map);
+
 /* Creates an inverse mapping for a given map */
-ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map);
+ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map,
+                                       int reversed_reordered_flag);
 
 ucc_status_t ucc_ep_map_create_nested(ucc_ep_map_t *base_map,
                                       ucc_ep_map_t *sub_map,

--- a/test/gtest/utils/test_ep_map.cc
+++ b/test/gtest/utils/test_ep_map.cc
@@ -131,7 +131,7 @@ class test_ep_map_inv : public test_ep_map {
     void check_inv(EpMap map)
     {
         ucc_ep_map_t inv;
-        EXPECT_EQ(UCC_OK, ucc_ep_map_create_inverse(map.map, &inv));
+        EXPECT_EQ(UCC_OK, ucc_ep_map_create_inverse(map.map, &inv, 0));
         for (int i = 0; i < map.map.ep_num; i++) {
             EXPECT_EQ(i, ucc_ep_map_eval(inv, ucc_ep_map_eval(map.map, i)));
         }

--- a/test/gtest/utils/test_ep_map.cc
+++ b/test/gtest/utils/test_ep_map.cc
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * See file LICENSE for terms.
  */
+
 extern "C" {
 #include "utils/ucc_coll_utils.h"
 }


### PR DESCRIPTION
## What
Add reordering ranks to reduce_scatter ring and reduce_scatterv ring 

## Why ?
Better performance

## How ?
Mapping ranks to first send messages within the same node
**Note:** in case of bidirectional, we need 2 use both mappings of reverse and reorder consecutively.
