### PR TITLE
GTEST: fix UMR QP create config set

### DIFF
--- a/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_qps.h
@@ -50,10 +50,11 @@ class test_tl_mlx5_rc_qp : public test_tl_mlx5_qp {
         qp.qp       = NULL;
         umr_qp.qp   = NULL;
         tx_depth    = 4;
-        umr_qp_conf = qp_conf;
 
         test_tl_mlx5_qp::SetUp();
         CHECK_TEST_STATUS();
+
+        umr_qp_conf = qp_conf;
 
         create_rc_qp = (ucc_tl_mlx5_create_rc_qp_fn_t)dlsym(
             tl_mlx5_so_handle, "ucc_tl_mlx5_create_rc_qp");


### PR DESCRIPTION
This should fix the recent CI failures (shown below) on multiple PRs  when CI gtest is running under torch_ucc containers. This error was only reproducible when it was running under that container environment. 
```qp_conf``` had uninitialized values that were set to junk values, leading to incorrect configuration and failures when creating the UMR QP.
On bare metal, uninitialized ```qp_conf``` was probably zeroed out and it did not have random garbage values, so the issue didn’t appear. This PR makes sure that the configuration is set properly. 

```
15:28:27  /opt/nvidia/src/ucc/test/gtest/tl/mlx5/test_tl_mlx5_qps.h:90: Failure
15:28:27  Expected equality of these values:
15:28:27    create_rc_umr_qp(ctx, pd, cq, port, &umr_qp.qp, &umr_qp_conf, &lib)
15:28:27      Which is: -6
15:28:27    UCC_OK
15:28:27      Which is: 0
````