### PR TITLE
TL/MLX5: fix fences in a2a's WQEs

### DIFF
--- a/src/components/tl/mlx5/alltoall/alltoall_inline.h
+++ b/src/components/tl/mlx5/alltoall/alltoall_inline.h
@@ -73,7 +73,7 @@ static inline ucc_status_t send_atomic(ucc_tl_mlx5_alltoall_t *a2a,
     struct mlx5dv_qp_ex *qp_dv;
 
     qp_ex           = tl_mlx5_get_qp_ex(a2a, rank);
-    qp_ex->wr_flags = 0;
+    qp_ex->wr_flags = IBV_SEND_FENCE;
     ibv_wr_atomic_fetch_add(qp_ex, rkey, (uintptr_t)remote_addr, 1ULL);
     if (a2a->is_dc) {
         qp_dv = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);

--- a/src/components/tl/mlx5/alltoall/alltoall_inline.h
+++ b/src/components/tl/mlx5/alltoall/alltoall_inline.h
@@ -73,7 +73,7 @@ static inline ucc_status_t send_atomic(ucc_tl_mlx5_alltoall_t *a2a,
     struct mlx5dv_qp_ex *qp_dv;
 
     qp_ex           = tl_mlx5_get_qp_ex(a2a, rank);
-    qp_ex->wr_flags = IBV_SEND_FENCE;
+    qp_ex->wr_flags = 0;
     ibv_wr_atomic_fetch_add(qp_ex, rkey, (uintptr_t)remote_addr, 1ULL);
     if (a2a->is_dc) {
         qp_dv = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);

--- a/src/components/tl/mlx5/tl_mlx5_wqe.c
+++ b/src/components/tl/mlx5/tl_mlx5_wqe.c
@@ -57,7 +57,7 @@ ucc_status_t ucc_tl_mlx5_post_transpose(struct ibv_qp *qp, uint32_t src_mr_lkey,
     uint32_t                  n_ds     = 4;
     struct ibv_qp_ex *        qp_ex    = ibv_qp_to_qp_ex(qp);
     struct mlx5dv_qp_ex *     mqp      = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);
-    int                       fm_ce_se = 0;
+    int                       fm_ce_se = MLX5_WQE_CTRL_INITIATOR_SMALL_FENCE;
     char                      wqe_desc[n_ds * DS_SIZE];
     struct mlx5_wqe_ctrl_seg *ctrl;
     struct mlx5_wqe_data_seg *data;
@@ -153,8 +153,7 @@ ucc_status_t ucc_tl_mlx5_post_umr(struct ibv_qp *     qp,
                        sizeof(struct mlx5_wqe_mkey_context_seg) +
                        sizeof(struct mlx5_wqe_umr_pointer_seg)) /
                        DS_SIZE;
-    uint8_t fm_ce_se =
-        MLX5_WQE_CTRL_INITIATOR_SMALL_FENCE | MLX5_WQE_CTRL_CQ_UPDATE;
+    uint8_t fm_ce_se = MLX5_WQE_CTRL_CQ_UPDATE;
     struct ibv_qp_ex *                qp_ex = ibv_qp_to_qp_ex(qp);
     struct mlx5dv_qp_ex *             mqp = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);
     struct mlx5_wqe_ctrl_seg *        ctrl;
@@ -275,7 +274,7 @@ ucc_status_t ucc_tl_mlx5_post_wait_on_data(struct ibv_qp *qp, uint64_t value,
     uint32_t             n_ds   = 3;   //CTRL + Wait on Data of Size 2
     struct ibv_qp_ex *   qp_ex  = ibv_qp_to_qp_ex(qp);
     struct mlx5dv_qp_ex *mqp    = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);
-    uint8_t fm_ce_se            = MLX5_WQE_CTRL_FENCE | MLX5_WQE_CTRL_CQ_UPDATE;
+    uint8_t fm_ce_se            = MLX5_WQE_CTRL_CQ_UPDATE;
     char    wqe_desc[n_ds * DS_SIZE];
     struct mlx5_wqe_ctrl_seg *ctrl;
     wait_on_data_seg_t *      wseg;

--- a/src/components/tl/mlx5/tl_mlx5_wqe.c
+++ b/src/components/tl/mlx5/tl_mlx5_wqe.c
@@ -153,13 +153,14 @@ ucc_status_t ucc_tl_mlx5_post_umr(struct ibv_qp *     qp,
                        sizeof(struct mlx5_wqe_mkey_context_seg) +
                        sizeof(struct mlx5_wqe_umr_pointer_seg)) /
                        DS_SIZE;
-    uint8_t fm_ce_se = MLX5_WQE_CTRL_CQ_UPDATE;
-    struct ibv_qp_ex *                qp_ex = ibv_qp_to_qp_ex(qp);
-    struct mlx5dv_qp_ex *             mqp = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);
-    struct mlx5_wqe_ctrl_seg *        ctrl;
-    struct mlx5_wqe_umr_ctrl_seg *    umr_ctrl_seg;
+    uint8_t                           fm_ce_se = MLX5_WQE_CTRL_CQ_UPDATE;
+    struct ibv_qp_ex                 *qp_ex    = ibv_qp_to_qp_ex(qp);
+    struct mlx5dv_qp_ex              *mqp      =
+                                           mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);
+    struct mlx5_wqe_ctrl_seg         *ctrl;
+    struct mlx5_wqe_umr_ctrl_seg     *umr_ctrl_seg;
     struct mlx5_wqe_mkey_context_seg *mk_seg;
-    struct mlx5_wqe_umr_pointer_seg * pseg;
+    struct mlx5_wqe_umr_pointer_seg  *pseg;
     char                              wqe_desc[n_ds * DS_SIZE];
     int                               xlat_size;
 
@@ -269,12 +270,12 @@ ucc_status_t ucc_tl_mlx5_post_wait_on_data(struct ibv_qp *qp, uint64_t value,
                                            void *task_ptr)
 {
 
-    uint32_t             opcode = MLX5_OPCODE_WAIT;
-    uint32_t             opmode = 0x1; //wait on data
-    uint32_t             n_ds   = 3;   //CTRL + Wait on Data of Size 2
-    struct ibv_qp_ex *   qp_ex  = ibv_qp_to_qp_ex(qp);
-    struct mlx5dv_qp_ex *mqp    = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);
-    uint8_t fm_ce_se            = MLX5_WQE_CTRL_CQ_UPDATE;
+    uint32_t             opcode   = MLX5_OPCODE_WAIT;
+    uint32_t             opmode   = 0x1; //wait on data
+    uint32_t             n_ds     = 3;   //CTRL + Wait on Data of Size 2
+    struct ibv_qp_ex    *qp_ex    = ibv_qp_to_qp_ex(qp);
+    struct mlx5dv_qp_ex *mqp      = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);
+    uint8_t              fm_ce_se = MLX5_WQE_CTRL_CQ_UPDATE;
     char    wqe_desc[n_ds * DS_SIZE];
     struct mlx5_wqe_ctrl_seg *ctrl;
     wait_on_data_seg_t *      wseg;

--- a/src/components/tl/mlx5/tl_mlx5_wqe.c
+++ b/src/components/tl/mlx5/tl_mlx5_wqe.c
@@ -57,7 +57,7 @@ ucc_status_t ucc_tl_mlx5_post_transpose(struct ibv_qp *qp, uint32_t src_mr_lkey,
     uint32_t                  n_ds     = 4;
     struct ibv_qp_ex *        qp_ex    = ibv_qp_to_qp_ex(qp);
     struct mlx5dv_qp_ex *     mqp      = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);
-    int                       fm_ce_se = MLX5_WQE_CTRL_INITIATOR_SMALL_FENCE;
+    int                       fm_ce_se = 0;
     char                      wqe_desc[n_ds * DS_SIZE];
     struct mlx5_wqe_ctrl_seg *ctrl;
     struct mlx5_wqe_data_seg *data;


### PR DESCRIPTION
[Edited]
## What
Fix fences in WQEs.

**QPs used by each node leader:**
- a QP with loop-back connection, which we call "UMR QP"
- one QP per remote peer (+1 with loop-back connection), which we call "RDMA QP"

**Here the different WQEs in the algorithm:**
1. UMR WQE posted to "UMR QP". CPU then blocks until completion of this WQE.
2. Transpose WQE+ RDMA write WQE + atomic fetch_and_add WQE, all posted to "RDMA QP"
3. wait-on-data posted to "UMR QP"

**Conclusion regarding flags:**
- UMR WQE doesn't need any fence since it is the first WQE posted.
- The transpose WQE, ~~which consumes UMR, needs a **small** fence.~~ doesn't need any fence.
- RDMA write, which consumes transpose, needs a **small** fence because it only uses local data
- atomic fetch_and_add WQE ~~needs a **strong fence** because it signals completion of RDMA write to the remote peer~~ doesn't need any fence
- Wait-on-data doesn't need any fence.

