### PR TITLE
Update README on building openmpi

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ $ ./autogen.sh; ./configure --prefix=<ucc-install-path> --with-ucx=<ucx-install-
 ```sh
 $ git clone https://github.com/open-mpi/ompi
 $ cd ompi
+$ git submodule update --init --recursive .
 $ ./autogen.pl; ./configure --prefix=<ompi-install-path> --with-ucx=<ucx-install-path> --with-ucc=<ucc-install-path>; make -j install
 ```
 


### PR DESCRIPTION
## What

Building openmpi requires having the submodules initiated, otherwise it would error out. This PR simply updates the README regarding this issue.

