### PR TITLE
TL/MLX5: fix client's socket closing

### DIFF
--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -26,6 +26,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_mlx5_config->super,
                               params->context);
     memcpy(&self->cfg, tl_mlx5_config, sizeof(*tl_mlx5_config));
+    self->sock       = 0;
     self->rcache     = NULL;
     self->shared_pd  = NULL;
     self->shared_ctx = NULL;
@@ -73,8 +74,11 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_context_t)
         tl_debug(self->super.super.lib, "failed to free ib ctx and pd");
     };
 
+    if (!self->sock) {
+        close(self->sock);
+    }
+
     ucc_mpool_cleanup(&self->req_mp, 1);
-    close(self->sock);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_mlx5_context_t, ucc_tl_context_t);

--- a/src/components/tl/mlx5/tl_mlx5_pd.c
+++ b/src/components/tl/mlx5/tl_mlx5_pd.c
@@ -127,7 +127,7 @@ out:
 
 static ucc_status_t client_recv_data(int *shared_cmd_fd,
                                      uint32_t *shared_pd_handle,
-                                     const char *sock_path,
+                                     const char *sock_path, int *sock_p,
                                      ucc_tl_mlx5_lib_t *lib)
 {
     struct sockaddr_storage sockaddr = {};
@@ -159,7 +159,8 @@ static ucc_status_t client_recv_data(int *shared_cmd_fd,
         goto out;
     }
 
-    return status;
+    *sock_p = sock;
+    return UCC_OK;
 
 out:
     if (close(sock) == -1) {
@@ -229,7 +230,8 @@ ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
     ucc_status_t status;
 
     if (!is_ctx_owner) {
-        status = client_recv_data(&ctx_fd, &pd_handle, sock_path, lib);
+        status =
+            client_recv_data(&ctx_fd, &pd_handle, sock_path, &ctx->sock, lib);
         if (UCC_OK != status) {
             tl_debug(lib, "failed to share ctx & pd from client side");
             return status;


### PR DESCRIPTION
## What
fix memory leak [Coverity® :: ucc :: Outstanding Issues :: Issue 628230 (mellanox.com)](https://coverity.mellanox.com/reports.htm#v20248/p10129/fileInstanceId=222742904&defectInstanceId=95022912&mergedDefectId=628230)

The socket handle used for pd sharing was not saved on the client side, and so could not be closed.
