### PR TITLE
TEST: add error checking and exit in gtest

### DIFF
--- a/src/components/tl/mlx5/tl_mlx5_ib.c
+++ b/src/components/tl/mlx5/tl_mlx5_ib.c
@@ -408,10 +408,10 @@ ucc_status_t ucc_tl_mlx5_create_umr_qp(struct ibv_context *ctx,
                                        ucc_base_lib_t           *lib)
 {
     ucc_status_t               status = UCC_OK;
+    struct ibv_qp_ex *         qp_ex  = NULL;
     struct ibv_qp_init_attr_ex umr_init_attr_ex;
     struct mlx5dv_qp_init_attr umr_mlx5dv_qp_attr;
     struct ibv_port_attr       port_attr;
-    struct ibv_qp_ex *         qp_ex;
 
     memset(&umr_mlx5dv_qp_attr, 0, sizeof(umr_mlx5dv_qp_attr));
     memset(&umr_init_attr_ex, 0, sizeof(umr_init_attr_ex));
@@ -475,8 +475,11 @@ ucc_status_t ucc_tl_mlx5_create_umr_qp(struct ibv_context *ctx,
     return UCC_OK;
 
 failure:
-    if (ibv_destroy_qp(*qp)) {
-        tl_debug(lib, "failed to destroy UMR QP, %m");
+    if (*qp) {
+        if (ibv_destroy_qp(*qp)) {
+            tl_debug(lib, "failed to destroy UMR QP, %m");
+        }
     }
+    *qp = NULL;
     return status;
 }

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -28,7 +28,7 @@ typedef struct ucc_global_config {
     char *install_path;
     int   initialized;
     /* Profiling mode */
-    unsigned                   profile_mode;
+    uint64_t                   profile_mode;
 
     /* Profiling output file name */
     char *profile_file;

--- a/test/gtest/common/gtest-all.cc
+++ b/test/gtest/common/gtest-all.cc
@@ -4713,7 +4713,6 @@ void PrettyUnitTestResultPrinter::OnTestPartResult(
   switch (result.type()) {
     // If the test part succeeded, or was skipped,
     // we don't need to do anything.
-    case TestPartResult::kSkip:
     case TestPartResult::kSuccess:
       return;
     default:

--- a/test/gtest/tl/mlx5/test_tl_mlx5.cc
+++ b/test/gtest/tl/mlx5/test_tl_mlx5.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * See file LICENSE for terms.
  */
 
@@ -27,8 +27,7 @@ void test_tl_mlx5::SetUp()
         std::string(ucc_global_config.component_path) + "/libucc_tl_mlx5.so";
     tl_mlx5_so_handle = dlopen(path.c_str(), RTLD_NOW);
     if (!tl_mlx5_so_handle) {
-        std::cerr << "cannot open ucc_tl_mlx5 library" << std::endl;
-        GTEST_SKIP();
+        GTEST_SKIP() << "cannot open ucc_tl_mlx5 library" ;
     }
 
     create_ibv_ctx = (ucc_tl_mlx5_create_ibv_ctx_fn_t)dlsym(
@@ -41,8 +40,7 @@ void test_tl_mlx5::SetUp()
 
     status = create_ibv_ctx(&devname, &ctx, &lib);
     if (UCC_OK != status) {
-        std::cerr << "no ib devices";
-        GTEST_SKIP();
+        GTEST_SKIP() << "no ib devices";
     }
     port = get_active_port(ctx);
     ASSERT_GE(port, 0);

--- a/test/gtest/tl/mlx5/test_tl_mlx5.cc
+++ b/test/gtest/tl/mlx5/test_tl_mlx5.cc
@@ -45,7 +45,7 @@ void test_tl_mlx5::SetUp()
     port = get_active_port(ctx);
     ASSERT_GE(port, 0);
 
-    ibv_query_port(ctx, port, &port_attr);
+    ASSERT_EQ(ibv_query_port(ctx, port, &port_attr), 0);
 
     pd = ibv_alloc_pd(ctx);
     ASSERT_NE(nullptr, pd);

--- a/test/gtest/tl/mlx5/test_tl_mlx5.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5.h
@@ -11,6 +11,11 @@
 #include "components/tl/mlx5/tl_mlx5_dm.h"
 #include "components/tl/mlx5/tl_mlx5_ib.h"
 
+#define CHECK_TEST_STATUS() \
+  if (Test::HasFatalFailure() || Test::IsSkipped()) { \
+    return; \
+  }
+
 typedef ucc_status_t (*ucc_tl_mlx5_create_ibv_ctx_fn_t)(
     char **ib_devname, struct ibv_context **ctx, ucc_base_lib_t *lib);
 

--- a/test/gtest/tl/mlx5/test_tl_mlx5_qps.cc
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_qps.cc
@@ -18,6 +18,7 @@ UCC_TEST_F(test_tl_mlx5_rc_qp, create_umr)
 UCC_TEST_F(test_tl_mlx5_rc_qp, connect_loopback)
 {
     create_qp();
+    CHECK_TEST_STATUS();
     connect_qp_loopback();
 }
 

--- a/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
@@ -47,6 +47,7 @@ class test_tl_mlx5_rc_qp : public test_tl_mlx5_qp {
     virtual void SetUp()
     {
         test_tl_mlx5_qp::SetUp();
+        CHECK_TEST_STATUS();
 
         create_rc_qp = (ucc_tl_mlx5_create_rc_qp_fn_t)dlsym(
             tl_mlx5_so_handle, "ucc_tl_mlx5_create_rc_qp");
@@ -129,6 +130,7 @@ class test_tl_mlx5_dc : public test_tl_mlx5_qp {
         struct ibv_srq_init_attr srq_attr;
 
         test_tl_mlx5_qp::SetUp();
+        CHECK_TEST_STATUS();
 
         init_dct = (ucc_tl_mlx5_init_dct_fn_t)dlsym(tl_mlx5_so_handle,
                                                     "ucc_tl_mlx5_init_dct");

--- a/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
@@ -47,6 +47,11 @@ class test_tl_mlx5_rc_qp : public test_tl_mlx5_qp {
 
     virtual void SetUp()
     {
+        qp.qp       = NULL;
+        umr_qp.qp   = NULL;
+        tx_depth    = 4;
+        umr_qp_conf = qp_conf;
+
         test_tl_mlx5_qp::SetUp();
         CHECK_TEST_STATUS();
 
@@ -62,10 +67,6 @@ class test_tl_mlx5_rc_qp : public test_tl_mlx5_qp {
             tl_mlx5_so_handle, "ucc_tl_mlx5_create_umr_qp");
         ASSERT_EQ(nullptr, dlerror());
 
-        qp.qp       = NULL;
-        umr_qp.qp   = NULL;
-        tx_depth    = 4;
-        umr_qp_conf = qp_conf;
     }
 
     ~test_tl_mlx5_rc_qp()

--- a/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
@@ -12,6 +12,7 @@ class test_tl_mlx5_qp : public test_tl_mlx5 {
     virtual void SetUp()
     {
         test_tl_mlx5::SetUp();
+        CHECK_TEST_STATUS();
 
         qp_conf.qp_rnr_retry  = 7;
         qp_conf.qp_rnr_timer  = 20;

--- a/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
@@ -118,11 +118,11 @@ typedef ucc_status_t (*ucc_tl_mlx5_create_ah_fn_t)(struct ibv_pd * pd,
 
 class test_tl_mlx5_dc : public test_tl_mlx5_qp {
   public:
-    struct ibv_qp *            dct_qp;
+    struct ibv_qp             *dct_qp = nullptr;
+    struct ibv_ah             *ah     = nullptr;
+    struct ibv_srq            *srq    = nullptr;
+    ucc_tl_mlx5_dci_t          dci    = {};
     uint32_t                   dct_qpn;
-    struct ibv_srq *           srq;
-    ucc_tl_mlx5_dci_t          dci;
-    struct ibv_ah *            ah;
     ucc_tl_mlx5_init_dct_fn_t  init_dct;
     ucc_tl_mlx5_init_dci_fn_t  init_dci;
     ucc_tl_mlx5_create_ah_fn_t create_ah;
@@ -145,11 +145,6 @@ class test_tl_mlx5_dc : public test_tl_mlx5_qp {
         create_ah = (ucc_tl_mlx5_create_ah_fn_t)dlsym(tl_mlx5_so_handle,
                                                       "ucc_tl_mlx5_create_ah");
         ASSERT_EQ(nullptr, dlerror());
-
-        ah         = NULL;
-        dct_qp     = NULL;
-        dci.dci_qp = NULL;
-        srq        = NULL;
 
         memset(&srq_attr, 0, sizeof(struct ibv_srq_init_attr));
         srq_attr.attr.max_wr  = 1;

--- a/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
@@ -36,9 +36,9 @@ typedef ucc_status_t (*ucc_tl_mlx5_create_rc_qp_fn_t)(
 
 class test_tl_mlx5_rc_qp : public test_tl_mlx5_qp {
   public:
-    ucc_tl_mlx5_qp_t               qp;
+    ucc_tl_mlx5_qp_t               qp     = {};
+    ucc_tl_mlx5_qp_t               umr_qp = {};
     uint32_t                       qpn;
-    ucc_tl_mlx5_qp_t               umr_qp;
     ucc_tl_mlx5_ib_qp_conf_t       umr_qp_conf;
     int                            tx_depth;
     ucc_tl_mlx5_create_rc_qp_fn_t  create_rc_qp;

--- a/test/gtest/tl/mlx5/test_tl_mlx5_wqe.cc
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_wqe.cc
@@ -98,6 +98,7 @@ UCC_TEST_P(test_tl_mlx5_rdma_write, RdmaWriteWqe)
 
     bufsize = GetParam();
     buffers_init();
+    CHECK_TEST_STATUS();
 
     memset(&sg, 0, sizeof(sg));
     sg.addr   = (uintptr_t)src;
@@ -117,6 +118,7 @@ UCC_TEST_P(test_tl_mlx5_rdma_write, RdmaWriteWqe)
     // This work request is posted with wr_id = 0
     GTEST_ASSERT_EQ(ibv_post_send(qp.qp, &wr, NULL), 0);
     wait_for_completion();
+    CHECK_TEST_STATUS();
 
     validate_buffers();
 }
@@ -125,6 +127,7 @@ UCC_TEST_P(test_tl_mlx5_rdma_write, CustomRdmaWriteWqe)
 {
     bufsize = GetParam();
     buffers_init();
+    CHECK_TEST_STATUS();
 
     ibv_wr_start(qp.qp_ex);
     post_rdma_write(qp.qp, qpn, nullptr, (uintptr_t)src, bufsize, src_mr->lkey,
@@ -132,6 +135,7 @@ UCC_TEST_P(test_tl_mlx5_rdma_write, CustomRdmaWriteWqe)
                     IBV_SEND_SIGNALED | IBV_SEND_FENCE, 0);
     GTEST_ASSERT_EQ(ibv_wr_complete(qp.qp_ex), 0);
     wait_for_completion();
+    CHECK_TEST_STATUS();
 
     validate_buffers();
 }
@@ -143,6 +147,7 @@ UCC_TEST_P(test_tl_mlx5_dm, MemcpyToDeviceMemory)
 {
     bufsize = GetParam();
     buffers_init();
+    CHECK_TEST_STATUS();
     if (!dm_ptr) {
         return;
     }
@@ -165,6 +170,7 @@ UCC_TEST_P(test_tl_mlx5_dm, RdmaToDeviceMemory)
 
     bufsize = GetParam();
     buffers_init();
+    CHECK_TEST_STATUS();
     if (!dm_ptr) {
         return;
     }
@@ -187,6 +193,7 @@ UCC_TEST_P(test_tl_mlx5_dm, RdmaToDeviceMemory)
 
     GTEST_ASSERT_EQ(ibv_post_send(qp.qp, &wr, NULL), 0);
     wait_for_completion();
+    CHECK_TEST_STATUS();
 
     // RDMA write from device memory to host destination
     memset(&sg, 0, sizeof(sg));
@@ -206,6 +213,7 @@ UCC_TEST_P(test_tl_mlx5_dm, RdmaToDeviceMemory)
 
     GTEST_ASSERT_EQ(ibv_post_send(qp.qp, &wr, NULL), 0);
     wait_for_completion();
+    CHECK_TEST_STATUS();
 
     validate_buffers();
 }
@@ -214,6 +222,7 @@ UCC_TEST_P(test_tl_mlx5_dm, CustomRdmaToDeviceMemory)
 {
     bufsize = GetParam();
     buffers_init();
+    CHECK_TEST_STATUS();
     if (!dm_ptr) {
         return;
     }
@@ -225,6 +234,7 @@ UCC_TEST_P(test_tl_mlx5_dm, CustomRdmaToDeviceMemory)
                     IBV_SEND_SIGNALED | IBV_SEND_FENCE, 0);
     GTEST_ASSERT_EQ(ibv_wr_complete(qp.qp_ex), 0);
     wait_for_completion();
+    CHECK_TEST_STATUS();
 
     // RDMA write from device memory to host destination
     ibv_wr_start(qp.qp_ex);
@@ -233,6 +243,7 @@ UCC_TEST_P(test_tl_mlx5_dm, CustomRdmaToDeviceMemory)
                     IBV_SEND_SIGNALED | IBV_SEND_FENCE, 0);
     GTEST_ASSERT_EQ(ibv_wr_complete(qp.qp_ex), 0);
     wait_for_completion();
+    CHECK_TEST_STATUS();
 
     validate_buffers();
 }

--- a/test/gtest/tl/mlx5/test_tl_mlx5_wqe.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_wqe.h
@@ -101,9 +101,11 @@ class test_tl_mlx5_rdma_write
     : public test_tl_mlx5_wqe,
       public ::testing::WithParamInterface<RdmaWriteParams> {
   public:
+    DT            *src    = nullptr;
+    DT            *dst    = nullptr;
+    struct ibv_mr *src_mr = nullptr;
+    struct ibv_mr *dst_mr = nullptr;
     int            bufsize;
-    DT *           src, *dst;
-    struct ibv_mr *src_mr, *dst_mr;
 
     void buffers_init()
     {
@@ -147,18 +149,26 @@ class test_tl_mlx5_rdma_write
 
     void TearDown()
     {
-        GTEST_ASSERT_EQ(ibv_dereg_mr(src_mr), UCC_OK);
-        GTEST_ASSERT_EQ(ibv_dereg_mr(dst_mr), UCC_OK);
-        free(src);
-        free(dst);
+        if (src_mr != nullptr) {
+            GTEST_ASSERT_EQ(ibv_dereg_mr(src_mr), UCC_OK);
+        }
+        if (dst_mr != nullptr) {
+            GTEST_ASSERT_EQ(ibv_dereg_mr(dst_mr), UCC_OK);
+        }
+        if (src != nullptr) {
+            free(src);
+        }
+        if (dst != nullptr) {
+            free(dst);
+        }
     }
 };
 
 class test_tl_mlx5_dm : public test_tl_mlx5_rdma_write {
   public:
-    struct ibv_dm *          dm_ptr = nullptr;
+    struct ibv_dm *dm_ptr = nullptr;
+    struct ibv_mr *dm_mr  = nullptr;
     struct ibv_alloc_dm_attr dm_attr;
-    struct ibv_mr *          dm_mr;
 
     void buffers_init()
     {

--- a/test/gtest/tl/mlx5/test_tl_mlx5_wqe.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_wqe.h
@@ -57,6 +57,7 @@ class test_tl_mlx5_wqe : public test_tl_mlx5_rc_qp {
     void SetUp()
     {
         test_tl_mlx5_rc_qp::SetUp();
+        CHECK_TEST_STATUS();
 
         post_rdma_write = (ucc_tl_mlx5_post_rdma_fn_t)dlsym(
             tl_mlx5_so_handle, "ucc_tl_mlx5_post_rdma");
@@ -75,7 +76,9 @@ class test_tl_mlx5_wqe : public test_tl_mlx5_rc_qp {
         ASSERT_EQ(nullptr, dlerror());
 
         create_qp();
+        CHECK_TEST_STATUS();
         connect_qp_loopback();
+        CHECK_TEST_STATUS();
         create_umr_qp();
     }
 };
@@ -160,6 +163,7 @@ class test_tl_mlx5_dm : public test_tl_mlx5_rdma_write {
     void buffers_init()
     {
         test_tl_mlx5_rdma_write::buffers_init();
+        CHECK_TEST_STATUS();
 
         struct ibv_device_attr_ex attr;
         memset(&attr, 0, sizeof(attr));
@@ -208,6 +212,7 @@ class test_tl_mlx5_dm_alloc_reg
     void SetUp()
     {
         test_tl_mlx5_wqe::SetUp();
+        CHECK_TEST_STATUS();
 
         dm_alloc_reg = (ucc_tl_mlx5_dm_alloc_reg_fn_t)dlsym(
             tl_mlx5_so_handle, "ucc_tl_mlx5_dm_alloc_reg");


### PR DESCRIPTION
When a gtest unit is skipped or failed, using gtest macros like `GTEST_ASSERT_EQ`, or `GTEST_SKIP`, the program only exits the current function, but not the whole test. Therefore, the error/skip must be propagated through all frames of the unit test. Bottom line, each time we call a function that is susceptible to call one of this macro, we need to check on return the test status and return if relevant.

Related issue:
- [CI failure](https://nbuprod.blsm.nvidia.com/hpcx-01/job/UCC/job/ucc/232/console) in https://github.com/openucx/ucc/pull/1077
- https://redmine.mellanox.com/issues/4148913
- (maybe) https://redmine.mellanox.com/issues/4280707