### PR TITLE
TL/MLX5: mcast multi-group support part 1

### DIFF
--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.c
@@ -119,11 +119,11 @@ static inline ucc_status_t ucc_tl_mlx5_mcast_one_sided_cleanup(ucc_tl_mlx5_mcast
         comm->mcast.rc_qp = NULL;
     }
 
-    if (comm->srq != NULL && ibv_destroy_srq(comm->srq)) {
+    if (comm->mcast.srq != NULL && ibv_destroy_srq(comm->mcast.srq)) {
         tl_error(comm->lib, "ibv_destroy_srq failed");
         return UCC_ERR_NO_RESOURCE;
     }
-    comm->srq = NULL;
+    comm->mcast.srq = NULL;
 
     if (comm->one_sided.slots_mr) {
         ibv_dereg_mr(comm->one_sided.slots_mr);

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_team.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_team.c
@@ -114,8 +114,8 @@ ucc_status_t ucc_tl_mlx5_mcast_team_init(ucc_base_context_t *base_context,
         goto cleanup;
     }
 
-    comm->rcq = ibv_create_cq(mcast_context->ctx, comm->params.rx_depth, NULL, NULL, 0);
-    if (!comm->rcq) {
+    comm->mcast.rcq = ibv_create_cq(mcast_context->ctx, comm->params.rx_depth, NULL, NULL, 0);
+    if (!comm->mcast.rcq) {
         ibv_dereg_mr(comm->grh_mr);
         tl_error(mcast_context->lib, "could not create recv cq, rx_depth %d, errno %d",
                   comm->params.rx_depth, errno);
@@ -123,10 +123,10 @@ ucc_status_t ucc_tl_mlx5_mcast_team_init(ucc_base_context_t *base_context,
         goto cleanup;
     }
 
-    comm->scq = ibv_create_cq(mcast_context->ctx, comm->params.sx_depth, NULL, NULL, 0);
-    if (!comm->scq) {
+    comm->mcast.scq = ibv_create_cq(mcast_context->ctx, comm->params.sx_depth, NULL, NULL, 0);
+    if (!comm->mcast.scq) {
         ibv_dereg_mr(comm->grh_mr);
-        ibv_destroy_cq(comm->rcq);
+        ibv_destroy_cq(comm->mcast.rcq);
         tl_error(mcast_context->lib, "could not create send cq, sx_depth %d, errno %d",
                   comm->params.sx_depth, errno);
         status = UCC_ERR_NO_RESOURCE;
@@ -263,7 +263,7 @@ ucc_status_t ucc_tl_mlx5_mcast_coll_setup_comm_resources(ucc_tl_mlx5_mcast_coll_
         ucc_list_add_tail(&comm->bpool, &comm->pp[i].super);
     }
 
-    comm->mcast.swr.wr.ud.ah          = comm->mcast.ah;
+    comm->mcast.swr.wr.ud.ah          = comm->mcast.groups[0].ah;
     comm->mcast.swr.num_sge           = 1;
     comm->mcast.swr.sg_list           = &comm->mcast.ssg;
     comm->mcast.swr.opcode            = IBV_WR_SEND_WITH_IMM;
@@ -325,8 +325,8 @@ ucc_status_t ucc_tl_mlx5_mcast_team_test(ucc_base_team_t *team)
                     return UCC_INPROGRESS;
                 }
 
-                comm->mcast_addr     = net_addr;
-                tl_team->mcast_state = TL_MLX5_TEAM_STATE_MCAST_GRP_JOIN_POST;
+                comm->mcast.groups[0].mcast_addr = net_addr;
+                tl_team->mcast_state             = TL_MLX5_TEAM_STATE_MCAST_GRP_JOIN_POST;
 
                 return UCC_INPROGRESS;
             }
@@ -373,11 +373,11 @@ ucc_status_t ucc_tl_mlx5_mcast_team_test(ucc_base_team_t *team)
 
                 if (tl_team->mcast_state == TL_MLX5_TEAM_STATE_MCAST_GRP_JOIN_READY) {
                     /* rank 0 bcast the lid/gid to other processes */
-                    data->status    = UCC_OK;
-                    data->dgid      = comm->event->param.ud.ah_attr.grh.dgid;
-                    data->dlid      = comm->event->param.ud.ah_attr.dlid;
-                    comm->mcast_lid = data->dlid;
-                    comm->mgid      = data->dgid;
+                    data->status               = UCC_OK;
+                    data->dgid                 = comm->event->param.ud.ah_attr.grh.dgid;
+                    data->dlid                 = comm->event->param.ud.ah_attr.dlid;
+                    comm->mcast.groups[0].lid  = data->dlid;
+                    comm->mcast.groups[0].mgid = data->dgid;
                 } else {
                     /* rank 0 bcast the failed status to other processes so others do not hang */
                     data->status = UCC_ERR_NO_RESOURCE;
@@ -522,8 +522,8 @@ ucc_status_t ucc_tl_mlx5_mcast_team_test(ucc_base_team_t *team)
                     return status;
                 }
 
-                comm->mcast_addr     = net_addr;
-                tl_team->mcast_state = TL_MLX5_TEAM_STATE_MCAST_GRP_JOIN_POST;
+                comm->mcast.groups[0].mcast_addr = net_addr;
+                tl_team->mcast_state             = TL_MLX5_TEAM_STATE_MCAST_GRP_JOIN_POST;
 
                 return UCC_INPROGRESS;
             }
@@ -549,8 +549,8 @@ ucc_status_t ucc_tl_mlx5_mcast_team_test(ucc_base_team_t *team)
 
                 ucc_assert(comm->event != NULL);
 
-                comm->mcast_lid  = comm->group_setup_info->dlid;
-                comm->mgid       = comm->group_setup_info->dgid;
+                comm->mcast.groups[0].lid  = comm->group_setup_info->dlid;
+                comm->mcast.groups[0].mgid = comm->group_setup_info->dgid;
 
                 ucc_free(comm->group_setup_info);
                 if (comm->event) {

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -198,7 +198,7 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
                         tl_warn(UCC_TL_TEAM_LIB(tl_team),
                                 "ibv_dereg_mr failed");
                     }
-                    if (ibv_destroy_cq(comm->rcq)) {
+                    if (ibv_destroy_cq(comm->mcast.rcq)) {
                         tl_warn(UCC_TL_TEAM_LIB(tl_team),
                                 "ibv_destroy_cq failed");
                     }


### PR DESCRIPTION
This patch adds support for multiple multicast groups in UCC. Since each group needs its own QP (and AH, address, etc.), it changes the code to use arrays instead of single variables (for example, ```comm->mcast.qp_list[]``` instead of ```comm->mcast.qp```). This is the first step in a bigger set of changes that will fully support multiple MCAST groups. In this patch, some references are still hardcoded to ```qp_list[0]```, but these will be replaced in Part 2 so that every group can use its own QP.