### PR TITLE
UTIL: Fix in parser serial to sequential

### DIFF
--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -280,7 +280,7 @@ void         ucc_config_release_uint_ranged(void *ptr, const void *arg);
             ucc_config_clone_pipeline_params,                                  \
             ucc_config_release_pipeline_params, ucs_config_help_generic,       \
             "thresh=<memunit>:fragsize=<memunit>:nfrags="                      \
-            "<uint>:pdepth=<uint>:<ordered/parallel/serial>"                   \
+            "<uint>:pdepth=<uint>:<ordered/parallel/sequential>"                   \
     }
 
 #endif


### PR DESCRIPTION
## What
Fix UCC parser documentation

## Why ?
In src/schedule/ucc_schedule_pipelined.c, ucc_pipeline_order_names - correct command is sequential

## How ?
Fix UCC parser documentation 
