### PR TITLE
Update context attribute query

### DIFF
--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -107,6 +107,13 @@ typedef struct ucc_base_ctx_attr_t {
     ucc_context_attr_t attr;
     uint32_t           topo_required;
 } ucc_base_ctx_attr_t;
+
+static inline void ucc_base_ctx_attr_clear(ucc_base_ctx_attr_t *attr)
+{
+    uint64_t mask = attr->attr.mask;
+    memset(attr, 0, sizeof(ucc_base_ctx_attr_t));
+    attr->attr.mask = mask;
+}
 
 typedef struct ucc_base_context_iface {
     ucc_status_t (*create)(const ucc_base_context_params_t *params,

--- a/src/components/cl/basic/cl_basic_context.c
+++ b/src/components/cl/basic/cl_basic_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -73,14 +73,11 @@ ucc_cl_basic_get_context_attr(const ucc_base_context_t *context,
     ucc_status_t        status;
     int                 i;
 
-    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
-        attr->attr.ctx_addr_len = 0;
-    }
+    ucc_base_ctx_attr_clear(attr);
 
     /* CL BASIC reports topo_required if any of the TL available
      * TL contexts needs it
      */
-    attr->topo_required = 0;
     for (i = 0; i < ctx->super.n_tl_ctxs; i++) {
         memset(&tl_attr, 0, sizeof(tl_attr));
         status = UCC_TL_CTX_IFACE(ctx->super.tl_ctxs[i])

--- a/src/components/cl/basic/cl_basic_lib.c
+++ b/src/components/cl/basic/cl_basic_lib.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -29,8 +29,8 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_lib_t)
 UCC_CLASS_DEFINE(ucc_cl_basic_lib_t, ucc_cl_lib_t);
 
 static inline ucc_status_t check_tl_lib_attr(const ucc_base_lib_t *lib,
-                                             ucc_tl_iface_t *      tl_iface,
-                                             ucc_cl_lib_attr_t *   attr)
+                                             ucc_tl_iface_t       *tl_iface,
+                                             ucc_cl_lib_attr_t    *attr)
 {
     ucc_tl_lib_attr_t tl_attr;
     ucc_status_t      status;

--- a/src/components/cl/doca_urom/cl_doca_urom_context.c
+++ b/src/components/cl/doca_urom/cl_doca_urom_context.c
@@ -553,9 +553,6 @@ ucc_status_t
 ucc_cl_doca_urom_get_context_attr(const ucc_base_context_t *context,
                                   ucc_base_ctx_attr_t      *attr)
 {
-    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
-        attr->attr.ctx_addr_len = 0;
-    }
-
+    ucc_base_ctx_attr_clear(attr);
     return UCC_OK;
 }

--- a/src/components/cl/hier/cl_hier_context.c
+++ b/src/components/cl/hier/cl_hier_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -87,9 +87,7 @@ ucc_status_t
 ucc_cl_hier_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
                              ucc_base_ctx_attr_t      *attr)
 {
-    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
-        attr->attr.ctx_addr_len = 0;
-    }
+    ucc_base_ctx_attr_clear(attr);
     attr->topo_required = 1;
     return UCC_OK;
 }

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -89,9 +89,7 @@ ucc_status_t
 ucc_tl_cuda_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
                              ucc_base_ctx_attr_t      *attr)
 {
-    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
-        attr->attr.ctx_addr_len = 0;
-    }
+    ucc_base_ctx_attr_clear(attr);
     attr->topo_required = 1;
     return UCC_OK;
 }

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -91,11 +91,9 @@ UCC_CLASS_DEFINE(ucc_tl_mlx5_context_t, ucc_tl_context_t);
 
 ucc_status_t
 ucc_tl_mlx5_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
-                             ucc_base_ctx_attr_t *     attr)
+                             ucc_base_ctx_attr_t      *attr)
 {
-    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
-        attr->attr.ctx_addr_len = 0;
-    }
+    ucc_base_ctx_attr_clear(attr);
     attr->topo_required = 1;
     return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Facebook, Inc. and its affiliates. 2021.
  *
  * See file LICENSE for terms.
@@ -220,9 +220,6 @@ ucc_status_t
 ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
                              ucc_base_ctx_attr_t      *attr)
 {
-    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
-        attr->attr.ctx_addr_len = 0;
-    }
-    attr->topo_required = 0;
+    ucc_base_ctx_attr_clear(attr);
     return UCC_OK;
 }

--- a/src/components/tl/rccl/tl_rccl_context.c
+++ b/src/components/tl/rccl/tl_rccl_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Facebook, Inc. and its affiliates. 2021.
  * Copyright (C) Advanced Micro Devices, Inc. 2022. ALL RIGHTS RESERVED.
  *
@@ -117,9 +117,6 @@ ucc_status_t
 ucc_tl_rccl_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
                              ucc_base_ctx_attr_t      *attr)
 {
-    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
-        attr->attr.ctx_addr_len = 0;
-    }
-    attr->topo_required = 0;
+    ucc_base_ctx_attr_clear(attr);
     return UCC_OK;
 }

--- a/src/components/tl/self/tl_self_context.c
+++ b/src/components/tl/self/tl_self_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -44,7 +44,8 @@ UCC_CLASS_DEFINE(ucc_tl_self_context_t, ucc_tl_context_t);
 
 ucc_status_t
 ucc_tl_self_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
-                             ucc_base_ctx_attr_t      *attr /* NOLINT */)
+                             ucc_base_ctx_attr_t      *attr)
 {
+    ucc_base_ctx_attr_clear(attr);
     return UCC_OK;
 }

--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -506,11 +506,7 @@ UCC_CLASS_DEFINE(ucc_tl_sharp_context_t, ucc_tl_context_t);
 ucc_status_t ucc_tl_sharp_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
                                            ucc_base_ctx_attr_t *attr)
 {
-    if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN) {
-        attr->attr.ctx_addr_len = 0;
-    }
-
+    ucc_base_ctx_attr_clear(attr);
     attr->topo_required = 1;
-
     return UCC_OK;
 }

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -564,6 +564,8 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
     size_t                packed_length;
     int                   i;
 
+    ucc_base_ctx_attr_clear(attr);
+
     if (attr->attr.mask & (UCC_CONTEXT_ATTR_FIELD_CTX_ADDR_LEN |
                            UCC_CONTEXT_ATTR_FIELD_CTX_ADDR)) {
         if (NULL == ctx->worker.worker_address) {
@@ -605,6 +607,7 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
         }
         attr->attr.ctx_addr_len = packed_length;
     }
+
     if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_CTX_ADDR) {
         *offset = ctx->worker.ucp_addrlen;
         offset  = TL_UCP_EP_ADDR_WORKER(offset);
@@ -621,10 +624,13 @@ ucc_status_t ucc_tl_ucp_get_context_attr(const ucc_base_context_t *context,
             ucc_tl_ucp_ctx_remote_pack_data(ctx, offset);
         }
     }
+
     if (attr->attr.mask & UCC_CONTEXT_ATTR_FIELD_WORK_BUFFER_SIZE) {
         attr->attr.global_work_buffer_size =
             ONESIDED_SYNC_SIZE + ONESIDED_REDUCE_SIZE;
     }
+
     attr->topo_required = ctx->topo_required;
+
     return UCC_OK;
 }


### PR DESCRIPTION
From the UCC Backlog:

```
Check all TLs and CLs lib and context attributes

Attribute query function should follow this scheme:
if attr.mask is not zero check each attributed defined in mask
Set attribute according to Tl/CL capabilities
Set attr.flags always

This logic is generally broker in UCC, for example
ucc_tl_self_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
                             ucc_base_ctx_attr_t      *attr)
{
    return UCC_OK;
}

attr.topo_required is not set (returns something random)
attr.global_work_buffer_size is not set
etc.
```

This PR updates UCC so that all context attribute queries read the mask for each field and then write a value, usually 0. Some of these were missing.

The backlog task mentions updating lib attributes as well, but it seems to me that both CL and TL lib attributes are filled correctly. There are two unused fields not filled--reduction types and sync type--but if the mask has these bits set UCC will error before it reaches the CL or TL (see `ucc_lib_get_attr`).
