### PR TITLE
TL/MLX5: fix IPv6 address conversion in inet_ntop

### DIFF
--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_helper.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_helper.c
@@ -203,7 +203,7 @@ ucc_status_t ucc_tl_mlx5_mcast_join_mcast_post(ucc_tl_mlx5_mcast_coll_context_t 
     char        buf[40];
     const char *dst;
 
-    dst = inet_ntop(AF_INET6, net_addr, buf, 40);
+    dst = inet_ntop(AF_INET6, &net_addr->sin6_addr, buf, 40);
     if (NULL == dst) {
         tl_error(ctx->lib, "inet_ntop failed");
         return UCC_ERR_NO_RESOURCE;
@@ -399,7 +399,7 @@ ucc_status_t ucc_tl_mlx5_fini_mcast_group(ucc_tl_mlx5_mcast_coll_context_t *ctx,
     char        buf[40];
     const char *dst;
 
-    dst = inet_ntop(AF_INET6, &comm->mcast_addr, buf, 40);
+    dst = inet_ntop(AF_INET6, &comm->mcast_addr.sin6_addr, buf, 40);
     if (NULL == dst) {
         tl_error(comm->lib, "inet_ntop failed");
         return UCC_ERR_NO_RESOURCE;


### PR DESCRIPTION
## What
This commit fixes the conversion of binary IPv6 address into the human-readable string using `inet_ntop`.

## Why ?
In our testing environment, the debug output of MLX5 TL prints garbage IPv6 addresses during the multicast initialization/teardown phase.

## How ?
Pass `sin6_addr` field of type `struct in6_addr` that is the part of the `sockaddr_in6` structure, as specified in [https://man7.org/linux/man-pages/man3/inet_ntop.3.html](https://man7.org/linux/man-pages/man3/inet_ntop.3.html) 