### PR TITLE
CL/HIER: check number of TLs per SBGP

### DIFF
--- a/src/components/ec/cuda/ec_cuda.c
+++ b/src/components/ec/cuda/ec_cuda.c
@@ -282,7 +282,9 @@ ucc_status_t ucc_ec_cuda_get_resources(ucc_ec_cuda_resources_t **resources)
 #else
     status = CUDADRV_FUNC(cuCtxGetId(cu_ctx, &cu_ctx_id));
     if (ucc_unlikely(status != UCC_OK)) {
-        ec_error(&ucc_ec_cuda.super, "failed to get currect CUDA context ID");
+        /* worakround for pytorch, progress thread doesn't have cuda context for GPU 0*/
+        cu_ctx_id = 0x12345;
+        ec_debug(&ucc_ec_cuda.super, "failed to get currect CUDA context ID");
     }
 #endif
 

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -368,7 +368,9 @@ ucc_status_t ucc_mc_cuda_get_resources(ucc_mc_cuda_resources_t **resources)
 #else
     status = CUDADRV_FUNC(cuCtxGetId(cu_ctx, &cu_ctx_id));
     if (ucc_unlikely(status != UCC_OK)) {
-        mc_error(&ucc_mc_cuda.super, "failed to get currect CUDA context ID");
+        /* worakround for pytorch, progress thread doesn't have cuda context for GPU 0*/
+        cu_ctx_id = 0x12345;
+        mc_debug(&ucc_mc_cuda.super, "failed to get currect CUDA context ID");
     }
 #endif
 

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Advanced Micro Devices, Inc. 2023. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -574,8 +574,8 @@ void ProcessArgs(int argc, char** argv)
 
 int main(int argc, char *argv[])
 {
-    int failed                                                          = 0;
-    int total_done_skipped_failed[ucc_ilog2(UCC_COLL_TYPE_LAST) + 1][4] = {0};
+    int failed = 0;
+    int total_done_skipped_failed[ucc_ilog2(UCC_COLL_TYPE_LAST) + 1][4];
     std::chrono::steady_clock::time_point begin;
     int size, required, provided, completed, rank;
     UccTestMpi *test;
@@ -583,6 +583,8 @@ int main(int argc, char *argv[])
     std::string err;
 
     begin = std::chrono::steady_clock::now();
+    memset(total_done_skipped_failed, 0,
+           sizeof(total_done_skipped_failed));
     try {
         ProcessArgs(argc, argv);
     } catch (const std::string &s) {


### PR DESCRIPTION
## What
Add check to CL/HIER to prevent SBGP TL list overflow.

## Why ?
For some systems CL/HIER might try to use more than 4 TLs per SBGP. 4 is compile time constant. Fixes bug https://redmine.mellanox.com/issues/3767158

## How ?
Ignore TLs if the list already full. Filter out TLs if we know in advance that SBGP size is not supported.