### PR TITLE
BUILD: Add support for optional filter argument in config parser print function

### DIFF
--- a/config/m4/ucx.m4
+++ b/config/m4/ucx.m4
@@ -138,6 +138,15 @@ AS_IF([test "x$ucx_checked" != "xyes"],[
                 [AC_DEFINE([UCS_HAVE_PARSER_CONFIG_DOC], [1], [flags for ucs_rcache_get])],
                 [],
                 [#include <ucs/memory/rcache.h>])
+
+            AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <ucs/config/parser.h>
+					            int main(int argc, char** argv) {
+				        	    	ucs_config_parser_print_opts(NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL);
+					        	    return 0;
+					            } ]])],
+                  [AC_DEFINE([UCS_HAVE_PARSER_PRINT_FILTER_ARG], [1], [flags for ucs_config_parser_print_opts])],
+                  [])
+
         ],
         [
             AS_IF([test "x$with_ucx" != "xguess"],

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -675,15 +675,8 @@ void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
         }
 
         snprintf(title, sizeof(title), "%s configuration", entry->name);
-#ifdef UCS_HAVE_PARSER_PRINT_FILTER_ARG
-        ucs_config_parser_print_opts(stream, title, opts, entry->table,
-                                     entry->prefix, prefix, ucs_flags,
-                                     NULL);
-#else
-        ucs_config_parser_print_opts(stream, title, opts, entry->table,
+        UCS_CONFIG_PARSER_PRINT_OPTS(stream, title, opts, entry->table,
                                      entry->prefix, prefix, ucs_flags);
-#endif
-
         ucs_config_parser_release_opts(opts, entry->table);
         ucc_free(opts);
     }

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -675,8 +675,14 @@ void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,
         }
 
         snprintf(title, sizeof(title), "%s configuration", entry->name);
+#ifdef UCS_HAVE_PARSER_PRINT_FILTER_ARG
+        ucs_config_parser_print_opts(stream, title, opts, entry->table,
+                                     entry->prefix, prefix, ucs_flags,
+                                     NULL);
+#else
         ucs_config_parser_print_opts(stream, title, opts, entry->table,
                                      entry->prefix, prefix, ucs_flags);
+#endif
 
         ucs_config_parser_release_opts(opts, entry->table);
         ucc_free(opts);

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -51,6 +51,14 @@ typedef struct ucc_file_config ucc_file_config_t;
     };
 #endif
 
+#ifdef UCS_HAVE_PARSER_PRINT_FILTER_ARG
+#define UCS_CONFIG_PARSER_PRINT_OPTS(_stream, _title, _opts, _fields, _tprefix, _prefix, _flags) \
+    ucs_config_parser_print_opts((_stream), (_title), (_opts), (_fields), (_tprefix), (_prefix), (_flags), NULL)
+#else
+#define UCS_CONFIG_PARSER_PRINT_OPTS(_stream, _title, _opts, _fields, _tprefix, _prefix, _flags) \
+    ucs_config_parser_print_opts((_stream), (_title), (_opts), (_fields), (_tprefix), (_prefix), (_flags))
+#endif
+
 #define UCC_CONFIG_GET_TABLE(_table)    &_table##_config_entry
 #define UCC_CONFIG_TYPE_LOG_COMP        UCS_CONFIG_TYPE_LOG_COMP
 #define UCC_CONFIG_REGISTER_TABLE       UCS_CONFIG_REGISTER_TABLE
@@ -211,13 +219,8 @@ static inline void ucc_config_parser_print_opts(FILE *stream, const char *title,
     ucs_config_print_flags_t ucs_flags;
 
     ucs_flags = ucc_print_flags_to_ucs_print_flags(flags);
-#ifdef UCS_HAVE_PARSER_PRINT_FILTER_ARG
-    ucs_config_parser_print_opts(stream, title, opts, fields, table_prefix,
-                                 prefix, ucs_flags, NULL);
-#else
-    ucs_config_parser_print_opts(stream, title, opts, fields, table_prefix,
+    UCS_CONFIG_PARSER_PRINT_OPTS(stream, title, opts, fields, table_prefix,
                                  prefix, ucs_flags);
-#endif
 }
 
 void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,

--- a/src/utils/ucc_parser.h
+++ b/src/utils/ucc_parser.h
@@ -211,8 +211,13 @@ static inline void ucc_config_parser_print_opts(FILE *stream, const char *title,
     ucs_config_print_flags_t ucs_flags;
 
     ucs_flags = ucc_print_flags_to_ucs_print_flags(flags);
+#ifdef UCS_HAVE_PARSER_PRINT_FILTER_ARG
+    ucs_config_parser_print_opts(stream, title, opts, fields, table_prefix,
+                                 prefix, ucs_flags, NULL);
+#else
     ucs_config_parser_print_opts(stream, title, opts, fields, table_prefix,
                                  prefix, ucs_flags);
+#endif
 }
 
 void ucc_config_parser_print_all_opts(FILE *stream, const char *prefix,


### PR DESCRIPTION
## What
This commit adds compatibility for a newer version of UCX's config parser print function by conditionally adding an optional NULL filter argument. The changes include:

- Modifying config/m4/ucx.m4 to check for the new function signature
- Updating src/utils/ucc_parser.c and src/utils/ucc_parser.h to conditionally call the function with an additional NULL argument
- Using preprocessor macros to maintain backward compatibility

