### PR TITLE
TL/SHARP: Use internal OOB if available.

### DIFF
--- a/src/components/tl/sharp/tl_sharp.c
+++ b/src/components/tl/sharp/tl_sharp.c
@@ -19,10 +19,10 @@ static ucc_config_field_t ucc_tl_sharp_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_sharp_lib_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)},
 
-    {"USE_INTERNAL_OOB", "n",
+    {"USE_INTERNAL_OOB", "try",
      "Use service team to create sharp context",
      ucc_offsetof(ucc_tl_sharp_lib_config_t, use_internal_oob),
-     UCC_CONFIG_TYPE_BOOL},
+     UCC_CONFIG_TYPE_TERNARY},
 
     {NULL}};
 

--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -92,7 +92,7 @@ static int ucc_tl_sharp_oob_bcast(void *arg, void *buf, int size, int root)
     ucc_status_t            status;
     void                   *req, *tmp_rbuf;
 
-    tmp_rbuf = ucc_malloc(msg_size * oob_coll->n_oob_eps, "tmp_barrier");
+    tmp_rbuf = ucc_malloc(msg_size * oob_coll->n_oob_eps, "tmp_bcast");
     if (!tmp_rbuf) {
         tl_error(ctx->super.super.lib,
                  "failed to allocate %zd bytes for tmp barrier array",
@@ -322,7 +322,7 @@ ucc_status_t ucc_tl_sharp_context_init(ucc_tl_sharp_context_t *sharp_ctx,
     init_spec.enable_thread_support          =
                     (sharp_ctx->tm == UCC_THREAD_MULTIPLE) ? 1 : 0;
 
-    if (lib->cfg.use_internal_oob) {
+    if (lib->cfg.use_internal_oob != UCC_NO && sharp_ctx->super.super.ucc_context->service_team) {
         tl_debug(sharp_ctx->super.super.lib,
                  "using internal oob.  rank:%u size:%lu",
                  oob_ctx->subset.myrank, oob_ctx->subset.map.ep_num);
@@ -428,7 +428,7 @@ ucc_status_t ucc_tl_sharp_context_create_epilog(ucc_base_context_t *context)
     set.myrank     = UCC_TL_CTX_OOB(sharp_ctx).oob_ep;
     set.map.ep_num = UCC_TL_CTX_OOB(sharp_ctx).n_oob_eps;
 
-    if (lib->cfg.use_internal_oob) {
+    if (lib->cfg.use_internal_oob != UCC_NO && core_ctx->service_team) {
         sharp_ctx->oob_ctx.subset = set;
     } else {
         sharp_ctx->oob_ctx.oob = &UCC_TL_CTX_OOB(sharp_ctx);

--- a/src/components/tl/sharp/tl_sharp_lib.c
+++ b/src/components/tl/sharp/tl_sharp_lib.c
@@ -36,7 +36,7 @@ ucc_status_t ucc_tl_sharp_get_lib_attr(const ucc_base_lib_t *lib,
 
     attr->super.flags = 0;
     if (lib != NULL) {
-        if (sharp_lib->cfg.use_internal_oob) {
+        if (sharp_lib->cfg.use_internal_oob == UCC_YES) {
             attr->super.flags |= UCC_BASE_LIB_FLAG_CTX_SERVICE_TEAM_REQUIRED;
         }
     }


### PR DESCRIPTION
## What
Try use ICC internal OOB if available. 

## Why ?
Interl OOB is optimal while external OOB BCAST is implemented using allgather which is not optimal. 

