### PR TITLE
TL/CUDA: Linear Broadcast for GPU

### DIFF
--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
 #
 

--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -59,6 +59,7 @@ sources =               \
 	$(allgatherv)       \
 	$(alltoall)         \
 	$(alltoallv)        \
+	$(bcast)            \
 	$(reduce_scatter)   \
 	$(reduce_scatterv)
 

--- a/src/components/tl/cuda/allgather/allgather.c
+++ b/src/components/tl/cuda/allgather/allgather.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/allgather/allgather.c
+++ b/src/components/tl/cuda/allgather/allgather.c
@@ -44,7 +44,7 @@ ucc_status_t ucc_tl_cuda_allgather_init(ucc_base_coll_args_t *coll_args,
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
 
-    if (ucc_tl_cuda_team_topo_is_fully_conntected(team->topo)) {
+    if (ucc_tl_cuda_team_topo_is_fully_connected(team->topo)) {
         return ucc_tl_cuda_allgather_linear_init(coll_args, tl_team, task_p);
     } else {
         return ucc_tl_cuda_allgather_ring_init(coll_args, tl_team, task_p);

--- a/src/components/tl/cuda/allgather/allgather_linear.c
+++ b/src/components/tl/cuda/allgather/allgather_linear.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/allgather/allgather_linear.c
+++ b/src/components/tl/cuda/allgather/allgather_linear.c
@@ -15,7 +15,7 @@ ucc_status_t ucc_tl_cuda_allgather_linear_init(ucc_base_coll_args_t *coll_args,
     ucc_tl_cuda_task_t *task;
     ucc_status_t        status;
 
-    if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_conntected(team->topo) ||
+    if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_connected(team->topo) ||
         UCC_TL_TEAM_SIZE(team) - 1 > UCC_EE_EXECUTOR_MULTI_OP_NUM_BUFS)) {
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/cuda/allgatherv/allgatherv.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/allgatherv/allgatherv.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv.c
@@ -47,7 +47,7 @@ ucc_status_t ucc_tl_cuda_allgatherv_init(ucc_base_coll_args_t *coll_args,
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
 
-    if (ucc_tl_cuda_team_topo_is_fully_conntected(team->topo)) {
+    if (ucc_tl_cuda_team_topo_is_fully_connected(team->topo)) {
         return ucc_tl_cuda_allgatherv_linear_init(coll_args, tl_team, task_p);
     } else {
         return ucc_tl_cuda_allgatherv_ring_init(coll_args, tl_team, task_p);

--- a/src/components/tl/cuda/allgatherv/allgatherv_linear.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv_linear.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/allgatherv/allgatherv_linear.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv_linear.c
@@ -55,22 +55,6 @@ enum
                     *  other ranks to finish */
 };
 
-static inline int get_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
-                                int step_id)
-{
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
-
-    return sync->seq_num[step_id];
-}
-
-static inline void set_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
-                                 int step, int step_id)
-{
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
-
-    sync->seq_num[step_id] = step;
-}
-
 ucc_status_t ucc_tl_cuda_allgatherv_linear_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);

--- a/src/components/tl/cuda/allgatherv/allgatherv_linear.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv_linear.c
@@ -416,7 +416,7 @@ ucc_status_t ucc_tl_cuda_allgatherv_linear_init(ucc_base_coll_args_t *coll_args,
     ucc_tl_cuda_task_t *task;
     ucc_status_t        status;
 
-    if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_conntected(team->topo) ||
+    if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_connected(team->topo) ||
         UCC_TL_TEAM_SIZE(team) - 1 > UCC_EE_EXECUTOR_MULTI_OP_NUM_BUFS)) {
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/cuda/bcast/bcast.c
+++ b/src/components/tl/cuda/bcast/bcast.c
@@ -20,7 +20,7 @@ ucc_status_t ucc_tl_cuda_bcast_init(ucc_base_coll_args_t *coll_args,
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
 
-    if (ucc_tl_cuda_team_topo_is_fully_conntected(team->topo)) {
+    if (ucc_tl_cuda_team_topo_is_fully_connected(team->topo)) {
         return ucc_tl_cuda_bcast_linear_init(coll_args, tl_team, task_p);
     } else {
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/cuda/bcast/bcast.c
+++ b/src/components/tl/cuda/bcast/bcast.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/bcast/bcast.h
+++ b/src/components/tl/cuda/bcast/bcast.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -68,8 +68,8 @@ static inline ucc_status_t ecopy(void *dst, void *src, size_t size,
 // Root rank searches for and claims a free barrier
 static inline ucc_status_t root_find_free_barrier(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    uint32_t max_concurrent  = UCC_TL_CUDA_TEAM_LIB(team)->cfg.max_concurrent;
+    ucc_tl_cuda_team_t        *team            = TASK_TEAM(task);
+    uint32_t                   max_concurrent  = UCC_TL_CUDA_TEAM_LIB(team)->cfg.max_concurrent;
     ucc_tl_cuda_shm_barrier_t *curr_bar;
     int                        i;
     ucc_status_t               st;

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -147,11 +147,9 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
     ucc_rank_t          tsize             = UCC_COLL_ARGS_ACTIVE_SET(&TASK_ARGS(task))
                                             ? (ucc_rank_t)task->subset.map.ep_num
                                             : UCC_TL_TEAM_SIZE(team);
-    size_t              chunk_size        =
-                            task->bcast_linear.step < task->bcast_linear.num_steps
-                            ? ucc_min(half_scratch_size, task->bcast_linear.size)
-                            : task->bcast_linear.size -
-                                (task->bcast_linear.step - 1) * half_scratch_size;
+    size_t              chunk_size        = ucc_min(
+        half_scratch_size,
+        task->bcast_linear.size - task->bcast_linear.step * half_scratch_size);
     size_t              offset_buff       = task->bcast_linear.step * half_scratch_size;
     ucc_ee_executor_t         *exec;
     ucc_ee_executor_task_t    *etask;
@@ -412,7 +410,7 @@ ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
     task->bcast_linear.dt   = coll_args->args.src.info.datatype;
     task->bcast_linear.sbuf = coll_args->args.src.info.buffer;
 
-    task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
+    task->super.flags   |= UCC_COLL_TASK_FLAG_EXECUTOR;
     task->super.post     = ucc_tl_cuda_bcast_linear_start;
     task->super.progress = ucc_tl_cuda_bcast_linear_progress;
     task->super.finalize = ucc_tl_cuda_bcast_linear_finalize;

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -6,6 +6,8 @@
 
 #include "bcast.h"
 
+#include <stdbool.h>
+
 enum {
     // Barrier setup
     STAGE_INIT_BAR_ROOT,

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -227,11 +227,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                         task->super.status = UCC_OK;
                         break;
                     }
-                } else {
-                    return;
                 }
-            } else {
-                return;
             }
         default:
             break;

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -4,7 +4,7 @@
  * See file LICENSE for terms.
  */
 
-#include "bcast/bcast.h"
+#include "bcast.h"
 
 enum {
     STAGE_SYNC,

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -94,6 +94,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
 
     st = ucc_coll_task_get_executor(&task->super, &exec);
     if (ucc_unlikely(st != UCC_OK)) {
+        task->status = st;
         return;
     }
 

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -209,7 +209,8 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
         st = ucc_tl_cuda_bcast_linear_setup_test(task);
         if (st != UCC_OK) {
             task->super.status = st;
-            return;the copy operation from the root's scratch buffer
+            return;
+        }
         if (trank == task->bcast_linear.root) {
             task->bcast_linear.stage = STAGE_COPY;
         } else {
@@ -257,7 +258,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                 return;
             }
         case STAGE_WAIT_ALL:
-            for (i = 0; i < tsize; ++i) {the copy operation from the root's scratch buffer
+            for (i = 0; i < tsize; ++i) {
                 if (UCC_COLL_ARGS_ACTIVE_SET(&TASK_ARGS(task))) {
                     // eval phys rank from virt
                     peer = ucc_ep_map_eval(task->subset.map, i);

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -29,7 +29,8 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
     ucc_status_t        st;
-
+    (void) team;
+    (void) st;
     task->super.status = UCC_INPROGRESS;
 }
 
@@ -40,11 +41,12 @@ ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
     ucc_coll_args_t *   args  = &TASK_ARGS(task);
     ucc_rank_t          tsize = UCC_TL_TEAM_SIZE(team);
     ucc_datatype_t      dt    = task->allgatherv_linear.dt;
-    ucc_rank_t          i;
-    size_t              send_size, frag_size, ssize;
 
+    (void) tsize;
+    (void) args;
+    (void) dt;
     task->bcast_linear.stage         = STAGE_SYNC;
-    task->allgatherv_linear.sbuf          = args->src.info.buffer;
+    // task->bcast_linear.sbuf          = args->src.info.buffer;
 
 
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
@@ -75,9 +77,9 @@ ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
     // task->allgatherv_linear.rbuf       = coll_args->args.dst.info.buffer;
 
     task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
-    task->super.post           = ucc_tl_cuda_allgatherv_linear_start;
-    task->super.progress       = ucc_tl_cuda_allgatherv_linear_progress;
-    task->super.finalize       = ucc_tl_cuda_allgatherv_linear_finalize;
+    task->super.post           = ucc_tl_cuda_bcast_linear_start;
+    task->super.progress       = ucc_tl_cuda_bcast_linear_progress;
+    task->super.finalize       = ucc_tl_cuda_bcast_linear_finalize;
     task->bar                  = TASK_BAR(task);
 
     *task_p = &task->super;

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -61,6 +61,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
         dbuf = TASK_SCRATCH(task, trank);
         sbuf = task->bcast_linear.sbuf;
         status = ecopy(dbuf, sbuf, task->bcast_linear.size, exec, &task->bcast_linear.exec_task);
+        task->bcast_linear.stage = STAGE_WAIT_COPY;
         break;
     default:
         break;
@@ -111,8 +112,10 @@ ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
     // task->allgatherv_linear.get_count  = ucc_tl_cuda_allgather_get_count;
     // task->allgatherv_linear.get_offset = ucc_tl_cuda_allgather_get_offset;
     task->bcast_linear.dt         = coll_args->args.src.info.datatype;
-
     ucc_info("bcast start with dt: %ld", task->bcast_linear.dt);
+
+    task->bcast_linear.size = coll_args->args.src.info.count * ucc_dt_size(task->bcast_linear.dt);
+    ucc_info("bcast start with data size: %ld", task->bcast_linear.size);
 
     // task->allgatherv_linear.sbuf       = coll_args->args.src.info.buffer;
     // task->allgatherv_linear.rbuf       = coll_args->args.dst.info.buffer;

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -391,9 +391,8 @@ ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
     ucc_tl_cuda_task_t *task;
     ucc_status_t        status;
 
-    if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_connected(team->topo) ||
-                     UCC_TL_TEAM_SIZE(team) - 1 >
-                         UCC_EE_EXECUTOR_MULTI_OP_NUM_BUFS)) {
+    if (!ucc_tl_cuda_team_topo_is_fully_connected(team->topo) ||
+        UCC_TL_TEAM_SIZE(team) - 1 > UCC_EE_EXECUTOR_MULTI_OP_NUM_BUFS) {
         return UCC_ERR_NOT_SUPPORTED;
     }
 

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -330,14 +330,13 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                 return;
             }
             // start barrier to sync with root
-            task->bcast_linear.stage = STAGE_CLIENT_WAIT_COMPLETION;
             st = ucc_tl_cuda_shm_barrier_start(trank, task->bar);
             if (ucc_unlikely(st != UCC_OK)) {
                 ucc_error("failed to start barrier from peer rank");
                 task->super.status = st;
                 return;
             }
-            break;
+            task->bcast_linear.stage = STAGE_CLIENT_WAIT_COMPLETION;
         case STAGE_CLIENT_WAIT_COMPLETION:
             st = ucc_tl_cuda_shm_barrier_test(trank, task->bar);
             if (st != UCC_OK) {

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -197,6 +197,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
             return;
         }
         task->bcast_linear.stage = STAGE_SETUP;
+        /* fall through */
     case STAGE_SETUP:
         st = ucc_tl_cuda_bcast_linear_setup_test(task);
         if (st != UCC_OK) {
@@ -208,6 +209,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
         } else {
             task->bcast_linear.stage = STAGE_WAIT_ROOT;
         }
+        /* fall through */
     default:
         break;
     }
@@ -229,6 +231,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                 return;
             }
             task->bcast_linear.stage = STAGE_WAIT_COPY;
+            /* fall through */
         case STAGE_WAIT_COPY:
             etask = task->bcast_linear.exec_task;
             ucc_assert(NULL != etask);
@@ -243,6 +246,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
             set_rank_step(task, task->bcast_linear.root,
                           task->bcast_linear.step, 0);
             task->bcast_linear.stage = STAGE_WAIT_ALL;
+            /* fall through */
         case STAGE_WAIT_ALL:
             for (i = 0; i < tsize; ++i) {
                 if (UCC_COLL_ARGS_ACTIVE_SET(&TASK_ARGS(task))) {
@@ -271,6 +275,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                 return;
             }
             task->bcast_linear.stage = STAGE_WAIT_COMPLETION;
+            /* fall through */
         case STAGE_WAIT_COMPLETION:
             st = ucc_tl_cuda_shm_barrier_test(trank, task->bar);
             if (st != UCC_OK) {
@@ -301,6 +306,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
             } else {
                 return;
             }
+            /* fall through */
         case STAGE_CLIENT_COPY:
             // need to copy from root's scratch buffer
             dbuf = PTR_OFFSET(task->bcast_linear.sbuf, offset_buff);
@@ -314,6 +320,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                 return;
             }
             task->bcast_linear.stage = STAGE_CLIENT_COPY_WAIT;
+            /* fall through */
         case STAGE_CLIENT_COPY_WAIT:
             etask = task->bcast_linear.exec_task;
             ucc_assert(NULL != etask);
@@ -337,6 +344,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                 return;
             }
             task->bcast_linear.stage = STAGE_CLIENT_WAIT_COMPLETION;
+            /* fall through */
         case STAGE_CLIENT_WAIT_COMPLETION:
             st = ucc_tl_cuda_shm_barrier_test(trank, task->bar);
             if (st != UCC_OK) {

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -94,7 +94,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
 
     st = ucc_coll_task_get_executor(&task->super, &exec);
     if (ucc_unlikely(st != UCC_OK)) {
-        task->status = st;
+        task->super.status = st;
         return;
     }
 

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -6,9 +6,10 @@
 
 #include "bcast/bcast.h"
 
-enum
-{
+enum {
     STAGE_DONE,
+    STAGE_SYNC,
+    STAGE_SETUP,
     // root
     STAGE_COPY,      // post copy task: copy block from src to scratch buffer
     STAGE_WAIT_COPY, // wait for copy finishes
@@ -36,8 +37,33 @@ static inline void set_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
     sync->seq_num[step_id] = step;
 }
 
+ucc_status_t ucc_tl_cuda_bcast_linear_setup_start(ucc_tl_cuda_task_t *task)
+{
+    ucc_tl_cuda_team_t *team  = TASK_TEAM(task);
+    ucc_rank_t          trank = UCC_TL_TEAM_RANK(team);
+    ucc_status_t        status;
+
+    set_rank_step(task, trank, 0, 0);
+    ucc_memory_cpu_store_fence();
+    status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
+    if (ucc_unlikely(status != UCC_OK)) {
+        goto exit_err;
+    }
+
+    return UCC_OK;
+
+exit_err:
+    return status;
+}
+
+ucc_status_t ucc_tl_cuda_bcast_linear_setup_test(ucc_tl_cuda_task_t *task)
+{
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    return ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team), task->bar);
+}
+
 static inline ucc_status_t ecopy(void *dst, void *src, size_t size,
-                                 ucc_ee_executor_t *      exec,
+                                 ucc_ee_executor_t       *exec,
                                  ucc_ee_executor_task_t **etask)
 {
     ucc_ee_executor_task_args_t exec_args = {0};
@@ -67,15 +93,47 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
     ucc_status_t        st;
     (void)team;
     (void)st;
-    ucc_ee_executor_t *     exec;
+    ucc_ee_executor_t      *exec;
     ucc_ee_executor_task_t *etask;
     ucc_status_t            status;
-    void *                  sbuf, *dbuf;
+    void                   *sbuf, *dbuf;
     task->super.status = UCC_INPROGRESS;
 
     status = ucc_coll_task_get_executor(&task->super, &exec);
     if (ucc_unlikely(status != UCC_OK)) {
         return;
+    }
+
+    switch (task->bcast_linear.stage) {
+    case STAGE_SYNC:
+        ucc_info("sync");
+        if (ucc_tl_cuda_get_sync(task) != UCC_OK) {
+            task->super.status = UCC_INPROGRESS;
+            return;
+        }
+        task->bcast_linear.step = 0;
+        ucc_info("setup");
+        st = ucc_tl_cuda_bcast_linear_setup_start(task);
+        if (st != UCC_OK) {
+            task->super.status = st;
+            return;
+        }
+        task->bcast_linear.stage = STAGE_SETUP;
+    case STAGE_SETUP:
+        ucc_info("test");
+        st = ucc_tl_cuda_bcast_linear_setup_test(task);
+        if (st != UCC_OK) {
+            task->super.status = st;
+            return;
+        }
+        ucc_tl_cuda_put_sync(task);
+        if (trank == 0 /* root */) {
+            task->bcast_linear.stage = STAGE_COPY;
+        } else {
+            task->bcast_linear.stage = STAGE_WAIT_ROOT;
+        }
+    default:
+        break;
     }
 
     if (trank == 0) {
@@ -141,7 +199,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
         case STAGE_CLIENT_COPY:
             dbuf   = task->bcast_linear.sbuf;
             sbuf   = TASK_SCRATCH(task,
-                                0); // need to copy from root's scratch buffer
+                                  0); // need to copy from root's scratch buffer
             status = ecopy(dbuf, sbuf, task->bcast_linear.size, exec,
                            &task->bcast_linear.exec_task);
             task->bcast_linear.stage = STAGE_CLIENT_COPY_WAIT;
@@ -155,7 +213,8 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                     task->bcast_linear.exec_task = NULL;
                     ++task->bcast_linear.step;
                     set_rank_step(task, trank, task->bcast_linear.step, 0);
-                    task->bcast_linear.stage = STAGE_DONE; // TODO: just for debug
+                    task->bcast_linear.stage =
+                        STAGE_DONE; // TODO: just for debug
                 }
             }
             break;
@@ -172,8 +231,7 @@ ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task  = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team  = TASK_TEAM(task);
-    ucc_rank_t          trank = UCC_TL_TEAM_RANK(team);
-    ucc_coll_args_t *   args  = &TASK_ARGS(task);
+    ucc_coll_args_t    *args  = &TASK_ARGS(task);
     ucc_rank_t          tsize = UCC_TL_TEAM_SIZE(team);
     ucc_datatype_t      dt    = task->bcast_linear.dt;
 
@@ -181,12 +239,10 @@ ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
     (void)args;
     (void)dt;
 
-    if (trank == 0) {
-        task->bcast_linear.stage = STAGE_COPY;
-    } else {
-        task->bcast_linear.stage = STAGE_WAIT_ROOT;
-    }
-    ucc_info("bcast start with dt: %ld and count: %ld", dt, args->src.info.count);
+    task->bcast_linear.stage = STAGE_SYNC;
+
+    ucc_info("bcast start with dt: %s and count: %ld", ucc_datatype_str(dt),
+             args->src.info.count);
 
     task->bcast_linear.size = ucc_dt_size(dt) * args->src.info.count;
 
@@ -199,8 +255,8 @@ ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
 }
 
 ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
-                                           ucc_base_team_t *     tl_team,
-                                           ucc_coll_task_t **    task_p)
+                                           ucc_base_team_t      *tl_team,
+                                           ucc_coll_task_t     **task_p)
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_task_t *task;
@@ -219,13 +275,8 @@ ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
         return status;
     }
 
-    // task->allgatherv_linear.get_count  = ucc_tl_cuda_allgather_get_count;
-    // task->allgatherv_linear.get_offset = ucc_tl_cuda_allgather_get_offset;
     task->bcast_linear.dt = coll_args->args.src.info.datatype;
-    ucc_info("bcast init with dt: %ld", task->bcast_linear.dt);
-
-    // task->allgatherv_linear.sbuf       = coll_args->args.src.info.buffer;
-    // task->allgatherv_linear.rbuf       = coll_args->args.dst.info.buffer;
+    ucc_info("bcast init with dt: %s", ucc_datatype_str(task->bcast_linear.dt));
 
     task->bcast_linear.sbuf = coll_args->args.src.info.buffer;
 

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -6,15 +6,34 @@
 
 #include "bcast/bcast.h"
 
-enum
-{
-    STAGE_COPY, // post copy task: copy block from src to scratch buffer
+enum {
+    STAGE_UNDEF,
+    // root
+    STAGE_COPY,      // post copy task: copy block from src to scratch buffer
     STAGE_WAIT_COPY, // wait for copy finishes
-    STAGE_WAIT_ALL, // wait for all others rank be on same step
+    STAGE_WAIT_ALL,  // wait for all others rank be on same step
+    // non-root
 };
 
+// TODO: move out to common with allgather
+static inline int get_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
+                                int step_id)
+{
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
+
+    return sync->seq_num[step_id];
+}
+
+static inline void set_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
+                                 int step, int step_id)
+{
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
+
+    sync->seq_num[step_id] = step;
+}
+
 static inline ucc_status_t ecopy(void *dst, void *src, size_t size,
-                                 ucc_ee_executor_t *      exec,
+                                 ucc_ee_executor_t       *exec,
                                  ucc_ee_executor_task_t **etask)
 {
     ucc_ee_executor_task_args_t exec_args = {0};
@@ -40,31 +59,68 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
     ucc_tl_cuda_task_t *task  = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team  = TASK_TEAM(task);
     ucc_rank_t          trank = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t          tsize = UCC_TL_TEAM_SIZE(team);
     ucc_status_t        st;
     (void)team;
     (void)st;
     ucc_ee_executor_t      *exec;
+    ucc_ee_executor_task_t *etask;
     ucc_status_t            status;
-    void *                  sbuf, *dbuf;
+    void                   *sbuf, *dbuf;
     task->super.status = UCC_INPROGRESS;
 
     status = ucc_coll_task_get_executor(&task->super, &exec);
     if (ucc_unlikely(status != UCC_OK)) {
         return;
     }
-    
-    // fall-through between cases is intentional
-    switch (task->bcast_linear.stage)
-    {
-    case STAGE_COPY:
-        // copy from src buffer to scratch
-        dbuf = TASK_SCRATCH(task, trank);
-        sbuf = task->bcast_linear.sbuf;
-        status = ecopy(dbuf, sbuf, task->bcast_linear.size, exec, &task->bcast_linear.exec_task);
-        task->bcast_linear.stage = STAGE_WAIT_COPY;
-        break;
-    default:
-        break;
+
+    if (trank == 0) {
+        // fall-through between cases is intentional
+        switch (task->bcast_linear.stage) {
+        case STAGE_COPY:
+            // copy from src buffer to scratch
+            dbuf   = TASK_SCRATCH(task, trank);
+            sbuf   = task->bcast_linear.sbuf;
+            status = ecopy(dbuf, sbuf, task->bcast_linear.size, exec,
+                           &task->bcast_linear.exec_task);
+            task->bcast_linear.stage = STAGE_WAIT_COPY;
+            break;
+        case STAGE_WAIT_COPY:
+            etask = task->bcast_linear.exec_task;
+            if (etask) {
+                status = ucc_ee_executor_task_test(etask);
+                if (status == UCC_OK) {
+                    ucc_ee_executor_task_finalize(etask);
+                    task->bcast_linear.exec_task = NULL;
+                    ucc_info("hello from rank: %d, copy done!", trank);
+                    // signal others
+                    ++task->bcast_linear.step;
+                    set_rank_step(task, 0, task->bcast_linear.step, 0);
+                    task->bcast_linear.stage = STAGE_WAIT_ALL;
+                }
+            }
+            break;
+        case STAGE_WAIT_ALL:
+            for (int i = 1; i < tsize; ++i) {
+                int other_rank_step = get_rank_step(task, i, 0);
+                ucc_info("rank %d, step: %d, my step: %d", i, other_rank_step,
+                         task->bcast_linear.step);
+                if (other_rank_step < task->bcast_linear.step) {
+                    ucc_info("rank %d is not ready", i);
+                    return;
+                }
+            }
+            task->bcast_linear.stage = STAGE_COPY;
+            ucc_info("all others ready for next step");
+            // TODO: remove
+            task->bcast_linear.stage = STAGE_UNDEF;
+            break;
+        default:
+            break;
+        }
+        // Root scenario
+    } else {
+        // others
     }
 }
 
@@ -72,26 +128,25 @@ ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task  = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team  = TASK_TEAM(task);
-    ucc_coll_args_t *   args  = &TASK_ARGS(task);
+    ucc_coll_args_t    *args  = &TASK_ARGS(task);
     ucc_rank_t          tsize = UCC_TL_TEAM_SIZE(team);
     ucc_datatype_t      dt    = task->bcast_linear.dt;
 
-    (void) tsize;
-    (void) args;
-    (void) dt;
-    task->bcast_linear.stage         = STAGE_COPY;
+    (void)tsize;
+    (void)args;
+    (void)dt;
+    task->bcast_linear.stage = STAGE_COPY;
     ucc_info("bcast start with dt: %ld", dt);
 
     task->bcast_linear.sbuf = args->src.info.buffer;
-    task->bcast_linear.rbuf = args->dst.info.buffer;
-
+    task->bcast_linear.step = 0;
 
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
 ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
-                                               ucc_base_team_t *     tl_team,
-                                               ucc_coll_task_t **    task_p)
+                                           ucc_base_team_t      *tl_team,
+                                           ucc_coll_task_t     **task_p)
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_task_t *task;
@@ -100,7 +155,8 @@ ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
     ucc_info("bcast init");
 
     if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_conntected(team->topo) ||
-        UCC_TL_TEAM_SIZE(team) - 1 > UCC_EE_EXECUTOR_MULTI_OP_NUM_BUFS)) {
+                     UCC_TL_TEAM_SIZE(team) - 1 >
+                         UCC_EE_EXECUTOR_MULTI_OP_NUM_BUFS)) {
         return UCC_ERR_NOT_SUPPORTED;
     }
 
@@ -111,25 +167,22 @@ ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
 
     // task->allgatherv_linear.get_count  = ucc_tl_cuda_allgather_get_count;
     // task->allgatherv_linear.get_offset = ucc_tl_cuda_allgather_get_offset;
-    task->bcast_linear.dt         = coll_args->args.src.info.datatype;
+    task->bcast_linear.dt = coll_args->args.src.info.datatype;
     ucc_info("bcast start with dt: %ld", task->bcast_linear.dt);
-
-    task->bcast_linear.size = coll_args->args.src.info.count * ucc_dt_size(task->bcast_linear.dt);
-    ucc_info("bcast start with data size: %ld", task->bcast_linear.size);
 
     // task->allgatherv_linear.sbuf       = coll_args->args.src.info.buffer;
     // task->allgatherv_linear.rbuf       = coll_args->args.dst.info.buffer;
 
+    task->bcast_linear.sbuf = coll_args->args.src.info.buffer;
 
     task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
-    task->super.post           = ucc_tl_cuda_bcast_linear_start;
-    task->super.progress       = ucc_tl_cuda_bcast_linear_progress;
-    task->super.finalize       = ucc_tl_cuda_bcast_linear_finalize;
-    task->bar                  = TASK_BAR(task);
+    task->super.post     = ucc_tl_cuda_bcast_linear_start;
+    task->super.progress = ucc_tl_cuda_bcast_linear_progress;
+    task->super.finalize = ucc_tl_cuda_bcast_linear_finalize;
+    task->bar            = TASK_BAR(task);
 
     ucc_info("bcast init success");
 
     *task_p = &task->super;
     return UCC_OK;
 }
-

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -24,7 +24,7 @@ enum {
     STAGE_CLIENT_COPY_WAIT, // Non-root ranks wait for the completion of the copy operation from the root's scratch buffer
 };
 
-ucc_status_t ucc_tl_cuda_bcast_linear_setup_start(ucc_tl_cuda_task_t *task)
+static inline ucc_status_t ucc_tl_cuda_bcast_linear_setup_start(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t *team  = TASK_TEAM(task);
     ucc_rank_t          trank = UCC_TL_TEAM_RANK(team);
@@ -45,7 +45,7 @@ exit_err:
 }
 
 // Tests if setup is complete for a linear broadcast task
-ucc_status_t ucc_tl_cuda_bcast_linear_setup_test(ucc_tl_cuda_task_t *task)
+static inline ucc_status_t ucc_tl_cuda_bcast_linear_setup_test(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
     return ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team), task->bar);
@@ -134,7 +134,7 @@ static inline ucc_status_t peer_find_free_barrier(ucc_tl_cuda_task_t *task)
     return UCC_ERR_NOT_FOUND;
 }
 
-ucc_status_t ucc_tl_cuda_bcast_linear_finalize(ucc_coll_task_t *coll_task)
+static ucc_status_t ucc_tl_cuda_bcast_linear_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
 
@@ -143,7 +143,7 @@ ucc_status_t ucc_tl_cuda_bcast_linear_finalize(ucc_coll_task_t *coll_task)
     return UCC_OK;
 }
 
-void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
+static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task              = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team              = TASK_TEAM(task);
@@ -366,7 +366,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
     }
 }
 
-ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
+static ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -195,7 +195,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
             }
             task->bcast_linear.stage = STAGE_COPY;
             // ucc_info("all others ready for next step");
-            if (task->bcast_linear.stage < task->bcast_linear.num_steps) {
+            if (task->bcast_linear.step < task->bcast_linear.num_steps) {
                 task->bcast_linear.stage = STAGE_COPY;
             } else {
                 task->bcast_linear.stage = STAGE_DONE;
@@ -241,9 +241,9 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                     set_rank_step(task, trank, task->bcast_linear.step, 0);
                     // task->bcast_linear.stage =
                     //     STAGE_DONE; // TODO: just for debug
-                    if (task->bcast_linear.stage <
+                    if (task->bcast_linear.step <
                         task->bcast_linear.num_steps) {
-                        task->bcast_linear.stage = STAGE_COPY;
+                        task->bcast_linear.stage = STAGE_WAIT_ROOT;
                     } else {
                         task->bcast_linear.stage = STAGE_DONE;
                     }

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -183,12 +183,11 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
         }
         if (st == UCC_OK) {
             task->bcast_linear.stage = STAGE_SYNC;
-            break;
+            break; // prevent from fall to next case
         } else {
             task->super.status = UCC_ERR_NO_RESOURCE;
             return;
         }
-        break;
     case STAGE_FIND_BAR_PEER:
         st = peer_find_free_barrier(task);
         if (st == UCC_ERR_NOT_FOUND) {

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -161,7 +161,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                     return;
                 }
             } else {
-                ucc_info("etask is nullptr");
+                ucc_debug("etask is nullptr");
                 return;
             }
         case STAGE_WAIT_ALL:
@@ -195,7 +195,6 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
             /* code */
             if (get_rank_step(task, task->bcast_linear.root, 0) >
                 task->bcast_linear.step) {
-                // ucc_info("something from root is ready!");
                 task->bcast_linear.stage = STAGE_CLIENT_COPY;
                 break;
             } else {
@@ -259,9 +258,9 @@ ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
     task->bcast_linear.num_steps =
         ucc_div_round_up(task->bcast_linear.size, half_scratch_size);
 
-    ucc_info("bcast dt: %s, buffer size: %ld, num_steps: %d",
-             ucc_datatype_str(dt), task->bcast_linear.size,
-             task->bcast_linear.num_steps);
+    ucc_debug("bcast linear dt: %s, buffer size: %ld, num_steps: %d",
+              ucc_datatype_str(dt), task->bcast_linear.size,
+              task->bcast_linear.num_steps);
 
     task->bcast_linear.sbuf = args->src.info.buffer;
     task->bcast_linear.step = 0;

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -306,7 +306,7 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
             // need to copy from root's scratch buffer
             dbuf = PTR_OFFSET(task->bcast_linear.sbuf, offset_buff);
             sbuf = PTR_OFFSET(TASK_SCRATCH(task, task->bcast_linear.root),
-                              task->bcast_linear.step % 2 * chunk_size);
+                              task->bcast_linear.step % 2 * half_scratch_size);
             st   = ecopy(dbuf, sbuf, chunk_size, exec,
                        &task->bcast_linear.exec_task);
             if (st != UCC_OK) {

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -73,17 +73,17 @@ ucc_status_t ucc_tl_cuda_bcast_linear_finalize(ucc_coll_task_t *coll_task)
 
 void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_cuda_task_t *task  = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
-    ucc_tl_cuda_team_t *team  = TASK_TEAM(task);
-    ucc_rank_t          trank = UCC_TL_TEAM_RANK(team);
-    ucc_rank_t          tsize = UCC_TL_TEAM_SIZE(team);
+    ucc_tl_cuda_task_t *task              = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+    ucc_tl_cuda_team_t *team              = TASK_TEAM(task);
+    ucc_rank_t          trank             = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t          tsize             = UCC_TL_TEAM_SIZE(team);
     size_t              half_scratch_size = get_raw_scratch_size(team) / 2;
-    size_t              chunk_size =
+    size_t              chunk_size        =
         task->bcast_linear.step < task->bcast_linear.num_steps
                          ? ucc_min(half_scratch_size, task->bcast_linear.size)
                          : task->bcast_linear.size -
                   (task->bcast_linear.step - 1) * half_scratch_size;
-    size_t offset_buff = task->bcast_linear.step * half_scratch_size;
+    size_t offset_buff                    = task->bcast_linear.step * half_scratch_size;
     ucc_ee_executor_t      *exec;
     ucc_ee_executor_task_t *etask;
     ucc_status_t            st;

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -6,7 +6,8 @@
 
 #include "bcast/bcast.h"
 
-enum {
+enum
+{
     STAGE_DONE,
     STAGE_SYNC,
     STAGE_SETUP,
@@ -68,7 +69,7 @@ static inline size_t get_raw_scratch_size(ucc_tl_cuda_team_t *team)
 }
 
 static inline ucc_status_t ecopy(void *dst, void *src, size_t size,
-                                 ucc_ee_executor_t       *exec,
+                                 ucc_ee_executor_t *      exec,
                                  ucc_ee_executor_task_t **etask)
 {
     ucc_ee_executor_task_args_t exec_args = {0};
@@ -97,10 +98,10 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
     ucc_rank_t          tsize = UCC_TL_TEAM_SIZE(team);
     // ucc_datatype_t      dt    = task->bcast_linear.dt;
 
-    ucc_ee_executor_t      *exec;
+    ucc_ee_executor_t *     exec;
     ucc_ee_executor_task_t *etask;
     ucc_status_t            st;
-    void                   *sbuf, *dbuf;
+    void *                  sbuf, *dbuf;
     task->super.status = UCC_INPROGRESS;
 
     st = ucc_coll_task_get_executor(&task->super, &exec);
@@ -158,9 +159,8 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
             dbuf = TASK_SCRATCH(task, trank);
             sbuf = PTR_OFFSET(task->bcast_linear.sbuf, offset_buff);
             st   = ecopy(dbuf, sbuf, chunk_size, exec,
-                         &task->bcast_linear.exec_task);
-            if (st != UCC_OK)
-            {
+                       &task->bcast_linear.exec_task);
+            if (st != UCC_OK) {
                 ucc_error("failed to post ecopy task");
                 task->super.status = st;
                 return;
@@ -179,15 +179,11 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                     set_rank_step(task, task->bcast_linear.root,
                                   task->bcast_linear.step, 0);
                     task->bcast_linear.stage = STAGE_WAIT_ALL;
-                }
-                else
-                {
+                } else {
                     // ucc_info("not ready");
                     return;
                 }
-            }
-            else
-            {
+            } else {
                 ucc_info("etask is nullptr");
                 return;
             }
@@ -226,9 +222,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                 // ucc_info("something from root is ready!");
                 task->bcast_linear.stage = STAGE_CLIENT_COPY;
                 break;
-            }
-            else
-            {
+            } else {
                 return;
             }
             // break;
@@ -238,8 +232,13 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                 task,
                 task->bcast_linear
                     .root); // need to copy from root's scratch buffer
-            st                   = ecopy(dbuf, sbuf, chunk_size, exec,
-                                             &task->bcast_linear.exec_task);
+            st = ecopy(dbuf, sbuf, chunk_size, exec,
+                       &task->bcast_linear.exec_task);
+            if (st != UCC_OK) {
+                ucc_error("failed to post ecopy task at client");
+                task->super.status = st;
+                return;
+            }
             task->bcast_linear.stage = STAGE_CLIENT_COPY_WAIT;
             // break;
         case STAGE_CLIENT_COPY_WAIT:
@@ -258,14 +257,10 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                     } else {
                         task->bcast_linear.stage = STAGE_DONE;
                     }
-                }
-                else
-                {
+                } else {
                     return;
                 }
-            }
-            else
-            {
+            } else {
                 return;
             }
             // break;
@@ -282,7 +277,7 @@ ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
-    ucc_coll_args_t    *args = &TASK_ARGS(task);
+    ucc_coll_args_t *   args = &TASK_ARGS(task);
     // ucc_rank_t          tsize = UCC_TL_TEAM_SIZE(team);
     ucc_datatype_t dt = task->bcast_linear.dt;
 
@@ -306,8 +301,8 @@ ucc_status_t ucc_tl_cuda_bcast_linear_start(ucc_coll_task_t *coll_task)
 }
 
 ucc_status_t ucc_tl_cuda_bcast_linear_init(ucc_base_coll_args_t *coll_args,
-                                           ucc_base_team_t      *tl_team,
-                                           ucc_coll_task_t     **task_p)
+                                           ucc_base_team_t *     tl_team,
+                                           ucc_coll_task_t **    task_p)
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_task_t *task;

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -97,6 +97,8 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
     int                        i;
     ucc_rank_t                 peer;
     ucc_tl_cuda_shm_barrier_t *curr_bar;
+    bool                       found;
+
 
     task->super.status = UCC_INPROGRESS;
 
@@ -109,7 +111,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
     switch (task->bcast_linear.stage) {
     case STAGE_INIT_BAR_ROOT:
         if (UCC_COLL_ARGS_ACTIVE_SET(&TASK_ARGS(task))) {
-            bool found = false;
+            found = false;
             peer = ucc_ep_map_eval(task->subset.map, 1);
             /* search first free barrier in active set pool */
             for (i = 0; i < max_concurrent; ++i) {
@@ -140,7 +142,7 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
             break; // TODO: move all logic to separate functions
         }
     case STAGE_FIND_BAR_PEER:
-        bool found = false;
+        found = false;
         for (i = 0; i < max_concurrent; ++i) {
             curr_bar = UCC_TL_CUDA_TEAM_BARRIER(team, max_concurrent + i);
             if (curr_bar->tag == task->bcast_linear.key) {

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -21,23 +21,6 @@ enum
     STAGE_CLIENT_COPY_WAIT,
 };
 
-// TODO: move out to common with allgather
-static inline int get_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
-                                int step_id)
-{
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
-
-    return sync->seq_num[step_id];
-}
-
-static inline void set_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
-                                 int step, int step_id)
-{
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
-
-    sync->seq_num[step_id] = step;
-}
-
 ucc_status_t ucc_tl_cuda_bcast_linear_setup_start(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t *team  = TASK_TEAM(task);

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -112,7 +112,6 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
     case STAGE_INIT_BAR_ROOT:
         if (UCC_COLL_ARGS_ACTIVE_SET(&TASK_ARGS(task))) {
             found = false;
-            peer = ucc_ep_map_eval(task->subset.map, 1);
             /* search first free barrier in active set pool */
             for (i = 0; i < max_concurrent; ++i) {
                 curr_bar = UCC_TL_CUDA_TEAM_BARRIER(team, max_concurrent + i);                

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -34,7 +34,7 @@ ucc_tl_cuda_bcast_linear_setup_start(ucc_tl_cuda_task_t *task)
     set_rank_step(task, trank, 0, 0); // Initialize rank step tracking
     ucc_memory_cpu_store_fence();
     // initiate barrier wait while all ranks set theirs steps to 0
-    return ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
+    return ucc_tl_cuda_shm_barrier_start(trank, task->bar);
 }
 
 // Tests if setup is complete for a linear broadcast task
@@ -258,7 +258,6 @@ static void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                     return;
                 }
             }
-            task->bcast_linear.stage = STAGE_COPY;
             if (task->bcast_linear.step < task->bcast_linear.num_steps) {
                 // go to next iteration
                 task->bcast_linear.stage = STAGE_COPY;

--- a/src/components/tl/cuda/bcast/bcast_linear.c
+++ b/src/components/tl/cuda/bcast/bcast_linear.c
@@ -7,7 +7,6 @@
 #include "bcast/bcast.h"
 
 enum {
-    STAGE_DONE,
     STAGE_SYNC,
     STAGE_SETUP,
     // root
@@ -178,11 +177,9 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                 return;
             } else {
                 // finish
-                task->bcast_linear.stage = STAGE_DONE;
+                task->super.status = UCC_OK;
+                break;
             }
-        case STAGE_DONE:
-            task->super.status = UCC_OK;
-            break;
         default:
             break;
         }
@@ -225,7 +222,9 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
                         task->bcast_linear.stage = STAGE_WAIT_ROOT;
                         return;
                     } else {
-                        task->bcast_linear.stage = STAGE_DONE;
+                        // Done
+                        task->super.status = UCC_OK;
+                        break;
                     }
                 } else {
                     return;
@@ -233,9 +232,6 @@ void ucc_tl_cuda_bcast_linear_progress(ucc_coll_task_t *coll_task)
             } else {
                 return;
             }
-        case STAGE_DONE:
-            task->super.status = UCC_OK;
-            break;
         default:
             break;
         }

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter.c
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter.c
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter.c
@@ -48,7 +48,7 @@ ucc_status_t ucc_tl_cuda_reduce_scatter_init(ucc_base_coll_args_t *coll_args,
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
 
-    if (ucc_tl_cuda_team_topo_is_fully_conntected(team->topo)) {
+    if (ucc_tl_cuda_team_topo_is_fully_connected(team->topo)) {
         return ucc_tl_cuda_reduce_scatter_linear_init(coll_args, tl_team,
                                                       task_p);
     } else {

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter_linear.c
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter_linear.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter_linear.c
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter_linear.c
@@ -19,7 +19,7 @@ ucc_status_t ucc_tl_cuda_reduce_scatter_linear_init(ucc_base_coll_args_t *coll_a
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_conntected(team->topo) ||
+    if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_connected(team->topo) ||
         UCC_TL_TEAM_SIZE(team) - 1 > UCC_EE_EXECUTOR_MULTI_OP_NUM_BUFS)) {
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/cuda/reduce_scatterv/reduce_scatterv.c
+++ b/src/components/tl/cuda/reduce_scatterv/reduce_scatterv.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/reduce_scatterv/reduce_scatterv.c
+++ b/src/components/tl/cuda/reduce_scatterv/reduce_scatterv.c
@@ -51,7 +51,7 @@ ucc_status_t ucc_tl_cuda_reduce_scatterv_init(ucc_base_coll_args_t *coll_args,
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
 
-    if (ucc_tl_cuda_team_topo_is_fully_conntected(team->topo)) {
+    if (ucc_tl_cuda_team_topo_is_fully_connected(team->topo)) {
         return ucc_tl_cuda_reduce_scatterv_linear_init(coll_args, tl_team,
                                                        task_p);
     } else {

--- a/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_linear.c
+++ b/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_linear.c
@@ -432,7 +432,7 @@ ucc_tl_cuda_reduce_scatterv_linear_init(ucc_base_coll_args_t *coll_args,
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_conntected(team->topo) ||
+    if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_connected(team->topo) ||
         UCC_TL_TEAM_SIZE(team) - 1 > UCC_EE_EXECUTOR_MULTI_OP_NUM_BUFS)) {
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_linear.c
+++ b/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_linear.c
@@ -59,22 +59,6 @@ enum
                     *  other ranks to finish */
 };
 
-static inline int get_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
-                                int step_id)
-{
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
-
-    return sync->seq_num[step_id];
-}
-
-static inline void set_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
-                                 int step, int step_id)
-{
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
-
-    sync->seq_num[step_id] = step;
-}
-
 ucc_status_t
 ucc_tl_cuda_reduce_scatterv_linear_finalize(ucc_coll_task_t *coll_task)
 {

--- a/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_linear.c
+++ b/src/components/tl/cuda/reduce_scatterv/reduce_scatterv_linear.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/tl_cuda.c
+++ b/src/components/tl/cuda/tl_cuda.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -242,6 +242,7 @@ struct ucc_tl_cuda_task {
             size_t                  size;
             int                     num_steps;
             ucc_ee_executor_task_t *exec_task;
+            uint64_t                key; // This is mix of user provided tag, root and peer to be unique for each task, algorithm uses it to mark barrier as used
         } bcast_linear;
         struct {
             int                     stage;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -230,7 +230,6 @@ struct ucc_tl_cuda_task {
             int stage;
             int step;
             void *                  sbuf;
-            void *                  rbuf;
             ucc_datatype_t          dt;
             size_t size;
             ucc_ee_executor_task_t *exec_task;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -228,6 +228,11 @@ struct ucc_tl_cuda_task {
         
         struct {
             int stage;
+            int step;
+            void *                  sbuf;
+            void *                  rbuf;
+            size_t size;
+            ucc_ee_executor_task_t *exec_task;
         } bcast_linear;
         struct {
             int                     stage;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -106,12 +106,12 @@ UCC_CLASS_DECLARE(ucc_tl_cuda_context_t, const ucc_base_context_params_t *,
 
 typedef uint32_t ucc_tl_cuda_sync_state_t;
 
-#define UCC_TAG_FREE 0xFFFFFFFF
+#define UCC_TAG_FREE 0xFFFFFFFFFFFFFFFF
 
 typedef struct ucc_tl_cuda_shm_barrier {
     ucc_rank_t   size;
     ucc_rank_t   count;
-    uint32_t     tag;
+    uint64_t     tag;
     int          sense;
     ucc_status_t state[UCC_TL_CUDA_MAX_PEERS];
     int          local_sense[UCC_TL_CUDA_MAX_PEERS];

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -231,6 +231,7 @@ struct ucc_tl_cuda_task {
             int step;
             void *                  sbuf;
             ucc_datatype_t          dt;
+            ucc_rank_t              root;
             size_t size;
             ucc_ee_executor_task_t *exec_task;
         } bcast_linear;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -74,7 +74,7 @@ extern ucc_tl_cuda_iface_t ucc_tl_cuda;
 
 typedef struct ucc_tl_cuda_lib_config {
     ucc_tl_lib_config_t super;
-    uint32_t            max_concurrent;
+    uint32_t            max_concurrent; // Maximum number of tasks that can be progressed simultaneously.
     size_t              scratch_size;
     unsigned long       allgather_ring_max_rings;
     uint32_t            allgather_ring_num_chunks;
@@ -106,7 +106,7 @@ UCC_CLASS_DECLARE(ucc_tl_cuda_context_t, const ucc_base_context_params_t *,
 
 typedef uint32_t ucc_tl_cuda_sync_state_t;
 
-#define UCC_TAG_FREE 0xFFFFFFFFFFFFFFFF
+#define UCC_TL_CUDA_TAG_FREE 0xFFFFFFFFFFFFFFFF
 
 typedef struct ucc_tl_cuda_shm_barrier {
     ucc_rank_t   size;
@@ -180,7 +180,7 @@ UCC_CLASS_DECLARE(ucc_tl_cuda_team_t, ucc_base_context_t *,
 typedef struct ucc_tl_cuda_task ucc_tl_cuda_task_t;
 struct ucc_tl_cuda_task {
     ucc_coll_task_t            super;
-    uint32_t                   seq_num; // Sequential identifier for each taks started within the team
+    uint32_t                   seq_num; // Sequential identifier for each task started within the team
     uint32_t                   coll_id; // Index of the collective task in flight, within the range [0; max_concurrent)
     ucc_tl_cuda_shm_barrier_t *bar;     // Pointer to the reserved barrier for this task in the CUDA team
     ucc_subset_t               subset;  // Mapping information for the active set, if it is present

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -226,13 +226,13 @@ struct ucc_tl_cuda_task {
                                  ucc_rank_t                block);
         } allgatherv_linear;
         struct {
-            int stage;
-            int step;
-            void *                  sbuf;
+            int                     stage;
+            int                     step;
+            void                   *sbuf;
             ucc_datatype_t          dt;
             ucc_rank_t              root;
-            size_t size;
-            int num_steps;
+            size_t                  size;
+            int                     num_steps;
             ucc_ee_executor_task_t *exec_task;
         } bcast_linear;
         struct {

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -225,7 +225,6 @@ struct ucc_tl_cuda_task {
             size_t (*get_offset)(const ucc_tl_cuda_task_t *task,
                                  ucc_rank_t                block);
         } allgatherv_linear;
-        
         struct {
             int stage;
             int step;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -106,6 +106,8 @@ UCC_CLASS_DECLARE(ucc_tl_cuda_context_t, const ucc_base_context_params_t *,
 
 typedef uint32_t ucc_tl_cuda_sync_state_t;
 
+#define UCC_TAG_FREE 0xFFFFFFFF
+
 typedef struct ucc_tl_cuda_shm_barrier {
     ucc_rank_t   size;
     ucc_rank_t   count;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -233,6 +233,7 @@ struct ucc_tl_cuda_task {
             ucc_datatype_t          dt;
             ucc_rank_t              root;
             size_t size;
+            int num_steps;
             ucc_ee_executor_task_t *exec_task;
         } bcast_linear;
         struct {

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -231,6 +231,7 @@ struct ucc_tl_cuda_task {
             int step;
             void *                  sbuf;
             void *                  rbuf;
+            ucc_datatype_t          dt;
             size_t size;
             ucc_ee_executor_task_t *exec_task;
         } bcast_linear;

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -93,6 +93,19 @@ ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
     }
 }
 
+ucc_status_t ucc_tl_cuda_shm_barrier_init_root(ucc_rank_t size, ucc_rank_t rank, ucc_rank_t root,
+                                          ucc_tl_cuda_shm_barrier_t *barrier)
+{
+    if (rank == root) {
+        barrier->size  = size;
+        barrier->count = 0;
+        barrier->sense = 0;
+    }
+    barrier->state[rank]       = UCC_OK;
+    barrier->local_sense[rank] = 1;
+    return UCC_OK;
+}
+
 ucc_status_t ucc_tl_cuda_shm_barrier_init(ucc_rank_t size, ucc_rank_t rank,
                                           ucc_tl_cuda_shm_barrier_t *barrier)
 {

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -133,12 +133,13 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
         if (task->subset.myrank == coll_args->args.root) {
             bool found = false;
             int peer = ucc_ep_map_eval(task->subset.map, 1);
-            uint64_t key = (coll_args->args.tag << 32 | coll_args->args.root << 16 | peer);
+            uint64_t key   = ((uint64_t)coll_args->args.tag << 32 |
+                            coll_args->args.root << 16 | peer);
             /* search first free barrier in active set pool */
             for (i = 0; i < max_concurrent; ++i) {
                 curr_bar = UCC_TL_CUDA_TEAM_BARRIER(team, max_concurrent + i);                
                 if (ucc_atomic_cswap64(&curr_bar->tag, UCC_TAG_FREE, key) == UCC_TAG_FREE) {
-                    ucc_print("found free barrier: %d marked with tag: %d", i, curr_bar->tag);
+                    ucc_print("found free barrier: %d marked with tag: %ld", i, curr_bar->tag);
                     // free
                     task->bar = curr_bar;
                     // set user specified tag to mark that this barrier is used by this task
@@ -162,8 +163,9 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
         } else {
             /* pool barrier while root mark any of it with tag */
             bool found = false;
-            
-            uint64_t key = (coll_args->args.tag << 32 | coll_args->args.root << 16 | task->subset.myrank);
+
+            uint64_t key = ((uint64_t)coll_args->args.tag << 32 |
+                            coll_args->args.root << 16 | task->subset.myrank);
 
             // TODO: get rid of inf loop?
             while (!found)

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -7,6 +7,8 @@
 #ifndef UCC_TL_CUDA_COLL_H_
 #define UCC_TL_CUDA_COLL_H_
 
+#include <stdbool.h>
+
 #include "tl_cuda.h"
 #include "components/mc/ucc_mc.h"
 
@@ -50,6 +52,19 @@ static inline void ucc_tl_cuda_task_reset(ucc_tl_cuda_task_t *task)
     task->super.status = UCC_INPROGRESS;
 }
 
+ucc_status_t ucc_tl_cuda_shm_barrier_init_root(ucc_rank_t size, ucc_rank_t rank, ucc_rank_t root,
+                                          ucc_tl_cuda_shm_barrier_t *barrier);
+
+ucc_status_t ucc_tl_cuda_shm_barrier_init(ucc_rank_t size, ucc_rank_t rank,
+                                          ucc_tl_cuda_shm_barrier_t *barrier);
+
+ucc_status_t ucc_tl_cuda_shm_barrier_start(ucc_rank_t rank,
+                                           ucc_tl_cuda_shm_barrier_t *barrier);
+
+ucc_status_t ucc_tl_cuda_shm_barrier_test(ucc_rank_t rank,
+                                          ucc_tl_cuda_shm_barrier_t *barrier);
+
+
 static inline ucc_tl_cuda_task_t *ucc_tl_cuda_task_get(ucc_tl_cuda_team_t *team)
 {
     ucc_tl_cuda_context_t *ctx  = UCC_TL_CUDA_TEAM_CTX(team);
@@ -79,11 +94,13 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
                                    ucc_tl_cuda_team_t *team,
                                    ucc_tl_cuda_task_t **task_h)
 {
-    ucc_rank_t          trank          = UCC_TL_TEAM_RANK(team);
-    ucc_tl_cuda_lib_t  *lib            = UCC_TL_CUDA_TEAM_LIB(team);
-    uint32_t            max_concurrent = lib->cfg.max_concurrent;
-    ucc_tl_cuda_task_t *task;
-    ucc_status_t        status;
+    ucc_rank_t                 trank          = UCC_TL_TEAM_RANK(team);
+    ucc_tl_cuda_lib_t         *lib            = UCC_TL_CUDA_TEAM_LIB(team);
+    uint32_t                   max_concurrent = lib->cfg.max_concurrent;
+    ucc_tl_cuda_shm_barrier_t *curr_bar;
+    ucc_tl_cuda_task_t        *task;
+    ucc_status_t               status;
+    uint32_t                   i;
 
     if (!ucc_coll_args_is_predefined_dt(&coll_args->args, trank)) {
         return UCC_ERR_NOT_SUPPORTED;
@@ -100,11 +117,92 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
         return status;
     }
 
-    task->seq_num = team->seq_num++;
-    task->coll_id = task->seq_num % max_concurrent;
+    /* active set */
+    if (UCC_COLL_ARGS_ACTIVE_SET(&coll_args->args)) {
+        ucc_assert(coll_args->args.coll_type == UCC_COLL_TYPE_BCAST);
+
+        task->subset.map    = ucc_active_set_to_ep_map(&coll_args->args);
+        task->subset.myrank = UCC_TL_TEAM_RANK(team);
+        // root
+        if (task->subset.myrank == coll_args->args.root) {
+            bool found = false;
+            /* search first free barrier in active set pool */
+            for (i = 0; i < max_concurrent; ++i) {
+                curr_bar = UCC_TL_CUDA_TEAM_BARRIER(team, max_concurrent + i);
+                if (curr_bar->tag == 0) {
+                    // free
+                    task->bar = curr_bar;
+                    // set user specified tag to mark that this barrier is used by this task
+                    task->bar->tag = coll_args->args.tag;
+                    status = ucc_tl_cuda_shm_barrier_init_root(task->subset.map.ep_num, task->subset.myrank, coll_args->args.root, task->bar);
+                    if (ucc_unlikely(status != UCC_OK)) {
+                        ucc_error("failed to init root barrier");
+                    }
+
+                    found = true;
+                    break;
+                }
+            }
+            ucc_assert(found);
+        } else {
+            /* pool barrier while root mark any of it with tag */
+            bool found = false;
+            // TODO: get rid of inf loop?
+            while (!found)
+            {
+                for (i = 0; i < max_concurrent; ++i) {
+                    curr_bar = UCC_TL_CUDA_TEAM_BARRIER(team, max_concurrent + i);
+                    if (curr_bar->tag == coll_args->args.tag) {
+                        task->bar = curr_bar;
+                        // TODO: pass root rank???
+                        status = ucc_tl_cuda_shm_barrier_init_root(task->subset.map.ep_num, task->subset.myrank, coll_args->args.root, task->bar);
+                        if (ucc_unlikely(status != UCC_OK)) {
+                            ucc_error("failed to init peer barrier");
+                        }
+
+                        found = true;
+                        break;
+                    }
+                }
+            }
+        }
+        task->seq_num = team->seq_num_active_set++;
+        task->coll_id = task->seq_num % max_concurrent + max_concurrent;
+    } else {
+        task->seq_num = team->seq_num++;
+        task->coll_id = task->seq_num % max_concurrent;
+        task->bar = TASK_BAR(task);
+    }
 
     *task_h = task;
     return UCC_OK;
+}
+
+// check if segment for current task is available and barrier is available (completed from prev iteration)
+static inline ucc_status_t ucc_tl_cuda_get_sync_root(ucc_tl_cuda_task_t *task, ucc_rank_t root)
+{
+    ucc_tl_cuda_team_t                *team  = TASK_TEAM(task);
+    volatile ucc_tl_cuda_sync_state_t *state = &team->sync_state[task->coll_id];
+
+    if ((UCC_TL_TEAM_RANK(team) == root) && (*state == 0)) {
+        *state = task->seq_num;
+    }
+    if ((*state != task->seq_num) ||
+        (task->bar->state[UCC_TL_TEAM_RANK(team)] != UCC_OK)) {
+        return UCC_INPROGRESS;
+    }
+    return UCC_OK;
+}
+
+static inline void ucc_tl_cuda_put_sync_root(ucc_tl_cuda_task_t *task, ucc_rank_t root)
+{
+    ucc_tl_cuda_team_t       *team  = TASK_TEAM(task);
+    ucc_tl_cuda_sync_state_t *state = &team->sync_state[task->coll_id];
+
+    if (UCC_TL_TEAM_RANK(team) == root) {
+        ucc_assert(*state == task->seq_num);
+        *state = 0;
+    }
 }
 
 static inline ucc_status_t ucc_tl_cuda_get_sync(ucc_tl_cuda_task_t *task)
@@ -115,8 +213,7 @@ static inline ucc_status_t ucc_tl_cuda_get_sync(ucc_tl_cuda_task_t *task)
     if ((UCC_TL_TEAM_RANK(team) == 0) && (*state == 0)) {
         *state = task->seq_num;
     }
-    if ((*state != task->seq_num) ||
-        (task->bar->state[UCC_TL_TEAM_RANK(team)] != UCC_OK)) {
+    if ((*state != task->seq_num) || (task->bar->state[UCC_TL_TEAM_RANK(team)] != UCC_OK)) {
         return UCC_INPROGRESS;
     }
     return UCC_OK;
@@ -142,14 +239,7 @@ ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
 
 ucc_status_t ucc_tl_cuda_coll_finalize(ucc_coll_task_t *coll_task);
 
-ucc_status_t ucc_tl_cuda_shm_barrier_init(ucc_rank_t size, ucc_rank_t rank,
-                                          ucc_tl_cuda_shm_barrier_t *barrier);
 
-ucc_status_t ucc_tl_cuda_shm_barrier_start(ucc_rank_t rank,
-                                           ucc_tl_cuda_shm_barrier_t *barrier);
-
-ucc_status_t ucc_tl_cuda_shm_barrier_test(ucc_rank_t rank,
-                                          ucc_tl_cuda_shm_barrier_t *barrier);
 
 ucc_status_t ucc_tl_cuda_alg_id_to_init(int alg_id, const char *alg_id_str,
                                         ucc_coll_type_t          coll_type,

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -147,6 +147,7 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
                         return UCC_ERR_NO_RESOURCE;
                     }
                     found = true;
+                    task->coll_id = i + max_concurrent;
                     break;
                 }
             }
@@ -173,13 +174,14 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
                             return UCC_ERR_NO_RESOURCE;
                         }
                         found = true;
+                        task->coll_id = i + max_concurrent;
                         break;
                     }
                 }
             }
         }
         task->seq_num = team->seq_num_active_set++;
-        task->coll_id = task->seq_num % max_concurrent + max_concurrent;
+        // task->coll_id = task->seq_num % max_concurrent + max_concurrent;
     } else {
         task->seq_num = team->seq_num++;
         task->coll_id = task->seq_num % max_concurrent;

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -88,7 +88,6 @@ static inline void ucc_tl_cuda_task_put(ucc_tl_cuda_task_t *task)
     UCC_TL_CUDA_PROFILE_REQUEST_FREE(task);
 
     if (UCC_TL_TEAM_RANK(TASK_TEAM(task)) == task->bcast_linear.root) {
-        ucc_print("free bar!");
         task->bar->tag = UCC_TAG_FREE;
     }
 

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -86,11 +86,6 @@ static inline ucc_tl_cuda_task_t *ucc_tl_cuda_task_get(ucc_tl_cuda_team_t *team)
 static inline void ucc_tl_cuda_task_put(ucc_tl_cuda_task_t *task)
 {
     UCC_TL_CUDA_PROFILE_REQUEST_FREE(task);
-
-    if (UCC_TL_TEAM_RANK(TASK_TEAM(task)) == task->bcast_linear.root) {
-        task->bar->tag = UCC_TAG_FREE;
-    }
-
     ucc_mpool_put(task);
 }
 

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -89,7 +89,7 @@ static inline void ucc_tl_cuda_task_put(ucc_tl_cuda_task_t *task)
 
     if (UCC_TL_TEAM_RANK(TASK_TEAM(task)) == task->bcast_linear.root) {
         ucc_print("free bar!");
-        task->bar->tag = 0;
+        task->bar->tag = UCC_TAG_FREE;
     }
 
     ucc_mpool_put(task);
@@ -135,7 +135,7 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
             /* search first free barrier in active set pool */
             for (i = 0; i < max_concurrent; ++i) {
                 curr_bar = UCC_TL_CUDA_TEAM_BARRIER(team, max_concurrent + i);
-                if (ucc_atomic_cswap32(&curr_bar->tag, 0, coll_args->args.tag) == 0) {
+                if (ucc_atomic_cswap32(&curr_bar->tag, UCC_TAG_FREE, coll_args->args.tag) == UCC_TAG_FREE) {
                     ucc_print("found free barrier: %d", i);
                     // free
                     task->bar = curr_bar;

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -7,8 +7,6 @@
 #ifndef UCC_TL_CUDA_COLL_H_
 #define UCC_TL_CUDA_COLL_H_
 
-#include <stdbool.h>
-
 #include "tl_cuda.h"
 #include "components/mc/ucc_mc.h"
 

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -156,4 +156,21 @@ ucc_status_t ucc_tl_cuda_alg_id_to_init(int alg_id, const char *alg_id_str,
                                         ucc_memory_type_t        mem_type,
                                         ucc_base_coll_init_fn_t *init);
 
+// common utils function for collectives:
+static inline int get_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
+                                int step_id)
+{
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
+
+    return sync->seq_num[step_id];
+}
+
+static inline void set_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
+                                 int step, int step_id)
+{
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
+
+    sync->seq_num[step_id] = step;
+}
+
 #endif

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -137,13 +137,18 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
                     status = ucc_tl_cuda_shm_barrier_init_root(task->subset.map.ep_num, task->subset.myrank, coll_args->args.root, task->bar);
                     if (ucc_unlikely(status != UCC_OK)) {
                         ucc_error("failed to init root barrier");
+                        return UCC_ERR_NO_RESOURCE;
                     }
-
                     found = true;
                     break;
                 }
             }
             ucc_assert(found);
+            if (!found)
+            {
+                ucc_error("Unable to find free barrier");
+                return UCC_ERR_NO_RESOURCE;
+            }
         } else {
             /* pool barrier while root mark any of it with tag */
             bool found = false;
@@ -158,8 +163,8 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
                         status = ucc_tl_cuda_shm_barrier_init_root(task->subset.map.ep_num, task->subset.myrank, coll_args->args.root, task->bar);
                         if (ucc_unlikely(status != UCC_OK)) {
                             ucc_error("failed to init peer barrier");
+                            return UCC_ERR_NO_RESOURCE;
                         }
-
                         found = true;
                         break;
                     }

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -136,7 +136,7 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
             for (i = 0; i < max_concurrent; ++i) {
                 curr_bar = UCC_TL_CUDA_TEAM_BARRIER(team, max_concurrent + i);
                 if (ucc_atomic_cswap32(&curr_bar->tag, UCC_TAG_FREE, coll_args->args.tag) == UCC_TAG_FREE) {
-                    ucc_print("found free barrier: %d", i);
+                    ucc_print("found free barrier: %d marked with tag: %d", i, curr_bar->tag);
                     // free
                     task->bar = curr_bar;
                     // set user specified tag to mark that this barrier is used by this task

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -94,11 +94,11 @@ ucc_status_t ucc_tl_cuda_task_init(ucc_base_coll_args_t *coll_args,
                                    ucc_tl_cuda_team_t *team,
                                    ucc_tl_cuda_task_t **task_h)
 {
-    ucc_rank_t                 trank          = UCC_TL_TEAM_RANK(team);
-    ucc_tl_cuda_lib_t         *lib            = UCC_TL_CUDA_TEAM_LIB(team);
-    uint32_t                   max_concurrent = lib->cfg.max_concurrent;
-    ucc_tl_cuda_task_t        *task;
-    ucc_status_t               status;
+    ucc_rank_t          trank          = UCC_TL_TEAM_RANK(team);
+    ucc_tl_cuda_lib_t  *lib            = UCC_TL_CUDA_TEAM_LIB(team);
+    uint32_t            max_concurrent = lib->cfg.max_concurrent;
+    ucc_tl_cuda_task_t *task;
+    ucc_status_t        status;
 
     if (!ucc_coll_args_is_predefined_dt(&coll_args->args, trank)) {
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -171,27 +171,12 @@ static inline void ucc_tl_cuda_put_sync_root(ucc_tl_cuda_task_t *task, ucc_rank_
 
 static inline ucc_status_t ucc_tl_cuda_get_sync(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t                *team  = TASK_TEAM(task);
-    volatile ucc_tl_cuda_sync_state_t *state = &team->sync_state[task->coll_id];
-
-    if ((UCC_TL_TEAM_RANK(team) == 0) && (*state == 0)) {
-        *state = task->seq_num;
-    }
-    if ((*state != task->seq_num) || (task->bar->state[UCC_TL_TEAM_RANK(team)] != UCC_OK)) {
-        return UCC_INPROGRESS;
-    }
-    return UCC_OK;
+    return ucc_tl_cuda_get_sync_root(task, 0);
 }
 
 static inline void ucc_tl_cuda_put_sync(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t       *team  = TASK_TEAM(task);
-    ucc_tl_cuda_sync_state_t *state = &team->sync_state[task->coll_id];
-
-    if (UCC_TL_TEAM_RANK(team) == 0) {
-        ucc_assert(*state == task->seq_num);
-        *state = 0;
-    }
+    ucc_tl_cuda_put_sync_root(task, 0);
 }
 
 ucc_status_t ucc_tl_cuda_mem_info_get(void *ptr, size_t length,

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -20,8 +20,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
     ucc_status_t status;
     int num_devices;
     cudaError_t cuda_st;
-    CUcontext cu_ctx;
-    CUresult cu_st;
+    // CUcontext cu_ctx;
+    // CUresult cu_st;
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_cuda_config->super,
                               params->context);
@@ -37,12 +37,12 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
         return UCC_ERR_NO_RESOURCE;
     }
 
-    cu_st = cuCtxGetCurrent(&cu_ctx);
-    if (cu_ctx == NULL || cu_st != CUDA_SUCCESS) {
-        tl_debug(self->super.super.lib,
-                 "cannot create CUDA TL context without active CUDA context");
-        return UCC_ERR_NO_RESOURCE;
-    }
+    // cu_st = cuCtxGetCurrent(&cu_ctx);
+    // if (cu_ctx == NULL || cu_st != CUDA_SUCCESS) {
+    //     tl_debug(self->super.super.lib,
+    //              "cannot create CUDA TL context without active CUDA context");
+    //     return UCC_ERR_NO_RESOURCE;
+    // }
 
     status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_cuda_task_t), 0,
                             UCC_CACHE_LINE_SIZE, 8, UINT_MAX,

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -20,8 +20,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
     ucc_status_t status;
     int num_devices;
     cudaError_t cuda_st;
-    // CUcontext cu_ctx;
-    // CUresult cu_st;
+    CUcontext cu_ctx;
+    CUresult cu_st;
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_cuda_config->super,
                               params->context);
@@ -37,12 +37,12 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
         return UCC_ERR_NO_RESOURCE;
     }
 
-    // cu_st = cuCtxGetCurrent(&cu_ctx);
-    // if (cu_ctx == NULL || cu_st != CUDA_SUCCESS) {
-    //     tl_debug(self->super.super.lib,
-    //              "cannot create CUDA TL context without active CUDA context");
-    //     return UCC_ERR_NO_RESOURCE;
-    // }
+    cu_st = cuCtxGetCurrent(&cu_ctx);
+    if (cu_ctx == NULL || cu_st != CUDA_SUCCESS) {
+        tl_debug(self->super.super.lib,
+                 "cannot create CUDA TL context without active CUDA context");
+        return UCC_ERR_NO_RESOURCE;
+    }
 
     status = ucc_mpool_init(&self->req_mp, 0, sizeof(ucc_tl_cuda_task_t), 0,
                             UCC_CACHE_LINE_SIZE, 8, UINT_MAX,

--- a/src/components/tl/cuda/tl_cuda_ring.h
+++ b/src/components/tl/cuda/tl_cuda_ring.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/tl_cuda_ring.h
+++ b/src/components/tl/cuda/tl_cuda_ring.h
@@ -83,20 +83,4 @@ static inline ucc_rank_t get_recv_block(ucc_tl_cuda_team_t *team,
     return ring->ring[(ring->iring[trank] + tsize - step - 1) % tsize];
 }
 
-static inline int get_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
-                                int ring_id)
-{
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
-
-    return sync->seq_num[ring_id];
-}
-
-static inline void set_rank_step(ucc_tl_cuda_task_t *task, ucc_rank_t rank,
-                                 int step, int ring_id)
-{
-    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
-
-    sync->seq_num[ring_id] = step;
-}
-
 #endif

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -84,7 +84,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
         /* active set */
         for (i = 0; i < lib->cfg.max_concurrent * 2; i++) {
             bar = UCC_TL_CUDA_TEAM_BARRIER(self, i);
-            bar->tag = 0; // mark as free
+            bar->tag = UCC_TAG_FREE; // mark as free
             for (j = 0; j < UCC_TL_TEAM_SIZE(self); j++) {
                 status = ucc_tl_cuda_shm_barrier_init(UCC_TL_TEAM_SIZE(self),
                                                       j, bar);

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -22,6 +22,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
         ucc_derived_of(tl_context, ucc_tl_cuda_context_t);
     ucc_tl_cuda_lib_t     *lib =
         ucc_derived_of(tl_context->lib, ucc_tl_cuda_lib_t);
+    // Number of preallocated resource groups for tasks, including the active set.
+    uint32_t      resource_num = lib->cfg.max_concurrent * 2;
     ucc_tl_cuda_shm_barrier_t *bar;
     ucc_status_t status;
     int shm_id, i, j;
@@ -46,7 +48,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
     }
 
     // active set
-    scratch_size = 2 * lib->cfg.max_concurrent * lib->cfg.scratch_size;
+    scratch_size = resource_num * lib->cfg.scratch_size;
     status = CUDA_FUNC(cudaMalloc(&self->scratch.loc, scratch_size));
     if (status != UCC_OK) {
         tl_error(tl_context->lib, "failed to alloc scratch buffer");
@@ -79,12 +81,12 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
             goto ids_exchange;
         }
         memset(self->sync, 0, ctrl_size);
-        self->bar  = (ucc_tl_cuda_shm_barrier_t*)UCC_TL_CUDA_TEAM_SYNC(self, 0,
-                                                       lib->cfg.max_concurrent * 2);
+        self->bar = (ucc_tl_cuda_shm_barrier_t *)UCC_TL_CUDA_TEAM_SYNC(
+            self, 0, resource_num);
         /* active set */
-        for (i = 0; i < lib->cfg.max_concurrent * 2; i++) {
+        for (i = 0; i < resource_num; i++) {
             bar = UCC_TL_CUDA_TEAM_BARRIER(self, i);
-            bar->tag = UCC_TAG_FREE; // mark as free
+            bar->tag = UCC_TL_CUDA_TAG_FREE; // mark as free
             for (j = 0; j < UCC_TL_TEAM_SIZE(self); j++) {
                 status = ucc_tl_cuda_shm_barrier_init(UCC_TL_TEAM_SIZE(self),
                                                       j, bar);
@@ -132,6 +134,8 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_team_t)
 {
     ucc_tl_cuda_lib_t *lib = ucc_derived_of(self->super.super.context->lib,
                                             ucc_tl_cuda_lib_t);
+    // Number of preallocated resource groups for tasks, including the active set.
+    uint32_t  resource_num = lib->cfg.max_concurrent * 2;
     ucc_tl_cuda_sync_t *sync;
     cudaError_t st;
     int i, j;
@@ -142,7 +146,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_team_t)
     }
     if (self->ids) {
         if (self->sync != (void*)-1) {
-            for (i = 0; i < lib->cfg.max_concurrent * 2; i++) {
+            for (i = 0; i < resource_num; i++) {
                 for (j = 0; j < UCC_TL_TEAM_SIZE(self); j++) {
                     if (j == UCC_TL_TEAM_RANK(self)) {
                         continue;
@@ -204,6 +208,8 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_lib_t  *lib  = ucc_derived_of(tl_team->context->lib,
                                               ucc_tl_cuda_lib_t);
+    // Number of preallocated resource groups for tasks, including the active set.
+    uint32_t    resource_num = lib->cfg.max_concurrent * 2;
     ucc_status_t status;
     ucc_tl_cuda_sync_t *sync;
     ucc_tl_cuda_shm_barrier_t *bar;
@@ -273,15 +279,14 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
             goto exit_err;
         }
         team->bar = (ucc_tl_cuda_shm_barrier_t*)UCC_TL_CUDA_TEAM_SYNC(team, 0,
-                                                       lib->cfg.max_concurrent * 2);
+                                                       resource_num);
     }
     team->sync_state = (ucc_tl_cuda_sync_state_t*)PTR_OFFSET(team->bar,
                             sizeof(ucc_tl_cuda_shm_barrier_t) *
-                            lib->cfg.max_concurrent * 2);
+                            resource_num);
     CUDA_CHECK_GOTO(cudaStreamCreateWithFlags(&team->stream,
                     cudaStreamNonBlocking), exit_err, status);
-    // second max_concurent events are unused for bcast active set
-    for (i = 0; i < lib->cfg.max_concurrent * 2; i++) {
+    for (i = 0; i < resource_num; i++) {
         sync = UCC_TL_CUDA_TEAM_SYNC(team, UCC_TL_TEAM_RANK(team), i);
         CUDA_CHECK_GOTO(cudaEventCreateWithFlags(&sync->ipc_event_local,
                                                 cudaEventDisableTiming |
@@ -309,7 +314,7 @@ barrier:
         goto exit_err;
     }
 
-    for (i = 0; i < lib->cfg.max_concurrent * 2; i++) {
+    for (i = 0; i < resource_num; i++) {
         sync = UCC_TL_CUDA_TEAM_SYNC(team, UCC_TL_TEAM_RANK(team), i);
         for (j = 0 ; j < UCC_TL_TEAM_SIZE(team); j++) {
             if (j == UCC_TL_TEAM_RANK(team)) {

--- a/src/components/tl/cuda/tl_cuda_team_topo.h
+++ b/src/components/tl/cuda/tl_cuda_team_topo.h
@@ -51,7 +51,7 @@ ucc_tl_cuda_team_topo_is_direct(const ucc_tl_team_t *team,
 }
 
 static inline int
-ucc_tl_cuda_team_topo_is_fully_conntected(const ucc_tl_cuda_team_topo_t *topo)
+ucc_tl_cuda_team_topo_is_fully_connected(const ucc_tl_cuda_team_topo_t *topo)
 {
     return topo->is_fully_connected;
 }

--- a/src/components/tl/cuda/tl_cuda_team_topo.h
+++ b/src/components/tl/cuda/tl_cuda_team_topo.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -22,7 +22,7 @@ void ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_rank_t         size      = (ucc_rank_t)task->subset.map.ep_num;
 
     uint32_t           radix     = task->bcast_kn.radix;
-    ucc_rank_t         root = (uint32_t)TASK_ARGS(task).root;
+    ucc_rank_t         root      = (uint32_t)TASK_ARGS(task).root;
     ucc_rank_t         dist      = task->bcast_kn.dist;
     void              *buffer    = TASK_ARGS(task).src.info.buffer;
     ucc_memory_type_t  mtype     = TASK_ARGS(task).src.info.mem_type;

--- a/src/components/tl/ucp/bcast/bcast_knomial.c
+++ b/src/components/tl/ucp/bcast/bcast_knomial.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -22,7 +22,7 @@ void ucc_tl_ucp_bcast_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_rank_t         size      = (ucc_rank_t)task->subset.map.ep_num;
 
     uint32_t           radix     = task->bcast_kn.radix;
-    ucc_rank_t         root      = (uint32_t)TASK_ARGS(task).root;
+    ucc_rank_t         root      = (ucc_rank_t)TASK_ARGS(task).root;
     ucc_rank_t         dist      = task->bcast_kn.dist;
     void              *buffer    = TASK_ARGS(task).src.info.buffer;
     ucc_memory_type_t  mtype     = TASK_ARGS(task).src.info.mem_type;

--- a/src/utils/ucc_atomic.h
+++ b/src/utils/ucc_atomic.h
@@ -16,7 +16,6 @@
 #define ucc_atomic_add64          ucs_atomic_add64
 #define ucc_atomic_sub64          ucs_atomic_sub64
 #define ucc_atomic_cswap8         ucs_atomic_cswap8
-#define ucc_atomic_cswap32        ucs_atomic_cswap32
 #define ucc_atomic_cswap64        ucs_atomic_cswap64
 #define ucc_atomic_bool_cswap8    ucs_atomic_bool_cswap8
 #define ucc_atomic_bool_cswap64   ucs_atomic_bool_cswap64

--- a/src/utils/ucc_atomic.h
+++ b/src/utils/ucc_atomic.h
@@ -16,6 +16,7 @@
 #define ucc_atomic_add64          ucs_atomic_add64
 #define ucc_atomic_sub64          ucs_atomic_sub64
 #define ucc_atomic_cswap8         ucs_atomic_cswap8
+#define ucc_atomic_cswap32        ucs_atomic_cswap32
 #define ucc_atomic_cswap64        ucs_atomic_cswap64
 #define ucc_atomic_bool_cswap8    ucs_atomic_bool_cswap8
 #define ucc_atomic_bool_cswap64   ucs_atomic_bool_cswap64

--- a/test/gtest/coll/test_bcast.cc
+++ b/test/gtest/coll/test_bcast.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * See file LICENSE for terms.
  */
 

--- a/test/gtest/coll/test_bcast.cc
+++ b/test/gtest/coll/test_bcast.cc
@@ -276,7 +276,7 @@ ucc_job_env_t two_step_env = {{"UCC_CL_HIER_TUNE", "bcast:@2step:0-inf:inf"},
                               {"UCC_CLS", "all"}};
 ucc_job_env_t dbt_env      = {{"UCC_TL_UCP_TUNE", "bcast:@dbt:0-inf:inf"},
                               {"UCC_CLS", "basic"}};
-ucc_job_env_t cuda_env     = {{"UCC_TL_CUDA_TUNE", "bcast:cuda:@0"},
+ucc_job_env_t cuda_env     = {{"UCC_TL_CUDA_TUNE", "bcast:cuda:@0:0-inf:inf"},
                               {"UCC_CLS", "basic"}};
 INSTANTIATE_TEST_CASE_P(
     , test_bcast_alg,

--- a/test/gtest/coll/test_bcast.cc
+++ b/test/gtest/coll/test_bcast.cc
@@ -276,6 +276,8 @@ ucc_job_env_t two_step_env = {{"UCC_CL_HIER_TUNE", "bcast:@2step:0-inf:inf"},
                               {"UCC_CLS", "all"}};
 ucc_job_env_t dbt_env      = {{"UCC_TL_UCP_TUNE", "bcast:@dbt:0-inf:inf"},
                               {"UCC_CLS", "basic"}};
+ucc_job_env_t cuda_env     = {{"UCC_TL_CUDA_TUNE", "bcast:cuda:@0"},
+                              {"UCC_CLS", "basic"}};
 INSTANTIATE_TEST_CASE_P(
     , test_bcast_alg,
     ::testing::Combine(
@@ -285,6 +287,10 @@ INSTANTIATE_TEST_CASE_P(
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
+#ifdef HAVE_CUDA
+        ::testing::Values(two_step_env, dbt_env, cuda_env), //env
+#else
         ::testing::Values(two_step_env, dbt_env), //env
+#endif
         ::testing::Values(8, 65536), // count
-        ::testing::Values(15,16))); // n_procs
+        ::testing::Values(15, 16))); // n_procs


### PR DESCRIPTION
## What
Linear CUDA Broadcast implementation with Active set feature support.

## Why ?
- Functional improvement, parity with others communication libraries.
- Ability to place many ranks on single GPU
- No GPU blocking, communication initiated from host
- Active set might be used to emulate P2P send/receive on top of broadcast collective

## How ?
Naive approach where root rank writes data to own shared buffer and others ranks read from it through NVLink (bi-copy).
The algorithm enables the initiation of multiple simultaneous peer-to-peer (P2P) communications, constrained only by user-defined tags. During its execution, the algorithm identifies the first available free barrier and acquires it. This barrier, along with associated resources, is then utilized as a scratch buffer to facilitate efficient operations.