### PR TITLE
CL/DOCA_UROM: disable core pinning in doca worker

### DIFF
--- a/contrib/doca_urom_ucc_plugin/dpu/worker_ucc.c
+++ b/contrib/doca_urom_ucc_plugin/dpu/worker_ucc.c
@@ -178,8 +178,11 @@ static doca_error_t urom_worker_ucc_open(struct urom_worker_ctx *ctx)
     ucp_worker_params_t     worker_params;
     struct urom_worker_ucc *ucc_worker;
 
+/*  This should be disabled unless worker sharing can be used or force 1
+ *  PPN usage
+    
     dpu_thread_set_affinity_specific_core(get_ncores() - 1);
-
+*/
     if (ctx == NULL) {
         return DOCA_ERROR_INVALID_VALUE;
     }
@@ -995,8 +998,11 @@ static void *urom_worker_ucc_progress_thread(void *arg)
     int                       size;
     struct ucc_queue_element *qe;
 
-    dpu_thread_set_affinity(thread_id);
+/*  This should be disabled unless worker sharing can be used or force 1
+ *  PPN usage
 
+    dpu_thread_set_affinity(thread_id);
+*/
     while (ucc_component_enabled) {
         size = queue_size[thread_id];
         for (i = 0; i < size; i++) {

--- a/contrib/doca_urom_ucc_plugin/dpu/worker_ucc.c
+++ b/contrib/doca_urom_ucc_plugin/dpu/worker_ucc.c
@@ -178,11 +178,6 @@ static doca_error_t urom_worker_ucc_open(struct urom_worker_ctx *ctx)
     ucp_worker_params_t     worker_params;
     struct urom_worker_ucc *ucc_worker;
 
-/*  This should be disabled unless worker sharing can be used or force 1
- *  PPN usage
-    
-    dpu_thread_set_affinity_specific_core(get_ncores() - 1);
-*/
     if (ctx == NULL) {
         return DOCA_ERROR_INVALID_VALUE;
     }
@@ -998,11 +993,6 @@ static void *urom_worker_ucc_progress_thread(void *arg)
     int                       size;
     struct ucc_queue_element *qe;
 
-/*  This should be disabled unless worker sharing can be used or force 1
- *  PPN usage
-
-    dpu_thread_set_affinity(thread_id);
-*/
     while (ucc_component_enabled) {
         size = queue_size[thread_id];
         for (i = 0; i < size; i++) {


### PR DESCRIPTION
## What
Disabling core pinning in the DOCA UROM worker unless worker sharing can be used.

## Why ?
When using more than 1 PPN, CL DOCA UROM will create multiple DOCA UROM workers that do not have knowledge of each other. Each worker will pin to the first core resulting in poor performance reduction. Disabling core pinning allows the Linux scheduler to assign a core and results in performance similar to the 1 PPN case. 