### PR TITLE
TOOLS: Add error handling for benchmark run

### DIFF
--- a/tools/perf/ucc_perftest.cc
+++ b/tools/perf/ucc_perftest.cc
@@ -35,7 +35,15 @@ int main(int argc, char *argv[])
         delete comm;
         std::exit(1);
     }
-    bench->run_bench();
+    st = bench->run_bench();
+    if (st != UCC_OK) {
+        std::cerr << "Benchmark failed with status " << st << " "
+                  << ucc_status_string(st) << std::endl;
+        delete bench;
+        comm->finalize();
+        delete comm;
+        std::exit(1);
+    }
     delete bench;
     comm->finalize();
     delete comm;


### PR DESCRIPTION
## What
Enhance error handling in the performance test tool by checking the return status of run_bench() and providing more detailed error reporting if the benchmark fails. This ensures better visibility into potential runtime issues during performance testing.

## Why ?
Fixes internal issue 4259479
