### PR TITLE
TL/UCP: add reduce scatter knomial

### DIFF
--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -14,7 +14,7 @@ ucc_base_coll_alg_info_t
         [UCC_TL_UCP_ALLGATHER_ALG_KNOMIAL] =
             {.id   = UCC_TL_UCP_ALLGATHER_ALG_KNOMIAL,
              .name = "knomial",
-             .desc = "recursive k-ing with arbitrary radix "},
+             .desc = "recursive k-ing with arbitrary radix"},
         [UCC_TL_UCP_ALLGATHER_ALG_RING] =
             {.id   = UCC_TL_UCP_ALLGATHER_ALG_RING,
              .name = "ring",
@@ -23,11 +23,11 @@ ucc_base_coll_alg_info_t
             {.id   = UCC_TL_UCP_ALLGATHER_ALG_NEIGHBOR,
              .name = "neighbor",
              .desc = "O(N) Neighbor Exchange N/2 steps"},
-        [UCC_TL_UCP_ALLGATHER_ALG_BRUCK] = 
+        [UCC_TL_UCP_ALLGATHER_ALG_BRUCK] =
             {.id   = UCC_TL_UCP_ALLGATHER_ALG_BRUCK,
              .name = "bruck",
              .desc = "O(log(N)) Variation of Bruck algorithm"},
-        [UCC_TL_UCP_ALLGATHER_ALG_SPARBIT] = 
+        [UCC_TL_UCP_ALLGATHER_ALG_SPARBIT] =
             {.id   = UCC_TL_UCP_ALLGATHER_ALG_SPARBIT,
              .name = "sparbit",
              .desc = "O(log(N)) SPARBIT algorithm"},

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -14,5 +14,9 @@ ucc_base_coll_alg_info_t
             {.id   = UCC_TL_UCP_REDUCE_SCATTER_ALG_RING,
              .name = "ring",
              .desc = "O(N) ring"},
+        [UCC_TL_UCP_REDUCE_SCATTER_ALG_KNOMIAL] =
+            {.id   = UCC_TL_UCP_REDUCE_SCATTER_ALG_KNOMIAL,
+             .name = "knomial",
+             .desc = "recursive k-ing with arbitrary radix"},
         [UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter.h
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter.h
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
+
 #ifndef REDUCE_SCATTER_H_
 #define REDUCE_SCATTER_H_
 #include "tl_ucp_coll.h"
@@ -10,6 +11,7 @@
 enum
 {
     UCC_TL_UCP_REDUCE_SCATTER_ALG_RING,
+    UCC_TL_UCP_REDUCE_SCATTER_ALG_KNOMIAL,
     UCC_TL_UCP_REDUCE_SCATTER_ALG_LAST
 };
 

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -15,8 +15,43 @@
         task->reduce_scatter_kn.phase = _phase;                                \
     } while (0)
 
-static inline void get_sbuf_rbuf(ucc_tl_ucp_task_t *task, size_t block_count,
-                                 void **sbuf, void **rbuf)
+#define GET_COUNT(_args)                                                       \
+    ({                                                                         \
+        size_t _count = 0;                                                     \
+        switch ((_args)->coll_type) {                                          \
+        case UCC_COLL_TYPE_ALLREDUCE:                                          \
+            _count = (_args)->dst.info.count;                                  \
+            break;                                                             \
+        case UCC_COLL_TYPE_REDUCE_SCATTER:                                     \
+            _count = UCC_IS_INPLACE(*(_args))                                  \
+                         ? (_args)->dst.info.count                             \
+                         : (_args)->src.info.count;                            \
+            break;                                                             \
+        default:                                                               \
+            break;                                                             \
+        }                                                                      \
+        _count;                                                                \
+    })
+
+#define GET_DT(_args)                                                          \
+    ((_args)->coll_type == UCC_COLL_TYPE_REDUCE_SCATTERV)                      \
+        ? (_args)->dst.info_v.datatype                                         \
+        : (_args)->dst.info.datatype
+
+typedef struct ucc_tl_ucp_rs_work_buf {
+    void *src_data;
+    void *dst_data;
+    void *src_loop;
+    void *dst_loop;
+    void *dst_proxy;
+    void *reduce_proxy;
+    void *reduce_loop;
+} ucc_tl_ucp_rs_work_buf_t;
+
+/* get work buffers for allreduce */
+static inline void get_sbuf_rbuf_ar(ucc_tl_ucp_task_t *task,
+                                    size_t block_count,
+                                    ucc_tl_ucp_rs_work_buf_t *wb)
 {
     ucc_coll_args_t       *args      = &TASK_ARGS(task);
     size_t                 dt_size   = ucc_dt_size(args->dst.info.datatype);
@@ -24,16 +59,17 @@ static inline void get_sbuf_rbuf(ucc_tl_ucp_task_t *task, size_t block_count,
     ucc_knomial_pattern_t *p         = &task->reduce_scatter_kn.p;
     size_t offset, local_seg_count;
     ptrdiff_t local_seg_offset;
+    void *sbuf, *rbuf;
 
     if (ucc_knomial_pattern_loop_first_iteration(p)) {
-        *sbuf = ((KN_NODE_PROXY ==  p->node_type) || UCC_IS_INPLACE(*args))
-                 ? args->dst.info.buffer: args->src.info.buffer;
-        *rbuf = scratch;
+        sbuf = ((KN_NODE_PROXY ==  p->node_type) || UCC_IS_INPLACE(*args))
+                ? args->dst.info.buffer: args->src.info.buffer;
+        rbuf = scratch;
     } else {
-        *sbuf = scratch;
+        sbuf = scratch;
         if (!ucc_knomial_pattern_loop_last_iteration(p) ||
             (task->reduce_scatter_kn.scratch_mc_header != NULL)) {
-            *rbuf = PTR_OFFSET(*sbuf, block_count * dt_size);
+            rbuf = PTR_OFFSET(sbuf, block_count * dt_size);
         } else {
             ucc_sra_kn_get_offset_and_seglen(args->dst.info.count, dt_size,
                                              p->rank, p->size,
@@ -41,15 +77,123 @@ static inline void get_sbuf_rbuf(ucc_tl_ucp_task_t *task, size_t block_count,
                                              &local_seg_count);
             local_seg_offset = local_seg_offset / dt_size;
             if ((local_seg_offset <= block_count) || (local_seg_count == 0)) {
-                *rbuf = PTR_OFFSET(*sbuf, block_count * dt_size);
+                rbuf = PTR_OFFSET(sbuf, block_count * dt_size);
             } else {
                 offset = (local_seg_offset - block_count) % local_seg_count;
                 /* check we have enough space to store segments */
                 ucc_assert(args->dst.info.count - (block_count + offset) >=
                            local_seg_count * (ucc_kn_compute_step_radix(p) - 1));
-                *rbuf = PTR_OFFSET(*sbuf, (block_count + offset) * dt_size);
+                rbuf = PTR_OFFSET(sbuf, (block_count + offset) * dt_size);
             }
         }
+    }
+
+    if (ucc_knomial_pattern_loop_last_iteration(p)) {
+        ucc_sra_kn_get_offset_and_seglen(args->dst.info.count, dt_size, p->rank,
+                                         p->size, p->radix, &local_seg_offset,
+                                         &local_seg_count);
+        wb->reduce_loop = PTR_OFFSET(args->dst.info.buffer, local_seg_offset);
+    } else {
+        wb->reduce_loop = scratch;
+    }
+    wb->src_data     = UCC_IS_INPLACE(*args) ? args->dst.info.buffer
+                                             : args->src.info.buffer;
+    wb->src_loop     = sbuf;
+    wb->dst_loop     = rbuf;
+    wb->dst_proxy    = scratch;
+    wb->reduce_proxy = args->dst.info.buffer;
+}
+
+/* get work buffers for reduce scatter */
+static inline void get_sbuf_rbuf_rs(ucc_tl_ucp_task_t *task,
+                                    ucc_tl_ucp_rs_work_buf_t *wb)
+{
+    ucc_coll_args_t       *args     = &TASK_ARGS(task);
+    ucc_knomial_pattern_t *p        = &task->reduce_scatter_kn.p;
+    void                  *scratch  = task->reduce_scatter_kn.scratch;
+    size_t                 dt_size  = ucc_dt_size(args->dst.info.datatype);
+    ucc_rank_t             trank    = task->subset.myrank;
+    ucc_rank_t             tsize    = task->subset.map.ep_num;
+    ucc_kn_radix_t         radix    = p->radix;
+    size_t max_seg;
+    void *sbuf, *rbuf, *data_buf;
+
+    max_seg = task->reduce_scatter_kn.max_seg;
+
+    if (UCC_IS_INPLACE(*args)) {
+        data_buf     = args->dst.info.buffer;
+        wb->dst_data = PTR_OFFSET(args->dst.info.buffer,
+                                  (args->dst.info.count / tsize) *
+                                  trank * dt_size);
+    } else {
+        data_buf     = args->src.info.buffer;
+        wb->dst_data = args->dst.info.buffer;
+    }
+
+    if (KN_NODE_PROXY == p->node_type) {
+        if (UCC_IS_INPLACE(*args)) {
+            rbuf = PTR_OFFSET(scratch, max_seg * dt_size);
+            if (ucc_knomial_pattern_loop_first_iteration(p)) {
+                sbuf = args->dst.info.buffer;
+            } else {
+                sbuf = scratch;
+            }
+            wb->dst_proxy = scratch;
+            wb->reduce_proxy = args->dst.info.buffer;
+        } else {
+            sbuf = PTR_OFFSET(scratch, max_seg * (radix - 1) * dt_size);
+            rbuf = scratch;
+            wb->dst_proxy    = PTR_OFFSET(scratch,
+                                          max_seg * (radix - 1) * dt_size);
+            wb->reduce_proxy = wb->dst_proxy;
+        }
+    } else {
+        rbuf = PTR_OFFSET(scratch, max_seg * dt_size);
+        if (ucc_knomial_pattern_loop_first_iteration(p)) {
+            sbuf = data_buf;
+        } else {
+            sbuf = scratch;
+        }
+    }
+
+    if (ucc_knomial_pattern_loop_last_iteration(p)) {
+         if (KN_NODE_PROXY == p->node_type) {
+            wb->reduce_loop = PTR_OFFSET(scratch,
+                                         max_seg * (radix - 1) * dt_size);
+        } else {
+            wb->reduce_loop = wb->dst_data;
+        }
+    } else {
+        if (KN_NODE_PROXY == p->node_type) {
+            if (UCC_IS_INPLACE(*args)) {
+                wb->reduce_loop = scratch;
+            } else {
+                wb->reduce_loop = PTR_OFFSET(scratch, max_seg * (radix - 1) * dt_size);
+            }
+        } else {
+            wb->reduce_loop = scratch;
+        }
+    }
+
+    wb->src_loop = sbuf;
+    wb->dst_loop = rbuf;
+    wb->src_data = data_buf;
+}
+
+static inline void get_rs_work_buf(ucc_tl_ucp_task_t *task,
+                                   size_t block_count,
+                                   ucc_tl_ucp_rs_work_buf_t *wb)
+{
+    ucc_coll_args_t *args     = &TASK_ARGS(task);
+    switch (args->coll_type) {
+    case UCC_COLL_TYPE_ALLREDUCE:
+        return get_sbuf_rbuf_ar(task, block_count, wb);
+    case UCC_COLL_TYPE_REDUCE_SCATTER:
+        return get_sbuf_rbuf_rs(task, wb);
+    case UCC_COLL_TYPE_REDUCE_SCATTERV:
+    default:
+        ucc_assert(0);
+        return;
     }
 }
 
@@ -62,45 +206,50 @@ void ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_kn_radix_t              radix     = task->reduce_scatter_kn.p.radix;
     ucc_knomial_pattern_t      *p         = &task->reduce_scatter_kn.p;
     uint8_t                     node_type = p->node_type;
-    void                       *scratch   = task->reduce_scatter_kn.scratch;
-    void                       *rbuf      = args->dst.info.buffer;
     ucc_memory_type_t           mem_type  = args->dst.info.mem_type;
-    size_t                      count     = args->dst.info.count;
+    size_t                      count     = GET_COUNT(args);
     ucc_datatype_t              dt        = args->dst.info.datatype;
-    void                       *sbuf      = UCC_IS_INPLACE(*args) ?
-                                             rbuf : args->src.info.buffer;
     size_t                      dt_size   = ucc_dt_size(dt);
     size_t                      data_size = count * dt_size;
     ucc_rank_t                  rank      = task->subset.myrank;
     ucc_rank_t                  size      = task->subset.map.ep_num;
-    ptrdiff_t      peer_seg_offset, local_seg_offset, offset;
-    ucc_rank_t     peer, step_radix;
-    ucc_status_t   status;
-    ucc_kn_radix_t loop_step;
-    size_t         block_count, peer_seg_count, local_seg_count;
-    void          *reduce_data, *local_data;
-    int            is_avg;
+    ptrdiff_t                peer_seg_offset, local_seg_offset;
+    ucc_rank_t               peer, step_radix;
+    ucc_status_t             status;
+    ucc_kn_radix_t           loop_step;
+    size_t                   block_count, peer_seg_count, local_seg_count;
+    void                    *local_data;
+    int                      is_avg;
+    ucc_tl_ucp_rs_work_buf_t wb;
 
     local_seg_count = 0;
-    block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
     UCC_KN_REDUCE_GOTO_PHASE(task->reduce_scatter_kn.phase);
+    block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
+    get_rs_work_buf(task, block_count, &wb);
     if (KN_NODE_EXTRA == node_type) {
         peer = ucc_ep_map_eval(task->subset.map,
                                ucc_knomial_pattern_get_proxy(p, rank));
         UCPCHECK_GOTO(
-            ucc_tl_ucp_send_nb(sbuf, data_size, mem_type, peer, team, task),
+            ucc_tl_ucp_send_nb(wb.src_data, data_size, mem_type, peer, team, task),
             task, out);
+        if (p->type != KN_PATTERN_REDUCE_SCATTERX) {
+            UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(wb.dst_data, (count / size) * dt_size,
+                                             mem_type, peer, team, task),
+                          task, out);
+        }
     }
 
     if (KN_NODE_PROXY == node_type) {
         peer = ucc_ep_map_eval(task->subset.map,
                                ucc_knomial_pattern_get_extra(p, rank));
         UCPCHECK_GOTO(
-            ucc_tl_ucp_recv_nb(scratch, data_size, mem_type, peer, team, task),
+            ucc_tl_ucp_recv_nb(wb.dst_proxy, data_size, mem_type, peer, team, task),
             task, out);
     }
 
 UCC_KN_PHASE_EXTRA:
+    block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
+    get_rs_work_buf(task, block_count, &wb);
     if ((KN_NODE_PROXY == node_type) || (KN_NODE_EXTRA == node_type)) {
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
             SAVE_STATE(UCC_KN_PHASE_EXTRA);
@@ -109,7 +258,8 @@ UCC_KN_PHASE_EXTRA:
         if (KN_NODE_EXTRA == node_type) {
             goto out;
         }
-        status = ucc_dt_reduce(sbuf, scratch, rbuf, count, dt, args, 0, 0,
+        status = ucc_dt_reduce(wb.src_data, wb.dst_proxy, wb.reduce_proxy,
+                               count, dt, args, 0, 0,
                                task->reduce_scatter_kn.executor,
                                &task->reduce_scatter_kn.etask);
         if (ucc_unlikely(status != UCC_OK)) {
@@ -124,10 +274,11 @@ UCC_KN_PHASE_EXTRA_REDUCE:
 
     }
     while (!ucc_knomial_pattern_loop_done(p)) {
-        block_count = ucc_sra_kn_compute_block_count(count, rank, p);
+        block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
+        local_seg_count = 0;
         ucc_kn_rs_pattern_peer_seg(rank, p, &local_seg_count,
                                    &local_seg_offset);
-        get_sbuf_rbuf(task, block_count, &sbuf, &rbuf);
+        get_rs_work_buf(task, block_count, &wb);
         for (loop_step = radix - 1; loop_step > 0; loop_step--) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, loop_step);
             if (peer == UCC_KN_PEER_NULL) {
@@ -137,15 +288,15 @@ UCC_KN_PHASE_EXTRA_REDUCE:
                                        &peer_seg_offset);
             peer = ucc_ep_map_eval(task->subset.map, peer);
             UCPCHECK_GOTO(
-                ucc_tl_ucp_send_nb(PTR_OFFSET(sbuf, peer_seg_offset * dt_size),
+                ucc_tl_ucp_send_nb(PTR_OFFSET(wb.src_loop, peer_seg_offset * dt_size),
                                    peer_seg_count * dt_size, mem_type, peer,
                                    team, task),
                 task, out);
             UCPCHECK_GOTO(
-                ucc_tl_ucp_recv_nb(rbuf, local_seg_count * dt_size, mem_type,
+                ucc_tl_ucp_recv_nb(wb.dst_loop, local_seg_count * dt_size, mem_type,
                                    peer, team, task),
                 task, out);
-            rbuf = PTR_OFFSET(rbuf, local_seg_count * dt_size);
+            wb.dst_loop = PTR_OFFSET(wb.dst_loop, local_seg_count * dt_size);
         }
 UCC_KN_PHASE_LOOP:
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
@@ -153,28 +304,18 @@ UCC_KN_PHASE_LOOP:
             return;
         }
         if (task->tagged.send_posted > p->iteration * (radix - 1)) {
-            step_radix = ucc_kn_compute_step_radix(p);
+            step_radix      = ucc_kn_compute_step_radix(p);
+            local_seg_count = 0;
+            block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
             ucc_kn_rs_pattern_peer_seg(rank, p, &local_seg_count,
                                        &local_seg_offset);
-            get_sbuf_rbuf(task, block_count, &sbuf, &rbuf);
-            local_data  = PTR_OFFSET(sbuf, local_seg_offset * dt_size);
+            get_rs_work_buf(task, block_count, &wb);
+            local_data  = PTR_OFFSET(wb.src_loop, local_seg_offset * dt_size);
             is_avg      = (args->op == UCC_OP_AVG) &&
                           (UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op ?
                                    ucc_knomial_pattern_loop_first_iteration(p) :
                                    ucc_knomial_pattern_loop_last_iteration(p));
-            ucc_assert((step_radix - 1) ==
-                       (task->tagged.send_posted - p->iteration * (radix - 1)));
-
-            if (ucc_knomial_pattern_loop_last_iteration(p)) {
-                ucc_sra_kn_get_offset_and_seglen(count, dt_size, rank, size,
-                                                 radix, &offset,
-                                                 &local_seg_count);
-                reduce_data = PTR_OFFSET(args->dst.info.buffer, offset);
-            } else {
-                reduce_data = task->reduce_scatter_kn.scratch;
-            }
-
-            status = ucc_dt_reduce_strided(local_data, rbuf, reduce_data,
+            status = ucc_dt_reduce_strided(local_data, wb.dst_loop, wb.reduce_loop,
                                            step_radix - 1, local_seg_count,
                                            local_seg_count * dt_size, dt, args,
                                            is_avg ? UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA : 0,
@@ -190,10 +331,31 @@ UCC_KN_PHASE_REDUCE:
                            "failed to perform dt reduction",
                            task->reduce_scatter_kn.etask);
         }
+        if ((args->coll_type == UCC_COLL_TYPE_REDUCE_SCATTER) &&
+            (KN_NODE_PROXY == node_type) &&
+            ucc_knomial_pattern_loop_last_iteration(p)) {
+            get_rs_work_buf(task, 0, &wb);
+            peer            = ucc_knomial_pattern_get_extra(p, rank);
+            peer_seg_count  = 0;
+            peer_seg_offset = 0;
+            ucc_kn_rs_pattern_extra_seg(p, &peer_seg_count, &peer_seg_offset);
+            UCPCHECK_GOTO(ucc_tl_ucp_send_nb(
+                            PTR_OFFSET(wb.reduce_loop,
+                                        peer_seg_offset * dt_size),
+                            peer_seg_count * dt_size, mem_type, peer, team, task),
+                          task, out);
+            ucc_mc_memcpy(wb.dst_data, wb.reduce_loop, peer_seg_count * dt_size,
+                          mem_type, mem_type);
+        }
         ucc_kn_rs_pattern_next_iter(p);
     }
+
 UCC_KN_PHASE_COMPLETE:
-UCC_KN_PHASE_PROXY: /* unused label */
+UCC_KN_PHASE_PROXY:
+    if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+        SAVE_STATE(UCC_KN_PHASE_PROXY);
+        return;
+    }
 out:
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_reduce_scatter_kn_done",
                                      0);
@@ -202,18 +364,28 @@ out:
 
 ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t   *args = &TASK_ARGS(task);
-    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
-    ucc_rank_t         rank = task->subset.myrank;
-    ucc_rank_t         size = task->subset.map.ep_num;
+    ucc_tl_ucp_task_t *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_coll_args_t   *args  = &TASK_ARGS(task);
+    ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
+    ucc_rank_t         rank  = task->subset.myrank;
+    ucc_rank_t         size  = task->subset.map.ep_num;
+    ucc_coll_type_t    ct    = args->coll_type;
+    size_t             count = GET_COUNT(args);
     ucc_status_t       status;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_reduce_scatter_kn_start",
                                      0);
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
-    ucc_kn_rsx_pattern_init(size, rank, task->reduce_scatter_kn.p.radix,
-                            args->dst.info.count, &task->reduce_scatter_kn.p);
+
+    if (ct == UCC_COLL_TYPE_ALLREDUCE) {
+        ucc_kn_rsx_pattern_init(size, rank, task->reduce_scatter_kn.p.radix,
+                                count, &task->reduce_scatter_kn.p);
+
+    } else {
+        ucc_kn_rs_pattern_init(size, rank, task->reduce_scatter_kn.p.radix,
+                               count, &task->reduce_scatter_kn.p);
+    }
+
     if (!task->reduce_scatter_kn.scratch_mc_header) {
         task->reduce_scatter_kn.scratch = args->dst.info.buffer;
     }
@@ -239,6 +411,50 @@ ucc_tl_ucp_reduce_scatter_knomial_finalize(ucc_coll_task_t *coll_task)
     return ucc_tl_ucp_coll_finalize(coll_task);
 }
 
+static size_t compute_scratch_size(ucc_tl_ucp_task_t *task)
+{
+    ucc_coll_args_t      *args      = &TASK_ARGS(task);
+    ucc_base_coll_args_t *coll_args = &task->super.bargs;
+    size_t                count     = GET_COUNT(args);
+    size_t                dt_size   = ucc_dt_size(GET_DT(args));
+    size_t                max_seg   = task->reduce_scatter_kn.max_seg;
+    size_t data_size;
+    ucc_kn_radix_t step_radix;
+    size_t max_recv_size;
+
+    if (args->coll_type == UCC_COLL_TYPE_ALLREDUCE) {
+        if (KN_NODE_EXTRA != task->reduce_scatter_kn.p.node_type) {
+            if (coll_args->mask & UCC_BASE_CARGS_MAX_FRAG_COUNT) {
+                count = coll_args->max_frag_count;
+            }
+            data_size = count * dt_size;
+            step_radix = ucc_kn_compute_step_radix(&task->reduce_scatter_kn.p);
+            max_recv_size = ucc_sra_kn_compute_seg_size(count, step_radix, 0) *
+                step_radix * dt_size;
+
+            if (UCC_IS_INPLACE(coll_args->args) ||
+                (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type) ||
+                max_recv_size > data_size) {
+                return ucc_max(max_recv_size, data_size);
+            } else {
+                return 0;
+            }
+        }
+    } else {
+        step_radix = task->reduce_scatter_kn.p.radix;
+        if (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type) {
+            if (UCC_IS_INPLACE(*args)) {
+                return max_seg * step_radix * dt_size;
+            } else {
+                return (max_seg * (step_radix - 1) + count) * dt_size;
+            }
+        } else if (KN_NODE_EXTRA != task->reduce_scatter_kn.p.node_type) {
+            return max_seg * step_radix * dt_size;
+        }
+    }
+    return 0;
+}
+
 ucc_status_t
 ucc_tl_ucp_reduce_scatter_knomial_init_r(ucc_base_coll_args_t *coll_args,
                                          ucc_base_team_t *team,
@@ -246,16 +462,15 @@ ucc_tl_ucp_reduce_scatter_knomial_init_r(ucc_base_coll_args_t *coll_args,
                                          ucc_kn_radix_t radix)
 {
     ucc_tl_ucp_team_t *tl_team   = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    size_t             count     = coll_args->args.dst.info.count;
-    ucc_datatype_t     dt        = coll_args->args.dst.info.datatype;
-    size_t             dt_size   = ucc_dt_size(dt);
     ucc_memory_type_t  mem_type  = coll_args->args.dst.info.mem_type;
+    size_t             count     = GET_COUNT(&coll_args->args);
+    ucc_coll_type_t    ct        = coll_args->args.coll_type;
     ucc_sbgp_t        *sbgp;
     ucc_tl_ucp_task_t *task;
     ucc_status_t       status;
-    size_t             max_recv_size, data_size;
-    ucc_kn_radix_t     step_radix;
+    size_t             scratch_size;
     ucc_rank_t         rank, size;
+    ptrdiff_t          max_seg_offset;
 
     task                 = ucc_tl_ucp_init_task(coll_args, team);
     task->super.flags    |= UCC_COLL_TASK_FLAG_EXECUTOR;
@@ -263,7 +478,7 @@ ucc_tl_ucp_reduce_scatter_knomial_init_r(ucc_base_coll_args_t *coll_args,
     task->super.progress = ucc_tl_ucp_reduce_scatter_knomial_progress;
     task->super.finalize = ucc_tl_ucp_reduce_scatter_knomial_finalize;
 
-    if (tl_team->cfg.use_reordering) {
+    if (tl_team->cfg.use_reordering && ct == UCC_COLL_TYPE_ALLREDUCE) {
         sbgp = ucc_topo_get_sbgp(tl_team->topo, UCC_SBGP_FULL_HOST_ORDERED);
         task->subset.myrank = sbgp->group_rank;
         task->subset.map    = sbgp->map;
@@ -271,30 +486,33 @@ ucc_tl_ucp_reduce_scatter_knomial_init_r(ucc_base_coll_args_t *coll_args,
 
     rank = task->subset.myrank;
     size = task->subset.map.ep_num;
-    ucc_assert(coll_args->args.src.info.mem_type ==
-               coll_args->args.dst.info.mem_type);
-    ucc_knomial_pattern_init(size, rank, radix, &task->reduce_scatter_kn.p);
+
+    ucc_assert(UCC_IS_INPLACE(coll_args->args) ||
+               (coll_args->args.src.info.mem_type ==
+                coll_args->args.dst.info.mem_type));
+
+    if (ct == UCC_COLL_TYPE_ALLREDUCE) {
+        ucc_kn_rsx_pattern_init(size, rank, radix,
+                                count, &task->reduce_scatter_kn.p);
+
+    } else {
+        ucc_kn_rs_pattern_init(size, rank, radix,
+                               count, &task->reduce_scatter_kn.p);
+    }
+
+    ucc_kn_rs_pattern_peer_seg(0, &task->reduce_scatter_kn.p,
+                               &task->reduce_scatter_kn.max_seg,
+                               &max_seg_offset);
     task->reduce_scatter_kn.scratch_mc_header = NULL;
 
-    if (KN_NODE_EXTRA != task->reduce_scatter_kn.p.node_type) {
-        if (coll_args->mask & UCC_BASE_CARGS_MAX_FRAG_COUNT) {
-            count = coll_args->max_frag_count;
-        }
-        data_size = count * dt_size;
-        step_radix = ucc_kn_compute_step_radix(&task->reduce_scatter_kn.p);
-        max_recv_size = ucc_sra_kn_compute_seg_size(count, step_radix, 0) *
-            step_radix * dt_size;
-
-        if (UCC_IS_INPLACE(coll_args->args) ||
-            (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type) ||
-            max_recv_size > data_size) {
-            status = ucc_mc_alloc(&task->reduce_scatter_kn.scratch_mc_header,
-                                  ucc_max(max_recv_size, data_size), mem_type);
-            task->reduce_scatter_kn.scratch =
-                task->reduce_scatter_kn.scratch_mc_header->addr;
-            if (UCC_OK != status) {
-                return status;
-            }
+    scratch_size = compute_scratch_size(task);
+    if (scratch_size != 0) {
+        status = ucc_mc_alloc(&task->reduce_scatter_kn.scratch_mc_header,
+                              scratch_size, mem_type);
+        task->reduce_scatter_kn.scratch =
+            task->reduce_scatter_kn.scratch_mc_header->addr;
+        if (UCC_OK != status) {
+            return status;
         }
     }
 

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -184,7 +184,8 @@ static inline void get_rs_work_buf(ucc_tl_ucp_task_t *task,
                                    size_t block_count,
                                    ucc_tl_ucp_rs_work_buf_t *wb)
 {
-    ucc_coll_args_t *args     = &TASK_ARGS(task);
+    ucc_coll_args_t *args = &TASK_ARGS(task);
+
     switch (args->coll_type) {
     case UCC_COLL_TYPE_ALLREDUCE:
         return get_sbuf_rbuf_ar(task, block_count, wb);
@@ -427,11 +428,10 @@ static size_t compute_scratch_size(ucc_tl_ucp_task_t *task)
             if (coll_args->mask & UCC_BASE_CARGS_MAX_FRAG_COUNT) {
                 count = coll_args->max_frag_count;
             }
-            data_size = count * dt_size;
-            step_radix = ucc_kn_compute_step_radix(&task->reduce_scatter_kn.p);
+            data_size     = count * dt_size;
+            step_radix    = ucc_kn_compute_step_radix(&task->reduce_scatter_kn.p);
             max_recv_size = ucc_sra_kn_compute_seg_size(count, step_radix, 0) *
-                step_radix * dt_size;
-
+                            step_radix * dt_size;
             if (UCC_IS_INPLACE(coll_args->args) ||
                 (KN_NODE_PROXY == task->reduce_scatter_kn.p.node_type) ||
                 max_recv_size > data_size) {

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -357,6 +357,9 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
         switch (alg_id) {
         case UCC_TL_UCP_REDUCE_SCATTER_ALG_RING:
             *init = ucc_tl_ucp_reduce_scatter_ring_init;
+            break;
+        case UCC_TL_UCP_REDUCE_SCATTER_ALG_KNOMIAL:
+            *init = ucc_tl_ucp_reduce_scatter_knomial_init;
             break;
         default:
             status = UCC_ERR_INVALID_PARAM;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -148,6 +148,7 @@ typedef struct ucc_tl_ucp_task {
             ucc_mc_buffer_header_t *scratch_mc_header;
             ucc_ee_executor_task_t *etask;
             ucc_ee_executor_t      *executor;
+            size_t                  max_seg;
         } reduce_scatter_kn;
         struct {
             void                   *scratch;


### PR DESCRIPTION
## What
Add reduce scatter knomial algorithm in TL/UCP

Performance:
8 nodes 64 ppn

msgsize: | knomia us. | ring us.
-- | -- | --
4 | 29.45 | 271.84
8 | 43.29 | 792.63
16 | 53.09 | 950.44
32 | 60.85 | 763.14
64 | 123.39 | 883.84
128 | 531.5 | 974.35
256 | 1026.58 | 1075.77
512 | 1028.21 | 1042.87
1024 | 1942.62 | 1331.72
2048 | 2149.71 | 1287.28
4096 | 4126.88 | 2087.69
8192 | 8338.22 | 3880.91

8 nodes 1 ppn
msgsize: | knomial us.| ring us.
-- | -- | --
4 | 5.47 | 11.59
8 | 5.56 | 14.15
16 | 4.69 | 13.96
32 | 4.83 | 13.92
64 | 5.34 | 14.36
128 | 5.52 | 15.37
256 | 6.16 | 15.88
512 | 7.43 | 19.06
1024 | 8.14 | 19.8
2048 | 9.48 | 21.71
4096 | 11.8 | 25.79
8192 | 18.59 | 30.37
16384 | 26.32 | 38.85
32768 | 47.18 | 58.44
65536 | 79.68 | 109.75
131072 | 130.79 | 171.54
