### PR TITLE
CORE: Fix/match spelling of collective hints

### DIFF
--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -1715,24 +1715,24 @@ typedef enum {
  *  @ingroup UCC_COLLECTIVES_DT
  */
 typedef enum {
-    UCC_COLL_ARGS_HINT_OPTMIZE_OVERLAP_CPU  = UCC_BIT(24), /*!< When the flag is
-                                                            set, the user
-                                                            prefers the library
-                                                            to choose an
-                                                            algorithm
-                                                            implementation
-                                                            optimized for the
-                                                            best overlap of CPU
-                                                            resources. */
-    UCC_COLL_ARGS_HINT_OPTMIZE_OVERLAP_GPU  = UCC_BIT(25), /*!< When the flag is
-                                                            set, the user
-                                                            prefers the library
-                                                            to choose an
-                                                            algorithm
-                                                            implementation
-                                                            optimized for the
-                                                            best overlap of GPU
-                                                            resources. */
+    UCC_COLL_ARGS_HINT_OPTIMIZE_OVERLAP_CPU  = UCC_BIT(24), /*!< When the flag is
+                                                              set, the user
+                                                              prefers the library
+                                                              to choose an
+                                                              algorithm
+                                                              implementation
+                                                              optimized for the
+                                                              best overlap of CPU
+                                                              resources. */
+    UCC_COLL_ARGS_HINT_OPTIMIZE_OVERLAP_GPU  = UCC_BIT(25), /*!< When the flag is
+                                                              set, the user
+                                                              prefers the library
+                                                              to choose an
+                                                              algorithm
+                                                              implementation
+                                                              optimized for the
+                                                              best overlap of GPU
+                                                              resources. */
     UCC_COLL_ARGS_HINT_OPTIMIZE_LATENCY     = UCC_BIT(26), /*!<  When the flag is
                                                            set, the user prefers
                                                            the library to choose


### PR DESCRIPTION
## What
Fixes a typo that make some (but not all) hints misspell optimize. 

## Why ?
Our OpenMPI code maintainer requested this fixup.

## How ?
n/a
