### PR TITLE
TL/SHARP: check comm size in sharp ctx create

### DIFF
--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -377,6 +377,11 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_context_t,
         goto err;
     }
 
+    if (params->params.oob.n_oob_eps < 2) {
+        status = UCC_ERR_NOT_SUPPORTED;
+        goto err;
+    }
+
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_sharp_config->super,
                               params->context);
     memcpy(&self->cfg, tl_sharp_config, sizeof(*tl_sharp_config));
@@ -434,6 +439,7 @@ ucc_status_t ucc_tl_sharp_context_create_epilog(ucc_base_context_t *context)
         sharp_ctx->oob_ctx.oob = &UCC_TL_CTX_OOB(sharp_ctx);
     }
 
+    ucc_assert(core_ctx->topo != NULL);
     status = ucc_topo_init(set, core_ctx->topo, &topo);
     if (UCC_OK != status) {
         tl_error(sharp_ctx->super.super.lib, "failed to init topo");


### PR DESCRIPTION
## What
Don't create sharp ctx if world size is less than 2

## Why ?
fixes
```
==== backtrace (tid:   1051) ====
0 0x0000000000042520 __sigaction()  ???:0
1 0x0000000000025562 ucc_sbgp_create()  /build-result/src/hpcx-v2.19-gcc-mlnx_ofed-redhat7-cuda12-x86_64/ucc-0b4a0780918900fa497b1e6a65485247fecec4a2/src/components/topo/ucc_sbgp.c:599
2 0x0000000000024c95 ucc_topo_get_sbgp()  /build-result/src/hpcx-v2.19-gcc-mlnx_ofed-redhat7-cuda12-x86_64/ucc-0b4a0780918900fa497b1e6a65485247fecec4a2/src/components/topo/ucc_topo.c:224
3 0x0000000000004ce2 ucc_tl_sharp_context_init()  /build-result/src/hpcx-v2.19-gcc-mlnx_ofed-redhat7-cuda12-x86_64/ucc-0b4a0780918900fa497b1e6a65485247fecec4a2/src/components/tl/sharp/tl_sharp_context.c:294
4 0x0000000000005158 ucc_tl_sharp_context_create_epilog()  /build-result/src/hpcx-v2.19-gcc-mlnx_ofed-redhat7-cuda12-x86_64/ucc-0b4a0780918900fa497b1e6a65485247fecec4a2/src/components/tl/sharp/tl_sharp_context.c:443
5 0x000000000000d597 ucc_context_create_proc_info()  /build-result/src/hpcx-v2.19-gcc-mlnx_ofed-redhat7-cuda12-x86_64/ucc-0b4a0780918900fa497b1e6a65485247fecec4a2/src/core/ucc_context.c:808
6 0x0000000000098bd2 ucc::context_wrapper::context_wrapper()  ???:0
```
