### PR TITLE
EC/CPU: Fix int8 auto-vectorization with gcc 4.8.2

### DIFF
--- a/src/components/ec/cpu/ec_cpu.c
+++ b/src/components/ec/cpu/ec_cpu.c
@@ -113,7 +113,7 @@ ucc_status_t ucc_cpu_executor_task_post(ucc_ee_executor_t *executor,
     eee_task->eee = executor;
     switch (task_args->task_type) {
     case UCC_EE_EXECUTOR_TASK_REDUCE:
-        status = ucc_ec_cpu_reduce((ucc_eee_task_reduce_t *)&task_args->reduce,
+        status = ucc_ec_cpu_reduce((ucc_eee_task_reduce_t *)&task_args->reduce, task_args->reduce.dst,
                                    (task_args->flags &
                                         UCC_EEE_TASK_FLAG_REDUCE_SRCS_EXT) ?
                                         task_args->reduce.srcs_ext :
@@ -151,7 +151,7 @@ ucc_status_t ucc_cpu_executor_task_post(ucc_ee_executor_t *executor,
         tr.dst    = trs->dst;
         tr.alpha  = trs->alpha;
 
-        status = ucc_ec_cpu_reduce(&tr, srcs, flags);
+        status = ucc_ec_cpu_reduce(&tr, tr.dst, srcs, flags);
         if (ucc_unlikely(UCC_OK != status)) {
             goto free_task;
         }

--- a/src/components/ec/cpu/ec_cpu.h
+++ b/src/components/ec/cpu/ec_cpu.h
@@ -25,5 +25,5 @@ typedef struct ucc_ec_cpu {
 
 extern ucc_ec_cpu_t ucc_ec_cpu;
 
-ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task, void * const * restrict srcs, uint16_t flags);
+ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task, void * restrict dst, void * const * restrict srcs, uint16_t flags);
 #endif

--- a/src/components/ec/cpu/ec_cpu_reduce.c
+++ b/src/components/ec/cpu/ec_cpu_reduce.c
@@ -224,45 +224,45 @@
         }                                                                      \
     } while (0)
 
-ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task,
+ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task, void * restrict dst,
                                void * const * restrict srcs, uint16_t flags)
 {
     switch (task->dt) {
     case UCC_DT_INT8:
-        DO_DT_REDUCE_INT(int8_t, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_INT(int8_t, srcs, dst, task->op, task->count,
                          task->n_srcs);
         break;
     case UCC_DT_INT16:
-        DO_DT_REDUCE_INT(int16_t, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_INT(int16_t, srcs, dst, task->op, task->count,
                          task->n_srcs);
         break;
     case UCC_DT_INT32:
-        DO_DT_REDUCE_INT(int32_t, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_INT(int32_t, srcs, dst, task->op, task->count,
                          task->n_srcs);
         break;
     case UCC_DT_INT64:
-        DO_DT_REDUCE_INT(int64_t, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_INT(int64_t, srcs, dst, task->op, task->count,
                          task->n_srcs);
         break;
     case UCC_DT_UINT8:
-        DO_DT_REDUCE_INT(uint8_t, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_INT(uint8_t, srcs, dst, task->op, task->count,
                          task->n_srcs);
         break;
     case UCC_DT_UINT16:
-        DO_DT_REDUCE_INT(uint16_t, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_INT(uint16_t, srcs, dst, task->op, task->count,
                          task->n_srcs);
         break;
     case UCC_DT_UINT32:
-        DO_DT_REDUCE_INT(uint32_t, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_INT(uint32_t, srcs, dst, task->op, task->count,
                          task->n_srcs);
         break;
     case UCC_DT_UINT64:
-        DO_DT_REDUCE_INT(uint64_t, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_INT(uint64_t, srcs, dst, task->op, task->count,
                          task->n_srcs);
         break;
     case UCC_DT_FLOAT32:
 #if SIZEOF_FLOAT == 4
-        DO_DT_REDUCE_FLOAT(float, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_FLOAT(float, srcs, dst, task->op, task->count,
                            task->n_srcs);
         break;
 #else
@@ -270,7 +270,7 @@ ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task,
 #endif
     case UCC_DT_FLOAT64:
 #if SIZEOF_DOUBLE == 8
-        DO_DT_REDUCE_FLOAT(double, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_FLOAT(double, srcs, dst, task->op, task->count,
                            task->n_srcs);
         break;
 #else
@@ -278,19 +278,19 @@ ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task,
 #endif
     case UCC_DT_FLOAT128:
 #if SIZEOF_LONG_DOUBLE == 16
-        DO_DT_REDUCE_FLOAT(long double, srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_FLOAT(long double, srcs, dst, task->op, task->count,
                            task->n_srcs);
         break;
 #else
         return UCC_ERR_NOT_SUPPORTED;
 #endif
     case UCC_DT_BFLOAT16:
-        DO_DT_REDUCE_BFLOAT16(srcs, task->dst, task->op, task->count,
+        DO_DT_REDUCE_BFLOAT16(srcs, dst, task->op, task->count,
                               task->n_srcs);
         break;
     case UCC_DT_FLOAT32_COMPLEX:
 #if SIZEOF_FLOAT__COMPLEX == 8
-        DO_DT_REDUCE_FLOAT_COMPLEX(float complex, srcs, task->dst, task->op,
+        DO_DT_REDUCE_FLOAT_COMPLEX(float complex, srcs, dst, task->op,
                                    task->count, task->n_srcs);
         break;
 #else
@@ -298,7 +298,7 @@ ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task,
 #endif
     case UCC_DT_FLOAT64_COMPLEX:
 #if SIZEOF_DOUBLE__COMPLEX == 16
-        DO_DT_REDUCE_FLOAT_COMPLEX(double complex, srcs, task->dst, task->op,
+        DO_DT_REDUCE_FLOAT_COMPLEX(double complex, srcs, dst, task->op,
                                    task->count, task->n_srcs);
         break;
 #else
@@ -306,7 +306,7 @@ ucc_status_t ucc_ec_cpu_reduce(ucc_eee_task_reduce_t *task,
 #endif
     case UCC_DT_FLOAT128_COMPLEX:
 #if SIZEOF_LONG_DOUBLE__COMPLEX == 32
-        DO_DT_REDUCE_FLOAT_COMPLEX(long double complex, srcs, task->dst,
+        DO_DT_REDUCE_FLOAT_COMPLEX(long double complex, srcs, dst,
                                    task->op, task->count, task->n_srcs);
         break;
 #else


### PR DESCRIPTION
This PR is an extension to https://github.com/openucx/ucc/pull/918.

Sergey had found through testing that while the previous patch worked for newer versions of gcc, the gcc version we use for testing HPCX (gcc 4.8.2) still wasn't auto-vectorizing int8 reductions. The problem was that the last patch did not also move the destination vector into the `ucc_ec_cpu_reduce` function's arguments as a `restrict` pointer. This patch fixes that.

In short, char/int8 datatypes are special to the compiler in that they can be used to modify other datatype's memory, so an int8 pointer needs to be marked as `restrict` in order for the compiler to be confident enough to auto-vectorize. We were doing that previously, but only by making a new local variable. For some reason, GCC will ignore the `restrict` keyword on local variables. Only function arguments can be marked as `restrict`. I did some looking around online and found that this is a long-withstanding bug in gcc, reported 10 years ago: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60712



