### PR TITLE
TL/UCP: Name UCP Context for Debug

### DIFF
--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -162,12 +162,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
               "failed to read ucp configuration", err_cfg_read, self);
 
     ucp_params.field_mask =
-        UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_TAG_SENDER_MASK;
+        UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_TAG_SENDER_MASK | UCP_PARAM_FIELD_NAME;
     ucp_params.features = UCP_FEATURE_TAG | UCP_FEATURE_AM;
     if (params->params.mask & UCC_CONTEXT_PARAM_FIELD_MEM_PARAMS) {
         ucp_params.features |= UCP_FEATURE_RMA | UCP_FEATURE_AMO64;
     }
     ucp_params.tag_sender_mask = UCC_TL_UCP_TAG_SENDER_MASK;
+    ucp_params.name = "UCC_UCP_CONTEXT";
 
     if (params->estimated_num_ppn > 0) {
         ucp_params.field_mask |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;


### PR DESCRIPTION
## What
Name UCP context for debug purposes 

## Why ?
While debugging UCX configs, we might have additional UCP context, from MPI for example. Naming our UCP context will aid in identifying the UCC context.

## How ?
UCP has built-in mechanism ready for that purpose.
