### PR TITLE
TL/MLX5: add librdmacm linkage

### DIFF
--- a/src/components/tl/mlx5/Makefile.am
+++ b/src/components/tl/mlx5/Makefile.am
@@ -51,7 +51,7 @@ libucc_tl_mlx5_la_SOURCES  = $(sources)
 libucc_tl_mlx5_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS)
 libucc_tl_mlx5_la_CFLAGS   = $(BASE_CFLAGS)
 libucc_tl_mlx5_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed
-libucc_tl_mlx5_la_LIBADD   = $(UCC_TOP_BUILDDIR)/src/libucc.la $(IBVERBS_LIBADD) $(MLX5DV_LIBADD)
+libucc_tl_mlx5_la_LIBADD   = $(UCC_TOP_BUILDDIR)/src/libucc.la $(IBVERBS_LIBADD) $(MLX5DV_LIBADD) $(RDMACM_LIBADD)
 
 include $(top_srcdir)/config/module.am
 


### PR DESCRIPTION
## What
Fix Makefile.am add librdmacm dependencies

## Why ?
Fixes several discovered bugs and showstoppers:
https://redmine.mellanox.com/issues/3752155
http://hpcweb.lab.mtl.com/hpc/mtr_scrap/users/qa_sharp/scratch/ucc/20240123_172600_774704_13631_r-hpc-gpu03/
https://redmine.mellanox.com/issues/3403021