### PR TITLE
Alltoallv Perftest - Transfer Matrix

### DIFF
--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -193,9 +193,9 @@ void ucc_pt_coll_alltoallv::free_args(ucc_pt_test_args_t &test_args)
     ucc_coll_args_t &args = test_args.coll_args;
 
     if (!UCC_IS_INPLACE(args)) {
-        //ucc_pt_free(src_header);
+        ucc_pt_free(src_header);
     }
-    //ucc_pt_free(dst_header);
+    ucc_pt_free(dst_header);
     ucc_free(args.dst.info_v.counts);
     ucc_free(args.dst.info_v.displacements);
     ucc_free(args.src.info_v.counts);

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -48,12 +48,12 @@ double parse_transfer_matrix_token(std::string token)
 {
     size_t size;
     double val;
-	try { 
-		val = std::stod(token, &size);
-	}
-	catch (...) {
-		throw std::invalid_argument("Invalid element in transfer matrix: " + token);
-	}
+    try { 
+        val = std::stod(token, &size);
+    }
+    catch (...) {
+        throw std::invalid_argument("Invalid element in transfer matrix: " + token);
+    }
 
     if (size < token.size())
     {
@@ -69,20 +69,20 @@ double parse_transfer_matrix_token(std::string token)
                 throw std::invalid_argument("Unknown suffix from transfer matrix: " + token[size]);
         }
     }
-		return val;
+    return val;
 }
 
 
 std::vector<std::vector<double>> fill_transfer_matrix(std::vector<std::vector<double>>& transfer_matrix)
 {
-	std::ifstream f;
-	std::string line, token;
-	std::istringstream linestream;
+    std::ifstream f;
+    std::string line, token;
+    std::istringstream linestream;
     int row = 0;
-	int col = 0;
+    int col = 0;
     int N = transfer_matrix.size();
 
-	char* transfer_matrix_fn = std::getenv("UCC_PT_COLL_ALLTOALLV_TRANSFER_MATRIX_FILE");
+    char* transfer_matrix_fn = std::getenv("UCC_PT_COLL_ALLTOALLV_TRANSFER_MATRIX_FILE");
     f.open(transfer_matrix_fn);
     if (!f.is_open())
         throw std::invalid_argument("Couldn't open transfer matrix file: " + (transfer_matrix_fn ? std::string(transfer_matrix_fn) : ""));
@@ -91,15 +91,15 @@ std::vector<std::vector<double>> fill_transfer_matrix(std::vector<std::vector<do
         if (row >= N)
             throw std::invalid_argument("Transfer matrix rows number exceed expected number of " + std::to_string(N));
 
-		linestream.str(line);
-		linestream.clear();
+	linestream.str(line);
+	linestream.clear();
         col = 0;
         while (linestream >> token){
             if (col >= N)
                 throw std::invalid_argument("Transfer matrix columns of row " + std::to_string(row+1) + " exceed expected number of " + std::to_string(N));
 
             transfer_matrix[row][col] = parse_transfer_matrix_token(token);
-			col++;
+	    col++;
         }
 
         if (col != N)
@@ -127,19 +127,19 @@ ucc_status_t ucc_pt_coll_alltoallv::init_args(size_t count,
     ucc_status_t                        st        = UCC_OK;
     int                                 src_displacement = 0;
     int                                 dst_displacement = 0;
-	int 								send_count, recv_count;
+    int 				send_count, recv_count;
 
     if (std::getenv("UCC_PT_COLL_ALLTOALLV_TRANSFER_MATRIX_FILE")){
         fill_transfer_matrix(transfer_matrix);
-	}
-
-	src_header_size = dst_header_size = 0;
-	for (size_t i=0; i < transfer_matrix.size(); i++){
-		src_header_size += transfer_matrix[comm_rank][i];
     }
 
-	for (size_t i=0; i < transfer_matrix.size(); i++){
-		dst_header_size += transfer_matrix[i][comm_rank];
+    src_header_size = dst_header_size = 0;
+    for (size_t i=0; i < transfer_matrix.size(); i++){
+	src_header_size += transfer_matrix[comm_rank][i];
+    }
+
+    for (size_t i=0; i < transfer_matrix.size(); i++){
+	dst_header_size += transfer_matrix[i][comm_rank];
     }
 
     args = coll_args;

--- a/tools/perf/ucc_pt_coll_alltoallv.cc
+++ b/tools/perf/ucc_pt_coll_alltoallv.cc
@@ -9,6 +9,11 @@
 #include <ucc/api/ucc.h>
 #include <utils/ucc_math.h>
 #include <utils/ucc_coll_utils.h>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
 
 ucc_pt_coll_alltoallv::ucc_pt_coll_alltoallv(ucc_datatype_t dt,
                          ucc_memory_type mt, bool is_inplace,
@@ -39,14 +44,103 @@ ucc_pt_coll_alltoallv::ucc_pt_coll_alltoallv(ucc_datatype_t dt,
 
 }
 
+double parse_transfer_matrix_token(std::string token)
+{
+    size_t size;
+    double val;
+	try { 
+		val = std::stod(token, &size);
+	}
+	catch (...) {
+		throw std::invalid_argument("Invalid element in transfer matrix: " + token);
+	}
+
+    if (size < token.size())
+    {
+        switch(token[size])
+        {
+            case 'M':
+                val *= 1e6;
+                break;
+            case 'G':
+                val *= 1e9;
+                break;
+            default:
+                throw std::invalid_argument("Unknown suffix from transfer matrix: " + token[size]);
+        }
+    }
+		return val;
+}
+
+
+std::vector<std::vector<double>> fill_transfer_matrix(std::vector<std::vector<double>>& transfer_matrix)
+{
+	std::ifstream f;
+	std::string line, token;
+	std::istringstream linestream;
+    int row = 0;
+	int col = 0;
+    int N = transfer_matrix.size();
+
+	char* transfer_matrix_fn = std::getenv("UCC_PT_COLL_ALLTOALLV_TRANSFER_MATRIX_FILE");
+    f.open(transfer_matrix_fn);
+    if (!f.is_open())
+        throw std::invalid_argument("Couldn't open transfer matrix file: " + (transfer_matrix_fn ? std::string(transfer_matrix_fn) : ""));
+
+    while (getline(f, line)){
+        if (row >= N)
+            throw std::invalid_argument("Transfer matrix rows number exceed expected number of " + std::to_string(N));
+
+		linestream.str(line);
+		linestream.clear();
+        col = 0;
+        while (linestream >> token){
+            if (col >= N)
+                throw std::invalid_argument("Transfer matrix columns of row " + std::to_string(row+1) + " exceed expected number of " + std::to_string(N));
+
+            transfer_matrix[row][col] = parse_transfer_matrix_token(token);
+			col++;
+        }
+
+        if (col != N)
+            throw std::invalid_argument("Transfer matrix row " + std::to_string(row+1) + " doesn't contain " + std::to_string(N) + " elements as expected.");
+
+        row++;
+    }
+
+    if (row != N)
+        throw std::invalid_argument("Transfer matrix is expected to have " + std::to_string(N) + " rows but only have " + std::to_string(row+1));
+
+    return transfer_matrix;
+}
+
+
 ucc_status_t ucc_pt_coll_alltoallv::init_args(size_t count,
                                               ucc_pt_test_args_t &test_args)
 {
-    ucc_coll_args_t &args      = test_args.coll_args;
-    int              comm_size = comm->get_size();
-    size_t           dt_size   = ucc_dt_size(coll_args.src.info_v.datatype);
-    size_t           size      = comm_size * count * dt_size;
-    ucc_status_t     st        = UCC_OK;
+    ucc_coll_args_t                     &args      = test_args.coll_args;
+    int                                 comm_size = comm->get_size();
+    int                                 comm_rank = comm->get_rank();
+    size_t                              dt_size   = ucc_dt_size(coll_args.src.info_v.datatype);
+    std::vector<std::vector<double>>    transfer_matrix(comm_size, std::vector<double>(comm_size, count*dt_size));
+    size_t                              dst_header_size, src_header_size;
+    ucc_status_t                        st        = UCC_OK;
+    int                                 src_displacement = 0;
+    int                                 dst_displacement = 0;
+	int 								send_count, recv_count;
+
+    if (std::getenv("UCC_PT_COLL_ALLTOALLV_TRANSFER_MATRIX_FILE")){
+        fill_transfer_matrix(transfer_matrix);
+	}
+
+	src_header_size = dst_header_size = 0;
+	for (size_t i=0; i < transfer_matrix.size(); i++){
+		src_header_size += transfer_matrix[comm_rank][i];
+    }
+
+	for (size_t i=0; i < transfer_matrix.size(); i++){
+		dst_header_size += transfer_matrix[i][comm_rank];
+    }
 
     args = coll_args;
     args.src.info_v.counts = (ucc_count_t *) ucc_malloc(comm_size * sizeof(uint32_t), "counts buf");
@@ -57,20 +151,28 @@ ucc_status_t ucc_pt_coll_alltoallv::init_args(size_t count,
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.counts, free_src_displ, st);
     args.dst.info_v.displacements = (ucc_aint_t *) ucc_malloc(comm_size * sizeof(uint32_t), "displacements buf");
     UCC_MALLOC_CHECK_GOTO(args.dst.info_v.displacements, free_dst_count, st);
-    UCCCHECK_GOTO(ucc_pt_alloc(&dst_header, size, args.dst.info_v.mem_type),
+    UCCCHECK_GOTO(ucc_pt_alloc(&dst_header, dst_header_size, args.dst.info_v.mem_type),
                   free_dst_displ, st);
     args.dst.info_v.buffer = dst_header->addr;
     if (!UCC_IS_INPLACE(args)) {
-        UCCCHECK_GOTO(ucc_pt_alloc(&src_header, size, args.src.info_v.mem_type),
+        UCCCHECK_GOTO(ucc_pt_alloc(&src_header, src_header_size, args.src.info_v.mem_type),
                       free_dst, st);
         args.src.info_v.buffer = src_header->addr;
     }
+
     for (int i = 0; i < comm_size; i++) {
-        ((uint32_t*)args.src.info_v.counts)[i] = count;
-        ((uint32_t*)args.src.info_v.displacements)[i] = count * i;
-        ((uint32_t*)args.dst.info_v.counts)[i] = count;
-        ((uint32_t*)args.dst.info_v.displacements)[i] = count * i;
+        send_count = std::floor(transfer_matrix[comm_rank][i] / dt_size);
+        recv_count = std::floor(transfer_matrix[i][comm_rank] / dt_size);
+
+        ((uint32_t*)args.src.info_v.counts)[i] = send_count;
+        ((uint32_t*)args.src.info_v.displacements)[i] = src_displacement;
+        ((uint32_t*)args.dst.info_v.counts)[i] = recv_count;
+        ((uint32_t*)args.dst.info_v.displacements)[i] = dst_displacement;
+
+        src_displacement += send_count;
+        dst_displacement += recv_count;
     }
+
     return UCC_OK;
 free_dst:
     ucc_pt_free(dst_header);
@@ -91,9 +193,9 @@ void ucc_pt_coll_alltoallv::free_args(ucc_pt_test_args_t &test_args)
     ucc_coll_args_t &args = test_args.coll_args;
 
     if (!UCC_IS_INPLACE(args)) {
-        ucc_pt_free(src_header);
+        //ucc_pt_free(src_header);
     }
-    ucc_pt_free(dst_header);
+    //ucc_pt_free(dst_header);
     ucc_free(args.dst.info_v.counts);
     ucc_free(args.dst.info_v.displacements);
     ucc_free(args.src.info_v.counts);


### PR DESCRIPTION
Currently in alltoallv perftest, every rank is sending the same amount of data to every other rank, this PR implements the possibility to define the amount of data rank i should send to rank j, using a matrix called "transfer matrix" (where the cell i,j is this amount of data)

The transfer matrix should be written in a file where each row contains the elements separated by a space, each element is a number of bytes. It support convenient unit usage of megabytes and gigabytes, in the format 1G or 5M.
The path to the transfer matrix file should be passed in the environment variable `UCC_PT_COLL_ALLTOALLV_TRANSFER_MATRIX_FILE` 