### PR TITLE
CORE: add progress throttle

### DIFF
--- a/src/components/tl/ucp/bcast/bcast_dbt.c
+++ b/src/components/tl/ucp/bcast/bcast_dbt.c
@@ -107,6 +107,8 @@ void ucc_tl_ucp_bcast_dbt_progress(ucc_coll_task_t *coll_task)
     task->bcast_dbt.state = SEND_T1;
 
 SEND_T1:
+/* test_recv is needed to progress ucp_worker */
+    ucc_tl_ucp_test_recv(task);
     if ((coll_root == rank) || (task->bcast_dbt.t1.recv > 0)) {
         for (i = 0; i < 2; i++) {
             if ((t1.children[i] != UCC_RANK_INVALID) &&
@@ -122,6 +124,8 @@ SEND_T1:
     task->bcast_dbt.state = SEND_T2;
 
 SEND_T2:
+/* test_recv is needed to progress ucp_worker */
+    ucc_tl_ucp_test_recv(task);
     if ((coll_root == rank) || (task->bcast_dbt.t2.recv > 0)) {
         for (i = 0; i < 2; i++) {
             if ((t2.children[i] != UCC_RANK_INVALID) &&
@@ -231,6 +235,7 @@ ucc_status_t ucc_tl_ucp_bcast_dbt_init(
     task->super.post     = ucc_tl_ucp_bcast_dbt_start;
     task->super.progress = ucc_tl_ucp_bcast_dbt_progress;
     task->super.finalize = ucc_tl_ucp_bcast_dbt_finalize;
+    task->n_polls        = ucc_max(1, task->n_polls);
     tl_team              = TASK_TEAM(task);
     rank                 = UCC_TL_TEAM_RANK(tl_team);
     size                 = UCC_TL_TEAM_SIZE(tl_team);

--- a/src/components/tl/ucp/reduce/reduce_dbt.c
+++ b/src/components/tl/ucp/reduce/reduce_dbt.c
@@ -155,6 +155,8 @@ void ucc_tl_ucp_reduce_dbt_progress(ucc_coll_task_t *coll_task)
     task->reduce_dbt.state = REDUCE;
 
 REDUCE:
+/* test_recv is needed to progress ucp_worker */
+    ucc_tl_ucp_test_recv(task);
     for (i = 0; i < 2; i++) {
         if (trees[i].recv == trees[i].n_children &&
             !task->reduce_dbt.reduction_comp[i]) {
@@ -216,6 +218,8 @@ TEST:
     }
 
 TEST_ROOT:
+/* test_recv is needed to progress ucp_worker */
+    ucc_tl_ucp_test_recv(task);
     if (UCC_INPROGRESS == ucc_tl_ucp_test_send(task) ||
         task->reduce_dbt.reduction_comp[0] != trees[0].recv ||
         task->reduce_dbt.reduction_comp[1] != trees[1].recv) {

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -77,6 +77,8 @@ typedef struct ucc_context {
     ucc_context_topo_t      *topo;
     uint64_t                 cl_flags;
     ucc_tl_team_t           *service_team;
+
+    int32_t                  throttle_progress;
 } ucc_context_t;
 
 typedef struct ucc_context_config {
@@ -90,6 +92,7 @@ typedef struct ucc_context_config {
     uint32_t                  estimated_num_ppn;
     uint32_t                  lock_free_progress_q;
     uint32_t                  internal_oob;
+    uint32_t                  throttle_progress;
 } ucc_context_config_t;
 
 /* Internal function for context creation that takes explicit

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -77,7 +77,6 @@ typedef struct ucc_context {
     ucc_context_topo_t      *topo;
     uint64_t                 cl_flags;
     ucc_tl_team_t           *service_team;
-
     int32_t                  throttle_progress;
 } ucc_context_t;
 

--- a/src/core/ucc_progress_queue.h
+++ b/src/core/ucc_progress_queue.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -14,6 +15,7 @@ struct ucc_progress_queue {
     void (*enqueue)(ucc_progress_queue_t *pq, ucc_coll_task_t *task);
     void (*dequeue)(ucc_progress_queue_t *pq, ucc_coll_task_t **task);
     int  (*progress)(ucc_progress_queue_t *pq);
+    int  (*is_empty)(ucc_progress_queue_t *pq);
     void (*finalize)(ucc_progress_queue_t *pq);
 };
 
@@ -44,6 +46,11 @@ static inline ucc_status_t ucc_progress_queue_enqueue(ucc_progress_queue_t *pq,
 static inline int ucc_progress_queue(ucc_progress_queue_t *pq)
 {
     return pq->progress(pq);
+}
+
+static inline int ucc_progress_queue_is_empty(ucc_progress_queue_t *pq)
+{
+    return pq->is_empty(pq);
 }
 
 void ucc_progress_queue_finalize(ucc_progress_queue_t *pq);

--- a/src/core/ucc_progress_queue_mt.c
+++ b/src/core/ucc_progress_queue_mt.c
@@ -105,13 +105,13 @@ static int ucc_pq_locked_mt_is_empty(ucc_progress_queue_t *pq)
 {
     ucc_pq_mt_locked_t *pq_mt = ucc_derived_of(pq, ucc_pq_mt_locked_t);
 
-/* this function should not be very accurate for the purpose of progress throttling */
+    /* this function should not be very accurate for the purpose of progress throttling */
     return ucc_list_is_empty(&pq_mt->queue);
 }
 
 static int ucc_pq_mt_is_empty(ucc_progress_queue_t *pq) //NOLINT: pq is unused
 {
-/* lock free progress queue never use throttling */
+    /* lock free progress queue never use throttling */
     return 0;
 }
 

--- a/src/core/ucc_progress_queue_st.c
+++ b/src/core/ucc_progress_queue_st.c
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -67,6 +68,13 @@ static void ucc_pq_st_finalize(ucc_progress_queue_t *pq)
     ucc_free(pq_st);
 }
 
+static int ucc_pq_st_is_empty(ucc_progress_queue_t *pq)
+{
+    ucc_pq_st_t *pq_st = ucc_derived_of(pq, ucc_pq_st_t);
+
+    return ucc_list_is_empty(&pq_st->list);
+}
+
 ucc_status_t ucc_pq_st_init(ucc_progress_queue_t **pq)
 {
     ucc_pq_st_t *pq_st = ucc_malloc(sizeof(*pq_st), "pq_st");
@@ -79,6 +87,8 @@ ucc_status_t ucc_pq_st_init(ucc_progress_queue_t **pq)
     pq_st->super.dequeue  = NULL;
     pq_st->super.progress = ucc_pq_st_progress;
     pq_st->super.finalize = ucc_pq_st_finalize;
+    pq_st->super.is_empty = ucc_pq_st_is_empty;
+
     *pq                   = &pq_st->super;
     return UCC_OK;
 }


### PR DESCRIPTION
## What
Add progress throttle to ucc_context_progress()

## Why ?
Point to point benchmarks might be affected by ucc_context_progress() even though collectives are not used there. Progress throttle helps to save cycles and not calling ucp_worker_progress (in TL UCP) if there are no active collective requests.
