### PR TITLE
TL/MLX5: fix warning and var names

### DIFF
--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast.h
@@ -157,7 +157,7 @@ typedef struct ucc_tl_mlx5_mcast_context {
     ucc_tl_mlx5_mcast_context_config_t cfg;
     ucc_mpool_t                        req_mp;
     int                                mcast_enabled;
-    int                                mcast_ready;
+    int                                mcast_ctx_ready;
     ucc_tl_mlx5_mcast_oob_ctx_t        oob_ctx;
 } ucc_tl_mlx5_mcast_context_t;
 

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_team.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_team.c
@@ -62,7 +62,7 @@ ucc_status_t ucc_tl_mlx5_mcast_team_init(ucc_base_context_t *base_context,
     ucc_tl_mlx5_mcast_coll_comm_t           *comm;
     int                                      i;
 
-    if (!ctx->mcast_enabled || !ctx->mcast_ready || NULL == mcast_context) {
+    if (!ctx->mcast_ctx_ready) {
         tl_debug(base_context->lib,
                 "mcast context not available, base_context = %p",
                  base_context );

--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -145,7 +145,7 @@ typedef struct ucc_tl_mlx5_team {
     ucc_tl_mlx5_alltoall_t         *a2a;
     ucc_topo_t                     *topo;
     ucc_ep_map_t                    ctx_map;
-    int                             local_mcast_ctx_ready;
+    int                             local_mcast_team_ready;
     ucc_tl_mlx5_mcast_team_t       *mcast;
     ucc_status_t                    local_status_array[UCC_TL_MLX5_FEATURES_COUNT];
     ucc_status_t                    global_status_array[UCC_TL_MLX5_FEATURES_COUNT];

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -49,13 +49,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
         goto err_rcache;
     }
 
-    self->mcast.mcast_ready = 0;
+    self->mcast.mcast_ctx_ready = 0;
     if (params->thread_mode == UCC_THREAD_SINGLE) {
         status = ucc_tl_mlx5_mcast_context_init(&(self->mcast), &(self->cfg.mcast_ctx_conf));
         if (UCC_OK != status) {
             tl_debug(self->super.super.lib, "failed to initialize mcast context");
         } else {
-            self->mcast.mcast_ready = 1;
+            self->mcast.mcast_ctx_ready = 1;
         }
     }
     return UCC_OK;
@@ -82,7 +82,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_context_t)
 
     ucc_mpool_cleanup(&self->req_mp, 1);
 
-    if (self->mcast.mcast_ready) {
+    if (self->mcast.mcast_ctx_ready) {
         ucc_tl_mlx5_mcast_clean_ctx(&self->mcast.mcast_context);
     }
 }


### PR DESCRIPTION
TL/MLX5: fix warning and var names
checking if the mcast ctx is created, then we attempt to create the mcast team to avoid warning + some of the variable names got enhanced