### PR TITLE
TL/MLX5: one-sided mcast reliability init

### DIFF
--- a/src/components/tl/mlx5/Makefile.am
+++ b/src/components/tl/mlx5/Makefile.am
@@ -12,19 +12,23 @@ alltoall =                      \
 	alltoall/alltoall_inline.h  \
 	alltoall/alltoall_coll.c
 
-mcast =                                 \
-	mcast/tl_mlx5_mcast_context.c       \
-	mcast/tl_mlx5_mcast.h               \
-	mcast/tl_mlx5_mcast_coll.c          \
-	mcast/tl_mlx5_mcast_coll.h          \
-	mcast/tl_mlx5_mcast_rcache.h        \
-	mcast/tl_mlx5_mcast_rcache.c        \
-	mcast/p2p/ucc_tl_mlx5_mcast_p2p.h   \
-	mcast/p2p/ucc_tl_mlx5_mcast_p2p.c   \
-	mcast/tl_mlx5_mcast_progress.h      \
-	mcast/tl_mlx5_mcast_progress.c      \
-	mcast/tl_mlx5_mcast_helper.h        \
-	mcast/tl_mlx5_mcast_helper.c        \
+mcast =                                         \
+	mcast/tl_mlx5_mcast_context.c               \
+	mcast/tl_mlx5_mcast.h                       \
+	mcast/tl_mlx5_mcast_coll.c                  \
+	mcast/tl_mlx5_mcast_coll.h                  \
+	mcast/tl_mlx5_mcast_rcache.h                \
+	mcast/tl_mlx5_mcast_rcache.c                \
+	mcast/p2p/ucc_tl_mlx5_mcast_p2p.h           \
+	mcast/p2p/ucc_tl_mlx5_mcast_p2p.c           \
+	mcast/tl_mlx5_mcast_progress.h              \
+	mcast/tl_mlx5_mcast_progress.c              \
+	mcast/tl_mlx5_mcast_helper.h                \
+	mcast/tl_mlx5_mcast_helper.c                \
+	mcast/tl_mlx5_mcast_service_coll.h          \
+	mcast/tl_mlx5_mcast_service_coll.c          \
+	mcast/tl_mlx5_mcast_one_sided_reliability.h \
+	mcast/tl_mlx5_mcast_one_sided_reliability.c \
 	mcast/tl_mlx5_mcast_team.c
 
 sources =             \

--- a/src/components/tl/mlx5/mcast/p2p/ucc_tl_mlx5_mcast_p2p.h
+++ b/src/components/tl/mlx5/mcast/p2p/ucc_tl_mlx5_mcast_p2p.h
@@ -16,3 +16,12 @@ ucc_status_t ucc_tl_mlx5_mcast_p2p_recv_nb(void* dst, size_t size, ucc_rank_t
                                            rank, void *context,
                                            ucc_tl_mlx5_mcast_p2p_completion_obj_t
                                            *obj);
+
+ucc_status_t ucc_tl_mlx5_one_sided_p2p_put(void* src, void* remote_addr, size_t length,
+                                           uint32_t lkey, uint32_t rkey, ucc_rank_t target_rank,
+                                           uint64_t wr_id, ucc_tl_mlx5_mcast_coll_comm_t *comm);
+
+ucc_status_t ucc_tl_mlx5_one_sided_p2p_get(void* src, void* remote_addr, size_t length,
+                                           uint32_t lkey, uint32_t rkey, ucc_rank_t target_rank,
+                                           uint64_t wr_id, ucc_tl_mlx5_mcast_coll_comm_t *comm);
+

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast.h
@@ -33,6 +33,14 @@
 #define DROP_THRESHOLD    1000
 #define MAX_COMM_POW2     32
 
+/* Allgather RDMA-based reliability designs */
+#define ONE_SIDED_RELIABILITY_MAX_TEAM_SIZE 1024
+#define ONE_SIDED_NO_RELIABILITY            0
+#define ONE_SIDED_SYNCHRONOUS_PROTO         1
+#define ONE_SIDED_ASYNCHRONOUS_PROTO        2
+#define ONE_SIDED_SLOTS_COUNT               2                /* number of memory slots during async design */
+#define ONE_SIDED_SLOTS_INFO_SIZE           sizeof(uint32_t) /* size of metadata prepended to each slots in bytes */
+
 enum {
     MCAST_PROTO_EAGER,     /* Internal staging buffers */
     MCAST_PROTO_ZCOPY
@@ -136,6 +144,7 @@ typedef struct ucc_tl_mlx5_mcast_coll_context {
     int                            ib_port;
     int                            pkey_index;
     int                            mtu;
+    uint16_t                       port_lid;
     struct rdma_cm_id             *id;
     struct rdma_event_channel     *channel;
     ucc_mpool_t                    compl_objects_mp;
@@ -174,6 +183,10 @@ struct mcast_ctx {
     struct ibv_ah     *ah;
     struct ibv_send_wr swr;
     struct ibv_sge     ssg;
+    // RC connection info for supporing one-sided based relibality
+    struct ibv_qp     **rc_qp;
+    uint16_t           *rc_lid;
+    union ibv_gid      *rc_gid;
 };
 
 struct packet {
@@ -183,65 +196,109 @@ struct packet {
     int        comm_id;
 };
 
+typedef struct ucc_tl_mlx5_mcast_slot_mem_info {
+    uint64_t remote_addr;
+    uint32_t rkey;
+} ucc_tl_mlx5_mcast_slot_mem_info_t;
+
+typedef struct ucc_tl_mlx5_one_sided_reliable_team_info {
+    ucc_tl_mlx5_mcast_slot_mem_info_t slot_mem;
+    uint16_t                          port_lid;
+    uint32_t                          rc_qp_num[ONE_SIDED_RELIABILITY_MAX_TEAM_SIZE];
+} ucc_tl_mlx5_one_sided_reliable_team_info_t;
+
+typedef struct ucc_tl_mlx5_mcast_one_sided_reliability_comm {
+    /* all the info required for establishing a reliable connection as
+     * well as temp slots memkeys that all processes in the team need
+     * to be aware of*/
+    ucc_tl_mlx5_one_sided_reliable_team_info_t *info;
+    /* holds all the remote-addr/rkey of sendbuf from processes in the team
+     * used in sync design. it needs to be set during each mcast-allgather call
+     * after sendbuf registration */
+    ucc_tl_mlx5_mcast_slot_mem_info_t          *sendbuf_memkey_list;
+    /* counter for each target recv packet */
+    uint32_t                                   *recvd_pkts_tracker;
+    /* holds the remote targets' collective call counter. it is used to check
+     * if remote temp slot is ready for RDMA READ in async design */
+    uint32_t                                   *remote_slot_info;
+    struct ibv_mr                              *remote_slot_info_mr;
+    int                                         reliability_scheme_msg_threshold;
+    /* mem address and mem keys of the temp slots in async design */
+    char                                       *slots_buffer;
+    struct ibv_mr                              *slots_mr;
+    /* size of a temp slot in async design */
+    int                                         slot_size;
+    /* coll req that is used during the oob service calls */
+    ucc_service_coll_req_t                     *reliability_req;
+} ucc_tl_mlx5_mcast_one_sided_reliability_comm_t;
+
+typedef struct ucc_tl_mlx5_mcast_service_coll {
+    ucc_status_t (*bcast_post) (void*, void*, size_t, ucc_rank_t, ucc_service_coll_req_t**);
+    ucc_status_t (*allgather_post) (void*, void*, void*, size_t, ucc_service_coll_req_t**);
+    ucc_status_t (*barrier_post) (void*, ucc_service_coll_req_t**);
+    ucc_status_t (*coll_test) (ucc_service_coll_req_t*);
+} ucc_tl_mlx5_mcast_service_coll_t;
+
 typedef struct ucc_tl_mlx5_mcast_coll_comm {
-    struct pp_packet                        dummy_packet;
-    ucc_tl_mlx5_mcast_coll_context_t       *ctx;
-    ucc_tl_mlx5_mcast_coll_comm_init_spec_t params;
-    ucc_tl_mlx5_mcast_p2p_interface_t       p2p;
-    int                                     tx;
-    struct ibv_cq                          *scq;
-    struct ibv_cq                          *rcq;
-    ucc_rank_t                              rank;
-    ucc_rank_t                              commsize;
-    char                                   *grh_buf;
-    struct ibv_mr                          *grh_mr;
-    uint16_t                                mcast_lid;
-    union ibv_gid                           mgid;
-    unsigned                                max_inline;
-    size_t                                  max_eager;
-    int                                     max_per_packet;
-    int                                     pending_send;
-    int                                     pending_recv;
-    struct ibv_mr                          *pp_mr;
-    char                                   *pp_buf;
-    struct pp_packet                       *pp;
-    uint32_t                                psn;
-    uint32_t                                last_psn;
-    uint32_t                                racks_n;
-    uint32_t                                sacks_n;
-    uint32_t                                last_acked;
-    uint32_t                                naks_n;
-    uint32_t                                child_n;
-    uint32_t                                parent_n;
-    int                                     buf_n;
-    struct packet                           p2p_pkt[MAX_COMM_POW2];
-    struct packet                           p2p_spkt[MAX_COMM_POW2];
-    ucc_list_link_t                         bpool;
-    ucc_list_link_t                         pending_q;
-    struct mcast_ctx                        mcast;
-    int                                     reliable_in_progress;
-    int                                     recv_drop_packet_in_progress;
-    struct ibv_recv_wr                     *call_rwr;
-    struct ibv_sge                         *call_rsgs;
-    uint64_t                                timer;
-    int                                     stalled;
-    int                                     comm_id;
-    void                                   *p2p_ctx;
-    ucc_base_lib_t                         *lib;
-    struct sockaddr_in6                     mcast_addr;
-    ucc_rank_t                              parents[MAX_COMM_POW2];
-    ucc_rank_t                              children[MAX_COMM_POW2];
-    int                                     nack_requests;
-    int                                     nacks_counter;
-    int                                     n_prep_reliable;
-    int                                     n_mcast_reliable;
-    int                                     wsize;
-    ucc_tl_mlx5_mcast_join_info_t          *group_setup_info;
-    ucc_service_coll_req_t                 *group_setup_info_req;
-    ucc_status_t                           (*bcast_post) (void*, void*, size_t, ucc_rank_t, ucc_service_coll_req_t**);
-    ucc_status_t                           (*bcast_test) (ucc_service_coll_req_t*);
-    struct rdma_cm_event                   *event;
-    struct pp_packet                       *r_window[1]; // do not add any new variable after here
+    struct pp_packet                                dummy_packet;
+    ucc_tl_mlx5_mcast_coll_context_t               *ctx;
+    ucc_tl_mlx5_mcast_coll_comm_init_spec_t         params;
+    ucc_tl_mlx5_mcast_p2p_interface_t               p2p;
+    int                                             tx;
+    struct ibv_cq                                  *scq;
+    struct ibv_cq                                  *rcq;
+    struct ibv_srq                                 *srq;
+    ucc_rank_t                                      rank;
+    ucc_rank_t                                      commsize;
+    char                                           *grh_buf;
+    struct ibv_mr                                  *grh_mr;
+    uint16_t                                        mcast_lid;
+    union ibv_gid                                   mgid;
+    unsigned                                        max_inline;
+    size_t                                          max_eager;
+    int                                             max_per_packet;
+    int                                             pending_send;
+    int                                             pending_recv;
+    struct ibv_mr                                  *pp_mr;
+    char                                           *pp_buf;
+    struct pp_packet                               *pp;
+    uint32_t                                        psn;
+    uint32_t                                        last_psn;
+    uint32_t                                        racks_n;
+    uint32_t                                        sacks_n;
+    uint32_t                                        last_acked;
+    uint32_t                                        naks_n;
+    uint32_t                                        child_n;
+    uint32_t                                        parent_n;
+    int                                             buf_n;
+    struct packet                                   p2p_pkt[MAX_COMM_POW2];
+    struct packet                                   p2p_spkt[MAX_COMM_POW2];
+    ucc_list_link_t                                 bpool;
+    ucc_list_link_t                                 pending_q;
+    struct mcast_ctx                                mcast;
+    int                                             reliable_in_progress;
+    int                                             recv_drop_packet_in_progress;
+    struct ibv_recv_wr                             *call_rwr;
+    struct ibv_sge                                 *call_rsgs;
+    uint64_t                                        timer;
+    int                                             stalled;
+    int                                             comm_id;
+    void                                           *p2p_ctx;
+    ucc_base_lib_t                                 *lib;
+    struct sockaddr_in6                             mcast_addr;
+    ucc_rank_t                                      parents[MAX_COMM_POW2];
+    ucc_rank_t                                      children[MAX_COMM_POW2];
+    int                                             nack_requests;
+    int                                             nacks_counter;
+    int                                             n_prep_reliable;
+    int                                             n_mcast_reliable;
+    int                                             wsize;
+    ucc_tl_mlx5_mcast_join_info_t                  *group_setup_info;
+    ucc_service_coll_req_t                         *group_setup_info_req;
+    ucc_tl_mlx5_mcast_service_coll_t                service_coll;
+    struct rdma_cm_event                           *event;
+    ucc_tl_mlx5_mcast_one_sided_reliability_comm_t  one_sided;
+    struct pp_packet                               *r_window[1]; // note: do not add any new variable after here
 } ucc_tl_mlx5_mcast_coll_comm_t;
 
 typedef struct ucc_tl_mlx5_mcast_team {
@@ -313,6 +370,7 @@ typedef struct ucc_tl_mlx5_mcast_oob_p2p_context {
     ucc_rank_t      my_team_rank;
     ucc_subset_t    subset;
     ucc_base_lib_t *lib;
+    int             tmp_buf;
 } ucc_tl_mlx5_mcast_oob_p2p_context_t;
 
 static inline struct pp_packet* ucc_tl_mlx5_mcast_buf_get_free(ucc_tl_mlx5_mcast_coll_comm_t* comm)

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_context.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_context.c
@@ -216,7 +216,8 @@ ucc_status_t ucc_tl_mlx5_mcast_context_init(ucc_tl_mlx5_mcast_context_t    *cont
         }
     }
 
-    ctx->mtu = active_mtu;
+    ctx->mtu      = active_mtu;
+    ctx->port_lid = port_attr.lid;
 
     tl_debug(ctx->lib, "port active MTU is %d and port max MTU is %d",
              active_mtu, max_mtu);

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_helper.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_helper.h
@@ -363,6 +363,12 @@ ucc_status_t ucc_tl_mlx5_mcast_init_qps(ucc_tl_mlx5_mcast_coll_context_t *ctx,
 ucc_status_t ucc_tl_mlx5_mcast_setup_qps(ucc_tl_mlx5_mcast_coll_context_t *ctx,
                                          ucc_tl_mlx5_mcast_coll_comm_t *comm);
 
+ucc_status_t ucc_tl_mlx5_mcast_create_rc_qps(ucc_tl_mlx5_mcast_coll_context_t *ctx,
+                                             ucc_tl_mlx5_mcast_coll_comm_t *comm);
+
+ucc_status_t ucc_tl_mlx5_mcast_modify_rc_qps(ucc_tl_mlx5_mcast_coll_context_t *ctx,
+                                             ucc_tl_mlx5_mcast_coll_comm_t *comm);
+
 ucc_status_t ucc_tl_mlx5_clean_mcast_comm(ucc_tl_mlx5_mcast_coll_comm_t *comm);
 
 ucc_status_t ucc_tl_mlx5_mcast_join_mcast_post(ucc_tl_mlx5_mcast_coll_context_t *ctx,

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.c
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_mlx5_mcast_one_sided_reliability.h"
+
+static ucc_status_t ucc_tl_mlx5_mcast_one_sided_setup_reliability_buffers(ucc_base_team_t *team)
+{
+    ucc_tl_mlx5_team_t            *tl_team = ucc_derived_of(team, ucc_tl_mlx5_team_t);
+    ucc_status_t                   status  = UCC_OK;
+    ucc_tl_mlx5_mcast_coll_comm_t *comm    = tl_team->mcast->mcast_comm;
+    int                            one_sided_total_slots_size, i;
+
+    /* this array keeps track of the number of recv packets from each process
+     * used in all the protocols */
+    comm->one_sided.recvd_pkts_tracker = ucc_calloc(1, comm->commsize * sizeof(uint32_t),
+                                                    "one_sided.recvd_pkts_tracker");
+    if (!comm->one_sided.recvd_pkts_tracker) {
+        tl_error(comm->lib, "unable to malloc for one_sided.recvd_pkts_tracker");
+        status = UCC_ERR_NO_MEMORY;
+        goto failed;
+    }
+
+    comm->one_sided.sendbuf_memkey_list = ucc_calloc
+            (1, comm->commsize * sizeof(ucc_tl_mlx5_mcast_slot_mem_info_t),
+             "one_sided.sendbuf_memkey_list");
+    if (!comm->one_sided.sendbuf_memkey_list) {
+        tl_error(comm->lib, "unable to malloc for one_sided.sendbuf_memkey_list");
+        status = UCC_ERR_NO_MEMORY;
+        goto failed;
+    }
+
+    /* below data structures are used in async design only */
+    comm->one_sided.slot_size    = comm->one_sided.reliability_scheme_msg_threshold
+                                           + ONE_SIDED_SLOTS_INFO_SIZE;
+    one_sided_total_slots_size   = comm->one_sided.slot_size *
+                                            ONE_SIDED_SLOTS_COUNT * sizeof(char);
+    comm->one_sided.slots_buffer = (char *)ucc_calloc(1, one_sided_total_slots_size,
+                                                      "one_sided.slots_buffer");
+    if (!comm->one_sided.slots_buffer) {
+        tl_error(comm->lib, "unable to malloc for one_sided.slots_buffer");
+        status = UCC_ERR_NO_MEMORY;
+        goto failed;
+    }
+    comm->one_sided.slots_mr = ibv_reg_mr(comm->ctx->pd, comm->one_sided.slots_buffer,
+                                          one_sided_total_slots_size, IBV_ACCESS_LOCAL_WRITE |
+                                          IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE);
+    if (!comm->one_sided.slots_mr) {
+        tl_error(comm->lib, "unable to register for one_sided.slots_mr");
+        status = UCC_ERR_NO_RESOURCE;
+        goto failed;
+    }
+    
+    /* this array holds local information about the slot status that was read from remote ranks */
+    comm->one_sided.remote_slot_info = ucc_calloc(1, comm->commsize * ONE_SIDED_SLOTS_INFO_SIZE,
+                                                  "one_sided.remote_slot_info");
+    if (!comm->one_sided.remote_slot_info) {
+        tl_error(comm->lib, "unable to malloc for one_sided.remote_slot_info");
+        status = UCC_ERR_NO_MEMORY;
+        goto failed;
+    }
+    comm->one_sided.remote_slot_info_mr = ibv_reg_mr(comm->ctx->pd, comm->one_sided.remote_slot_info,
+                                                     comm->commsize * ONE_SIDED_SLOTS_INFO_SIZE,
+                                                     IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE |
+                                                     IBV_ACCESS_REMOTE_READ);
+    if (!comm->one_sided.remote_slot_info_mr) {
+        tl_error(comm->lib, "unable to register for one_sided.remote_slot_info_mr");
+        status = UCC_ERR_NO_RESOURCE;
+        goto failed;
+    }
+
+    comm->one_sided.info = ucc_calloc(1, sizeof(ucc_tl_mlx5_one_sided_reliable_team_info_t) *
+                                      comm->commsize, "one_sided.info");
+    if (!comm->one_sided.info) {
+        tl_error(comm->lib, "unable to allocate mem for one_sided.info");
+        status = UCC_ERR_NO_MEMORY;
+        goto failed;
+    }
+
+    status = ucc_tl_mlx5_mcast_create_rc_qps(comm->ctx, comm);
+    if (UCC_OK != status) {
+        tl_error(comm->lib, "RC qp create failed");
+        goto failed;
+    }
+
+    /* below holds the remote addr/rkey to local slot field of all the
+     * processes used in async protocol */
+    comm->one_sided.info[comm->rank].slot_mem.rkey        = comm->one_sided.slots_mr->rkey;
+    comm->one_sided.info[comm->rank].slot_mem.remote_addr = (uint64_t)comm->one_sided.slots_buffer;
+    comm->one_sided.info[comm->rank].port_lid             = comm->ctx->port_lid;
+    for (i = 0; i < comm->commsize; i++) {
+        comm->one_sided.info[comm->rank].rc_qp_num[i] = comm->mcast.rc_qp[i]->qp_num;
+    }
+
+    tl_debug(comm->lib, "created the allgather reliability structures");
+
+    return UCC_OK;
+
+failed:
+    return status;
+}
+
+static inline ucc_status_t ucc_tl_mlx5_mcast_one_sided_cleanup(ucc_tl_mlx5_mcast_coll_comm_t *comm)
+{
+    int j;
+
+    if (comm->mcast.rc_qp != NULL) {
+        for (j=0; j<comm->commsize; j++) {
+            if (comm->mcast.rc_qp[j] != NULL && ibv_destroy_qp(comm->mcast.rc_qp[j])) {
+                tl_error(comm->lib, "ibv_destroy_qp failed");
+                return UCC_ERR_NO_RESOURCE;
+            }
+            comm->mcast.rc_qp[j] = NULL;
+        }
+
+        ucc_free(comm->mcast.rc_qp);
+        comm->mcast.rc_qp = NULL;
+    }
+
+    if (comm->srq != NULL && ibv_destroy_srq(comm->srq)) {
+        tl_error(comm->lib, "ibv_destroy_srq failed");
+        return UCC_ERR_NO_RESOURCE;
+    }
+    comm->srq = NULL;
+
+    if (comm->one_sided.slots_mr) {
+        ibv_dereg_mr(comm->one_sided.slots_mr);
+        comm->one_sided.slots_mr = 0;
+    }
+
+    if (comm->one_sided.remote_slot_info_mr) {
+        ibv_dereg_mr(comm->one_sided.remote_slot_info_mr);
+        comm->one_sided.remote_slot_info_mr = 0;
+    }
+
+    if (comm->one_sided.slots_buffer) {
+        ucc_free(comm->one_sided.slots_buffer);
+        comm->one_sided.slots_buffer = NULL;
+    }
+
+    if (comm->one_sided.recvd_pkts_tracker) {
+        ucc_free(comm->one_sided.recvd_pkts_tracker);
+        comm->one_sided.recvd_pkts_tracker = NULL;
+    }
+
+    if (comm->one_sided.sendbuf_memkey_list) {
+        ucc_free(comm->one_sided.sendbuf_memkey_list);
+        comm->one_sided.sendbuf_memkey_list = NULL;
+    }
+
+    if (comm->one_sided.remote_slot_info) {
+        ucc_free(comm->one_sided.remote_slot_info);
+        comm->one_sided.remote_slot_info = NULL;
+    }
+
+    if (comm->one_sided.info) {
+        ucc_free(comm->one_sided.info);
+        comm->one_sided.info = NULL;
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_init(ucc_base_team_t *team)
+{
+    ucc_tl_mlx5_team_t            *tl_team  = ucc_derived_of(team, ucc_tl_mlx5_team_t);
+    ucc_tl_mlx5_mcast_coll_comm_t *comm     = tl_team->mcast->mcast_comm;
+    ucc_status_t                   status   = UCC_OK;
+
+    status = ucc_tl_mlx5_mcast_one_sided_setup_reliability_buffers(team);
+    if (status != UCC_OK) {
+        tl_error(comm->lib, "setup reliablity resources failed");
+        goto failed;
+    }
+
+     /* TODO double check if ucc inplace allgather is working properly */
+    status = comm->service_coll.allgather_post(comm->p2p_ctx, NULL /*inplace*/, comm->one_sided.info,
+                                               sizeof(ucc_tl_mlx5_one_sided_reliable_team_info_t),
+                                               &comm->one_sided.reliability_req);
+    if (UCC_OK != status) {
+        tl_error(comm->lib, "oob allgather failed during one-sided reliability init");
+        goto failed;
+    }
+
+    return status;
+
+failed:
+    if (UCC_OK != ucc_tl_mlx5_mcast_one_sided_cleanup(comm)) {
+        tl_error(comm->lib, "mcast one-sided reliablity resource cleanup failed");
+    }
+
+    return status;
+}
+
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_test(ucc_base_team_t *team)
+{
+    ucc_tl_mlx5_team_t            *tl_team  = ucc_derived_of(team, ucc_tl_mlx5_team_t);
+    ucc_status_t                   status   = UCC_OK;
+    ucc_tl_mlx5_mcast_coll_comm_t *comm     = tl_team->mcast->mcast_comm;
+
+    /* check if the one sided config info is exchanged */
+    status = comm->service_coll.coll_test(comm->one_sided.reliability_req);
+    if (UCC_OK != status) {
+        /* allgather is not completed yet */
+        if (status < 0) {
+            tl_error(comm->lib, "one sided config info exchange failed");
+            goto failed;
+        }
+        return status;
+    }
+
+    /* we have all the info to make the reliable connections */
+    status = ucc_tl_mlx5_mcast_modify_rc_qps(comm->ctx, comm);
+    if (UCC_OK != status) {
+        tl_error(comm->lib, "RC qp modify failed");
+        goto failed;
+    }
+
+failed:
+    if (UCC_OK != ucc_tl_mlx5_mcast_one_sided_cleanup(comm)) {
+        tl_error(comm->lib, "mcast one-sided reliablity resource cleanup failed");
+    }
+    
+    return status;
+}
+

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+
+#include "tl_mlx5.h"
+#include "tl_mlx5_mcast_coll.h"
+#include "coll_score/ucc_coll_score.h"
+#include "tl_mlx5_mcast_helper.h"
+#include "p2p/ucc_tl_mlx5_mcast_p2p.h"
+#include "mcast/tl_mlx5_mcast_helper.h"
+#include "mcast/tl_mlx5_mcast_service_coll.h"
+
+
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_init(ucc_base_team_t *team);
+
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_test(ucc_base_team_t *team);

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_service_coll.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_service_coll.c
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "mcast/tl_mlx5_mcast_service_coll.h"
+ 
+ucc_status_t ucc_tl_mlx5_mcast_service_bcast_post(void *arg, void *buf, size_t size, ucc_rank_t root,
+                                                  ucc_service_coll_req_t **bcast_req)
+{
+    ucc_tl_mlx5_mcast_oob_p2p_context_t *ctx    = (ucc_tl_mlx5_mcast_oob_p2p_context_t *)arg;
+    ucc_status_t                         status = UCC_OK;
+    ucc_team_t                          *team   = ctx->base_team;
+    ucc_subset_t                         subset = ctx->subset;
+    ucc_service_coll_req_t              *req    = NULL;
+
+    status = ucc_service_bcast(team, buf, size, root, subset, &req);
+    if (ucc_unlikely(UCC_OK != status)) {
+        tl_error(ctx->base_ctx->lib, "tl service mcast bcast failed");
+        return status;
+    }
+
+    *bcast_req = req;
+
+    return status;
+}
+
+ucc_status_t ucc_tl_mlx5_mcast_service_allgather_post(void *arg, void *sbuf, void *rbuf, size_t size,
+                                                      ucc_service_coll_req_t **ag_req)
+{
+    ucc_tl_mlx5_mcast_oob_p2p_context_t *ctx    = (ucc_tl_mlx5_mcast_oob_p2p_context_t *)arg;
+    ucc_status_t                         status = UCC_OK;
+    ucc_team_t                          *team   = ctx->base_team;
+    ucc_subset_t                         subset = ctx->subset;
+    ucc_service_coll_req_t              *req    = NULL;
+
+    status =  ucc_service_allgather(team, sbuf, rbuf, size, subset, &req);
+    if (ucc_unlikely(UCC_OK != status)) {
+        tl_error(ctx->base_ctx->lib, "tl service mcast allgather failed");
+        return status;
+    }
+
+    *ag_req = req;
+
+    return status;
+}
+
+ucc_status_t ucc_tl_mlx5_mcast_service_barrier_post(void *arg, ucc_service_coll_req_t **barrier_req)
+{
+    ucc_tl_mlx5_mcast_oob_p2p_context_t *ctx    = (ucc_tl_mlx5_mcast_oob_p2p_context_t *)arg;
+    ucc_status_t                         status = UCC_OK;
+    ucc_team_t                          *team   = ctx->base_team;
+    ucc_subset_t                         subset = ctx->subset;
+    ucc_service_coll_req_t              *req    = NULL;
+
+    status =  ucc_service_allreduce(team, &ctx->tmp_buf, &ctx->tmp_buf, UCC_DT_INT8, 1,
+                                    UCC_OP_SUM, subset, &req);
+    if (ucc_unlikely(UCC_OK != status)) {
+        tl_error(ctx->base_ctx->lib, "tl service mcast barrier failed");
+        return status;
+    }
+
+    *barrier_req = req;
+
+    return status;
+}
+
+ucc_status_t ucc_tl_mlx5_mcast_service_coll_test(ucc_service_coll_req_t *req)
+{
+    ucc_status_t status = UCC_OK;
+
+    status = ucc_service_coll_test(req);
+
+    if (UCC_INPROGRESS != status) {
+        if (status < 0) {
+            ucc_error("oob service coll progress failed");
+        }
+        ucc_service_coll_finalize(req);
+    }
+
+    return status;
+}

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_service_coll.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_service_coll.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_mlx5_mcast_coll.h"
+ 
+ucc_status_t ucc_tl_mlx5_mcast_service_bcast_post(void *arg, void *buf, size_t size, ucc_rank_t root,
+                                                  ucc_service_coll_req_t **bcast_req);
+
+ucc_status_t ucc_tl_mlx5_mcast_service_allgather_post(void *arg, void *sbuf, void *rbuf, size_t size,
+                                                      ucc_service_coll_req_t **ag_req);
+
+ucc_status_t ucc_tl_mlx5_mcast_service_barrier_post(void *arg, ucc_service_coll_req_t **barrier_req);
+
+ucc_status_t ucc_tl_mlx5_mcast_service_coll_test(ucc_service_coll_req_t *req);
+


### PR DESCRIPTION
TL/MLX5: one-sided mcast reliability init that will be used for mcast-based allgather