### PR TITLE
TL/UCP: bugfix in allreduce dbt

### DIFF
--- a/src/components/tl/ucp/allreduce/allreduce.c
+++ b/src/components/tl/ucp/allreduce/allreduce.c
@@ -21,7 +21,7 @@ ucc_base_coll_alg_info_t
              .desc = "recursive knomial scatter-reduce followed by knomial "
                      "allgather (optimized for BW)"},
         [UCC_TL_UCP_ALLREDUCE_ALG_DBT] =
-            {.id   = UCC_TL_UCP_ALLREDUCE_ALG_SRA_KNOMIAL,
+            {.id   = UCC_TL_UCP_ALLREDUCE_ALG_DBT,
              .name = "dbt",
              .desc = "alreduce over double binary tree where a leaf in one tree "
                      "will be intermediate in other (optimized for BW)"},


### PR DESCRIPTION
## What
This PR updates the ID field of `ucc_tl_ucp_allreduce_algs` in `src/components/tl/ucp/allreduce/allreduce.c`. The incorrect ID `UCC_TL_UCP_ALLREDUCE_ALG_SRA_KNOMIAL` has been replaced with the correct `UCC_TL_UCP_ALLREDUCE_ALG_DBT`.

## Why ?
The change addresses a bug where the ID field of `UCC_TL_UCP_ALLREDUCE_ALG_DBT` was mistakenly set to `UCC_TL_UCP_ALLREDUCE_ALG_SRA_KNOMIAL`. This fix ensures that the ID accurately reflects the corresponding algorithm, aligning with the intended design and improving the functionality of the component.

## How ?
The fix was straightforward - the incorrect ID in the specified file was simply replaced with the correct ID. This ensures that the `UCC_TL_UCP_ALLREDUCE_ALG_DBT` is now accurately represented in the system.