### PR TITLE
TL/MLX5: fix context create hang

### DIFF
--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -33,7 +33,7 @@ jobs:
         wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
         sudo dpkg -i cuda-keyring_1.0-1_all.deb
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends  cuda-cudart-dev-${CUDA_VER} cuda-nvcc-${CUDA_VER} cuda-nvml-dev-${CUDA_VER}
+        sudo apt-get install -y --no-install-recommends cuda-cudart-dev-${CUDA_VER} cuda-nvcc-${CUDA_VER} cuda-nvml-dev-${CUDA_VER}
     - name: Get UCX
       run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
     - name: Build UCX

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -66,7 +66,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_team_t, ucc_base_context_t *tl_context,
     }
 
     self->a2a = NULL;
-    status    = ucc_tl_mlx5_team_init_alltoall(self);
+    status = ucc_tl_mlx5_team_init_alltoall(self);
     if (UCC_OK != status) {
         return status;
     }


### PR DESCRIPTION
## What
Fix hanging in TL MLX5 context create.

## How ?
PD_OWNER_RANK doesn't start service bcast If no IB devices found, other ranks hang in sbcast waiting for PD_OWNER_RANK 
