### PR TITLE
TL/UCP: add knomial allgatherv

### DIFF
--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -48,8 +48,10 @@ typedef struct ucc_knomial_pattern {
     ucc_rank_t     n_extra;       /* number of "extra" ranks to be served by "proxies" */
     size_t         block_size_counts;
     size_t         count;         /* collective buffer size */
+    ucc_count_t   *counts;
     ucc_rank_t     block_size;
     ptrdiff_t      block_offset;
+    int            is64;
 } ucc_knomial_pattern_t;
 
 /**

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -18,10 +18,11 @@ allgather =                        \
 	allgather/allgather_sparbit.c  \
 	allgather/allgather_knomial.c
 
-allgatherv =                     \
-	allgatherv/allgatherv.h      \
-	allgatherv/allgatherv.c      \
-	allgatherv/allgatherv_ring.c
+allgatherv =                        \
+	allgatherv/allgatherv.h         \
+	allgatherv/allgatherv.c         \
+	allgatherv/allgatherv_ring.c    \
+	allgatherv/allgatherv_knomial.c
 
 alltoall =                       \
 	alltoall/alltoall.h          \

--- a/src/components/tl/ucp/allgatherv/allgatherv.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -15,6 +15,10 @@ ucc_base_coll_alg_info_t
             {.id   = UCC_TL_UCP_ALLGATHERV_ALG_RING,
              .name = "ring",
              .desc = "O(N) Ring"},
+        [UCC_TL_UCP_ALLGATHERV_ALG_KNOMIAL] =
+            {.id   = UCC_TL_UCP_ALLGATHERV_ALG_KNOMIAL,
+             .name = "knomial",
+             .desc = "recursive k-ing with arbitrary radix"},
         [UCC_TL_UCP_ALLGATHERV_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 

--- a/src/components/tl/ucp/allgatherv/allgatherv.h
+++ b/src/components/tl/ucp/allgatherv/allgatherv.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -12,13 +12,38 @@
 
 enum {
     UCC_TL_UCP_ALLGATHERV_ALG_RING,
+    UCC_TL_UCP_ALLGATHERV_ALG_KNOMIAL,
     UCC_TL_UCP_ALLGATHERV_ALG_LAST
 };
 
 extern ucc_base_coll_alg_info_t
              ucc_tl_ucp_allgatherv_algs[UCC_TL_UCP_ALLGATHERV_ALG_LAST + 1];
 
+#define UCC_TL_UCP_ALLGATHERV_DEFAULT_ALG_SELECT_STR                           \
+    "allgatherv:@0"
+
+char *ucc_tl_ucp_allgatherv_score_str_get(ucc_tl_ucp_team_t *team);
+
+static inline int ucc_tl_ucp_allgatherv_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_TL_UCP_ALLGATHERV_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_tl_ucp_allgatherv_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
+
 ucc_status_t ucc_tl_ucp_allgatherv_ring_init_common(ucc_tl_ucp_task_t *task);
+
+ucc_status_t ucc_tl_ucp_allgatherv_ring_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t *team,
+                                             ucc_coll_task_t **task_h);
+
+ucc_status_t ucc_tl_ucp_allgatherv_knomial_init(ucc_base_coll_args_t *coll_args,
+                                                ucc_base_team_t *team,
+                                                ucc_coll_task_t **task_h);
 
 ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task);
 #endif

--- a/src/components/tl/ucp/allgatherv/allgatherv_knomial.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv_knomial.c
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "allgatherv/allgatherv.h"
+#include "allgather/allgather.h"
+
+ucc_status_t ucc_tl_ucp_allgatherv_knomial_init(ucc_base_coll_args_t *coll_args,
+                                                ucc_base_team_t *team,
+                                                ucc_coll_task_t **task_h)
+{
+    if (!UCC_COLL_IS_DST_CONTIG(&coll_args->args)) {
+        return ucc_tl_ucp_allgatherv_ring_init(coll_args, team, task_h);
+    }
+    return ucc_tl_ucp_allgather_knomial_init(coll_args, team, task_h);
+}

--- a/src/components/tl/ucp/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv_ring.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -126,5 +126,22 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_init_common(ucc_tl_ucp_task_t *task)
     task->super.post     = ucc_tl_ucp_allgatherv_ring_start;
     task->super.progress = ucc_tl_ucp_allgatherv_ring_progress;
 
+    return UCC_OK;
+}
+
+ucc_status_t ucc_tl_ucp_allgatherv_ring_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t *team,
+                                             ucc_coll_task_t **task_h)
+{
+    ucc_tl_ucp_task_t *task;
+    ucc_status_t status;
+
+    task = ucc_tl_ucp_init_task(coll_args, team);
+    status = ucc_tl_ucp_allgatherv_ring_init_common(task);
+    if (status != UCC_OK) {
+        ucc_tl_ucp_put_task(task);
+        return status;
+    }
+    *task_h = &task->super;
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -31,6 +31,10 @@ const ucc_tl_ucp_default_alg_desc_t
             .str_get_fn = ucc_tl_ucp_allgather_score_str_get
         },
         {
+            .select_str = UCC_TL_UCP_ALLGATHERV_DEFAULT_ALG_SELECT_STR,
+            .str_get_fn = NULL
+        },
+        {
             .select_str = NULL,
             .str_get_fn = ucc_tl_ucp_alltoall_score_str_get
         },
@@ -219,6 +223,8 @@ static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
     switch (coll_type) {
     case UCC_COLL_TYPE_ALLGATHER:
         return ucc_tl_ucp_allgather_alg_from_str(str);
+    case UCC_COLL_TYPE_ALLGATHERV:
+        return ucc_tl_ucp_allgatherv_alg_from_str(str);
     case UCC_COLL_TYPE_ALLREDUCE:
         return ucc_tl_ucp_allreduce_alg_from_str(str);
     case UCC_COLL_TYPE_ALLTOALL:
@@ -267,6 +273,19 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
             break;
         case UCC_TL_UCP_ALLGATHER_ALG_SPARBIT:
             *init = ucc_tl_ucp_allgather_sparbit_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    case UCC_COLL_TYPE_ALLGATHERV:
+        switch (alg_id) {
+        case UCC_TL_UCP_ALLGATHERV_ALG_KNOMIAL:
+            *init = ucc_tl_ucp_allgatherv_knomial_init;
+            break;
+        case UCC_TL_UCP_ALLGATHERV_ALG_RING:
+            *init = ucc_tl_ucp_allgatherv_ring_init;
             break;
         default:
             status = UCC_ERR_INVALID_PARAM;

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -17,8 +17,8 @@
 #include "tl_ucp_tag.h"
 
 #define UCC_UUNITS_AUTO_RADIX 4
-#define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 8
 #define UCC_TL_UCP_TASK_PLUGIN_MAX_DATA 128
+#define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 9
 
 ucc_status_t ucc_tl_ucp_team_default_score_str_alloc(ucc_tl_ucp_team_t *team,
     char *default_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR]);

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -281,6 +281,25 @@ static inline size_t ucc_buffer_block_offset(size_t     total_count,
     return (block < left) ? offset - (left - block) : offset;
 }
 
+static inline size_t ucc_buffer_vector_block_offset(ucc_count_t *counts,
+                                                    int is64,
+                                                    ucc_rank_t rank)
+{
+    size_t offset = 0;
+    ucc_rank_t i;
+
+    if (is64) {
+        for (i = 0; i < rank; i++) {
+            offset += ((uint64_t *)counts)[i];
+        }
+    } else {
+        for (i = 0; i < rank; i++) {
+            offset += ((uint32_t *)counts)[i];
+        }
+    }
+    return offset;
+}
+
 /* Given the rank space A (e.g. core ucc team), a subset B (e.g. active set
    within the core team), the ep_map that maps ranks from the subset B to A,
    and the rank of a process within A. The function below computes the local

--- a/test/gtest/coll/test_allgatherv.cc
+++ b/test/gtest/coll/test_allgatherv.cc
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
  * See file LICENSE for terms.
  */
 
@@ -8,6 +9,7 @@
 
 using Param_0 = std::tuple<int, ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
 using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t>;
+using Param_2 = std::tuple<ucc_datatype_t, ucc_memory_type_t, int, gtest_ucc_inplace_t, std::string>;
 
 class test_allgatherv : public UccCollArgs, public ucc::test
 {
@@ -33,7 +35,8 @@ public:
                 displs[i] = all_counts;
                 all_counts += counts[i];
             }
-            coll->mask = 0;
+            coll->mask = UCC_COLL_ARGS_FIELD_FLAGS;
+            coll->flags = UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER;
             coll->coll_type = UCC_COLL_TYPE_ALLGATHERV;
 
             coll->src.info.mem_type = mem_type;
@@ -250,7 +253,7 @@ UCC_TEST_P(test_allgatherv_1, multiple)
     UccReq::waitall(reqs);
 
     for (auto ctx : ctxs) {
-        EXPECT_EQ(true, data_validate(ctx));;
+        EXPECT_EQ(true, data_validate(ctx));
         data_fini(ctx);
     }
 }
@@ -267,3 +270,56 @@ INSTANTIATE_TEST_CASE_P(
 #endif
         ::testing::Values(1,3,8192), // count
         ::testing::Values(TEST_INPLACE, TEST_NO_INPLACE)));
+
+class test_allgatherv_alg : public test_allgatherv,
+        public ::testing::WithParamInterface<Param_2> {};
+
+UCC_TEST_P(test_allgatherv_alg, alg)
+{
+    const ucc_datatype_t      dtype    = std::get<0>(GetParam());
+    const ucc_memory_type_t   mem_type = std::get<1>(GetParam());
+    const int                 count    = std::get<2>(GetParam());
+    const gtest_ucc_inplace_t inplace  = std::get<3>(GetParam());
+    int                       n_procs  = 5;
+    char                      tune[32];
+
+    sprintf(tune, "allgatherv:@%s:inf", std::get<4>(GetParam()).c_str());
+    ucc_job_env_t env     = {{"UCC_CL_BASIC_TUNE", "inf"},
+                             {"UCC_TL_UCP_TUNE", tune}};
+    UccJob        job(n_procs, UccJob::UCC_JOB_CTX_GLOBAL, env);
+    UccTeam_h     team    = job.create_team(n_procs);
+    UccCollCtxVec ctxs;
+
+    set_inplace(inplace);
+    SET_MEM_TYPE(mem_type);
+
+    data_init(n_procs, dtype, count, ctxs, false);
+    UccReq    req(team, ctxs);
+    req.start();
+    req.wait();
+    EXPECT_EQ(true, data_validate(ctxs));;
+    data_fini(ctxs);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    , test_allgatherv_alg,
+    ::testing::Combine(
+        PREDEFINED_DTYPES,
+#ifdef HAVE_CUDA
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED),
+#else
+        ::testing::Values(UCC_MEMORY_TYPE_HOST),
+#endif
+        ::testing::Values(1,3,8192), // count
+        ::testing::Values(TEST_INPLACE, TEST_NO_INPLACE),
+        ::testing::Values("knomial", "ring")),
+        [](const testing::TestParamInfo<test_allgatherv_alg::ParamType>& info) {
+            std::string name;
+            name += ucc_datatype_str(std::get<0>(info.param));
+            name += std::string("_") + std::string(ucc_mem_type_str(std::get<1>(info.param)));
+            name += std::string("_count_")+std::to_string(std::get<2>(info.param));
+            name += std::string("_inplace_")+std::to_string(std::get<3>(info.param));
+            name += std::string("_")+std::get<4>(info.param);
+            return name;
+        });

--- a/test/mpi/test_allgatherv.cc
+++ b/test/mpi/test_allgatherv.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -61,6 +61,8 @@ TestAllgatherv::TestAllgatherv(ucc_test_team_t &_team, TestCaseParams &params) :
     UCC_MALLOC_CHECK(check_buf);
     fill_counts_and_displacements(size, count, counts, displacements);
 
+    args.mask  |= UCC_COLL_ARGS_FIELD_FLAGS;
+    args.flags |= UCC_COLL_ARGS_FLAG_CONTIG_DST_BUFFER;
     if (!inplace) {
         UCC_CHECK(ucc_mc_alloc(&sbuf_mc_header, counts[rank] * dt_size, mem_type));
         sbuf                   = sbuf_mc_header->addr;
@@ -74,6 +76,7 @@ TestAllgatherv::TestAllgatherv(ucc_test_team_t &_team, TestCaseParams &params) :
     args.dst.info_v.displacements = (ucc_aint_t*)displacements;
     args.dst.info_v.datatype      = dt;
     args.dst.info_v.mem_type      = mem_type;
+
     UCC_CHECK(set_input());
     UCC_CHECK_SKIP(ucc_collective_init(&args, &req, team.team), test_skip);
 }

--- a/tools/perf/ucc_pt_coll_allgatherv.cc
+++ b/tools/perf/ucc_pt_coll_allgatherv.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -21,8 +21,8 @@ ucc_pt_coll_allgatherv::ucc_pt_coll_allgatherv(ucc_datatype_t dt,
     has_bw_        = false;
     root_shift_    = 0;
 
-    coll_args.mask                = 0;
-    coll_args.flags               = 0;
+    coll_args.mask               |= UCC_COLL_ARGS_FIELD_FLAGS;
+    coll_args.flags              |= UCC_COLL_ARGS_FLAG_IN_PLACE;
     coll_args.coll_type           = UCC_COLL_TYPE_ALLGATHERV;
     coll_args.src.info.datatype   = dt;
     coll_args.src.info.mem_type   = mt;


### PR DESCRIPTION
## What
Adding knomial allgatherv algorithm in TL/UCP. The algorithm requires contig dst buffer and based on knomial allgather implementation where count and offset computed based on user provided args.

## Why ?
Improves small msg allgatherv performance.
