### PR TITLE
fix unannotated fall-through between switch labels in utils/ucc_coll_utils.h

### DIFF
--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -288,6 +288,7 @@ static inline ucc_rank_t ucc_ep_map_local_rank(ucc_ep_map_t map,
                 break;
             }
         }
+        break;
     default:
         break;
     }


### PR DESCRIPTION
## What
fix unannotated fall-through between switch labels in `utils/ucc_coll_utils.h`

## Why ?
When building on x86_64 Linux and clang 15,

```
...
utils/ucc_coll_utils.h:291:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
    default:
    ^
...
```
