### PR TITLE
Replace bashisms with POSIX syntax

### DIFF
--- a/config/m4/check_tls.m4
+++ b/config/m4/check_tls.m4
@@ -18,13 +18,13 @@ AC_DEFUN([CHECK_TLS_REQUIRED], [
        CHECKED_TL_REQUIRED=n
        required="y"
        tls_str=${TLS_REQUIRED}
-       AS_IF([ test "${TLS_REQUIRED:0:1}" == "^" ], [
+       AS_IF([ expr "x${TLS_REQUIRED} : 'x\^'" -eq 2 ], [
           CHECKED_TL_REQUIRED=y
           required="n"
-          tls_str=${TLS_REQUIRED:1}])
+          tls_str=${TLS_REQUIRED#^}])
        # AC_MSG_WARN([checking tl : $tl_name, TLS_REQUIRED=${TLS_REQUIRED}, tls_str=${tls_str}, required=${required}])
        for t in $(echo ${tls_str} | tr "," " "); do
-           AS_IF([ test "$t" == "$tl_name" ], [CHECKED_TL_REQUIRED=$required], [])
+           AS_IF([ test "$t" = "$tl_name" ], [CHECKED_TL_REQUIRED=$required], [])
        done
     ])
 ])

--- a/config/m4/configure.m4
+++ b/config/m4/configure.m4
@@ -40,7 +40,7 @@ AC_DEFUN([CHECK_NEED_TL_PROFILING], [
     AS_IF([ test x"$with_profiling" = "xall" ], [TL_PROFILING_REQUIRED=y],
     [
        for t in $(echo ${with_profiling} | tr ":" " "); do
-           AS_IF([ test "$t" == "$tl_name" ], [TL_PROFILING_REQUIRED=y], [])
+           AS_IF([ test "$t" = "$tl_name" ], [TL_PROFILING_REQUIRED=y], [])
        done
     ])
 ])

--- a/config/m4/gtest.m4
+++ b/config/m4/gtest.m4
@@ -12,6 +12,6 @@ dnl Provide a flag to enable or disable Google Test usage.
                   [enable_gtest=no])
 
     AM_CONDITIONAL([HAVE_GTEST],[test "x$enable_gtest" = "xyes"])
-    AS_IF([test "x$enable_gtest" == "xyes"],
+    AS_IF([test "x$enable_gtest" = "xyes"],
           [gtest_enable=enabled], [gtest_enable=disabled])
 ])

--- a/config/m4/tl_coll_plugins.m4
+++ b/config/m4/tl_coll_plugins.m4
@@ -26,7 +26,7 @@ AC_DEFUN([CHECK_TLCP_REQUIRED], [
           [CHECKED_TLCP_REQUIRED=y],
     [
         for t in $(echo ${TLCP_REQUIRED} | tr "," " "); do
-            AS_IF([ test "$t" == "$tlcp_name" ], [CHECKED_TLCP_REQUIRED=y], [])
+            AS_IF([ test "$t" = "$tlcp_name" ], [CHECKED_TLCP_REQUIRED=y], [])
         done
     ])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ AC_ARG_WITH([docs_only],
 AC_DEFUN([UCC_DX_ENABLE_CHECK],
          [AS_IF([DX_TEST_FEATURE($1)],
                 [],
-                [AS_IF([test "x$enable_doxygen_$1" == xyes],
+                [AS_IF([test "x$enable_doxygen_$1" = xyes],
                        [AC_MSG_ERROR([--enable-doxygen-$1 was specified, but $1
                        doxygen was not found])],
                        [])])])


### PR DESCRIPTION
This replaces some bashisms (notably equality check with `==` and substring replacement) with POSIX equivalents, for distros where `sh` operates in strict POSIX mode. I will not claim that all bashisms are thereby purged from the configure files (they may lurk in conditionals not taken), but at least it allows a basic build to proceed.