### PR TITLE
BUILD: Add ucc pkg-config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,9 @@ include $(srcdir)/docs/doxygen/doxygen.am
 
 .PHONY: docs docs-clean
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = ucc.pc
+
 DOCLIST = docs/doxygen/doxygen-doc/ucc.tag
 
 FORMAT = pdf

--- a/configure.ac
+++ b/configure.ac
@@ -253,6 +253,7 @@ AC_CONFIG_FILES([
                  cmake/ucc-config-version.cmake
                  cmake/ucc-config.cmake
                  cmake/ucc-targets.cmake
+                 ucc.pc
                  ])
 AC_OUTPUT
 

--- a/ucc.pc.in
+++ b/ucc.pc.in
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See file LICENSE for terms.
+#
+
+prefix = @prefix@
+exec_prefix = @exec_prefix@
+bindir = @exec_prefix@/bin
+libdir = @libdir@
+includedir = @includedir@
+
+Name: @PACKAGE@
+Description: Unified Collective Communication Library
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lucc
+Libs.private: -Wl


### PR DESCRIPTION
## What
Add a ucc pkg-config file

## Why ?
DOCA requires it to build UROM_UCC. Plus, UCX has it since it's pretty standard. It would be good for UCC to have it too.

## How ?
`ucc.pc` is automatically generated from ucc.pc.in via `AC_CONFIG` macro. The changes to the Makefile make it so `ucc.pc` is installed with `make install` into the prefix.
