### PR TITLE
TL/NCCL: disable active set colls for lazyinit

### DIFF
--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -145,6 +145,10 @@ ucc_status_t ucc_tl_nccl_init_task(ucc_base_coll_args_t *coll_args,
     }
 
     if (ucc_unlikely(nccl_team->comm_state != TL_NCCL_COMM_STATE_READY)) {
+        if (UCC_COLL_ARGS_ACTIVE_SET(&coll_args->args)) {
+            /* active set is not supported with lazy comm init*/
+            return UCC_ERR_NOT_SUPPORTED;
+        }
         status = ucc_tl_nccl_comm_init(nccl_team);
         if (ucc_unlikely(status != UCC_OK)) {
             return status;


### PR DESCRIPTION
## What
Disable active set bcast in TL NCCL when lazy communicator init is used

## Why ?
With lazy init we cannot create communicator on first collective since not all ranks participate in init

