### PR TITLE
TL/UCP: select bigger knomial radix for ppn1

### DIFF
--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -8,7 +8,6 @@
 #define RECURSIVE_KNOMIAL_H_
 
 #define UCC_KN_PEER_NULL ((ucc_rank_t)-1)
-#define UCC_KN_MIN_RADIX 2
 typedef uint16_t ucc_kn_radix_t;
 
 enum {
@@ -240,15 +239,16 @@ ucc_knomial_calc_recv_dist(ucc_rank_t team_size, ucc_rank_t rank,
 /* Calculates (sub) opt radix for Allreduce SRA and Bcast SAG,
    by minimizing n_extra ranks */
 static inline ucc_rank_t ucc_kn_get_opt_radix(ucc_rank_t team_size,
+                                              ucc_kn_radix_t min_radix,
                                               ucc_kn_radix_t max_radix)
 {
     ucc_rank_t     n_extra = 0, min_val = team_size;
-    ucc_kn_radix_t min_i   = UCC_KN_MIN_RADIX;
-    ucc_kn_radix_t max_r   = ucc_max(max_radix, UCC_KN_MIN_RADIX);
+    ucc_kn_radix_t min_i   = min_radix;
+    ucc_kn_radix_t max_r   = ucc_max(max_radix, min_radix);
     ucc_kn_radix_t r;
     ucc_rank_t     fs;
 
-    for (r = UCC_KN_MIN_RADIX; r <= max_r; r++) {
+    for (r = min_radix; r <= max_r; r++) {
         fs = r;
         while (fs < team_size) {
             fs = fs * r;

--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/ec/cpu/ec_cpu.c
+++ b/src/components/ec/cpu/ec_cpu.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/ec/cpu/ec_cpu.c
+++ b/src/components/ec/cpu/ec_cpu.c
@@ -70,7 +70,7 @@ ucc_status_t ucc_cpu_executor_init(const ucc_ee_executor_params_t *params,
 {
     ucc_ee_executor_t *eee = ucc_mpool_get(&ucc_ec_cpu.executors);
 
-    ec_debug(&ucc_ec_cpu.super, "executor init, eee: %p", eee);
+    ec_trace(&ucc_ec_cpu.super, "executor init, eee: %p", eee);
     if (ucc_unlikely(!eee)) {
         ec_error(&ucc_ec_cpu.super, "failed to allocate executor");
         return UCC_ERR_NO_MEMORY;
@@ -187,7 +187,7 @@ ucc_status_t ucc_cpu_executor_task_finalize(ucc_ee_executor_task_t *task)
 
 ucc_status_t ucc_cpu_executor_finalize(ucc_ee_executor_t *executor)
 {
-    ec_debug(&ucc_ec_cpu.super, "executor finalize, eee: %p", executor);
+    ec_trace(&ucc_ec_cpu.super, "executor finalize, eee: %p", executor);
     ucc_mpool_put(executor);
 
     return UCC_OK;

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -47,6 +47,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     ucc_tl_ucp_context_t *ctx =
         ucc_derived_of(tl_context, ucc_tl_ucp_context_t);
     ucc_kn_radix_t max_radix, min_radix;
+    ucc_rank_t     tsize;
     ucc_status_t   status;
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
@@ -91,14 +92,11 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     }
 
     if (self->topo && !IS_SERVICE_TEAM(self) && self->topo->topo->sock_bound) {
-        max_radix = ucc_min(UCC_TL_TEAM_SIZE(self),
-                            ucc_topo_max_ppn(self->topo) == 1 ?
-                            UCC_TL_TEAM_SIZE(self):
-                            ucc_topo_min_socket_size(self->topo));
-        min_radix = ucc_min(UCC_TL_TEAM_SIZE(self),
-                            ucc_topo_max_ppn(self->topo) == 1 ? 3: 2);
-        self->opt_radix = ucc_kn_get_opt_radix(UCC_TL_TEAM_SIZE(self),
-                                               min_radix, max_radix);
+        tsize = UCC_TL_TEAM_SIZE(self);
+        max_radix = (ucc_topo_max_ppn(self->topo) == 1) ? tsize :
+                    ucc_min(tsize, ucc_topo_min_socket_size(self->topo));
+        min_radix = ucc_min(tsize, ucc_topo_max_ppn(self->topo) == 1 ? 3: 2);
+        self->opt_radix = ucc_kn_get_opt_radix(tsize, min_radix, max_radix);
         tl_debug(tl_context->lib, "opt knomial radix: %d", self->opt_radix);
     }
 


### PR DESCRIPTION
## What
Use min raidx=3 for ppn1 teams. Such radix improves performance providing more network parallelism.

```
# UCC with patch
# OSU MPI-CUDA Broadcast Latency Test v7.3
# Datatype: MPI_CHAR.
# Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
1                       5.97              3.14              8.17        1000
2                       5.89              3.13              8.05        1000
4                       5.93              3.26              8.07        1000
8                       5.88              3.18              8.00        1000
16                      5.89              3.19              7.97        1000
32                      6.00              3.30              8.09        1000
64                      6.62              3.83              8.76        1000
128                     6.67              3.69              8.84        1000
256                     6.34              3.88              8.28        1000
512                     6.34              3.62              8.36        1000
1024                    6.41              4.06              8.48        1000
2048                    6.56              3.87              8.74        1000
4096                    6.92              4.24              9.34        1000
8192                    7.64              4.67             10.12        1000
16384                  14.95              9.16             19.87         100
32768                  18.88             14.46             21.59         100
65536                  28.83             25.68             32.49         100
131072                 39.65             34.42             46.40         100
262144                 50.26             41.51             58.21         100
524288                 75.56             61.76             85.24         100
1048576               123.21             98.07            143.94         100

# UCC without patch
# OSU MPI-CUDA Broadcast Latency Test v7.3
# Datatype: MPI_CHAR.
# Size       Avg Latency(us)   Min Latency(us)   Max Latency(us)  Iterations
1                       6.21              3.58              8.65        1000
2                       6.13              3.51              8.54        1000
4                       6.10              3.41              8.55        1000
8                       6.12              3.42              8.54        1000
16                      6.12              3.50              8.52        1000
32                      6.20              3.56              8.62        1000
64                      6.95              4.30              9.45        1000
128                     6.98              4.04              9.57        1000
256                     6.91              4.68              9.10        1000
512                     7.12              4.67              9.37        1000
1024                    6.93              4.78              9.03        1000
2048                    6.97              4.31              9.44        1000
4096                    7.26              4.80              9.79        1000
8192                    8.23              5.49             11.00        1000
16384                  14.71              8.99             19.75         100
32768                  32.50             25.91             37.50         100
65536                  41.15             32.58             46.29         100
131072                 51.94             40.57             59.31         100
262144                 68.33             53.42             77.67         100
524288                 91.97             72.29            102.24         100
1048576               148.00            111.05            167.37         100

```