### PR TITLE
TEST: fix summary calculation in test_mpi

### DIFF
--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -648,10 +648,9 @@ int main(int argc, char *argv[])
 
         /* check if all tests have been skipped */
         if (total_done_skipped_failed[0] == total_done_skipped_failed[2]) {
-                std::cout <<
-                    "\n All tests have been skipped, indicating most likely "
-                    "a problem\n";
-                failed = 1;
+            std::cout << "\n All tests have been skipped, indicating most likely "
+                         "a problem\n";
+            failed = 1;
         }
     }
 


### PR DESCRIPTION
## What
Fixes summary calc for ucc_test_mpi

## Why ?
Different ranks might execute different number of tests, e.g. if odd_even team split is used and initial world size is odd number.
internal issue https://redmine.mellanox.com/issues/3477397
