### PR TITLE
CORE: Add fn name to score print

### DIFF
--- a/src/coll_score/ucc_coll_score_map.c
+++ b/src/coll_score/ucc_coll_score_map.c
@@ -9,6 +9,10 @@
 #include "utils/ucc_string.h"
 #include "schedule/ucc_schedule.h"
 
+#if ENABLE_DEBUG == 1
+#include <dlfcn.h>
+#endif
+
 typedef struct ucc_score_map {
     ucc_coll_score_t *score;
     /* Size, rank of the process in the base_team associated with that
@@ -157,6 +161,20 @@ ucc_status_t ucc_coll_init(ucc_score_map_t      *map,
     }                                                                \
 }
 
+#if ENABLE_DEBUG == 1
+static const char *get_fn_name(ucc_base_coll_init_fn_t init_fn)
+{
+    int status;
+    Dl_info info;
+    const char *fn_ptr_str = "?";
+    status = dladdr(init_fn, &info);
+    if (status && info.dli_sname != NULL) {
+        fn_ptr_str = info.dli_sname;
+    }
+    return fn_ptr_str;
+}
+#endif
+
 void ucc_coll_score_map_print_info(const ucc_score_map_t *map)
 {
     size_t           left;
@@ -193,10 +211,19 @@ void ucc_coll_score_map_print_info(const ucc_score_map_t *map)
                                        sizeof(range_str));
                 ucc_score_to_str(range->super.score, score_str,
                                  sizeof(score_str));
+#if ENABLE_DEBUG == 1
+                // If debug, get the name of the init function through dladdr
+                const char *fn_ptr_str = get_fn_name(range->super.init);
+                STR_APPEND(coll_str, left, 256, "{%s}:%s:%s=%s ",
+                           range_str,
+                           range->super.team->context->lib->log_component.name,
+                           score_str, fn_ptr_str);
+#else
                 STR_APPEND(coll_str, left, 256, "{%s}:%s:%s ",
                            range_str,
                            range->super.team->context->lib->log_component.name,
                            score_str);
+#endif
             }
             STR_APPEND(coll_str, left, 4, "\n");
         }


### PR DESCRIPTION
This PR adds the name of the init function in the score print when debug is enabled. It grabs the name using dladdr. If it can't find the symbol, it will show as `?`.

I found this useful for my own debugging, so I'm opening this PR in case it might be useful for others as well.

Here is the before-and-after:

Before

```
       ucc_team.c:471  UCC  INFO  ===== COLL_SCORE_MAP (team_id 32768, size 144) =====
ucc_coll_score_map.c:230  UCC  INFO  Allgather:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..4095}:TL_UCP:10 {4K..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Allgatherv:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Allreduce:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..4095}:TL_UCP:10 {4K..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Alltoall:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..18575}:TL_UCP:10 {18576..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Alltoallv:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Barrier:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Bcast:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..32767}:TL_UCP:10 {32K..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Fanin:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Fanout:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Gather:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Gatherv:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10
ucc_coll_score_map.c:230  UCC  INFO  Reduce:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10
```

After

```
       ucc_team.c:471  UCC  INFO  ===== COLL_SCORE_MAP (team_id 32768, size 144) =====
ucc_coll_score_map.c:230  UCC  INFO  Allgather:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..4095}:TL_UCP:10=ucc_tl_ucp_allgather_knomial_init {4K..inf}:TL_UCP:10=ucc_tl_ucp_allgather_neighbor_init
ucc_coll_score_map.c:230  UCC  INFO  Allgatherv:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10=ucc_tl_ucp_allgatherv_ring_init
ucc_coll_score_map.c:230  UCC  INFO  Allreduce:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..4095}:TL_UCP:10=ucc_tl_ucp_allreduce_knomial_init {4K..inf}:TL_UCP:10=ucc_tl_ucp_allreduce_sra_knomial_init
ucc_coll_score_map.c:230  UCC  INFO  Alltoall:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..18575}:TL_UCP:10=ucc_tl_ucp_alltoall_bruck_init {18576..inf}:TL_UCP:10=ucc_tl_ucp_coll_init
ucc_coll_score_map.c:230  UCC  INFO  Alltoallv:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10=ucc_tl_ucp_alltoallv_hybrid_init
ucc_coll_score_map.c:230  UCC  INFO  Barrier:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10=ucc_tl_ucp_coll_init
ucc_coll_score_map.c:230  UCC  INFO  Bcast:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..32767}:TL_UCP:10=ucc_tl_ucp_bcast_knomial_init {32K..inf}:TL_UCP:10=ucc_tl_ucp_bcast_sag_knomial_init
ucc_coll_score_map.c:230  UCC  INFO  Fanin:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10=ucc_tl_ucp_coll_init
ucc_coll_score_map.c:230  UCC  INFO  Fanout:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10=ucc_tl_ucp_coll_init
ucc_coll_score_map.c:230  UCC  INFO  Gather:
ucc_coll_score_map.c:230  UCC  INFO  	Host: {0..inf}:TL_UCP:10=ucc_tl_ucp_coll_init
```
