### PR TITLE
TOPO: Fix socket leader sbgp creation if libnuma.so is not installed

### DIFF
--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -21,9 +21,10 @@ const char* ucc_sbgp_str(ucc_sbgp_type_t type)
     return ucc_sbgp_type_str[type];
 }
 
-#define UCC_TOPO_IS_BOUND(_topo, _sbgp_type)                \
-    (UCC_SBGP_SOCKET == (_sbgp_type)) ?                     \
-    (_topo)->topo->sock_bound : (_topo)->topo->numa_bound
+#define UCC_TOPO_IS_BOUND(_topo, _sbgp_type)                    \
+    (UCC_SBGP_SOCKET         == (_sbgp_type) ||                 \
+     UCC_SBGP_SOCKET_LEADERS == (_sbgp_type)) ?                 \
+        (_topo)->topo->sock_bound : (_topo)->topo->numa_bound
 
 static inline int ucc_ranks_on_local_sn(ucc_rank_t rank1, ucc_rank_t rank2,
                                         ucc_topo_t *topo, ucc_sbgp_type_t type)


### PR DESCRIPTION
On the lego-grace system, I found that no socket leader groups are created. This is making it so the tuning perfkey being picked up in TL_SHM is wrong. I traced the issue back to the line I'm updating in this PR.

What's happening is that on this system there is no installation of libnuma.so. This is causing every topo's `topo->numa_bound` to be equal to 0. In the macro that I updated, it will check to see if the group type is SOCKET, and if it's not it will use the value of `topo->numa_bound` to determine boundedness. Since numa_bound is zero, socket leader subgroup creation is skipped in `ucc_sbgp_create` in the switch `case UCC_SBGP_SOCKET_LEADERS:`.

After the update in this PR to use `topo->sock_bound` in the case that the group type is `UCC_SBGP_SOCKET_LEADERS`, the socket leader subgroup is created as expected.