### PR TITLE
TL/MLX5: Disable mlx5 team by default

### DIFF
--- a/src/components/tl/mlx5/tl_mlx5_lib.c
+++ b/src/components/tl/mlx5/tl_mlx5_lib.c
@@ -48,7 +48,7 @@ ucc_status_t ucc_tl_mlx5_get_lib_attr(const ucc_base_lib_t *lib, /* NOLINT */
 
 ucc_status_t ucc_tl_mlx5_get_lib_properties(ucc_base_lib_properties_t *prop)
 {
-    prop->default_team_size = 2;
+    prop->default_team_size = UCC_RANK_MAX;
     prop->min_team_size     = 2;
     prop->max_team_size     = UCC_RANK_MAX;
     return UCC_OK;


### PR DESCRIPTION
This PR increases the default min size supported for tl_mlx5 to uint32_max thus disabling tl_mlx5 team unless the users increase the min size via env. variable

We have noticed several corner-case bugs in tl_mlx5 algorithms, therefore until the features mature we disable tl_mlx5 when the team is built rather than not building the team at all.



