### PR TITLE
BUILD: add support for specific gpu ach with ROCM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,9 @@ AC_MSG_NOTICE([      C++ compiler:   ${CXX} ${CXXFLAGS} ${BASE_CXXFLAGS}])
 AS_IF([test "x$cuda_happy" = "xyes"],[
 AC_MSG_NOTICE([     NVCC gencodes:   ${NVCC_ARCH}])
 ])
+AS_IF([test "x$rocm_happy" = xyes],[
+AC_MSG_NOTICE([ROCM architectures:   ${ROCM_ARCH}])
+])
 AC_MSG_NOTICE([          Perftest:   ${mpi_enable}])
 AC_MSG_NOTICE([             Gtest:   ${gtest_enable}])
 AC_MSG_NOTICE([        MC modules:   <$(echo ${mc_modules}|tr ':' ' ') >])

--- a/cuda_lt.sh
+++ b/cuda_lt.sh
@@ -28,7 +28,7 @@ mkdir -p $pic_dir
 
 tmpcmd="${@:3}"
 if [[ "$tmpcmd" == *"amdclang"* ]]; then
-  cmd="${@:3:2} -x hip -target x86_64-unknown-linux-gnu --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx940 --offload-arch=gfx941 --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102 --offload-arch=native ${@:5} -fPIC -O3 -o ${pic_filepath}"
+  cmd="${@:3:2} -x hip -target x86_64-unknown-linux-gnu ${@:5} -fPIC -O3 -o ${pic_filepath}"
 elif [[ "$tmpcmd" == *"hipcc"* ]]; then
   cmd="${@:3} -fPIC -o ${pic_filepath}"
 else
@@ -38,7 +38,7 @@ echo $cmd
 $cmd
 
 if [[ "$tmpcmd" == *"amdclang"* ]]; then
-  cmd="${@:3:2} -x hip -target x86_64-unknown-linux-gnu --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx940 --offload-arch=gfx941 --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102 --offload-arch=native ${@:5} -O3 -o ${npic_filepath}"
+  cmd="${@:3:2} -x hip -target x86_64-unknown-linux-gnu ${@:5} -O3 -o ${npic_filepath}"
 else
   cmd="${@:3} -o ${npic_filepath}"
 fi

--- a/src/components/ec/rocm/kernel/Makefile.am
+++ b/src/components/ec/rocm/kernel/Makefile.am
@@ -17,10 +17,10 @@ HIPCCFLAGS =                                     \
 LINK = $(LIBTOOL) --mode=link $(CC) -o $@
 
 .cu.o:
-	$(HIPCC) -c $< -o $@  $(HIPCCFLAGS)
+	$(HIPCC) -c $< -o $@  $(ROCM_ARCH) $(HIPCCFLAGS)
 
 .cu.lo:
-	/bin/bash $(top_srcdir)/cuda_lt.sh "$(LIBTOOL)" $@ $(HIPCC) -c  $< $(HIPCCFLAGS)
+	/bin/bash $(top_srcdir)/cuda_lt.sh "$(LIBTOOL)" $@ $(HIPCC) -c  $< $(ROCM_ARCH) $(HIPCCFLAGS)
 
 comp_noinst = libucc_ec_rocm_kernels.la
 


### PR DESCRIPTION
## What
Added ability to specify ROCM architecture on configure with --with-rocm-arch
options are:
`all` which does the same behavior as before,
`all-arch-no-native` does all default rocm architectures with the exception of native (to be used if no rocm enabled gpus exist in the system)
`--offload-arch=gfx###` for specifying a specific architecture

## Why ?
This allows specifying a specific architecture. It will fix the https://github.com/openucx/ucc/issues/969 issue

