### PR TITLE
TEST: set cuda device in gtest

### DIFF
--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2001-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2001-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
  * Copyright (C) Huawei Technologies Co., Ltd. 2020.  All rights reserved.
  * See file LICENSE for terms.
@@ -9,12 +9,19 @@
 #  include "config.h"
 #endif
 
+#ifdef HAVE_CUDA
+#include <cuda_runtime.h>
+#endif
+
 #include "test_ucc.h"
 
 int main(int argc, char **argv)
 {
     int ret;
 
+#ifdef HAVE_CUDA
+    cudaSetDevice(0);
+#endif
     ::testing::InitGoogleTest(&argc, argv);
 
     ret = RUN_ALL_TESTS();


### PR DESCRIPTION
## What
set cuda device in gtest to create cuda context 

## Why ?
fixes 
```
mc_cuda.c:369  UCC  ERROR cuCtxGetId(cu_ctx, &cu_ctx_id)() failed: 201(invalid device context)
```