### PR TITLE
TL/MLX5: a2a various optimizations

### DIFF
--- a/src/components/tl/mlx5/alltoall/alltoall_coll.c
+++ b/src/components/tl/mlx5/alltoall/alltoall_coll.c
@@ -82,7 +82,10 @@ static ucc_status_t ucc_tl_mlx5_poll_cq(struct ibv_cq *cq, ucc_base_lib_t *lib)
         } else {
             ucc_tl_mlx5_dm_chunk_t *dm = (ucc_tl_mlx5_dm_chunk_t *)wcs[i].wr_id;
             dm->task->alltoall.blocks_completed++;
-            ucc_mpool_put(dm);
+            dm->completed_sends++;
+            if (dm->posted_all && dm->completed_sends == dm->posted_sends) {
+                ucc_mpool_put(dm);
+            }
         }
     }
     return UCC_OK;
@@ -379,33 +382,57 @@ static void ucc_tl_mlx5_asr_barrier_progress(ucc_coll_task_t *coll_task)
     }
 }
 
+ucc_tl_mlx5_dm_chunk_t *
+ucc_tl_mlx5_a2a_wait_for_dm_chunk(ucc_tl_mlx5_schedule_t *task)
+{
+    ucc_base_lib_t         *lib  = UCC_TASK_LIB(task);
+    ucc_tl_mlx5_team_t     *team = TASK_TEAM(&task->super);
+    ucc_tl_mlx5_dm_chunk_t *dm   = NULL;
+
+    dm = ucc_mpool_get(&team->dm_pool);
+    while (!dm) {
+        if (UCC_OK != ucc_tl_mlx5_poll_cq(team->a2a->net.cq, lib)) {
+            return NULL;
+        }
+        dm = ucc_mpool_get(&team->dm_pool);
+    }
+    dm->task = task;
+
+    return dm;
+}
+
 // add polling mechanism for blocks in order to maintain const qp tx rx
 static ucc_status_t ucc_tl_mlx5_send_blocks_start(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_mlx5_schedule_t *task           = TASK_SCHEDULE(coll_task);
-    ucc_tl_mlx5_team_t     *team           = SCHEDULE_TEAM(task);
-    ucc_tl_mlx5_alltoall_t *a2a            = team->a2a;
-    int                     node_size      = a2a->node.sbgp->group_size;
-    int                     net_size       = a2a->net.sbgp->group_size;
-    int                     op_msgsize     = node_size * a2a->max_msg_size
-                                                     * UCC_TL_TEAM_SIZE(team)
-                                                     * a2a->max_num_of_columns;
-    int                     node_msgsize   = SQUARED(node_size)
-                                                     * task->alltoall.msg_size;
-    int                     block_size     = task->alltoall.block_size;
-    int                     col_msgsize    = task->alltoall.msg_size
-                                                      * block_size * node_size;
-    int                     block_msgsize  = SQUARED(block_size)
-                                                     * task->alltoall.msg_size;
-    int                     dm_host        = UCC_TL_MLX5_TEAM_LIB(team)
-                                                                 ->cfg.dm_host;
-    ucc_status_t            status         = UCC_OK;
-    ucc_base_lib_t         *lib            = UCC_TASK_LIB(task);
-    int                     seq_index      = task->alltoall.seq_index;
-    int                     i, j, k, rank, dest_rank, cyc_rank;
-    uint64_t                src_addr, remote_addr;
-    ucc_tl_mlx5_dm_chunk_t *dm;
-    uintptr_t               dm_addr;
+    ucc_tl_mlx5_schedule_t *task      = TASK_SCHEDULE(coll_task);
+    ucc_base_lib_t *        lib       = UCC_TASK_LIB(task);
+    ucc_tl_mlx5_team_t *    team      = TASK_TEAM(&task->super);
+    ucc_tl_mlx5_alltoall_t *a2a       = team->a2a;
+    ucc_rank_t              node_size = a2a->node.sbgp->group_size;
+    ucc_rank_t              net_size  = a2a->net.sbgp->group_size;
+    size_t op_msgsize = node_size * a2a->max_msg_size * UCC_TL_TEAM_SIZE(team) *
+                        a2a->max_num_of_columns;
+    size_t       node_msgsize  = SQUARED(node_size) * task->alltoall.msg_size;
+    int          block_h       = task->alltoall.block_height;
+    int          block_w       = task->alltoall.block_width;
+    size_t       col_msgsize   = task->alltoall.msg_size * block_w * node_size;
+    size_t       line_msgsize  = task->alltoall.msg_size * block_h * node_size;
+    size_t       block_msgsize = block_h * block_w * task->alltoall.msg_size;
+    ucc_status_t status        = UCC_OK;
+    int          node_grid_w   = node_size / block_w;
+    int      node_nbr_blocks   = (node_size * node_size) / (block_h * block_w);
+    int      seq_index         = task->alltoall.seq_index;
+    int      block_row         = 0;
+    int      block_col         = 0;
+    uint64_t remote_addr       = 0;
+    ucc_tl_mlx5_dm_chunk_t *dm = NULL;
+    int batch_size = UCC_TL_MLX5_TEAM_LIB(team)->cfg.block_batch_size;
+    int num_serialized_batches =
+        UCC_TL_MLX5_TEAM_LIB(team)->cfg.num_serialized_batches;
+    int num_batches_per_passage =
+        UCC_TL_MLX5_TEAM_LIB(team)->cfg.num_batches_per_passage;
+    int i, j, k, send_to_self, block_idx, rank, dest_rank, cyc_rank, node_idx;
+    uint64_t src_addr;
 
     coll_task->status       = UCC_INPROGRESS;
     coll_task->super.status = UCC_INPROGRESS;
@@ -417,94 +444,102 @@ static ucc_status_t ucc_tl_mlx5_send_blocks_start(ucc_coll_task_t *coll_task)
                                           "mlx5_alltoall_block_send_start", 0);
     }
 
-    for (i = 0; i < net_size; i++) {
-        cyc_rank  = (i + a2a->net.sbgp->group_rank) % net_size;
-        dest_rank = a2a->net.rank_map[cyc_rank];
-        if (task->alltoall.op->blocks_sent[cyc_rank] ||
-            tl_mlx5_barrier_flag(task, cyc_rank) != task->alltoall.seq_num) {
-            continue;
-        }
-
-        //send all blocks from curr node to some ARR
-        for (j = 0; j < (node_size / block_size); j++) {
-            for (k = 0; k < (node_size / block_size); k++) {
-                src_addr = (uintptr_t)(node_msgsize * dest_rank +
-                                       col_msgsize * j + block_msgsize * k);
-                remote_addr =
-                    (uintptr_t)(op_msgsize * seq_index + node_msgsize * rank +
-                                block_msgsize * j + col_msgsize * k);
-
-                send_start(team, cyc_rank);
-                if (cyc_rank == a2a->net.sbgp->group_rank) {
-                    status = ucc_tl_mlx5_post_transpose(
-                        tl_mlx5_get_qp(a2a, cyc_rank),
-                        a2a->node.ops[seq_index].send_mkeys[0]->lkey,
-                        a2a->net.rkeys[cyc_rank], src_addr, remote_addr,
-                        task->alltoall.msg_size, block_size, block_size,
-                        (j == 0 && k == 0) ? IBV_SEND_SIGNALED : 0);
-                    if (UCC_OK != status) {
-                        return status;
+    for (j = 0; j < num_batches_per_passage; j++) {
+        for (node_idx = 0; node_idx < net_size; node_idx++) {
+            cyc_rank     = (node_idx + a2a->net.sbgp->group_rank) % net_size;
+            dest_rank    = a2a->net.rank_map[cyc_rank];
+            send_to_self = (cyc_rank == a2a->net.sbgp->group_rank);
+            if (tl_mlx5_barrier_flag(task, cyc_rank) !=
+                task->alltoall.seq_num) {
+                continue;
+            }
+            dm = NULL;
+            if (!send_to_self &&
+                task->alltoall.op->blocks_sent[cyc_rank] < node_nbr_blocks) {
+                dm = ucc_tl_mlx5_a2a_wait_for_dm_chunk(task);
+            }
+            send_start(team, cyc_rank);
+            for (i = 0; i < num_serialized_batches; i++) {
+                for (k = 0;
+                     k < batch_size &&
+                     task->alltoall.op->blocks_sent[cyc_rank] < node_nbr_blocks;
+                     k++, task->alltoall.op->blocks_sent[cyc_rank]++) {
+                    block_idx = task->alltoall.op->blocks_sent[cyc_rank];
+                    block_col = block_idx % node_grid_w;
+                    block_row = block_idx / node_grid_w;
+                    src_addr  = (uintptr_t)(
+                        op_msgsize * seq_index + node_msgsize * dest_rank +
+                        col_msgsize * block_col + block_msgsize * block_row);
+                    if (send_to_self || !k) {
+                        remote_addr = (uintptr_t)(op_msgsize * seq_index +
+                                                  node_msgsize * rank +
+                                                  block_msgsize * block_col +
+                                                  line_msgsize * block_row);
                     }
-                } else {
-                    dm = ucc_mpool_get(&team->dm_pool);
-                    while (!dm) {
-                        status = send_done(team, cyc_rank);
+                    if (send_to_self) {
+                        status = ucc_tl_mlx5_post_transpose(
+                            tl_mlx5_get_qp(a2a, cyc_rank),
+                            a2a->node.ops[seq_index].send_mkeys[0]->lkey,
+                            a2a->net.rkeys[cyc_rank], src_addr, remote_addr,
+                            task->alltoall.msg_size, block_w, block_h,
+                            (block_row == 0 && block_col == 0)
+                                ? IBV_SEND_SIGNALED
+                                : 0);
                         if (UCC_OK != status) {
                             return status;
                         }
-
-                        status = ucc_tl_mlx5_poll_cq(a2a->net.cq, lib);
-                        if (UCC_OK != status) {
-                            return status;
-                        }
-                        dm = ucc_mpool_get(&team->dm_pool);
-                        send_start(team, cyc_rank);
-                    }
-                    if (dm_host) {
-                        dm_addr =
-                            (uintptr_t)PTR_OFFSET(team->dm_ptr, dm->offset);
                     } else {
-                        dm_addr = dm->offset; // dm reg mr 0 based
+                        ucc_assert(dm != NULL);
+                        status = ucc_tl_mlx5_post_transpose(
+                            tl_mlx5_get_qp(a2a, cyc_rank),
+                            a2a->node.ops[seq_index].send_mkeys[0]->lkey,
+                            team->dm_mr->rkey, src_addr,
+                            dm->addr + k * block_msgsize,
+                            task->alltoall.msg_size, block_w, block_h, 0);
+                        if (UCC_OK != status) {
+                            return status;
+                        }
                     }
-                    dm->task = task;
-
-                    status = ucc_tl_mlx5_post_transpose(
-                        tl_mlx5_get_qp(a2a, cyc_rank),
-                        a2a->node.ops[seq_index].send_mkeys[0]->lkey,
-                        team->dm_mr->rkey, src_addr, dm_addr,
-                        task->alltoall.msg_size, block_size, block_size, 0);
-                    if (UCC_OK != status) {
-                        return status;
-                    }
+                }
+                if (!send_to_self && k) {
                     status = send_block_data(
-                        a2a, cyc_rank, dm_addr, block_msgsize,
+                        a2a, cyc_rank, dm->addr, block_msgsize * k,
                         team->dm_mr->lkey, remote_addr,
                         a2a->net.rkeys[cyc_rank], IBV_SEND_SIGNALED, dm);
                     if (status != UCC_OK) {
-                        tl_error(lib, "failed sending block [%d,%d,%d]", i, j,
-                                 k);
+                        tl_error(lib, "failed sending block [%d,%d,%d]",
+                                 node_idx, block_row, block_col);
                         return status;
                     }
-                }
-                status = send_done(team, cyc_rank);
-                if (status != UCC_OK) {
-                    return status;
+                    dm->posted_sends++;
                 }
             }
-        }
-        send_start(team, cyc_rank);
-        status = send_atomic(a2a, cyc_rank, tl_mlx5_atomic_addr(task, cyc_rank),
-                             tl_mlx5_atomic_rkey(task, cyc_rank));
-
-        if (UCC_OK == status) {
             status = send_done(team, cyc_rank);
-        }
-        task->alltoall.op->blocks_sent[cyc_rank] = 1;
-        task->alltoall.started++;
-        if (status != UCC_OK) {
-            tl_error(UCC_TASK_LIB(task), "Failed sending atomic to node [%d]",
-                     cyc_rank);
-            return status;
+            if (status != UCC_OK) {
+                return status;
+            }
+            if (dm) {
+                dm->posted_all = 1;
+            }
+            if (task->alltoall.op->blocks_sent[cyc_rank] == node_nbr_blocks) {
+                send_start(team, cyc_rank);
+                status = send_atomic(a2a, cyc_rank,
+                                     tl_mlx5_atomic_addr(task, cyc_rank),
+                                     tl_mlx5_atomic_rkey(task, cyc_rank));
+
+                if (status != UCC_OK) {
+                    tl_error(UCC_TASK_LIB(task),
+                             "Failed sending atomic to node [%d]", cyc_rank);
+                    return status;
+                }
+                status = send_done(team, cyc_rank);
+                if (UCC_OK != status) {
+                    tl_error(lib, "Failed sending atomic to node %d", node_idx);
+                    return status;
+                }
+                task->alltoall.op->blocks_sent[cyc_rank]++;
+                task->alltoall.started++;
+            }
         }
     }
     if (!task->alltoall.send_blocks_enqueued) {
@@ -541,24 +576,24 @@ ucc_tl_mlx5_send_blocks_leftovers_start(ucc_coll_task_t *coll_task)
     int                     net_size  = a2a->net.sbgp->group_size;
     int                     seq_index = task->alltoall.seq_index;
     size_t                  msg_size  = task->alltoall.msg_size;
-    int op_msgsize = node_size * a2a->max_msg_size * UCC_TL_TEAM_SIZE(team) *
-                     a2a->max_num_of_columns;
-    int mkey_msgsize  = node_size * a2a->max_msg_size * UCC_TL_TEAM_SIZE(team);
-    int block_size    = task->alltoall.block_size;
-    int col_msgsize   = msg_size * block_size * node_size;
-    int block_msgsize = SQUARED(block_size) * msg_size;
-    int block_size_leftovers_side = node_size % block_size;
-    int col_msgsize_leftovers =
+    size_t op_msgsize = node_size * a2a->max_msg_size * UCC_TL_TEAM_SIZE(team) *
+                        a2a->max_num_of_columns;
+    size_t mkey_msgsize =
+        node_size * a2a->max_msg_size * UCC_TL_TEAM_SIZE(team);
+    int    block_size                = task->alltoall.block_height;
+    size_t col_msgsize               = msg_size * block_size * node_size;
+    size_t block_msgsize             = SQUARED(block_size) * msg_size;
+    int    block_size_leftovers_side = node_size % block_size;
+    size_t col_msgsize_leftovers =
         msg_size * block_size_leftovers_side * node_size;
-    int block_msgsize_leftovers =
+    size_t block_msgsize_leftovers =
         block_size_leftovers_side * block_size * msg_size;
-    int          corner_msgsize = SQUARED(block_size_leftovers_side) * msg_size;
-    int          dm_host        = UCC_TL_MLX5_TEAM_LIB(team)->cfg.dm_host;
+    size_t       corner_msgsize = SQUARED(block_size_leftovers_side) * msg_size;
     ucc_status_t status         = UCC_OK;
     ucc_base_lib_t *lib         = UCC_TASK_LIB(coll_task);
     int             nbc         = task->alltoall.num_of_blocks_columns;
-
-    int i, j, k, dest_rank, rank, cyc_rank, current_block_msgsize, bs_x, bs_y;
+    int                     i, j, k, dest_rank, rank, cyc_rank, bs_x, bs_y;
+    size_t                  current_block_msgsize;
     uint64_t                src_addr, remote_addr;
     ucc_tl_mlx5_dm_chunk_t *dm;
     uintptr_t               dm_addr;
@@ -627,12 +662,7 @@ ucc_tl_mlx5_send_blocks_leftovers_start(ucc_coll_task_t *coll_task)
                         dm = ucc_mpool_get(&team->dm_pool);
                         send_start(team, cyc_rank);
                     }
-                    if (dm_host) {
-                        dm_addr =
-                            (uintptr_t)PTR_OFFSET(team->dm_ptr, dm->offset);
-                    } else {
-                        dm_addr = dm->offset; // dm reg mr 0 based
-                    }
+                    dm_addr  = dm->addr;
                     dm->task = task;
 
                     status = ucc_tl_mlx5_post_transpose(
@@ -750,36 +780,60 @@ ucc_status_t ucc_tl_mlx5_alltoall_finalize(ucc_coll_task_t *coll_task)
     return status;
 }
 
-static inline int power2(int value)
+static inline int block_size_fits(size_t msgsize, int height, int width)
 {
-    int p = 2;
+    int t;
 
-    while (p < value) {
-        p *= 2;
+    if (msgsize > MAX_MSG_SIZE || height > MAX_BLOCK_SIZE ||
+        width > MAX_BLOCK_SIZE) {
+        return false;
     }
-    return p;
-}
-
-static inline int block_size_fits(size_t msgsize, int block_size)
-{
-    return block_size * ucc_max(power2(block_size) * msgsize, MAX_MSG_SIZE) <=
+    t = ucc_lowest_greater_power2(ucc_max(msgsize, 8));
+    return height *
+               ucc_max(ucc_lowest_greater_power2(width) * t, MAX_MSG_SIZE) <=
            MAX_TRANSPOSE_SIZE;
 }
 
-static inline int get_block_size(ucc_tl_mlx5_schedule_t *task)
-{
-    ucc_tl_mlx5_team_t *team              = SCHEDULE_TEAM(task);
-    int                 ppn               = team->a2a->node.sbgp->group_size;
-    size_t              effective_msgsize = power2(ucc_max(
-                                                task->alltoall.msg_size, 8));
-    int                 block_size;
-
-    block_size = ppn;
-    while (!block_size_fits(effective_msgsize, block_size)) {
-        block_size--;
+#define MAYBE_CONTINUE_OR_BREAK_IF_REGULAR(x)                                  \
+    if (force_regular) {                                                       \
+        if (x > ppn) {                                                         \
+            break;                                                             \
+        } else if (ppn % x) {                                                  \
+            continue;                                                          \
+        }                                                                      \
     }
 
-    return ucc_max(1, block_size);
+static inline void
+get_block_dimensions(int ppn, int msgsize, int force_regular,
+                     ucc_tl_mlx5_alltoall_block_shape_modes_t block_shape_mode,
+                     int *block_height, int *block_width)
+{
+    int h_best = 1;
+    int w_best = 1;
+    int h, w, w_min, w_max;
+
+    for (h = 1; h <= MAX_BLOCK_SIZE; h++) {
+        MAYBE_CONTINUE_OR_BREAK_IF_REGULAR(h);
+        w_max = block_shape_mode != UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_LONG
+                    ? MAX_BLOCK_SIZE
+                    : h;
+        w_min =
+            block_shape_mode != UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_WIDE ? 1 : h;
+        w_min = ucc_max(w_min, h_best * w_best / h);
+        for (w = w_min; w <= w_max; w++) {
+            MAYBE_CONTINUE_OR_BREAK_IF_REGULAR(w);
+            if (block_size_fits(msgsize, h, w)) {
+                if (h * w > h_best * w_best ||
+                    abs(h / w - 1) < abs(h_best / w_best - 1)) {
+                    h_best = h;
+                    w_best = w;
+                }
+            }
+        }
+    }
+
+    *block_height = h_best;
+    *block_width  = w_best;
 }
 
 UCC_TL_MLX5_PROFILE_FUNC(ucc_status_t, ucc_tl_mlx5_alltoall_init,
@@ -794,12 +848,15 @@ UCC_TL_MLX5_PROFILE_FUNC(ucc_status_t, ucc_tl_mlx5_alltoall_init,
                                                         == a2a->node.asr_rank);
     int                     n_tasks   = is_asr ? 5 : 3;
     int                     curr_task = 0;
+    int                       ppn       = tl_team->a2a->node.sbgp->group_size;
+    ucc_tl_mlx5_lib_config_t *cfg       = &UCC_TL_MLX5_TEAM_LIB(tl_team)->cfg;
     ucc_schedule_t         *schedule;
     ucc_tl_mlx5_schedule_t *task;
     size_t                  msg_size;
     int                     block_size, i;
     ucc_coll_task_t        *tasks[5];
     ucc_status_t            status;
+    size_t bytes_count, bytes_count_last, bytes_skip, bytes_skip_last;
 
     if (UCC_IS_INPLACE(coll_args->args)) {
         return UCC_ERR_NOT_SUPPORTED;
@@ -843,15 +900,41 @@ UCC_TL_MLX5_PROFILE_FUNC(ucc_status_t, ucc_tl_mlx5_alltoall_init,
     tl_trace(UCC_TL_TEAM_LIB(tl_team), "Seq num is %d", task->alltoall.seq_num);
     a2a->sequence_number += 1;
 
-    block_size = a2a->requested_block_size ? a2a->requested_block_size
-                                           : get_block_size(task);
+    if (a2a->requested_block_size) {
+        task->alltoall.block_height = task->alltoall.block_width =
+            a2a->requested_block_size;
+        if (cfg->force_regular && ((ppn % task->alltoall.block_height) ||
+                                   (ppn % task->alltoall.block_width))) {
+            tl_debug(UCC_TL_TEAM_LIB(tl_team),
+                     "the requested block size implies irregular case"
+                     "consider changing the block size or turn off the config "
+                     "FORCE_REGULAR");
+            return UCC_ERR_INVALID_PARAM;
+        }
+    } else {
+        if (!cfg->force_regular) {
+            if (!(cfg->block_shape_mode !=
+                  UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_SQUARE)) {
+                tl_debug(UCC_TL_TEAM_LIB(tl_team),
+                         "turning off FORCE_REGULAR automatically forces the "
+                         "blocks to be square");
+                cfg->block_shape_mode = UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_SQUARE;
+            }
+        }
+        get_block_dimensions(ppn, task->alltoall.msg_size, cfg->force_regular,
+                             cfg->block_shape_mode,
+                             &task->alltoall.block_height,
+                             &task->alltoall.block_width);
+    }
+    tl_debug(UCC_TL_TEAM_LIB(tl_team), "block dimensions: [%d,%d]",
+             task->alltoall.block_height, task->alltoall.block_width);
 
     //todo following section correct assuming homogenous PPN across all nodes
     task->alltoall.num_of_blocks_columns =
-        (a2a->node.sbgp->group_size % block_size)
-            ? ucc_div_round_up(a2a->node.sbgp->group_size, block_size)
+        (a2a->node.sbgp->group_size % task->alltoall.block_height)
+            ? ucc_div_round_up(a2a->node.sbgp->group_size,
+                               task->alltoall.block_height)
             : 0;
-    task->alltoall.block_size = block_size;
 
     // TODO remove for connectX-7 - this is mkey_entry->stride (count+skip) limitation - only 16 bits
     if (task->alltoall
@@ -860,14 +943,15 @@ UCC_TL_MLX5_PROFILE_FUNC(ucc_status_t, ucc_tl_mlx5_alltoall_init,
         size_t limit =
             (1ULL
              << 16); // TODO We need to query this from device (or device type) and not user hardcoded values
-        size_t bytes_count, bytes_count_last, bytes_skip, bytes_skip_last;
-        int    ppn = a2a->node.sbgp->group_size;
-        int    bs  = block_size;
+        ucc_assert(task->alltoall.block_height == task->alltoall.block_width);
+        block_size = task->alltoall.block_height;
 
-        bytes_count_last = (ppn % bs) * msg_size;
-        bytes_skip_last  = (ppn - (ppn % bs)) * msg_size;
-        bytes_count      = bs * msg_size;
-        bytes_skip       = (ppn - bs) * msg_size;
+        ucc_assert(task->alltoall.block_height == task->alltoall.block_width);
+
+        bytes_count_last = (ppn % block_size) * msg_size;
+        bytes_skip_last  = (ppn - (ppn % block_size)) * msg_size;
+        bytes_count      = block_size * msg_size;
+        bytes_skip       = (ppn - block_size) * msg_size;
         if ((bytes_count + bytes_skip >= limit) ||
             (bytes_count_last + bytes_skip_last >= limit)) {
             tl_debug(UCC_TL_TEAM_LIB(tl_team), "unsupported operation");

--- a/src/components/tl/mlx5/tl_mlx5.c
+++ b/src/components/tl/mlx5/tl_mlx5.c
@@ -13,6 +13,12 @@ ucc_status_t ucc_tl_mlx5_get_context_attr(const ucc_base_context_t *context,
 
 ucc_status_t ucc_tl_mlx5_get_lib_properties(ucc_base_lib_properties_t *prop);
 
+static const char *alltoall_block_shape_modes[] = {
+    [UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_LONG]   = "long",
+    [UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_WIDE]   = "wide",
+    [UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_SQUARE] = "square",
+    [UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_LAST]   = NULL};
+
 static ucc_config_field_t ucc_tl_mlx5_lib_config_table[] = {
     {"", "", NULL, ucc_offsetof(ucc_tl_mlx5_lib_config_t, super),
      UCC_CONFIG_TYPE_TABLE(ucc_tl_lib_config_table)},
@@ -28,8 +34,23 @@ static ucc_config_field_t ucc_tl_mlx5_lib_config_table[] = {
      ucc_offsetof(ucc_tl_mlx5_lib_config_t, dm_buf_num),
      UCC_CONFIG_TYPE_ULUNITS},
 
-    {"BLOCK_SIZE", "0",
-     "Size of the blocks that are sent using blocked AlltoAll Algorithm",
+    {"ALLTOALL_FORCE_REGULAR", "y",
+     "Enforce the regular case where the block dimensions evenly divide ppn. "
+     "This option requires BLOCK_SIZE = 0.",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t, force_regular),
+     UCC_CONFIG_TYPE_BOOL},
+
+    {"ALLTOALL_BLOCK_SHAPE", "long",
+     "Shape of the blocks that are sent using blocked AlltoAll Algorithm\n"
+     "long - blocks are more long than wide\n"
+     "wide - blocks are more wide than long\n"
+     "square - blocks are square",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t, block_shape_mode),
+     UCC_CONFIG_TYPE_ENUM(alltoall_block_shape_modes)},
+
+    {"ALLTOALL_BLOCK_SIZE", "0",
+     "Size of the blocks that are sent using blocked AlltoAll Algorithm. "
+     "A block size of 0 means it will be calculated automatically",
      ucc_offsetof(ucc_tl_mlx5_lib_config_t, block_size), UCC_CONFIG_TYPE_UINT},
 
     {"NUM_DCI_QPS", "16",
@@ -80,7 +101,7 @@ static ucc_config_field_t ucc_tl_mlx5_lib_config_table[] = {
      UCC_CONFIG_TYPE_INT},
 
     {"MCAST_POST_RECV_THRESH", "64",
-        "Threshold for posting recv into rx ctx of the Mcast comm",
+     "Threshold for posting recv into rx ctx of the Mcast comm",
      ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.post_recv_thresh),
      UCC_CONFIG_TYPE_INT},
 
@@ -88,30 +109,57 @@ static ucc_config_field_t ucc_tl_mlx5_lib_config_table[] = {
      ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.wsize),
      UCC_CONFIG_TYPE_INT},
 
-    {"MCAST_MAX_PUSH_SEND", "16", "Max number of concurrent send wq for mcast based allgather",
+    {"MCAST_MAX_PUSH_SEND", "16",
+     "Max number of concurrent send wq for mcast based allgather",
      ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.max_push_send),
      UCC_CONFIG_TYPE_INT},
 
-    {"MCAST_MAX_EAGER", "65536", "Max msg size to be used for Mcast with the eager protocol",
+    {"MCAST_MAX_EAGER", "65536",
+     "Max msg size to be used for Mcast with the eager protocol",
      ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.max_eager),
      UCC_CONFIG_TYPE_MEMUNITS},
 
-    {"MCAST_CUDA_MEM_ENABLE", "0", "Enable GPU CUDA memory support for Mcast. GPUDirect RDMA must be enabled",
+    {"MCAST_CUDA_MEM_ENABLE", "0",
+     "Enable GPU CUDA memory support for Mcast. GPUDirect RDMA must be enabled",
      ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.cuda_mem_enabled),
      UCC_CONFIG_TYPE_BOOL},
 
-    {"MCAST_ONE_SIDED_RELIABILITY_ENABLE", "1", "Enable one sided reliability for mcast",
-     ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.one_sided_reliability_enable),
+    {"MCAST_ONE_SIDED_RELIABILITY_ENABLE", "1",
+     "Enable one sided reliability for mcast",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t,
+                  mcast_conf.one_sided_reliability_enable),
      UCC_CONFIG_TYPE_BOOL},
 
-    {"MCAST_ZERO_COPY_ALLGATHER_ENABLE", "1", "Enable truly zero copy allgather design for mcast",
-     ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.truly_zero_copy_allgather_enabled),
+    {"MCAST_ZERO_COPY_ALLGATHER_ENABLE", "1",
+     "Enable truly zero copy allgather design for mcast",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t,
+                  mcast_conf.truly_zero_copy_allgather_enabled),
      UCC_CONFIG_TYPE_BOOL},
 
-    {"MCAST_ZERO_COPY_PREPOST_BUCKET_SIZE", "16", "Number of posted recvs during each stage of the pipeline"
+    {"MCAST_ZERO_COPY_PREPOST_BUCKET_SIZE", "16",
+     "Number of posted recvs during each stage of the pipeline"
      " in truly zero copy mcast allgather design",
-     ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.mcast_prepost_bucket_size),
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t,
+                  mcast_conf.mcast_prepost_bucket_size),
      UCC_CONFIG_TYPE_INT},
+
+    {"ALLTOALL_SEND_BATCH_SIZE", "2",
+     "Number of blocks that are transposed "
+     "on the NIC before being sent as a batch to a remote peer",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t, block_batch_size),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLTOALL_NUM_SERIALIZED_BATCHES", "4",
+     "Number of block batches "
+     "(within the set of blocks to be sent to a given remote peer) "
+     "serialized on the same device memory chunk",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t, num_serialized_batches),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"ALLTOALL_NUM_BATCHES_PER_PASSAGE", "1",
+     "Number of batches of blocks sent to one remote node before enqueing",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t, num_batches_per_passage),
+     UCC_CONFIG_TYPE_UINT},
 
     {NULL}};
 

--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -49,17 +49,30 @@ typedef struct ucc_tl_mlx5_ib_qp_conf {
     uint32_t            qp_max_atomic;
 } ucc_tl_mlx5_ib_qp_conf_t;
 
+typedef enum ucc_tl_mlx5_alltoall_block_shape_modes
+{
+    UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_LONG,
+    UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_WIDE,
+    UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_SQUARE,
+    UCC_TL_MLX5_ALLTOALL_BLOCK_SHAPE_LAST,
+} ucc_tl_mlx5_alltoall_block_shape_modes_t;
+
 typedef struct ucc_tl_mlx5_lib_config {
-    ucc_tl_lib_config_t                     super;
-    int                                     asr_barrier;
-    int                                     block_size;
-    int                                     num_dci_qps;
-    int                                     dc_threshold;
-    size_t                                  dm_buf_size;
-    unsigned long                           dm_buf_num;
-    int                                     dm_host;
-    ucc_tl_mlx5_ib_qp_conf_t                qp_conf;
-    ucc_tl_mlx5_mcast_coll_comm_init_spec_t mcast_conf;
+    ucc_tl_lib_config_t                      super;
+    int                                      asr_barrier;
+    int                                      block_size;
+    int                                      num_dci_qps;
+    int                                      dc_threshold;
+    size_t                                   dm_buf_size;
+    unsigned long                            dm_buf_num;
+    int                                      dm_host;
+    ucc_tl_mlx5_ib_qp_conf_t                 qp_conf;
+    ucc_tl_mlx5_mcast_coll_comm_init_spec_t  mcast_conf;
+    int                                      num_serialized_batches;
+    int                                      num_batches_per_passage;
+    int                                      block_batch_size;
+    int                                      force_regular;
+    ucc_tl_mlx5_alltoall_block_shape_modes_t block_shape_mode;
 } ucc_tl_mlx5_lib_config_t;
 
 typedef struct ucc_tl_mlx5_context_config {
@@ -93,10 +106,13 @@ UCC_CLASS_DECLARE(ucc_tl_mlx5_context_t, const ucc_base_context_params_t*,
 
 typedef struct ucc_tl_mlx5_task ucc_tl_mlx5_task_t;
 typedef struct ucc_tl_mlx5_schedule ucc_tl_mlx5_schedule_t;
-typedef struct ucc_tl_mlx5_dm_chunk {
-    ptrdiff_t               offset; /* 0 based offset from the beginning of
-                                       memic_mr (obtained with ibv_reg_dm_mr) */
+typedef struct ucc_tl_mlx5_dm_chunk_t {
+    uintptr_t addr; // 0 based offset from the beginning of
+                    // memic_mr (obtained with ibv_reg_dm_mr)
     ucc_tl_mlx5_schedule_t *task;
+    int                     posted_sends;
+    int                     posted_all;
+    int                     completed_sends;
 } ucc_tl_mlx5_dm_chunk_t;
 
 typedef struct ucc_tl_mlx5_alltoall ucc_tl_mlx5_alltoall_t;

--- a/src/components/tl/mlx5/tl_mlx5_coll.h
+++ b/src/components/tl/mlx5/tl_mlx5_coll.h
@@ -27,7 +27,8 @@ typedef struct ucc_tl_mlx5_schedule {
             int                          seq_num;
             int                          seq_index;
             int                          num_of_blocks_columns;
-            int                          block_size;
+            int                          block_height;
+            int                          block_width;
             int                          started;
             int                          send_blocks_enqueued;
             int                          blocks_sent;

--- a/src/components/tl/mlx5/tl_mlx5_dm.c
+++ b/src/components/tl/mlx5/tl_mlx5_dm.c
@@ -78,9 +78,15 @@ static void ucc_tl_mlx5_dm_chunk_init(ucc_mpool_t *mp,        //NOLINT
     ucc_tl_mlx5_team_t     *team =
         ucc_container_of(mp, ucc_tl_mlx5_team_t, dm_pool);
 
-    c->offset       = (ptrdiff_t)team->dm_offset;
-    team->dm_offset = PTR_OFFSET(team->dm_offset,
-                                 UCC_TL_MLX5_TEAM_LIB(team)->cfg.dm_buf_size);
+    c->addr = (uintptr_t)PTR_OFFSET(
+        (UCC_TL_MLX5_TEAM_LIB(team)->cfg.dm_host) ? team->dm_ptr : NULL,
+        team->dm_offset);
+    c->posted_sends    = 0;
+    c->posted_all      = 0;
+    c->completed_sends = 0;
+    team->dm_offset    = PTR_OFFSET(
+        team->dm_offset, UCC_TL_MLX5_TEAM_LIB(team)->cfg.dm_buf_size *
+                             UCC_TL_MLX5_TEAM_LIB(team)->cfg.block_batch_size);
 }
 
 static ucc_mpool_ops_t ucc_tl_mlx5_dm_ops = {
@@ -219,13 +225,15 @@ ucc_status_t ucc_tl_mlx5_dm_init(ucc_tl_mlx5_team_t *team)
     }
 
     status = ucc_tl_mlx5_dm_alloc_reg(
-        ctx->shared_ctx, ctx->shared_pd, cfg->dm_host, cfg->dm_buf_size,
-        &cfg->dm_buf_num, &team->dm_ptr, &team->dm_mr, UCC_TL_TEAM_LIB(team));
+        ctx->shared_ctx, ctx->shared_pd, cfg->dm_host,
+        cfg->dm_buf_size * cfg->block_batch_size, &cfg->dm_buf_num,
+        &team->dm_ptr, &team->dm_mr, UCC_TL_TEAM_LIB(team));
     if (status != UCC_OK) {
         goto err_dm_alloc;
     }
-    team->dm_offset = NULL;
-
+    team->dm_offset = 0;
+    // TODO: fix/check the case dm_host=true
+    ucc_assert(!cfg->dm_host);
     status = ucc_mpool_init(
         &team->dm_pool, 0, sizeof(ucc_tl_mlx5_dm_chunk_t), 0,
         UCC_CACHE_LINE_SIZE, 1, cfg->dm_buf_num, &ucc_tl_mlx5_dm_ops,

--- a/src/components/tl/mlx5/tl_mlx5_wqe.c
+++ b/src/components/tl/mlx5/tl_mlx5_wqe.c
@@ -39,8 +39,9 @@ static inline uint8_t get_umr_mr_flags(uint32_t acc)
 
 typedef struct transpose_seg {
     __be32 element_size; /* 8 bit value */
-    __be16 num_rows;     /* 7 bit value */
+    //From PRM we should have the rows first and then the colls. This is probably a naming error
     __be16 num_cols;     /* 7 bit value */
+    __be16 num_rows;     /* 7 bit value */
     __be64 padding;
 } transpose_seg_t;
 

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -140,4 +140,14 @@ static inline uint32_t ucc_ilog2_ceil(uint32_t n)
     return 31 - x + 1;
 }
 
+/* return the lowest greater or equal power of 2 */
+static inline int ucc_lowest_greater_power2(int value)
+{
+    int p = 1;
+    while (p < value) {
+        p *= 2;
+    }
+    return p;
+}
+
 #endif

--- a/test/gtest/tl/mlx5/test_tl_mlx5_wqe.cc
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_wqe.cc
@@ -64,7 +64,7 @@ UCC_TEST_P(test_tl_mlx5_transpose, transposeWqe)
 
     ibv_wr_start(qp.qp_ex);
     post_transpose(qp.qp, src_mr->lkey, dst_mr->rkey, (uintptr_t)src,
-                   (uintptr_t)dst, elem_size, nrows, ncols, IBV_SEND_SIGNALED);
+                   (uintptr_t)dst, elem_size, ncols, nrows, IBV_SEND_SIGNALED);
     GTEST_ASSERT_EQ(ibv_wr_complete(qp.qp_ex), 0);
 
     while (!completions_num) {


### PR DESCRIPTION
# What

This PR contains various optimizations for TL/MLX5/a2a, leading to significant performance gain
![before_after](https://github.com/user-attachments/assets/ceb73ec8-86d4-46ac-b155-8cce16bebf26)



## Support rectangular blocks

this is a critical optimization that brings immediate performance benefits since it gives more flexibility in choosing the block dimension to better saturate the transpose unit. To complete this feature, we expose two (independent) options for determining the block dimensions h and w:
   - `ALLTOALL_BLOCK_SHAPE=long`, imposing `h >= w`
   - `ALLTOALL_BLOCK_SHAPE=wide`, imposing `h <= w`
   - `ALLTOALL_BLOCK_SHAPE=wide`, imposing `h = w`
![rect_blocks](https://github.com/user-attachments/assets/1cb0a829-ba90-4569-9c18-f7419b988502)

## Reuse device memory chunks for several blocks
as long as two blocks need to be sent to the same remote peer, the WQEs dealing with those blocks can 1) be enqueued on the same QPE and 2) use the same device memory chunks. This allows to use one dm chunk to post (and offload to the NIC) the processing of a batch of blocks. This makes the algorithm wait less on free device memory chunks. This option is controlled by the option `NBR_SERIALIZED_BATCHES`.


![output5](https://github.com/user-attachments/assets/743c8b82-fa27-4e08-b74a-44819e1b0f2d)

## batch the inter-node RDMA sends
we allow successive results of the transpose WQE to be batched before being sent to a remote peer. This allows to better saturate the network by aggregating the message. The batch size is controlled by `SEND_BATCH_SIZE`

![batch_size](https://github.com/user-attachments/assets/0b0d12e7-8b8f-4736-9618-9b4fa3416adc)





## Iterate across nodes before blocks when posting the WQEs
allows to better saturate the NW. This option is controlled by `NBR_BATCHES_PER_PASSAGE` which sets the number of batches to send to a remote peer before moving to the next one. The old behavior corresponds to large values of this parameter, i.e.,`NBR_BATCHES_PER_PASSAGE >> 1`

![batch_per_passage2](https://github.com/user-attachments/assets/fdba081a-e874-48d9-8e91-0373a8d19769)


## option to force regular case
through the TL/MLX5's env `FORCE_REGULAR`, forcing the chosen block dimensions to divide ppn. This option is useful 1) for debug purposes, and also 2) since the regular case is expected to perform better than the irregular case.


All those optimizations are independent, but we introduce them in a single PR to avoid resolving many conflicts.

