### PR TITLE
UTIL: fix names array memory leak

### DIFF
--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -238,6 +238,9 @@ ucc_status_t ucc_config_names_array_dup(ucc_config_names_array_t *dst,
 {
     int i;
 
+    if (dst->count != 0) {
+        ucc_config_names_array_free(dst);
+    }
     dst->names = ucc_malloc(sizeof(char*) * src->count, "ucc_config_names_array");
     if (!dst->names) {
         ucc_error("failed to allocate %zd bytes for ucc_config_names_array",
@@ -263,10 +266,13 @@ err:
 void ucc_config_names_array_free(ucc_config_names_array_t *array)
 {
     int i;
-    for (i = 0; i < array->count; i++) {
-        free(array->names[i]);
+    if (array->names != NULL) {
+        for (i = 0; i < array->count; i++) {
+            free(array->names[i]);
+        }
+        ucc_free(array->names);
     }
-    ucc_free(array->names);
+    array->count = 0;
 }
 
 int ucc_config_names_search(const ucc_config_names_array_t *config_names,


### PR DESCRIPTION
we see memory leaks from CI tests in https://github.com/openucx/ucc/pull/1023

This PR fixes these memory leaks. One instance of leaks can happen when a function such ```ucc_cl_basic_get_lib_attr()``` gets called multiple times, which can potentially lead to calling ```ucc_config_names_array_dup``` on the same cl_lib object. Each time this ```duplicate``` function is called, we were allocating new memory for names array, without making sure that that array has already been allocated or not.