### PR TITLE
CORE: Use uint64_t for bitmap configs

### DIFF
--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -28,7 +28,7 @@ typedef struct ucc_global_config {
     char *install_path;
     int   initialized;
     /* Profiling mode */
-    unsigned                   profile_mode;
+    uint64_t                   profile_mode;
 
     /* Profiling output file name */
     char *profile_file;


### PR DESCRIPTION
## What
Make the bitmap-type config `profile_mode` uint64_t to align with recent UCX(S) changes.

## Why ?
UCX(S) now uses uint64_t for bitmap-type (declared via UCS_CONFIG_TYPE_BITMAP) configurations (see https://github.com/openucx/ucx/commit/8a84af89e87b57e72a2e9f6a8945e5ff5ab24295). UCC should align with this change, otherwise setting bitmap-type config may overwrite the next 4-byte memory during config parsing (see https://github.com/openucx/ucx/commit/8a84af89e87b57e72a2e9f6a8945e5ff5ab24295#diff-8dd28fc04f39623f32e719552443482db8a07986754b3ba0ba48387db94d8bbdL446). In the case of UCC, the `profile_file` option of `ucc_global_opts` will be overwritten when `profile_mode` is set.
