### PR TITLE
CORE: fix n deps overflow in pipelined schedule

### DIFF
--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -107,9 +107,9 @@ typedef struct ucc_coll_task {
         /* used for lf mt progress queue */
         ucc_lf_queue_elem_t            lf_elem;
     };
-    uint8_t                            n_deps;
-    uint8_t                            n_deps_satisfied;
-    uint8_t                            n_deps_base;
+    uint32_t                           n_deps;
+    uint32_t                           n_deps_satisfied;
+    uint32_t                           n_deps_base;
     /* timestamp of the start time: either post or triggered_post */
     double                             start_time;
     uint32_t                           seq_num;

--- a/src/schedule/ucc_schedule.h
+++ b/src/schedule/ucc_schedule.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -254,7 +254,7 @@ ucc_status_t ucc_dependency_handler(ucc_coll_task_t *parent,
                                     ucc_coll_task_t *task)
 {
     ucc_status_t status;
-    uint8_t      n_deps_satisfied;
+    uint32_t     n_deps_satisfied;
 
     n_deps_satisfied = ucc_atomic_fadd32(&task->n_deps_satisfied, 1);
     ucc_assert(task->n_deps_satisfied > n_deps_satisfied);

--- a/src/schedule/ucc_schedule_pipelined.c
+++ b/src/schedule/ucc_schedule_pipelined.c
@@ -256,7 +256,8 @@ ucc_status_t ucc_dependency_handler(ucc_coll_task_t *parent,
     ucc_status_t status;
     uint8_t      n_deps_satisfied;
 
-    n_deps_satisfied = ucc_atomic_fadd8(&task->n_deps_satisfied, 1);
+    n_deps_satisfied = ucc_atomic_fadd32(&task->n_deps_satisfied, 1);
+    ucc_assert(task->n_deps_satisfied > n_deps_satisfied);
 
     ucc_trace_req("task %p, n_deps %d, satisfied %d", task, task->n_deps,
                   n_deps_satisfied);


### PR DESCRIPTION
## What
Fixes overflow which happens if number of restarts in pipelined schedule is bigger than 256
