### PR TITLE
CI: fix docs gh actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,8 +17,8 @@ jobs:
         ./configure --with-docs-only
         make docs
     - name: Upload docs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: Docs
+        name: docs
         path: ${{ github.workspace }}/docs/doxygen-doc/ucc.pdf
         retention-days: 7


### PR DESCRIPTION
## What
Fixes docs build actions.

## How ?
upload actions v2 is deprecated, https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/