### PR TITLE
TOOLS: Add perftest msg size multiplication factor flag

### DIFF
--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -98,7 +98,7 @@ ucc_status_t ucc_pt_benchmark::run_bench() noexcept
     double             time;
 
     print_header();
-    for (size_t cnt = min_count; cnt <= max_count; cnt *= 2) {
+    for (size_t cnt = min_count; cnt <= max_count; cnt *= config.mult_factor) {
         size_t coll_size = cnt * ucc_dt_size(config.dt);
         int iter = config.n_iter_small;
         int warmup = config.n_warmup_small;

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -29,6 +29,7 @@ ucc_pt_config::ucc_pt_config() {
     bench.n_bufs         = UCC_PT_DEFAULT_N_BUFS;
     bench.root           = 0;
     bench.root_shift     = 0;
+    bench.mult_factor    = 2;
     comm.mt              = bench.mt;
 }
 
@@ -153,6 +154,9 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
                 std::stringstream(optarg) >> bench.n_warmup_small;
                 bench.n_warmup_large = bench.n_warmup_small;
                 break;
+            case 'f':
+                std::stringstream(optarg) >> bench.mult_factor;
+                break;
             case 'N':
                 std::stringstream(optarg) >> bench.n_bufs;
                 break;
@@ -191,6 +195,7 @@ void ucc_pt_config::print_help()
     std::cout << "  -m <mtype name>: memory type"<<std::endl;
     std::cout << "  -n <number>: number of iterations"<<std::endl;
     std::cout << "  -w <number>: number of warmup iterations"<<std::endl;
+    std::cout << "  -f <number>: multiplication factor between sizes. Default : 2."<<std::endl;
     std::cout << "  -N <number>: number of buffers"<<std::endl;
     std::cout << "  -T: triggered collective"<<std::endl;
     std::cout << "  -F: enable full print"<<std::endl;

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -90,6 +90,7 @@ struct ucc_pt_benchmark_config {
     bool               full_print;
     int                root;
     int                root_shift;
+    int                mult_factor;
 };
 
 struct ucc_pt_config {


### PR DESCRIPTION
## What
Adding option to control ucc perftest multiplication factor size for msg size ranges

## Why ?
Adding option to use "report BW" mode by putting -f 1
