### PR TITLE
Nsarka/ucc int8 reduce bugfix

### DIFF
--- a/src/components/ec/cpu/ec_cpu.c
+++ b/src/components/ec/cpu/ec_cpu.c
@@ -114,7 +114,11 @@ ucc_status_t ucc_cpu_executor_task_post(ucc_ee_executor_t *executor,
     switch (task_args->task_type) {
     case UCC_EE_EXECUTOR_TASK_REDUCE:
         status = ucc_ec_cpu_reduce((ucc_eee_task_reduce_t *)&task_args->reduce,
-                                   task_args->flags);
+                                   (task_args->flags &
+                                        UCC_EEE_TASK_FLAG_REDUCE_SRCS_EXT) ?
+                                        task_args->reduce.srcs_ext :
+                                        task_args->reduce.srcs,
+                                    task_args->flags);
         if (ucc_unlikely(UCC_OK != status)) {
             goto free_task;
         }
@@ -147,7 +151,7 @@ ucc_status_t ucc_cpu_executor_task_post(ucc_ee_executor_t *executor,
         tr.dst    = trs->dst;
         tr.alpha  = trs->alpha;
 
-        status = ucc_ec_cpu_reduce(&tr, flags);
+        status = ucc_ec_cpu_reduce(&tr, srcs, flags);
         if (ucc_unlikely(UCC_OK != status)) {
             goto free_task;
         }

--- a/src/components/ec/cpu/ec_cpu.h
+++ b/src/components/ec/cpu/ec_cpu.h
@@ -25,5 +25,5 @@ typedef struct ucc_ec_cpu {
 
 extern ucc_ec_cpu_t ucc_ec_cpu;
 
-ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task, uint16_t flags);
+ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task, void * const * restrict srcs, uint16_t flags);
 #endif

--- a/src/components/ec/cpu/ec_cpu_reduce.c
+++ b/src/components/ec/cpu/ec_cpu_reduce.c
@@ -12,48 +12,49 @@
     do {                                                                       \
         size_t _i, _j;                                                         \
         type  _tmp;                                                            \
+        size_t __count = _count;                                               \
         switch (_n_srcs) {                                                     \
         case 2:                                                                \
-            for (_i = 0; _i < _count; _i++) {                                  \
+            for (_i = 0; _i < __count; _i++) {                                 \
                 d[_i] = OP##_2(s[0][_i], s[1][_i]);                            \
             }                                                                  \
             break;                                                             \
         case 3:                                                                \
-            for (_i = 0; _i < _count; _i++) {                                  \
+            for (_i = 0; _i < __count; _i++) {                                 \
                 d[_i] = OP##_3(s[0][_i], s[1][_i], s[2][_i]);                  \
             }                                                                  \
             break;                                                             \
         case 4:                                                                \
-            for (_i = 0; _i < _count; _i++) {                                  \
+            for (_i = 0; _i < __count; _i++) {                                 \
                 d[_i] = OP##_4(s[0][_i], s[1][_i], s[2][_i], s[3][_i]);        \
             }                                                                  \
             break;                                                             \
         case 5:                                                                \
-            for (_i = 0; _i < _count; _i++) {                                  \
+            for (_i = 0; _i < __count; _i++) {                                 \
                 d[_i] =                                                        \
                     OP##_5(s[0][_i], s[1][_i], s[2][_i], s[3][_i], s[4][_i]);  \
             }                                                                  \
             break;                                                             \
         case 6:                                                                \
-            for (_i = 0; _i < _count; _i++) {                                  \
+            for (_i = 0; _i < __count; _i++) {                                 \
                 d[_i] = OP##_6(s[0][_i], s[1][_i], s[2][_i], s[3][_i],         \
                                s[4][_i], s[5][_i]);                            \
             }                                                                  \
             break;                                                             \
         case 7:                                                                \
-            for (_i = 0; _i < _count; _i++) {                                  \
+            for (_i = 0; _i < __count; _i++) {                                 \
                 d[_i] = OP##_7(s[0][_i], s[1][_i], s[2][_i], s[3][_i],         \
                                s[4][_i], s[5][_i], s[6][_i]);                  \
             }                                                                  \
             break;                                                             \
         case 8:                                                                \
-            for (_i = 0; _i < _count; _i++) {                                  \
+            for (_i = 0; _i < __count; _i++) {                                 \
                 d[_i] = OP##_8(s[0][_i], s[1][_i], s[2][_i], s[3][_i],         \
                                s[4][_i], s[5][_i], s[6][_i], s[7][_i]);        \
             }                                                                  \
             break;                                                             \
         default:                                                               \
-            for (_i = 0; _i < _count; _i++) {                                  \
+            for (_i = 0; _i < __count; _i++) {                                 \
                 _tmp = OP##_8(s[0][_i], s[1][_i], s[2][_i], s[3][_i],          \
                               s[4][_i], s[5][_i], s[6][_i], s[7][_i]);         \
                 for (_j = 8; _j < _n_srcs; _j++) {                             \
@@ -223,11 +224,9 @@
         }                                                                      \
     } while (0)
 
-ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task, uint16_t flags)
+ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task,
+                               void * const * restrict srcs, uint16_t flags)
 {
-    void **srcs = (flags & UCC_EEE_TASK_FLAG_REDUCE_SRCS_EXT) ? task->srcs_ext
-                                                              : task->srcs;
-
     switch (task->dt) {
     case UCC_DT_INT8:
         DO_DT_REDUCE_INT(int8_t, srcs, task->dst, task->op, task->count,


### PR DESCRIPTION
This PR fixes int8_t reductions not getting vectorized when compiled with GCC.

## Background

A sum reduction may look like this:

```
 size_t _i, count = ...
 int8_t * src_1 = ...
 int8_t * src_2 = ...
 int8_t * dst = ...

  for (_i = 0; _i < count; _i++) {
      d[_i] = src_1[_i] + src_2[_i]);
  }  
```

When `src_1` and `src_2` are arrays of type int8, the performance drops. The reason is that `int8` is a typedef for `char`, and `char` is the only type allowed to read and modify memory occupied by other types. (https://gist.github.com/alexei-zaripov/dcc14c78819c5f1354afe8b70932007c?permalink_comment_id=4677393). This means that the compiler does not know that `d[_i] = src_1[_i] + src_2[_i]);` isn't changing `src_1` or `src_2`, and thus can't vectorize the loop.

The `restrict` keyword--introduced in the C99 standard--allows the programmer to tell the compiler that the pointers do not overlap in any way and thus can be vectorized.

## Bug

Even though UCC already makes a new restricted pointer in ec_cpu_reduce.c:78 and uses that pointer in the reduction, what I assume is a bug in GCC makes it so the `restrict` keyword is not respected and loop auto-vectorization does not take place.

## Solution

Through some debugging, I found that GCC will respect the `restrict` keyword, but only if the pointer is passed via a function argument. See https://godbolt.org/z/feP766obr for a minimal reproducer of this issue.
To get the fix into ucc, I made the `ucc_ec_cpu_reduce` function take in a restrict pointer to the input vectors. Also, I made a copy of the _count variable because the loop bounds are indeterminate (task_args is not a const pointer, so task_args->reduce.count could change).