### PR TITLE
CL/HIER: add reduce to supported colls

### DIFF
--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -115,7 +115,8 @@ UCC_CLASS_DECLARE(ucc_cl_hier_team_t, ucc_base_context_t *,
      UCC_COLL_TYPE_ALLTOALLV |                                                 \
      UCC_COLL_TYPE_ALLREDUCE |                                                 \
      UCC_COLL_TYPE_BARRIER |                                                   \
-     UCC_COLL_TYPE_BCAST)
+     UCC_COLL_TYPE_BCAST |                                                     \
+     UCC_COLL_TYPE_REDUCE)
 
 ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t      *team,


### PR DESCRIPTION
## What
Adding reduce to list of supported colls in CL HIER.

## Why ?
UCC_COLL_TYPE_REDUCE was missing. CL HIER never selects 2step reduce algorithm.
