### PR TITLE
EC/CUDA: batch memory operations

### DIFF
--- a/src/components/ec/cuda/ec_cuda_executor_persistent_wait.c
+++ b/src/components/ec/cuda/ec_cuda_executor_persistent_wait.c
@@ -17,20 +17,20 @@ ucc_ec_cuda_post_driver_stream_task(ucc_ec_cuda_executor_state_t *state,
     CUdeviceptr              state_ptr       = (CUdeviceptr)state;
     CUstreamBatchMemOpParams batch_memops[3] = {};
 
-    batch_memops[0].operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+    batch_memops[0].operation          = CU_STREAM_MEM_OP_WRITE_VALUE_32;
     batch_memops[0].writeValue.address = state_ptr;
-    batch_memops[0].writeValue.value = UCC_EC_CUDA_EXECUTOR_STARTED;
-    batch_memops[0].writeValue.flags = 0;
+    batch_memops[0].writeValue.value   = UCC_EC_CUDA_EXECUTOR_STARTED;
+    batch_memops[0].writeValue.flags   = 0;
 
-    batch_memops[1].operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
+    batch_memops[1].operation         = CU_STREAM_MEM_OP_WAIT_VALUE_32;
     batch_memops[1].waitValue.address = state_ptr;
-    batch_memops[1].waitValue.value = UCC_EC_CUDA_EXECUTOR_SHUTDOWN;
-    batch_memops[1].waitValue.flags = CU_STREAM_WAIT_VALUE_EQ;
+    batch_memops[1].waitValue.value   = UCC_EC_CUDA_EXECUTOR_SHUTDOWN;
+    batch_memops[1].waitValue.flags   = CU_STREAM_WAIT_VALUE_EQ;
 
-    batch_memops[2].operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+    batch_memops[2].operation          = CU_STREAM_MEM_OP_WRITE_VALUE_32;
     batch_memops[2].writeValue.address = state_ptr;
-    batch_memops[2].writeValue.value = UCC_EC_CUDA_EXECUTOR_SHUTDOWN_ACK;
-    batch_memops[2].writeValue.flags = 0;
+    batch_memops[2].writeValue.value   = UCC_EC_CUDA_EXECUTOR_SHUTDOWN_ACK;
+    batch_memops[2].writeValue.flags   = 0;
 
     CUDADRV_FUNC(cuStreamBatchMemOp(stream, 3, batch_memops, 0));
     return UCC_OK;

--- a/src/components/ec/cuda/ec_cuda_executor_persistent_wait.c
+++ b/src/components/ec/cuda/ec_cuda_executor_persistent_wait.c
@@ -14,15 +14,25 @@ static ucc_status_t
 ucc_ec_cuda_post_driver_stream_task(ucc_ec_cuda_executor_state_t *state,
                                     cudaStream_t stream)
 {
-    CUdeviceptr state_ptr  = (CUdeviceptr)state;
+    CUdeviceptr              state_ptr       = (CUdeviceptr)state;
+    CUstreamBatchMemOpParams batch_memops[3] = {};
 
-    CUDADRV_FUNC(cuStreamWriteValue32(stream, state_ptr,
-                                      UCC_EC_CUDA_EXECUTOR_STARTED, 0));
-    CUDADRV_FUNC(cuStreamWaitValue32(stream, state_ptr,
-                                     UCC_EC_CUDA_EXECUTOR_SHUTDOWN,
-                                     CU_STREAM_WAIT_VALUE_EQ));
-    CUDADRV_FUNC(cuStreamWriteValue32(stream, state_ptr,
-                                      UCC_EC_CUDA_EXECUTOR_SHUTDOWN_ACK, 0));
+    batch_memops[0].operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+    batch_memops[0].writeValue.address = state_ptr;
+    batch_memops[0].writeValue.value = UCC_EC_CUDA_EXECUTOR_STARTED;
+    batch_memops[0].writeValue.flags = 0;
+
+    batch_memops[1].operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
+    batch_memops[1].waitValue.address = state_ptr;
+    batch_memops[1].waitValue.value = UCC_EC_CUDA_EXECUTOR_SHUTDOWN;
+    batch_memops[1].waitValue.flags = CU_STREAM_WAIT_VALUE_EQ;
+
+    batch_memops[2].operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+    batch_memops[2].writeValue.address = state_ptr;
+    batch_memops[2].writeValue.value = UCC_EC_CUDA_EXECUTOR_SHUTDOWN_ACK;
+    batch_memops[2].writeValue.flags = 0;
+
+    CUDADRV_FUNC(cuStreamBatchMemOp(stream, 3, batch_memops, 0));
     return UCC_OK;
 }
 


### PR DESCRIPTION
## What
Batch cuda stream memory operations to single call to reduce cpu and gpu execution overhead.

## Why ?
Experiments with profiling shows noticable holes in gpu stream activity related to stream mem ops.
`mpirun --mca coll ^hcoll --mca coll_ucc_enable 0 -x LD_LIBRARY_PATH=<user>/ucc/install/lib:$LD_LIBRARY_PATH -x UCC_CLS=basic -x UCC_TLS=ucp -x UCX_TLS=rc,cuda -x UCX_RNDV_THRESH=0 -x UCC_LOG_LEVEL=info -x UCC_CONFIG_FILE= -np 2 ./install/bin/ucc_perftest -m cuda -c bcast -F -d uint8 -b 1 -e 8k -T`

```
Master:

Collective:             Bcast
Memory type:            cuda
Datatype:               uint8
Reduction:              N/A
Inplace:                N/A
Warmup:                 
  small                 100
  large                 20
Iterations:             
  small                 1000
  large                 200

       Count        Size                Time, us                           Bandwidth, GB/s
                                 avg         min         max         avg         max         min
           1           1       37.99       37.17       38.81        0.00        0.00        0.00
           2           2       38.39       37.92       38.87        0.00        0.00        0.00
           4           4       38.09       37.41       38.77        0.00        0.00        0.00
           8           8       38.43       38.10       38.77        0.00        0.00        0.00
          16          16       38.13       37.45       38.81        0.00        0.00        0.00
          32          32       38.28       37.78       38.78        0.00        0.00        0.00
          64          64       37.91       36.96       38.87        0.00        0.00        0.00
         128         128       38.07       37.38       38.76        0.00        0.00        0.00
         256         256       37.96       37.25       38.67        0.01        0.01        0.01
         512         512       37.99       37.27       38.70        0.01        0.01        0.01
        1024        1024       38.26       37.69       38.83        0.03        0.03        0.03
        2048        2048       38.17       37.58       38.76        0.05        0.05        0.05
        4096        4096       38.24       37.71       38.78        0.11        0.11        0.11
        8192        8192       38.41       38.10       38.71        0.21        0.21        0.21

Batched:

Collective:             Bcast
Memory type:            cuda
Datatype:               uint8
Reduction:              N/A
Inplace:                N/A
Warmup:                 
  small                 100
  large                 20
Iterations:             
  small                 1000
  large                 200

       Count        Size                Time, us                           Bandwidth, GB/s
                                 avg         min         max         avg         max         min
           1           1       35.16       34.86       35.46        0.00        0.00        0.00
           2           2       35.18       34.96       35.40        0.00        0.00        0.00
           4           4       35.12       34.95       35.30        0.00        0.00        0.00
           8           8       35.22       35.02       35.42        0.00        0.00        0.00
          16          16       35.05       34.84       35.26        0.00        0.00        0.00
          32          32       35.06       34.79       35.33        0.00        0.00        0.00
          64          64       34.94       34.69       35.19        0.00        0.00        0.00
         128         128       35.04       34.74       35.34        0.00        0.00        0.00
         256         256       35.57       34.91       36.23        0.01        0.01        0.01
         512         512       35.20       35.03       35.38        0.01        0.01        0.01
        1024        1024       35.10       34.90       35.30        0.03        0.03        0.03
        2048        2048       35.02       34.83       35.21        0.06        0.06        0.06
        4096        4096       35.01       34.76       35.25        0.12        0.12        0.12
        8192        8192       35.05       34.76       35.33        0.23        0.24        0.23
```
