### PR TITLE
BUILD: re-order m4 flags for RCCL

### DIFF
--- a/config/m4/rccl.m4
+++ b/config/m4/rccl.m4
@@ -36,8 +36,8 @@ AS_IF([test "x$rccl_checked" != "xyes"],[
 
         AS_IF([test "x$rocm_happy" = "xyes"],
         [
-            CPPFLAGS="$HIP_CPPFLAGS $CPPFLAGS"
-            LDFLAGS="$ROCM_LDFLAGS $LDFLAGS"
+            CPPFLAGS="$CPPFLAGS $HIP_CPPFLAGS"
+            LDFLAGS="$LDFLAGS $ROCM_LDFLAGS"
             AC_CHECK_HEADER([rccl/rccl.h],
             [
                 AC_CHECK_LIB([rccl], [ncclCommInitRank],


### PR DESCRIPTION
## What
Re-ordering CPPFLAGS and LDFLAGS to prioritize RCCL installation path over ROCM/HIP installation path for ncclCommInitRank check.

## Why ?
Pre-installed RCCL libraries and header files can exist in the ROCm installation path, with features (like BFD) that are not supported by all platforms. When checking for ncclCommInitRank during UCC configure, the current order chooses these pre-installed RCCL files in the ROCm installation path (if found in the path by `--with-rocm`) over custom-built files in the RCCL installation path (as pointed by `--with-rccl`). This fix prioritizes files in the RCCL installation path over ROCm installation path.

@edgargabriel 