### PR TITLE
onesided collective perftest 

### DIFF
--- a/tools/perf/ucc_perftest.cc
+++ b/tools/perf/ucc_perftest.cc
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
     ucc_pt_cuda_init();
     ucc_pt_rocm_init();
     try {
-        comm = new ucc_pt_comm(pt_config.comm);
+        comm = new ucc_pt_comm(pt_config.comm,pt_config.bench);
     } catch(std::exception &e) {
         std::cerr << e.what() << std::endl;
         std::exit(1);

--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -31,7 +31,7 @@ ucc_pt_benchmark::ucc_pt_benchmark(ucc_pt_benchmark_config cfg,
         break;
     case UCC_PT_OP_TYPE_ALLTOALL:
         coll = new ucc_pt_coll_alltoall(cfg.dt, cfg.mt, cfg.inplace,
-                                        cfg.persistent, comm);
+                                        cfg.persistent, cfg.onesided, comm);
         break;
     case UCC_PT_OP_TYPE_ALLTOALLV:
         coll = new ucc_pt_coll_alltoallv(cfg.dt, cfg.mt, cfg.inplace,

--- a/tools/perf/ucc_pt_coll.h
+++ b/tools/perf/ucc_pt_coll.h
@@ -13,6 +13,9 @@ extern "C" {
 #include <components/ec/ucc_ec.h>
 #include <components/mc/ucc_mc.h>
 }
+#define UCC_IS_ONESIDED(_args)                             \
+        (((_args).mask & UCC_COLL_ARGS_FIELD_FLAGS) &&     \
+        ((_args).flags & UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS))
 
 ucc_status_t ucc_pt_alloc(ucc_mc_buffer_header_t **h_ptr, size_t len,
                           ucc_memory_type_t mem_type);
@@ -87,7 +90,7 @@ public:
 class ucc_pt_coll_alltoall: public ucc_pt_coll {
 public:
     ucc_pt_coll_alltoall(ucc_datatype_t dt, ucc_memory_type mt,
-                         bool is_inplace, bool is_persistent,
+                         bool is_inplace, bool is_persistent, bool is_onesided,
                          ucc_pt_comm *communicator);
     ucc_status_t init_args(size_t count, ucc_pt_test_args_t &args) override;
     void free_args(ucc_pt_test_args_t &args) override;

--- a/tools/perf/ucc_pt_comm.h
+++ b/tools/perf/ucc_pt_comm.h
@@ -14,8 +14,11 @@
 extern "C" {
 #include "components/ec/ucc_ec.h"
 }
+#define UCC_TEST_N_MEM_SEGMENTS 3
+#define UCC_TEST_MEM_SEGMENT_SIZE (1 << 21)
 
 class ucc_pt_comm {
+    ucc_pt_benchmark_config bcfg;
     ucc_pt_comm_config cfg;
     ucc_lib_h lib;
     ucc_context_h context;
@@ -24,11 +27,20 @@ class ucc_pt_comm {
     ucc_ee_h ee;
     ucc_ee_executor_t *executor;
     ucc_pt_bootstrap *bootstrap;
+    void             *onesided_buffers[3];
     void set_gpu_device();
 public:
-    ucc_pt_comm(ucc_pt_comm_config config);
+    ucc_pt_comm(ucc_pt_comm_config config,ucc_pt_benchmark_config ben_config);
     int get_rank();
     int get_size();
+    void* get_global_buffer(int index){
+        if (index < 0 || index >=3)
+        {
+            throw std::out_of_range("Index out range");
+        }
+        return onesided_buffers[index];
+        
+    };
     ucc_ee_executor_t* get_executor();
     ucc_ee_h get_ee();
     ucc_team_h get_team();

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -31,6 +31,7 @@ ucc_pt_config::ucc_pt_config() {
     bench.root_shift     = 0;
     bench.mult_factor    = 2;
     comm.mt              = bench.mt;
+    bench.onesided       = false;
 }
 
 const std::map<std::string, ucc_reduction_op_t> ucc_pt_reduction_op_map = {
@@ -91,7 +92,7 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
     int c;
     ucc_status_t st;
 
-    while ((c = getopt(argc, argv, "c:b:e:d:m:n:w:o:N:r:S:iphFT")) != -1) {
+    while ((c = getopt(argc, argv, "c:b:e:d:m:n:w:o:N:r:S:iphFTJ")) != -1) {
         switch (c) {
             case 'c':
                 if (ucc_pt_op_map.count(optarg) == 0) {
@@ -172,6 +173,9 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
             case 'F':
                 bench.full_print = true;
                 break;
+            case 'J':
+                bench.onesided = true;
+                break;
             case 'h':
             default:
                 print_help();
@@ -201,5 +205,6 @@ void ucc_pt_config::print_help()
     std::cout << "  -F: enable full print"<<std::endl;
     std::cout << "  -S: <number>: root shift for rooted collectives"<<std::endl;
     std::cout << "  -h: show this help message"<<std::endl;
+    std::cout << "  -J: onesided collective"<<std::endl;
     std::cout << std::endl;
 }

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -91,6 +91,7 @@ struct ucc_pt_benchmark_config {
     int                root;
     int                root_shift;
     int                mult_factor;
+    bool               onesided;
 };
 
 struct ucc_pt_config {


### PR DESCRIPTION
## What
Add onesided collective in perf to test ucp alltoall_onesided alg

## Why ?
Direct testing will appear the error of TL_UCP ERROR global work buffer not provided nor associated with team

## How ?
When test onesided alltoall ,add -J 