### PR TITLE
TL/UCP: Allow self copy in allgather using network loopback

### DIFF
--- a/src/components/tl/ucp/allgather/allgather.h
+++ b/src/components/tl/ucp/allgather/allgather.h
@@ -7,6 +7,7 @@
 #define ALLGATHER_H_
 #include "../tl_ucp.h"
 #include "../tl_ucp_coll.h"
+#include "tl_ucp_sendrecv.h"
 
 enum {
     UCC_TL_UCP_ALLGATHER_ALG_KNOMIAL,
@@ -37,6 +38,16 @@ static inline int ucc_tl_ucp_allgather_alg_from_str(const char *str)
 }
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task);
+
+ucc_status_t loopback_self_copy(void *rbuf, void *sbuf, size_t data_size,
+                                ucc_memory_type_t rmem, ucc_memory_type_t smem,
+                                ucc_rank_t rank, ucc_tl_ucp_team_t *team,
+                                ucc_tl_ucp_task_t *task);
+
+ucc_status_t allgather_copy(void *rbuf, void *sbuf, size_t data_size,
+                            ucc_memory_type_t rmem, ucc_memory_type_t smem,
+                            ucc_rank_t rank, ucc_tl_ucp_team_t *team,
+                            ucc_tl_ucp_task_t *task);
 
 /* Ring */
 ucc_status_t ucc_tl_ucp_allgather_ring_init(ucc_base_coll_args_t *coll_args,

--- a/src/components/tl/ucp/allgather/allgather_sparbit.c
+++ b/src/components/tl/ucp/allgather/allgather_sparbit.c
@@ -131,8 +131,8 @@ ucc_status_t ucc_tl_ucp_allgather_sparbit_start(ucc_coll_task_t *coll_task)
     task->allgather_sparbit.data_expected = 1;
 
     if (!UCC_IS_INPLACE(TASK_ARGS(task))) {
-        status = ucc_mc_memcpy(PTR_OFFSET(rbuf, data_size * trank), sbuf,
-                               data_size, rmem, smem);
+        status = allgather_copy(PTR_OFFSET(rbuf, data_size * trank), sbuf,
+                                data_size, rmem, smem, trank, team, task);
         if (ucc_unlikely(UCC_OK != status)) {
             return status;
         }

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -48,7 +48,7 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_pairwise_num_posts),
      UCC_CONFIG_TYPE_ULUNITS},
 
-/* TODO: add radix to config once it's fully supported by the algorithm
+    /* TODO: add radix to config once it's fully supported by the algorithm
     {"ALLTOALLV_HYBRID_RADIX", "2",
      "Radix of the Hybrid Alltoallv algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, alltoallv_hybrid_radix),
@@ -140,6 +140,12 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allgather_kn_radix),
      UCC_CONFIG_TYPE_UINT},
 
+    {"ALLGATHER_USE_LOOPBACK", "0",
+     "If set to 1 performs network loopback for self copy, otherwise uses mc "
+     "cuda copy",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allgather_use_loopback),
+     UCC_CONFIG_TYPE_BOOL},
+
     {"BCAST_KN_RADIX", "4", "Radix of the recursive-knomial bcast algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, bcast_kn_radix),
      UCC_CONFIG_TYPE_UINT},
@@ -196,10 +202,8 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, reduce_scatterv_ring_bidirectional),
      UCC_CONFIG_TYPE_BOOL},
 
-    {"USE_TOPO", "try",
-     "Allow usage of tl ucp topo",
-     ucc_offsetof(ucc_tl_ucp_lib_config_t, use_topo),
-     UCC_CONFIG_TYPE_TERNARY},
+    {"USE_TOPO", "try", "Allow usage of tl ucp topo",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, use_topo), UCC_CONFIG_TYPE_TERNARY},
 
     {"RANKS_REORDERING", "y",
      "Use topology information in TL UCP to reorder ranks. Requires topo info",

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -55,6 +55,7 @@ typedef struct ucc_tl_ucp_lib_config {
     ucc_mrange_uint_t        allreduce_sra_kn_radix;
     uint32_t                 reduce_scatter_kn_radix;
     uint32_t                 allgather_kn_radix;
+    int                      allgather_use_loopback;
     uint32_t                 bcast_kn_radix;
     ucc_mrange_uint_t        bcast_sag_kn_radix;
     uint32_t                 reduce_kn_radix;


### PR DESCRIPTION
## What
Add option for self copy loopback in out of place start for allgather algorithms: knomial, ring, neighbor, sparbit 

## Why ?
When using UCC plugin for NCCL, using cuda_memcpy might cause deadlock

## How ?
Add UCC_TL_UCP_ALLGATHER_USE_LOOPBACK flag to control this
Tested on ISRAEL-1 with multiple test cases - showed good results and same performance with and without loopback
![image](https://github.com/user-attachments/assets/f15a1994-c0be-4ac4-bfa4-35941d3b0589)
