### PR TITLE
EC/CUDA: check ctx valid before resource cleanup

### DIFF
--- a/src/components/ec/cuda/ec_cuda_resources.c
+++ b/src/components/ec/cuda/ec_cuda_resources.c
@@ -180,7 +180,16 @@ void ucc_ec_cuda_resources_cleanup(ucc_ec_cuda_resources_t *resources)
 {
     int i;
     CUcontext tmp_context;
+#if CUDA_VERSION >= 12000
+    CUresult status;
+    unsigned long long int cu_ctx_id;
 
+    status = cuCtxGetId(resources->cu_ctx, &cu_ctx_id);
+    if (ucc_unlikely(status != CUDA_SUCCESS)) {
+        // ctx is not available, can be due to cudaDeviceReset
+        return;
+    }
+#endif
     cuCtxPushCurrent(resources->cu_ctx);
     for (i = 0; i < ucc_ec_cuda_config->exec_num_streams; i++) {
         if (resources->exec_streams[i] != NULL) {

--- a/src/components/ec/ucc_ec.c
+++ b/src/components/ec/ucc_ec.c
@@ -69,7 +69,7 @@ ucc_status_t ucc_ec_init(const ucc_ec_params_t *ec_params)
                 return status;
             }
             if (attr.thread_mode < ec_params->thread_mode) {
-                ucc_warn("ec %s was allready initilized with "
+                ucc_info("ec %s was allready initilized with "
                          "different thread mode: current tm %d, provided tm %d",
                          ec->super.name, attr.thread_mode,
                          ec_params->thread_mode);

--- a/src/components/mc/cuda/mc_cuda_resources.c
+++ b/src/components/mc/cuda/mc_cuda_resources.c
@@ -84,6 +84,16 @@ free_scratch_mpool:
 void ucc_mc_cuda_resources_cleanup(ucc_mc_cuda_resources_t *resources)
 {
     CUcontext tmp_context;
+#if CUDA_VERSION >= 12000
+    CUresult status;
+    unsigned long long int cu_ctx_id;
+
+    status = cuCtxGetId(resources->cu_ctx, &cu_ctx_id);
+    if (ucc_unlikely(status != CUDA_SUCCESS)) {
+        // ctx is not available, can be due to cudaDeviceReset
+        return;
+    }
+#endif
 
     cuCtxPushCurrent(resources->cu_ctx);
     ucc_mpool_cleanup(&resources->scratch_mpool, 1);

--- a/src/components/mc/ucc_mc.c
+++ b/src/components/mc/ucc_mc.c
@@ -72,7 +72,7 @@ ucc_status_t ucc_mc_init(const ucc_mc_params_t *mc_params)
                 return status;
             }
             if (attr.thread_mode < mc_params->thread_mode) {
-                ucc_warn("mc %s was allready initilized with "
+                ucc_info("mc %s was allready initilized with "
                          "different thread mode: current tm %d, provided tm %d",
                          mc->super.name, attr.thread_mode,
                          mc_params->thread_mode);


### PR DESCRIPTION
## What
During EC CUDA resource cleanup original CUDA context can be already destroyed. In such case calls to cudaStreamDestroy, cudaEventDestroy etc. might result in segfault. This PR adds check that CUDA context is valid before doing cleanup.
