### PR TITLE
TL/MLX5: Stabilize staging-based AG and Add zcopy AG

### DIFF
--- a/src/components/tl/mlx5/Makefile.am
+++ b/src/components/tl/mlx5/Makefile.am
@@ -29,6 +29,8 @@ mcast =                                         \
 	mcast/tl_mlx5_mcast_service_coll.c          \
 	mcast/tl_mlx5_mcast_one_sided_reliability.h \
 	mcast/tl_mlx5_mcast_one_sided_reliability.c \
+	mcast/tl_mlx5_mcast_one_sided_progress.h    \
+	mcast/tl_mlx5_mcast_one_sided_progress.c    \
 	mcast/tl_mlx5_mcast_allgather.h             \
 	mcast/tl_mlx5_mcast_allgather.c             \
 	mcast/tl_mlx5_mcast_team.c

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_allgather.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_allgather.c
@@ -21,9 +21,9 @@ do {                                                                            
                     ucc_ilog2(_max_counter));                                       \
 } while (0);
 
-#define MCAST_ALLGATHER_IN_PROGRESS(_req, _comm)                                             \
-        (_req->to_send || _req->to_recv || _comm->pending_send ||                            \
-         _comm->one_sided.rdma_read_in_progress || (NULL != _req->allgather_rkeys_req))      \
+#define MCAST_ALLGATHER_IN_PROGRESS(_req, _comm)                                    \
+        (_req->to_send || _req->to_recv || _comm->pending_send ||                   \
+         comm->one_sided.pending_reads || (NULL != _req->allgather_rkeys_req))      \
 
 static inline ucc_status_t ucc_tl_mlx5_mcast_check_collective(ucc_tl_mlx5_mcast_coll_comm_t *comm,
                                                               ucc_tl_mlx5_mcast_coll_req_t  *req)
@@ -32,7 +32,7 @@ static inline ucc_status_t ucc_tl_mlx5_mcast_check_collective(ucc_tl_mlx5_mcast_
 
     ucc_assert(comm->one_sided.reliability_ready);
 
-    if (comm->one_sided.rdma_read_in_progress) {
+    if (comm->one_sided.pending_reads) {
         return ucc_tl_mlx5_mcast_progress_one_sided_communication(comm, req);
     }
 
@@ -88,21 +88,19 @@ static inline ucc_status_t ucc_tl_mlx5_mcast_check_collective(ucc_tl_mlx5_mcast_
     return UCC_INPROGRESS;
 }
 
-static inline ucc_status_t ucc_tl_mlx5_mcast_reset_reliablity(ucc_tl_mlx5_mcast_coll_req_t *req)
+static inline ucc_status_t ucc_tl_mlx5_mcast_reliability_ready(ucc_tl_mlx5_mcast_coll_req_t *req)
 {
     ucc_tl_mlx5_mcast_coll_comm_t *comm = req->comm;
     ucc_tl_mlx5_mcast_reg_t       *reg  = NULL;
     ucc_status_t                   status;
 
     ucc_assert(req->ag_counter == comm->allgather_comm.under_progress_counter);
-
     if (comm->one_sided.reliability_enabled && !comm->one_sided.reliability_ready) {
-        /* initialize the structures needed by reliablity protocol */ 
+        /* initialize the structures needed by reliability protocol */
         memset(comm->one_sided.recvd_pkts_tracker, 0, comm->commsize * sizeof(uint32_t));
-        memset(comm->one_sided.remote_slot_info, ONE_SIDED_INVALID, comm->commsize * sizeof(uint32_t));
+        memset(comm->one_sided.remote_slot_info, ONE_SIDED_INVALID, comm->commsize * sizeof(int));
         /* local slots state */
         comm->one_sided.slots_state = ONE_SIDED_INVALID;
-
         if (ONE_SIDED_SYNCHRONOUS_PROTO == req->one_sided_reliability_scheme) {
             /* do nonblocking allgather over remote addresses/keys */
             if (!req->rreg) {
@@ -114,14 +112,12 @@ static inline ucc_status_t ucc_tl_mlx5_mcast_reset_reliablity(ucc_tl_mlx5_mcast_
                req->rreg = reg;
                req->mr   = reg->mr;
             }
-
             comm->one_sided.sendbuf_memkey_list[comm->rank].rkey        = req->mr->rkey;
             comm->one_sided.sendbuf_memkey_list[comm->rank].remote_addr = (uint64_t)req->ptr;
-
-            tl_trace(comm->lib, "Allgather over sendbuf addresses/rkey: address %p rkey %d",
+            tl_trace(comm->lib, "allgather over sendbuf addresses/rkey: address %p rkey %d",
                      req->ptr, req->mr->rkey);
-
-            status = comm->service_coll.allgather_post(comm->p2p_ctx, NULL /* in-place */,
+            status = comm->service_coll.allgather_post(comm->p2p_ctx,
+                                                       &(comm->one_sided.sendbuf_memkey_list[comm->rank]),
                                                        comm->one_sided.sendbuf_memkey_list,
                                                        sizeof(ucc_tl_mlx5_mcast_slot_mem_info_t),
                                                        &req->allgather_rkeys_req);
@@ -130,11 +126,9 @@ static inline ucc_status_t ucc_tl_mlx5_mcast_reset_reliablity(ucc_tl_mlx5_mcast_
                 return status;
             }
         }
-
         memset(comm->pending_recv_per_qp, 0, sizeof(int) * MAX_GROUP_COUNT);
         comm->one_sided.reliability_ready = 1;
     }
-
     return UCC_OK;
 }
 
@@ -154,7 +148,7 @@ static inline void ucc_tl_mlx5_mcast_init_async_reliability_slots(ucc_tl_mlx5_mc
                           (req->ag_counter % ONE_SIDED_SLOTS_COUNT)
                           * comm->one_sided.slot_size);
     
-        /* both user buffer and reliablity slots are on host */
+        /* both user buffer and reliability slots are on host */
         memcpy(PTR_OFFSET(dest, ONE_SIDED_SLOTS_INFO_SIZE), req->ptr, req->length);
         memcpy(dest, &req->ag_counter, ONE_SIDED_SLOTS_INFO_SIZE);
 
@@ -162,16 +156,18 @@ static inline void ucc_tl_mlx5_mcast_init_async_reliability_slots(ucc_tl_mlx5_mc
     }
 }
 
-static inline ucc_status_t ucc_tl_mlx5_mcast_do_staging_based_allgather(ucc_tl_mlx5_mcast_coll_req_t *req)
+static inline ucc_status_t ucc_tl_mlx5_mcast_do_staging_based_allgather(void *req_handle)
 {
+
     ucc_status_t                   status = UCC_OK;
+    ucc_tl_mlx5_mcast_coll_req_t  *req    = (ucc_tl_mlx5_mcast_coll_req_t *)req_handle;
     ucc_tl_mlx5_mcast_coll_comm_t *comm   = req->comm;
     const int                      zcopy  = req->proto != MCAST_PROTO_EAGER;
     int                            num_recvd;
 
     ucc_assert(req->to_recv >= 0 && req->to_send >= 0);
 
-    status = ucc_tl_mlx5_mcast_reset_reliablity(req);
+    status = ucc_tl_mlx5_mcast_reliability_ready(req);
     if (UCC_OK != status) {
         return status;
     }
@@ -202,14 +198,15 @@ static inline ucc_status_t ucc_tl_mlx5_mcast_do_staging_based_allgather(ucc_tl_m
     }
 
     if (comm->pending_send) {
-        if (ucc_tl_mlx5_mcast_poll_send(comm) < 0) {
-            return UCC_ERR_NO_MESSAGE;
+        status = ucc_tl_mlx5_mcast_poll_send(comm);
+        if (status != UCC_OK) {
+            return status;
         }
     }
 
     if (comm->one_sided.reliability_enabled) {
         status = ucc_tl_mlx5_mcast_check_collective(comm, req);
-        if (UCC_INPROGRESS != status && UCC_OK != status) {
+        if (status < 0) {
             return status;
         }
     }
@@ -264,8 +261,8 @@ void ucc_tl_mlx5_mcast_allgather_progress(ucc_coll_task_t *coll_task)
         return;
     }
 
-    coll_task->status = ucc_tl_mlx5_mcast_do_staging_based_allgather(req);
-    if (UCC_OK != coll_task->status) {
+    coll_task->status = (req->progress)(req);
+    if (coll_task->status < 0) {
         tl_error(UCC_TASK_LIB(task), "progress mcast allgather failed:%d", coll_task->status);
     }
 }
@@ -309,7 +306,6 @@ ucc_tl_mlx5_mcast_validate_zero_copy_allgather_params(ucc_tl_mlx5_mcast_coll_com
 
     return UCC_OK;
 }
-
 
 /*
  * at each stage half of the mcast groups are ready for receiving mcast
@@ -433,6 +429,195 @@ ucc_tl_mlx5_mcast_prepare_zero_copy_allgather(ucc_tl_mlx5_mcast_coll_comm_t *com
     return UCC_OK;
 }
 
+static inline ucc_status_t
+ucc_tl_mlx5_mcast_check_zcopy_collective(ucc_tl_mlx5_mcast_coll_comm_t *comm,
+                                         ucc_tl_mlx5_mcast_coll_req_t  *req)
+{
+    ucc_tl_mlx5_mcast_pipelined_ag_schedule_t *sched = req->ag_schedule;
+    ucc_status_t                               status;
+
+    if (!sched[req->step].prepost_buf_op_done || !sched[req->step].multicast_op_done) {
+        // it is not yet the time to start the reliability protocol
+        return UCC_INPROGRESS;
+    }
+    if (comm->one_sided.pending_reads) {
+        return ucc_tl_mlx5_mcast_progress_one_sided_communication(comm, req);
+    }
+    if (req->allgather_rkeys_req) {
+        status = comm->service_coll.coll_test(req->allgather_rkeys_req);
+        if (status != UCC_OK) {
+            return status;
+        }
+        req->allgather_rkeys_req = NULL;
+        tl_trace(comm->lib, "allgather for remote_addr/rkey is completed");
+    }
+
+    if (sched[req->step].num_recvd == sched[req->step].to_recv) {
+        /* check for out of order packets, if any root sent a out of order
+         * packet to us in the current step, go ahead and issue RDMA READ
+         * from that root for this specific piece of send buffer */
+        return ucc_tl_mlx5_mcast_reliable_zcopy_pipelined_one_sided_get(comm, req, NULL);
+    } else if (!comm->timer) {
+        if (comm->stalled < DROP_THRESHOLD) {
+            comm->stalled++;
+        } else {
+            // kick the timer
+            comm->timer   = ucc_tl_mlx5_mcast_get_timer();
+            comm->stalled = 0;
+        }
+    } else {
+        if (comm->stalled < DROP_THRESHOLD) {
+            comm->stalled++;
+        } else {
+            // calcuate the current time and check if it's time to do RDMA READ
+            if (ucc_tl_mlx5_mcast_get_timer() - comm->timer >=
+                    comm->ctx->params.timeout) {
+                tl_debug(comm->lib, "[REL] time out");
+                return ucc_tl_mlx5_mcast_reliable_zcopy_pipelined_one_sided_get(comm, req, NULL);
+            } else {
+                comm->stalled = 0;
+            }
+        }
+    }
+    return UCC_INPROGRESS;
+}
+
+static inline ucc_status_t
+ucc_tl_mlx5_mcast_do_zero_copy_pipelined_allgather(void *req_handle)
+{
+    ucc_tl_mlx5_mcast_coll_req_t              *req   = (ucc_tl_mlx5_mcast_coll_req_t *)req_handle;
+    ucc_tl_mlx5_mcast_coll_comm_t             *comm  = req->comm;
+    const int                                  zcopy = req->proto != MCAST_PROTO_EAGER;
+    ucc_tl_mlx5_mcast_pipelined_ag_schedule_t *sched = req->ag_schedule;
+    int                                        num_recvd, root, to_send_left,
+                                               j, group_id, num_packets, count;
+    size_t                                     offset, offset_left;
+    ucc_status_t                               status;
+
+    status = ucc_tl_mlx5_mcast_reliability_ready(req);
+    if (UCC_OK != status) {
+        return status;
+    }
+
+    ucc_assert(req->to_recv>=0 && req->to_send >=0);
+    if (req->barrier_req) {
+        status = comm->service_coll.coll_test(req->barrier_req);
+        if (status != UCC_OK) {
+            return status;
+        }
+        tl_trace(comm->lib, "barrier at end of req->step %d is completed", req->step);
+        req->barrier_req = NULL;
+        req->step++;
+        if (comm->one_sided.reliability_enabled) {
+            memset(comm->one_sided.recvd_pkts_tracker, 0, sizeof(int) * comm->commsize);
+        }
+        if (req->step == sched->total_steps) {
+            ucc_assert(!req->to_send && !req->to_recv);
+            return UCC_OK;
+        }
+    }
+
+    ucc_assert(req->step < sched->total_steps);
+    if (!sched[req->step].multicast_op_done) {
+        for (j = 0; j < req->concurrency_level; j++) {
+            root = sched[req->step].multicast_op[j].root;
+            if (comm->rank == root) {
+                /* it's my turn to place mcast packets on wire */
+                group_id     = sched[req->step].multicast_op[j].group_id;
+                to_send_left = sched[req->step].multicast_op[j].to_send_left;
+                offset_left  = sched[req->step].multicast_op[j].offset_left;
+                num_packets  = ucc_min(comm->allgather_comm.max_push_send - comm->pending_send, to_send_left);
+                if (to_send_left &&
+                    (comm->allgather_comm.max_push_send - comm->pending_send) > 0) {
+                    status = ucc_tl_mlx5_mcast_send_collective(comm, req, num_packets,
+                                                               zcopy, UCC_COLL_TYPE_ALLGATHER,
+                                                               group_id, offset_left);
+                    if (UCC_OK != status) {
+                        return status;
+                    }
+                    sched[req->step].multicast_op[j].to_send_left -= num_packets;
+                    sched[req->step].multicast_op[j].offset_left  += (num_packets * comm->max_per_packet);
+                }
+                if (comm->pending_send) {
+                    status = ucc_tl_mlx5_mcast_poll_send(comm);
+                    if (status != UCC_OK) {
+                        return status;
+                    }
+                }
+                if (!sched[req->step].multicast_op[j].to_send_left && !comm->pending_send) {
+                    tl_trace(comm->lib, "done with mcast ops step %d group id %d to_send %d",
+                             req->step, group_id, sched[req->step].to_send);
+                    sched[req->step].multicast_op_done = 1;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!sched[req->step].prepost_buf_op_done) {
+        /* prepost the user buffers for a set of processes */
+        for (j = 0; j < req->concurrency_level; j++) {
+            root     = sched[req->step].prepost_buf_op[j].root;
+            group_id = sched[req->step].prepost_buf_op[j].group_id;
+            count    = sched[req->step].prepost_buf_op[j].count;
+            offset   = sched[req->step].prepost_buf_op[j].offset;
+            status   = ucc_tl_mlx5_mcast_post_user_recv_buffers(comm, req, group_id, root,
+                                                                UCC_COLL_TYPE_ALLGATHER, count,
+                                                                offset);
+            if (UCC_OK != status) {
+                return status;
+            }
+            /* progress the recvd packets in between */
+            if (req->to_recv) {
+                num_recvd = ucc_tl_mlx5_mcast_recv_collective(comm, req,
+                                                              req->to_recv,
+                                                              UCC_COLL_TYPE_ALLGATHER);
+                if (num_recvd < 0) {
+                    tl_error(comm->lib, "a failure happend during cq polling");
+                    status = UCC_ERR_NO_MESSAGE;
+                    return status;
+                }
+                sched[req->step].num_recvd += num_recvd;
+            }
+        }
+        tl_trace(comm->lib, "done with prepost bufs step %d group id %d count %d offset %ld root %d",
+                 req->step, group_id, count, offset, root);
+        sched[req->step].prepost_buf_op_done = 1;
+    }
+    if (req->to_recv) {
+        num_recvd = ucc_tl_mlx5_mcast_recv_collective(comm, req,
+                                                      req->to_recv,
+                                                      UCC_COLL_TYPE_ALLGATHER);
+        if (num_recvd < 0) {
+            tl_error(comm->lib, "a failure happend during cq polling");
+            status = UCC_ERR_NO_MESSAGE;
+            return status;
+        }
+        sched[req->step].num_recvd += num_recvd;
+    }
+
+    if (comm->one_sided.reliability_enabled) {
+        status = ucc_tl_mlx5_mcast_check_zcopy_collective(comm, req);
+        if (status != UCC_OK) {
+            return status;
+        }
+    }
+
+    if (sched[req->step].prepost_buf_op_done &&
+        sched[req->step].multicast_op_done &&
+        sched[req->step].num_recvd == sched[req->step].to_recv) {
+        // current step done
+        ucc_assert(sched[req->step].prepost_buf_op_done && sched[req->step].multicast_op_done);
+        ucc_assert(req->barrier_req == NULL);
+        status = comm->service_coll.barrier_post(comm->p2p_ctx, &req->barrier_req);
+        if (status != UCC_OK) {
+            return status;
+        }
+        tl_trace(comm->lib, "init global sync req->step %d", req->step);
+    }
+    return UCC_INPROGRESS;
+}
+
 ucc_status_t ucc_tl_mlx5_mcast_allgather_init(ucc_tl_mlx5_task_t *task)
 {
     ucc_coll_task_t               *coll_task =  &(task->super);
@@ -519,12 +704,14 @@ ucc_status_t ucc_tl_mlx5_mcast_allgather_init(ucc_tl_mlx5_task_t *task)
     req->ag_counter = comm->allgather_comm.coll_counter;
     req->to_send    = req->num_packets;
     req->to_recv    = comm->commsize * req->num_packets;
+    req->progress   = ucc_tl_mlx5_mcast_do_staging_based_allgather;
 
     if (comm->allgather_comm.truly_zero_copy_allgather_enabled) {
         status = ucc_tl_mlx5_mcast_prepare_zero_copy_allgather(comm, req);
         if (UCC_OK != status) {
             goto failed;
         }
+        req->progress = ucc_tl_mlx5_mcast_do_zero_copy_pipelined_allgather;
     }
 
     comm->allgather_comm.coll_counter++;

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_helper.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_helper.c
@@ -8,6 +8,7 @@
 #include <glob.h>
 #include <net/if.h>
 #include <ifaddrs.h>
+#include "tl_mlx5_mcast_one_sided_reliability.h"
 
 #define PREF        "/sys/class/net/"
 #define SUFF        "/device/resource"
@@ -518,7 +519,6 @@ ucc_status_t ucc_tl_mlx5_mcast_modify_rc_qps(ucc_tl_mlx5_mcast_coll_context_t *c
         attr.max_dest_rd_atomic	   = 16;
         attr.min_rnr_timer         = 12;
         attr.ah_attr.is_global     = 0;
-        attr.ah_attr.dlid          = comm->mcast.rc_lid[i];
         attr.ah_attr.dlid          = comm->one_sided.info[i].port_lid;
         attr.ah_attr.sl            = DEF_SL;
         attr.ah_attr.src_path_bits = 0;
@@ -632,6 +632,10 @@ ucc_status_t ucc_tl_mlx5_clean_mcast_comm(ucc_tl_mlx5_mcast_coll_comm_t *comm)
     if (status) {
         tl_error(comm->lib, "couldn't leave mcast group");
         return status;
+    }
+
+    if (comm->one_sided.reliability_enabled) {
+        ucc_tl_mlx5_mcast_one_sided_cleanup(comm);
     }
 
     if (comm->mcast.rcq) {

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_helper.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_helper.h
@@ -13,25 +13,52 @@
 
 static inline ucc_status_t ucc_tl_mlx5_mcast_poll_send(ucc_tl_mlx5_mcast_coll_comm_t *comm)
 {
-    struct ibv_wc wc;
-    int           num_comp;
-    
-    num_comp = ibv_poll_cq(comm->mcast.scq, 1, &wc);
-    
-    tl_trace(comm->lib, "polled send completions: %d", num_comp);
-    
+    int               num_comp;
+    struct pp_packet *pp;
+    struct ibv_wc     wc[POLL_PACKED];
+
+    num_comp = ibv_poll_cq(comm->mcast.scq, POLL_PACKED, &wc[0]);
     if (num_comp < 0) {
         tl_error(comm->lib, "send queue poll completion failed %d", num_comp);
         return UCC_ERR_NO_MESSAGE;
     } else if (num_comp > 0) {
-        if (IBV_WC_SUCCESS != wc.status) {
-           tl_error(comm->lib, "mcast_poll_send: %s err %d num_comp",
-                    ibv_wc_status_str(wc.status), num_comp);
-            return UCC_ERR_NO_MESSAGE;
+        tl_trace(comm->lib, "polled send completions: %d", num_comp);
+        for (int i = 0 ; i < num_comp ; i++) {
+            if (IBV_WC_SUCCESS != wc[i].status) {
+                tl_warn(comm->lib, "mcast_poll_send: %s err %d num_comp %d op %ld wr_id\n",
+                        ibv_wc_status_str(wc[i].status), num_comp, wc[i].opcode, wc[i].wr_id);
+                return UCC_ERR_NO_MESSAGE;
+            }
+            switch (wc[i].wr_id) {
+                case MCAST_AG_RDMA_READ_WR:
+                    /* completion of a RDMA Read to remote send buffer during
+                     * reliability protocol */
+                    comm->one_sided.pending_reads--;
+                    tl_trace(comm->lib, "RDMA READ completion, pending reads %d",
+                             comm->one_sided.pending_reads);
+                    break;
+                case MCAST_AG_RDMA_READ_INFO_WR:
+                    tl_trace(comm->lib, "RDMA READ remote slot info completion, pending reads %d",
+                             comm->one_sided.pending_reads);
+                    comm->one_sided.pending_reads--;
+                    break;
+                case MCAST_BCASTSEND_WR:
+                    tl_trace(comm->lib, "completion of mcast send for bcast, opcode %d",
+                             wc[i].opcode);
+                    comm->pending_send--;
+                    break;
+                default:
+                    tl_trace(comm->lib, "completion of mcast send for allgather, opcode %d",
+                             wc[i].opcode);
+                    comm->pending_send--;
+                    pp = (struct pp_packet*)wc[i].wr_id;
+                    assert(pp != 0);
+                    pp->context = 0;
+                    ucc_list_add_tail(&comm->bpool, &pp->super);
+                    break;
+            }
         }
-        comm->pending_send -= num_comp;
     }
-
     return UCC_OK;
 }
 
@@ -412,8 +439,8 @@ static inline int ucc_tl_mlx5_mcast_recv_collective(ucc_tl_mlx5_mcast_coll_comm_
         }
 
         if (IBV_WC_SUCCESS != wc[0].status) {
-            fprintf(stderr, "mcast_recv: %s err pending_recv %d wr_id %ld num_comp %d byte_len %d\n",
-                    ibv_wc_status_str(wc[0].status), comm->pending_recv, wc[0].wr_id, num_comp, wc[0].byte_len);
+            tl_error(comm->lib, "mcast_recv: %s err pending_recv %d wr_id %ld num_comp %d byte_len %d\n",
+                     ibv_wc_status_str(wc[0].status), comm->pending_recv, wc[0].wr_id, num_comp, wc[0].byte_len);
             return -1;
         }
 

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_progress.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_progress.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -26,126 +26,110 @@ ucc_status_t ucc_tl_mlx5_mcast_reliable_one_sided_get(ucc_tl_mlx5_mcast_coll_com
 
     /* in sync design this function is only called once */
     ucc_assert(!(ONE_SIDED_SYNCHRONOUS_PROTO == req->one_sided_reliability_scheme &&
-           comm->one_sided.rdma_read_in_progress));
-
+                 comm->one_sided.pending_reads));
     for (target = 0; target < comm->commsize; target++) {
-        if (comm->one_sided.recvd_pkts_tracker[target] != req->num_packets) {
-           tl_trace(comm->lib, "%d of the packets from source target %d are dropped",
-                    req->num_packets - comm->one_sided.recvd_pkts_tracker[target], target);
-            
-           // register the recv buf if it is not already registered
-
-           if (NULL == req->recv_rreg) {
-               tl_debug(comm->lib, "registering recv buf of size %d", comm->commsize * req->length);
-
-               status = ucc_tl_mlx5_mcast_mem_register(comm->ctx, req->rptr, comm->commsize * req->length, &reg);
-               if (UCC_OK != status) {
-                    return status;
-               }
-
-               req->recv_rreg = reg;
-               req->recv_mr   = reg->mr;
-           }
-
-           switch(req->one_sided_reliability_scheme) {
-                case ONE_SIDED_ASYNCHRONOUS_PROTO:
-                    /* first check if the remote slot is valid */
-                    /* in this design, if reliability protocol is kicked, allgather is
-                     * completed once all the values in one_sided.recvd_pkts_tracker[] is set to req->num_packets
-                     * and comm->pending_reads is set to 0 */
-                    if (req->ag_counter == comm->one_sided.remote_slot_info[target]) {
-                        /* read remote data from remote slot
-                         * the content of this data is copied from send buffer by remote
-                         * process */
-                        src_addr    = PTR_OFFSET(req->rptr, (req->length * target));
-                        remote_addr = PTR_OFFSET(comm->one_sided_async_slots_info_list[target].remote_addr,
-                                      ((req->ag_counter % ONE_SIDED_SLOTS_COUNT) * comm->one_sided.slot_size
-                                      + ONE_SIDED_SLOTS_INFO_SIZE));
-                        lkey        = req->recv_mr->lkey;
-                        rkey        = comm->one_sided_async_slots_info_list[target].rkey;
-                        size        = req->length;
-                        wr          = MCAST_AG_RDMA_READ_WR;
-
-                        comm->pending_reads++;
-                        target_completed++;
-                        comm->one_sided.remote_slot_info[target]   = ONE_SIDED_PENDING_DATA;
-                        comm->one_sided.recvd_pkts_tracker[target] = req->num_packets;
-
-                    } else if (ONE_SIDED_PENDING_INFO != comm->one_sided.remote_slot_info[target] &&
-                               ONE_SIDED_PENDING_DATA != comm->one_sided.remote_slot_info[target]) {
-                        /* remote slot is not valid yet. Need to do an rdma
-                         * read to check the latest state */
-                        src_addr    = &comm->one_sided.remote_slot_info[target];
-                        remote_addr = PTR_OFFSET(comm->one_sided_async_slots_info_list[target].remote_addr,
-                                      ((req->ag_counter % ONE_SIDED_SLOTS_COUNT) * comm->one_sided.slot_size));
-                        lkey        = comm->one_sided.remote_slot_info_mr->lkey;
-                        rkey        = comm->one_sided_async_slots_info_list[target].rkey;
-                        size        = ONE_SIDED_SLOTS_INFO_SIZE;
-                        wr          = MCAST_AG_RDMA_READ_INFO_WR;
-
-                        comm->one_sided.remote_slot_info[target] = ONE_SIDED_PENDING_INFO;
-
-                    } else {
-                        /* rdma read to remote info or data has already been issue but it
-                         * has not been completed */
-                        continue;
-                    }
-                    break;
-
-                case ONE_SIDED_SYNCHRONOUS_PROTO:
-                    /* read the whole remote send buffer */
+        if (comm->one_sided.recvd_pkts_tracker[target] == req->num_packets) {
+            target_completed++;
+            continue;
+        }
+        if (NULL == req->recv_rreg) {
+            tl_debug(comm->lib, "registering recv buf of size %ld", comm->commsize * req->length);
+            status = ucc_tl_mlx5_mcast_mem_register(comm->ctx, req->rptr, comm->commsize * req->length, &reg);
+            if (UCC_OK != status) {
+                 return status;
+            }
+            req->recv_rreg = reg;
+            req->recv_mr   = reg->mr;
+        }
+        switch(req->one_sided_reliability_scheme) {
+            case ONE_SIDED_ASYNCHRONOUS_PROTO:
+                /* first check if the remote slot is valid in this design, if
+                 * reliability protocol is kicked, allgather is completed once
+                 * all the values in one_sided.recvd_pkts_tracker[] is set to
+                 * req->num_packets and comm->pending_reads is set to 0 */
+                if (req->ag_counter == comm->one_sided.remote_slot_info[target]) {
+                    /* read remote data from remote slot
+                     * the content of this data is copied from send buffer by remote
+                     * process */
                     src_addr    = PTR_OFFSET(req->rptr, (req->length * target));
-                    remote_addr = comm->ag_info_list[target].remote_addr;
-                    rkey        = comm->ag_info_list[target].rkey;
+                    remote_addr = PTR_OFFSET(comm->one_sided.info[target].slot_mem.remote_addr,
+                                             ((req->ag_counter %
+                                              ONE_SIDED_SLOTS_COUNT) *
+                                              comm->one_sided.slot_size +
+                                              ONE_SIDED_SLOTS_INFO_SIZE));
                     lkey        = req->recv_mr->lkey;
+                    rkey        = comm->one_sided.info[target].slot_mem.rkey;
                     size        = req->length;
                     wr          = MCAST_AG_RDMA_READ_WR;
-
-                    comm->pending_reads++;
+                    comm->one_sided.pending_reads++;
                     target_completed++;
-                    break;
-
-                default:
-                    return UCC_ERR_NOT_IMPLEMENTED;
-           }
-
-           issued++;
-           status = ucc_tl_one_sided_p2p_get(src_addr, remote_addr, size, lkey, rkey, target, wr, comm);
-           if (UCC_OK != status) {
-                return status;
-           }
-        } else {
-            /* all the expected packets from this target have arrived */
-            target_completed++;
+                    comm->one_sided.remote_slot_info[target]   = ONE_SIDED_PENDING_DATA;
+                    comm->one_sided.recvd_pkts_tracker[target] = req->num_packets;
+                } else if (ONE_SIDED_PENDING_INFO != comm->one_sided.remote_slot_info[target] &&
+                           ONE_SIDED_PENDING_DATA != comm->one_sided.remote_slot_info[target]) {
+                    /* remote slot is not valid yet. Need to do an rdma
+                     * read to check the latest state */
+                    src_addr    = &comm->one_sided.remote_slot_info[target];
+                    remote_addr = PTR_OFFSET(comm->one_sided.info[target].slot_mem.remote_addr,
+                                             ((req->ag_counter % ONE_SIDED_SLOTS_COUNT) *
+                                             comm->one_sided.slot_size));
+                    lkey        = comm->one_sided.remote_slot_info_mr->lkey;
+                    rkey        = comm->one_sided.info[target].slot_mem.rkey;
+                    size        = ONE_SIDED_SLOTS_INFO_SIZE;
+                    wr          = MCAST_AG_RDMA_READ_INFO_WR;
+                    comm->one_sided.pending_reads++;
+                    comm->one_sided.remote_slot_info[target] = ONE_SIDED_PENDING_INFO;
+                } else {
+                    /* rdma read to remote info or data has already been issue but it
+                     * has not been completed */
+                    continue;
+                }
+                break;
+            case ONE_SIDED_SYNCHRONOUS_PROTO:
+                /* read the whole remote send buffer */
+                src_addr    = PTR_OFFSET(req->rptr, (req->length * target));
+                remote_addr = (void *)comm->one_sided.sendbuf_memkey_list[target].remote_addr;
+                rkey        = comm->one_sided.sendbuf_memkey_list[target].rkey;
+                lkey        = req->recv_mr->lkey;
+                size        = req->length;
+                wr          = MCAST_AG_RDMA_READ_WR;
+                comm->one_sided.pending_reads++;
+                target_completed++;
+                break;
+            default:
+                return UCC_ERR_NOT_IMPLEMENTED;
+        }
+        issued++;
+        status = ucc_tl_mlx5_one_sided_p2p_get(src_addr, remote_addr, size,
+                                              lkey, rkey, target, wr, comm);
+        if (UCC_OK != status) {
+            return status;
         }
     }
-
-    comm->one_sided.rdma_read_in_progress = 1;
-
     if (completed) {
         *completed = target_completed;
     }
-
     if (issued) {
-        tl_debug(comm->lib, "issued %d RDMA READ to remote INFO/DATA. Number of target ranks completed: %d",
+        tl_debug(comm->lib,
+                 "issued %d RDMA READ to remote INFO/DATA. Number of target ranks completed: %d",
                  issued, target_completed);
     }
-
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_mlx5_mcast_progress_one_sided_communication(ucc_tl_mlx5_mcast_coll_comm_t *comm,
-                                                                ucc_tl_mlx5_mcast_coll_req_t *req)
+ucc_status_t
+ucc_tl_mlx5_mcast_progress_one_sided_communication(ucc_tl_mlx5_mcast_coll_comm_t *comm,
+                                                   ucc_tl_mlx5_mcast_coll_req_t *req)
 {
     int          completed = 0;
     ucc_status_t status;
     
-    ucc_assert(comm->one_sided.rdma_read_in_progress);
+    ucc_assert(comm->one_sided.pending_reads);
 
     if (!req->to_send && !req->to_recv) {
         // need to wait until all the rdma reads are done to avoid data invalidation 
         tl_trace(comm->lib,
-                "All the mcast packets arrived during the reliablity protocol. Current timeout is %d usec",
+                "all the mcast packets arrived during the reliability protocol- current timeout is %d usec",
                 comm->ctx->params.timeout);
     }
 
@@ -161,19 +145,19 @@ ucc_status_t ucc_tl_mlx5_mcast_progress_one_sided_communication(ucc_tl_mlx5_mcas
                 return status;
             }
 
-            if (!comm->pending_reads && (completed == comm->commsize)) {
-                tl_debug(comm->lib, "All the pending RDMA READ are comepleted in async reliablity protocol");
-                comm->one_sided.rdma_read_in_progress = 0;
-                req->to_recv                          = 0;
+            if (!comm->one_sided.pending_reads && (completed == comm->commsize)) {
+                tl_debug(comm->lib,
+                         "all the pending RDMA READ are comepleted in async reliability protocol");
+                req->to_recv = 0;
                 return UCC_OK;
             }
             break;
 
         case ONE_SIDED_SYNCHRONOUS_PROTO:
-            if (!comm->pending_reads) {
-                tl_debug(comm->lib, "All the pending RDMA READ are comepleted in sync reliablity protocol");
-                comm->one_sided.rdma_read_in_progress = 0;
-                req->to_recv                          = 0;
+            if (!comm->one_sided.pending_reads) {
+                tl_debug(comm->lib,
+                         "all the pending RDMA READ are comepleted in sync reliability protocol");
+                req->to_recv = 0;
                 return UCC_OK;
             } 
             break;
@@ -190,21 +174,11 @@ ucc_status_t ucc_tl_mlx5_mcast_process_packet_collective(ucc_tl_mlx5_mcast_coll_
                                                          struct pp_packet  *pp,
                                                          int coll_type)
 {
-    int                      out_of_order_recvd = 0;
-    void                    *dest;
-    int                      offset;
-    int                      source_rank;
-    uint32_t                 ag_counter;
-    ucc_status_t             status;
-    int                      count;
-    ucc_rank_t               target;
-    ucc_tl_mlx5_mcast_reg_t *reg;
-    void                    *src_addr;
-    void                    *remote_addr;
-    uint32_t                 rkey;
-    uint32_t                 lkey;
-    size_t                   size;
-    uint64_t                 wr;
+    int          out_of_order_recvd = 0;
+    void        *dest;
+    int          offset;
+    int          source_rank;
+    uint32_t     ag_counter;
 
     ucc_assert(pp->context == 0); // making sure it's a recv packet not send
     ucc_assert(UCC_COLL_TYPE_ALLGATHER == coll_type);
@@ -224,11 +198,21 @@ ucc_status_t ucc_tl_mlx5_mcast_process_packet_collective(ucc_tl_mlx5_mcast_coll_
     // need to check the allgather call counter and ignore this packet if it does not match
 
     if (ag_counter == (req->ag_counter % ONE_SIDED_MAX_ALLGATHER_COUNTER)) {
-        if (pp->length) {
+        if (comm->allgather_comm.truly_zero_copy_allgather_enabled) {
+            /* no need for memcopy - packet must be delivered by hca into
+             * the user buffer double check that ordering is correct */
+            if (offset != pp->packet_counter) {
+                /* recevied out of order packet */
+                tl_trace(comm->lib, "recevied out of order: packet counter %d expected recv counter %d",
+                         offset, pp->packet_counter);
+                out_of_order_recvd = 1;
+            }
+        } else if (pp->length) {
+            /* staging based allgather */
             if (pp->length == comm->max_per_packet) {
                 dest = PTR_OFFSET(req->rptr, (offset * pp->length + source_rank * req->length));
             } else {
-                dest = PTR_OFFSET(req->rptr, ((req->length - pp->length) + source_rank * req->length);
+                dest = PTR_OFFSET(req->rptr, ((req->length - pp->length) + source_rank * req->length));
             }
             memcpy(dest, (void*) pp->buf, pp->length);
         }
@@ -239,9 +223,8 @@ ucc_status_t ucc_tl_mlx5_mcast_process_packet_collective(ucc_tl_mlx5_mcast_coll_
             if (out_of_order_recvd == 0) {
                 comm->one_sided.recvd_pkts_tracker[source_rank]++;
             }
-
             if (comm->one_sided.recvd_pkts_tracker[source_rank] > req->num_packets) {
-                tl_error(comm->lib, "reliablity failed: comm->one_sided.recvd_pkts_tracker[%d] %d"
+                tl_error(comm->lib, "reliability failed: comm->one_sided.recvd_pkts_tracker[%d] %d"
                         " req->num_packets %d offset %d"
                         " comm->allgather_comm.under_progress_counter %d req->ag_counter"
                         " %d \n", source_rank, comm->one_sided.recvd_pkts_tracker[source_rank],
@@ -261,7 +244,7 @@ ucc_status_t ucc_tl_mlx5_mcast_process_packet_collective(ucc_tl_mlx5_mcast_coll_
         ucc_list_add_tail(&comm->pending_q, &pp->super);
     } else {
         /* received a packet which was left from previous iterations
-         * it is due to the fact that reliablity protocol was initiated.
+         * it is due to the fact that reliability protocol was initiated.
          * return the posted receive buffer back to the pool */
         ucc_assert(comm->one_sided.reliability_enabled);
         pp->context = 0;
@@ -271,3 +254,128 @@ ucc_status_t ucc_tl_mlx5_mcast_process_packet_collective(ucc_tl_mlx5_mcast_coll_
     return UCC_OK;
 }
 
+static inline ucc_status_t ucc_tl_mlx5_mcast_drain_recv_wr(ucc_tl_mlx5_mcast_coll_comm_t *comm,
+                                                           ucc_tl_mlx5_mcast_coll_context_t *ctx,
+                                                           int qp_id)
+{
+    struct ibv_qp_attr attr = {
+        .qp_state   = IBV_QPS_ERR,
+        .pkey_index = ctx->pkey_index,
+        .port_num   = ctx->ib_port,
+        .qkey       = DEF_QKEY
+    };
+
+    /* set the qp state to ERR to flush the posted recv buffers */
+    if (ibv_modify_qp(comm->mcast.groups[qp_id].qp, &attr, IBV_QP_STATE)) {
+        tl_error(ctx->lib, "failed to move mcast qp to ERR, errno %d", errno);
+        return UCC_ERR_NO_RESOURCE;
+    }
+
+    attr.qp_state = IBV_QPS_RESET;
+    if (ibv_modify_qp(comm->mcast.groups[qp_id].qp, &attr, IBV_QP_STATE)) {
+        tl_error(ctx->lib, "failed to move mcast qp to RESET, errno %d", errno);
+        return UCC_ERR_NO_RESOURCE;
+    }
+
+    attr.qp_state = IBV_QPS_INIT;
+    if (ibv_modify_qp(comm->mcast.groups[qp_id].qp, &attr,
+                      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_QKEY)) {
+        tl_error(ctx->lib, "failed to move mcast qp to INIT, errno %d", errno);
+        return UCC_ERR_NO_RESOURCE;
+    }
+
+    attr.qp_state = IBV_QPS_RTR;
+    if (ibv_modify_qp(comm->mcast.groups[qp_id].qp, &attr, IBV_QP_STATE)) {
+        tl_error(ctx->lib, "failed to modify QP to RTR, errno %d", errno);
+        return UCC_ERR_NO_RESOURCE;
+    }
+
+    attr.qp_state = IBV_QPS_RTS;
+    attr.sq_psn   = DEF_PSN;
+    if (ibv_modify_qp(comm->mcast.groups[qp_id].qp, &attr, IBV_QP_STATE | IBV_QP_SQ_PSN)) {
+        tl_error(ctx->lib, "failed to modify QP to RTS, errno %d", errno);
+        return UCC_ERR_NO_RESOURCE;
+    }
+    return UCC_OK;
+}
+
+/* TODO handle packet size < MTU */
+ucc_status_t
+ucc_tl_mlx5_mcast_reliable_zcopy_pipelined_one_sided_get(ucc_tl_mlx5_mcast_coll_comm_t *comm,
+                                                         ucc_tl_mlx5_mcast_coll_req_t *req,
+                                                         int *completed)
+{
+    ucc_tl_mlx5_mcast_pipelined_ag_schedule_t *sched = req->ag_schedule;
+    ucc_status_t                               status;
+    struct pp_packet                          *pp;
+    struct pp_packet                          *next;
+    void                                      *src_addr;
+    void                                      *remote_addr;
+    uint32_t                                   rkey;
+    uint32_t                                   lkey;
+    size_t                                     size;
+    uint64_t                                   wr;
+    int                                        target_completed = 0;
+    int                                        issued = 0, j, root;
+
+    ucc_assert(!comm->one_sided.pending_reads);
+    // cancel all the preposted recvs regarding this target before RDMA READ
+    for (j = 0; j < comm->mcast_group_count; j++) {
+        if (comm->pending_recv_per_qp[j] != 0) {
+            status = ucc_tl_mlx5_mcast_drain_recv_wr(comm, comm->ctx, j);
+            if (UCC_OK != status) {
+                tl_error(comm->lib, "unable to drain the posted recv wr on qp %d", j);
+                return status;
+            }
+            comm->pending_recv          -= comm->pending_recv_per_qp[j];
+            req->to_recv                -= comm->pending_recv_per_qp[j];
+            comm->pending_recv_per_qp[j] = 0;
+            ucc_assert(comm->pending_recv >= 0 && req->to_recv >= 0);
+        }
+    }
+    // return the recv pp back to free pool
+    ucc_list_for_each_safe(pp, next, &comm->posted_q, super) {
+        ucc_list_del(&pp->super);
+        pp->context = 0;
+        ucc_list_add_tail(&comm->bpool, &pp->super);
+    }
+    ucc_assert(!comm->pending_recv);
+    for (j = 0; j < req->concurrency_level; j++) {
+        root = sched[req->step].multicast_op[j].root;
+        /* comm->one_sided.recvd_pkts_tracker[root] will not be incremented if there is out of
+         order packet */
+        if (comm->one_sided.recvd_pkts_tracker[root] == sched[req->step].multicast_op[j].to_recv) {
+            target_completed++;
+            continue;
+        }
+        /* issue RDMA Read to this root and read a piece of sendbuf
+         * from related to this step*/
+        src_addr    = PTR_OFFSET(req->rptr, req->length * root +
+                                 sched[req->step].multicast_op[j].offset);
+        remote_addr = PTR_OFFSET(comm->one_sided.sendbuf_memkey_list[root].remote_addr,
+                                 sched[req->step].multicast_op[j].offset);
+        rkey        = comm->one_sided.sendbuf_memkey_list[root].rkey;
+        lkey        = req->recv_mr->lkey;
+        size        = sched[req->step].multicast_op[j].to_recv * comm->max_per_packet;
+        wr          = MCAST_AG_RDMA_READ_WR;
+        ucc_assert(size != 0);
+        comm->one_sided.pending_reads++;
+        issued++;
+        status = ucc_tl_mlx5_one_sided_p2p_get(src_addr, remote_addr, size,
+                                               lkey, rkey, root, wr, comm);
+        if (UCC_OK != status) {
+             return status;
+        }
+        tl_trace(comm->lib, "RDMA READ for step %d total steps %d",
+                 req->step, req->total_steps);
+    }
+    if (completed) {
+        *completed = target_completed;
+    }
+    if (issued) {
+        tl_debug(comm->lib, "issued %d RDMA READ to remote DATA for step %d. Number of"
+                 " target ranks completed: %d",
+                 req->step, issued, target_completed);
+    }
+    return UCC_OK;
+}

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_progress.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_progress.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 #include "tl_mlx5_mcast.h"
+#include "utils/ucc_math.h"
 #include "tl_mlx5_mcast_helper.h"
 #include "p2p/ucc_tl_mlx5_mcast_p2p.h"
 
@@ -25,5 +26,8 @@ ucc_status_t ucc_tl_mlx5_mcast_process_packet_collective(ucc_tl_mlx5_mcast_coll_
                                                          ucc_tl_mlx5_mcast_coll_req_t *req,
                                                          struct pp_packet* pp, int coll_type);
 
+ucc_status_t ucc_tl_mlx5_mcast_reliable_zcopy_pipelined_one_sided_get(ucc_tl_mlx5_mcast_coll_comm_t *comm,
+                                                                      ucc_tl_mlx5_mcast_coll_req_t *req,
+                                                                      int *completed);
 #endif
 

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.c
@@ -6,12 +6,11 @@
 
 #include "tl_mlx5_mcast_one_sided_reliability.h"
 
-static ucc_status_t ucc_tl_mlx5_mcast_one_sided_setup_reliability_buffers(ucc_base_team_t *team)
+inline static ucc_status_t
+ucc_tl_mlx5_mcast_one_sided_setup_reliability_buffers(ucc_tl_mlx5_mcast_coll_comm_t *comm)
 {
-    ucc_tl_mlx5_team_t            *tl_team = ucc_derived_of(team, ucc_tl_mlx5_team_t);
-    ucc_status_t                   status  = UCC_OK;
-    ucc_tl_mlx5_mcast_coll_comm_t *comm    = tl_team->mcast->mcast_comm;
-    int                            one_sided_total_slots_size, i;
+    ucc_status_t status = UCC_OK;
+    int          one_sided_total_slots_size, i;
 
     /* this array keeps track of the number of recv packets from each process
      * used in all the protocols */
@@ -54,8 +53,8 @@ static ucc_status_t ucc_tl_mlx5_mcast_one_sided_setup_reliability_buffers(ucc_ba
     }
     
     /* this array holds local information about the slot status that was read from remote ranks */
-    comm->one_sided.remote_slot_info = ucc_calloc(1, comm->commsize * ONE_SIDED_SLOTS_INFO_SIZE,
-                                                  "one_sided.remote_slot_info");
+    comm->one_sided.remote_slot_info = (int *)ucc_calloc(comm->commsize, ONE_SIDED_SLOTS_INFO_SIZE,
+                                                         "one_sided.remote_slot_info");
     if (!comm->one_sided.remote_slot_info) {
         tl_error(comm->lib, "unable to malloc for one_sided.remote_slot_info");
         status = UCC_ERR_NO_MEMORY;
@@ -94,15 +93,13 @@ static ucc_status_t ucc_tl_mlx5_mcast_one_sided_setup_reliability_buffers(ucc_ba
         comm->one_sided.info[comm->rank].rc_qp_num[i] = comm->mcast.rc_qp[i]->qp_num;
     }
 
-    tl_debug(comm->lib, "created the allgather reliability structures");
-
     return UCC_OK;
 
 failed:
     return status;
 }
 
-static inline ucc_status_t ucc_tl_mlx5_mcast_one_sided_cleanup(ucc_tl_mlx5_mcast_coll_comm_t *comm)
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_cleanup(ucc_tl_mlx5_mcast_coll_comm_t *comm)
 {
     int j;
 
@@ -163,11 +160,13 @@ static inline ucc_status_t ucc_tl_mlx5_mcast_one_sided_cleanup(ucc_tl_mlx5_mcast
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_init(ucc_base_team_t *team)
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_init(ucc_tl_mlx5_mcast_coll_comm_t *comm)
 {
-    ucc_tl_mlx5_team_t            *tl_team  = ucc_derived_of(team, ucc_tl_mlx5_team_t);
-    ucc_tl_mlx5_mcast_coll_comm_t *comm     = tl_team->mcast->mcast_comm;
-    ucc_status_t                   status   = UCC_OK;
+    ucc_status_t status = UCC_OK;
+
+    if (!comm->one_sided.reliability_enabled) {
+        return UCC_OK;
+    }
 
     if (comm->commsize > ONE_SIDED_RELIABILITY_MAX_TEAM_SIZE) {
         tl_warn(comm->lib,
@@ -176,41 +175,35 @@ ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_init(ucc_base_team_t *team)
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    status = ucc_tl_mlx5_mcast_one_sided_setup_reliability_buffers(team);
+    status = ucc_tl_mlx5_mcast_one_sided_setup_reliability_buffers(comm);
     if (status != UCC_OK) {
-        tl_error(comm->lib, "setup reliablity resources failed");
-        goto failed;
-    }
-
-     /* TODO double check if ucc inplace allgather is working properly */
-    status = comm->service_coll.allgather_post(comm->p2p_ctx, NULL /*inplace*/, comm->one_sided.info,
-                                               sizeof(ucc_tl_mlx5_one_sided_reliable_team_info_t),
-                                               &comm->one_sided.reliability_req);
-    if (UCC_OK != status) {
-        tl_error(comm->lib, "oob allgather failed during one-sided reliability init");
-        goto failed;
-    }
-
-    return status;
-
-failed:
-    if (UCC_OK != ucc_tl_mlx5_mcast_one_sided_cleanup(comm)) {
-        tl_error(comm->lib, "mcast one-sided reliablity resource cleanup failed");
+        tl_error(comm->lib, "setup reliability resources failed");
     }
 
     return status;
 }
 
-ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_test(ucc_base_team_t *team)
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_test(ucc_tl_mlx5_mcast_coll_comm_t *comm)
 {
-    ucc_tl_mlx5_team_t            *tl_team  = ucc_derived_of(team, ucc_tl_mlx5_team_t);
-    ucc_status_t                   status   = UCC_OK;
-    ucc_tl_mlx5_mcast_coll_comm_t *comm     = tl_team->mcast->mcast_comm;
+    ucc_status_t status = UCC_OK;
 
-    /* check if the one sided config info is exchanged */
+    if (!comm->one_sided.reliability_enabled) {
+        return UCC_OK;
+    }
+
+    if (comm->one_sided.reliability_req == NULL) {
+        status = comm->service_coll.allgather_post(comm->p2p_ctx, &(comm->one_sided.info[comm->rank]),
+                                                   comm->one_sided.info,
+                                                   sizeof(ucc_tl_mlx5_one_sided_reliable_team_info_t),
+                                                   &comm->one_sided.reliability_req);
+        if (UCC_OK != status) {
+            tl_error(comm->lib, "oob allgather failed during one-sided reliability init");
+            goto failed;
+        }
+    }
+
     status = comm->service_coll.coll_test(comm->one_sided.reliability_req);
     if (UCC_OK != status) {
-        /* allgather is not completed yet */
         if (status < 0) {
             tl_error(comm->lib, "one sided config info exchange failed");
             goto failed;
@@ -225,9 +218,13 @@ ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_test(ucc_base_team_t *team)
         goto failed;
     }
 
+    tl_debug(comm->lib, "support for allgather reliability is enabled");
+    comm->one_sided.reliability_req = NULL;
+    return UCC_OK;
+
 failed:
     if (UCC_OK != ucc_tl_mlx5_mcast_one_sided_cleanup(comm)) {
-        tl_error(comm->lib, "mcast one-sided reliablity resource cleanup failed");
+        tl_error(comm->lib, "mcast one-sided reliability resource cleanup failed");
     }
     
     return status;

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_one_sided_reliability.h
@@ -14,6 +14,8 @@
 #include "mcast/tl_mlx5_mcast_service_coll.h"
 
 
-ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_init(ucc_base_team_t *team);
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_init(ucc_tl_mlx5_mcast_coll_comm_t *comm);
 
-ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_test(ucc_base_team_t *team);
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_reliability_test(ucc_tl_mlx5_mcast_coll_comm_t *comm);
+
+ucc_status_t ucc_tl_mlx5_mcast_one_sided_cleanup(ucc_tl_mlx5_mcast_coll_comm_t *comm);

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_service_coll.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_service_coll.c
@@ -70,8 +70,7 @@ ucc_status_t ucc_tl_mlx5_mcast_service_coll_test(ucc_service_coll_req_t *req)
 {
     ucc_status_t status = UCC_OK;
 
-    status = ucc_service_coll_test(req);
-
+    status = ucc_collective_test(&req->task->super);
     if (UCC_INPROGRESS != status) {
         if (status < 0) {
             ucc_error("oob service coll progress failed");

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_team.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_team.c
@@ -12,6 +12,7 @@
 #include "p2p/ucc_tl_mlx5_mcast_p2p.h"
 #include "mcast/tl_mlx5_mcast_helper.h"
 #include "mcast/tl_mlx5_mcast_service_coll.h"
+#include "mcast/tl_mlx5_mcast_one_sided_reliability.h"
 
 ucc_status_t ucc_tl_mlx5_mcast_team_init(ucc_base_context_t *base_context,
                                          ucc_tl_mlx5_mcast_team_t **mcast_team,
@@ -95,6 +96,8 @@ ucc_status_t ucc_tl_mlx5_mcast_team_init(ucc_base_context_t *base_context,
     comm->allgather_comm.truly_zero_copy_allgather_enabled
                                         = conf_params->truly_zero_copy_allgather_enabled;
     comm->one_sided.reliability_enabled = conf_params->one_sided_reliability_enable;
+    comm->one_sided.reliability_scheme_msg_threshold
+                                        = conf_params->reliability_scheme_msg_threshold;
     comm->bcast_comm.wsize              = conf_params->wsize;
     comm->allgather_comm.max_push_send  = conf_params->max_push_send;
     comm->max_eager                     = conf_params->max_eager;
@@ -147,8 +150,13 @@ ucc_status_t ucc_tl_mlx5_mcast_team_init(ucc_base_context_t *base_context,
 
     comm->lib                  = base_context->lib;
     new_mcast_team->mcast_comm = comm;
-    *mcast_team                = new_mcast_team;
 
+    status = ucc_tl_mlx5_mcast_one_sided_reliability_init(comm);
+    if (status != UCC_OK) {
+        goto cleanup;
+    }
+
+    *mcast_team = new_mcast_team;
     tl_debug(base_context->lib, "posted tl mcast team : %p", new_mcast_team);
 
     return UCC_OK;
@@ -455,10 +463,20 @@ ucc_status_t ucc_tl_mlx5_mcast_team_test(ucc_base_team_t *team)
                     return status;
                 }
 
-                tl_debug(comm->lib, "initialized tl mcast team: %p", tl_team);
-                tl_team->mcast_state = TL_MLX5_TEAM_STATE_MCAST_READY;
+                tl_team->mcast_state = TL_MLX5_TEAM_STATE_MCAST_RELIABLITY;
 
                 return UCC_INPROGRESS;
+            }
+
+            case TL_MLX5_TEAM_STATE_MCAST_RELIABLITY:
+            {
+                status = ucc_tl_mlx5_mcast_one_sided_reliability_test(comm);
+                if (UCC_OK != status) {
+                    return status;
+                }
+
+                tl_debug(comm->lib, "initialized tl mcast team: %p", tl_team);
+                tl_team->mcast_state = TL_MLX5_TEAM_STATE_MCAST_READY;
             }
 
             case TL_MLX5_TEAM_STATE_MCAST_READY:
@@ -569,10 +587,19 @@ ucc_status_t ucc_tl_mlx5_mcast_team_test(ucc_base_team_t *team)
                     return status;
                 }
 
+                tl_team->mcast_state = TL_MLX5_TEAM_STATE_MCAST_RELIABLITY;
+                return UCC_INPROGRESS;
+            }
+
+            case TL_MLX5_TEAM_STATE_MCAST_RELIABLITY:
+            {
+                status = ucc_tl_mlx5_mcast_one_sided_reliability_test(comm);
+                if (UCC_OK != status) {
+                    return status;
+                }
+
                 tl_debug(comm->lib, "initialized tl mcast team: %p", tl_team);
                 tl_team->mcast_state = TL_MLX5_TEAM_STATE_MCAST_READY;
-
-                return UCC_INPROGRESS;
             }
 
             case TL_MLX5_TEAM_STATE_MCAST_READY:

--- a/src/components/tl/mlx5/tl_mlx5.c
+++ b/src/components/tl/mlx5/tl_mlx5.c
@@ -124,16 +124,17 @@ static ucc_config_field_t ucc_tl_mlx5_lib_config_table[] = {
      ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.cuda_mem_enabled),
      UCC_CONFIG_TYPE_BOOL},
 
-    {"MCAST_ONE_SIDED_RELIABILITY_ENABLE", "1",
-     "Enable one sided reliability for mcast",
-     ucc_offsetof(ucc_tl_mlx5_lib_config_t,
-                  mcast_conf.one_sided_reliability_enable),
+    {"MCAST_ONE_SIDED_RELIABILITY_ENABLE", "0", "Enable one sided reliability for mcast",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.one_sided_reliability_enable),
      UCC_CONFIG_TYPE_BOOL},
 
-    {"MCAST_ZERO_COPY_ALLGATHER_ENABLE", "1",
-     "Enable truly zero copy allgather design for mcast",
-     ucc_offsetof(ucc_tl_mlx5_lib_config_t,
-                  mcast_conf.truly_zero_copy_allgather_enabled),
+    {"MCAST_ONE_SIDED_RELIABILITY_THRESHOLD", "65536",
+     "Message threshold to toggle async to sync reliability protocol in mcast Allgather",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.reliability_scheme_msg_threshold),
+     UCC_CONFIG_TYPE_INT},
+
+    {"MCAST_ZERO_COPY_ALLGATHER_ENABLE", "0", "Enable truly zero copy allgather design for mcast",
+     ucc_offsetof(ucc_tl_mlx5_lib_config_t, mcast_conf.truly_zero_copy_allgather_enabled),
      UCC_CONFIG_TYPE_BOOL},
 
     {"MCAST_ZERO_COPY_PREPOST_BUCKET_SIZE", "16",

--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -137,6 +137,7 @@ typedef enum
     TL_MLX5_TEAM_STATE_MCAST_GRP_JOIN_READY,
     TL_MLX5_TEAM_STATE_MCAST_GRP_JOIN_FAILED,
     TL_MLX5_TEAM_STATE_MCAST_GRP_BCAST_POST,
+    TL_MLX5_TEAM_STATE_MCAST_RELIABLITY,
     TL_MLX5_TEAM_STATE_MCAST_READY,
     TL_MLX5_TEAM_STATE_MCAST_NOT_AVAILABLE
 } ucc_tl_mlx5_team_mcast_state_t;
@@ -183,7 +184,8 @@ typedef struct ucc_tl_mlx5_rcache_region {
     ucc_tl_mlx5_reg_t   reg;
 } ucc_tl_mlx5_rcache_region_t;
 
-#define UCC_TL_MLX5_SUPPORTED_COLLS (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_BCAST)
+#define UCC_TL_MLX5_SUPPORTED_COLLS                                            \
+    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_BCAST | UCC_COLL_TYPE_ALLGATHER)
 
 #define UCC_TL_MLX5_TEAM_LIB(_team)                                            \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_mlx5_lib_t))

--- a/src/components/tl/mlx5/tl_mlx5_coll.c
+++ b/src/components/tl/mlx5/tl_mlx5_coll.c
@@ -50,7 +50,7 @@ ucc_status_t ucc_tl_mlx5_coll_mcast_init(ucc_base_coll_args_t *coll_args,
         goto free_task;
     }
 
-    tl_debug(UCC_TASK_LIB(task), "initialized mcast collective task %p", task);
+    tl_trace(UCC_TASK_LIB(task), "initialized mcast collective task %p", task);
 
     return UCC_OK;
 

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -324,7 +324,8 @@ ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *tl_team,
     team_info.supported_mem_types = mt;
     team_info.supported_colls =
         (UCC_COLL_TYPE_ALLTOALL * (team->a2a_state == TL_MLX5_TEAM_STATE_ALLTOALL_READY)) |
-        UCC_COLL_TYPE_BCAST * (team->mcast_state == TL_MLX5_TEAM_STATE_MCAST_READY);
+        (UCC_COLL_TYPE_BCAST | UCC_COLL_TYPE_ALLGATHER) *
+        (team->mcast_state == TL_MLX5_TEAM_STATE_MCAST_READY);
     team_info.size                = UCC_TL_TEAM_SIZE(team);
 
     status = ucc_coll_score_build_default(


### PR DESCRIPTION
This PR improves the **staging-based Allgather** and adds a **zero-copy Allgather** to TL/MLX5. The staging approach is now more stable, fixing issues like message truncation, MTU handling, and CQ polling. This PR also enhances **one-sided reliability**, adding RDMA reads to handle dropped or out-of-order packets. Other fixes include preventing hangs by avoiding recursive progress calls, cleaning up reliability resources, and simplifying data structures for better performance and maintainability.