### PR TITLE
TL/UCP: add task plugin data

### DIFF
--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -18,6 +18,7 @@
 
 #define UCC_UUNITS_AUTO_RADIX 4
 #define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 8
+#define UCC_TL_UCP_TASK_PLUGIN_MAX_DATA 128
 
 ucc_status_t ucc_tl_ucp_team_default_score_str_alloc(ucc_tl_ucp_team_t *team,
     char *default_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR]);
@@ -266,6 +267,7 @@ typedef struct ucc_tl_ucp_task {
             ucc_rank_t              iteration;
             int                     phase;
         } alltoall_bruck;
+        char                        plugin_data[UCC_TL_UCP_TASK_PLUGIN_MAX_DATA];
     };
 } ucc_tl_ucp_task_t;
 

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -27,6 +27,16 @@
 #define ucc_likely        ucs_likely
 #define ucc_unlikely      ucs_unlikely
 #define ucc_string_split  ucs_string_split
+
+/*
+ * Assertions which are checked in compile-time
+ * In case of failure a compiler msg looks like this:
+ * error: duplicate case value switch(0) {case 0:case (_cond):;}
+ *
+ * Usage: UCC_STATIC_ASSERT(condition)
+ */
+#define UCC_STATIC_ASSERT(_cond)                                               \
+     switch(0) {case 0:case (_cond):;}
 
 /**
  * Prevent compiler from reordering instructions


### PR DESCRIPTION
## What
Add special field to algorithms union in tl ucp task. 

## Why ?
Plugin data field might be used by tl ucp plugins to store algorithm specific data inside tl ucp task
