### PR TITLE
CORE: Get node sbgps and leaders

### DIFF
--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -615,6 +615,7 @@ ucc_status_t ucc_sbgp_cleanup(ucc_sbgp_t *sbgp)
 {
     if (sbgp->rank_map) {
         ucc_free(sbgp->rank_map);
+        sbgp->rank_map = NULL;
     }
     return UCC_OK;
 }

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -140,7 +140,7 @@ ucc_status_t ucc_sbgp_create_node(ucc_topo_t *topo, ucc_sbgp_t *sbgp)
     if (0 == node_size) {
         /* We should always have at least 1 local rank */
         ucc_free(local_ranks);
-        return UCC_ERR_NO_MESSAGE;
+        return UCC_ERR_NOT_FOUND;
     }
     sbgp->group_size = node_size;
     sbgp->group_rank = node_rank;

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -97,7 +97,7 @@ static inline ucc_status_t sbgp_create_sn(ucc_topo_t *topo, ucc_sbgp_t *sbgp,
     return UCC_OK;
 }
 
-static inline ucc_status_t sbgp_create_node(ucc_topo_t *topo, ucc_sbgp_t *sbgp)
+ucc_status_t ucc_sbgp_create_node(ucc_topo_t *topo, ucc_sbgp_t *sbgp)
 {
     ucc_subset_t *set            = &topo->set;
     ucc_rank_t    group_size     = ucc_subset_size(set);
@@ -300,12 +300,11 @@ skip:
     if (n_node_leaders > 1) {
         sbgp->group_size = n_node_leaders;
         if (i_am_node_leader) {
-            sbgp->rank_map   = nl_array_1;
-            sbgp->status     = UCC_SBGP_ENABLED;
+            sbgp->status = UCC_SBGP_ENABLED;
         } else {
-            ucc_free(nl_array_1);
             sbgp->status = UCC_SBGP_DISABLED;
         }
+        sbgp->rank_map = nl_array_1;
     } else {
         ucc_free(nl_array_1);
         sbgp->status = UCC_SBGP_NOT_EXISTS;
@@ -552,7 +551,7 @@ ucc_status_t ucc_sbgp_create(ucc_topo_t *topo, ucc_sbgp_type_t type)
     sbgp->rank_map = NULL;
     switch (type) {
     case UCC_SBGP_NODE:
-        status = sbgp_create_node(topo, sbgp);
+        status = ucc_sbgp_create_node(topo, sbgp);
         break;
     case UCC_SBGP_FULL:
         status = sbgp_create_full(topo, sbgp);

--- a/src/components/topo/ucc_sbgp.h
+++ b/src/components/topo/ucc_sbgp.h
@@ -86,6 +86,8 @@ ucc_status_t ucc_sbgp_create_all_sockets(ucc_topo_t *topo, ucc_sbgp_t **sbgps,
 ucc_status_t ucc_sbgp_create_all_numas(ucc_topo_t *topo, ucc_sbgp_t **sbgps,
                                        int *n_sbgps);
 
+ucc_status_t ucc_sbgp_create_node(ucc_topo_t *topo, ucc_sbgp_t *sbgp);
+
 static inline ucc_subset_t ucc_sbgp_to_subset(ucc_sbgp_t *sbgp)
 {
     ucc_subset_t s = {

--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -374,7 +374,7 @@ ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leade
     ucc_subset_t *set = &topo->set;
     ucc_rank_t size = ucc_subset_size(set);
     ucc_rank_t nnodes = topo->topo->nnodes;
-    ucc_rank_t i;
+    ucc_rank_t i, j;
     ucc_rank_t *ranks_seen_per_node;
     ucc_rank_t *per_node_leaders;
     ucc_rank_t *node_leaders;
@@ -430,8 +430,8 @@ ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leade
         ucc_rank_t ctx_rank = ucc_ep_map_eval(set->map, i);
         ucc_host_id_t current_host = topo->topo->procs[ctx_rank].host_id;
 
-        for (ucc_rank_t j = 0; j < nnodes; j++) {
-            ucc_rank_t ctx_rank_j = ucc_ep_map_eval(set->map, j);
+        for (j = 0; j < nnodes; j++) {
+            ucc_rank_t ctx_rank_j = ucc_ep_map_eval(set->map, per_node_leaders[j]);
             ucc_host_id_t current_host_j = topo->topo->procs[ctx_rank_j].host_id;
 
             if (current_host_j == current_host) {
@@ -442,6 +442,7 @@ ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leade
     }
 
     topo->node_leaders = node_leaders;
+    *node_leaders_out = node_leaders;
     ucc_free(ranks_seen_per_node);
     ucc_free(per_node_leaders);
     return UCC_OK;

--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -325,7 +325,7 @@ ucc_status_t ucc_sbgp_create_all_nodes(ucc_topo_t *topo, ucc_sbgp_t **_sbgps,
             leader_rank = topo->node_leader_rank;
         } else {
             status = ucc_sbgp_create_node(topo, &sbgps[i]);
-            if (status == UCC_ERR_NO_MESSAGE) {
+            if (status == UCC_ERR_NOT_FOUND) {
                 /* ucc_sbgp_create_node returned because 0 == node_size */
                 sbgps[i].status = UCC_SBGP_NOT_EXISTS;
                 continue;
@@ -355,6 +355,7 @@ ucc_status_t ucc_sbgp_create_all_nodes(ucc_topo_t *topo, ucc_sbgp_t **_sbgps,
 
     return UCC_OK;
 error:
+    topo->set.myrank = myrank;
     for (i = 0; i < nnodes; i++) {
         if (sbgps[i].rank_map) {
             ucc_free(sbgps[i].rank_map);

--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -184,6 +184,7 @@ ucc_status_t ucc_topo_init(ucc_subset_t set, ucc_context_topo_t *ctx_topo,
     topo->max_numa_size       = 0;
     topo->all_sockets         = NULL;
     topo->all_numas           = NULL;
+    topo->all_nodes           = NULL;
 
     *_topo = topo;
     return UCC_OK;
@@ -309,6 +310,7 @@ ucc_status_t ucc_sbgp_create_all_nodes(ucc_topo_t *topo, ucc_sbgp_t **_sbgps,
         }
 
         if (node_size == 0) {
+            sbgps[i].status = UCC_SBGP_NOT_EXISTS;
             continue;
         }
 
@@ -331,7 +333,7 @@ ucc_status_t ucc_sbgp_create_all_nodes(ucc_topo_t *topo, ucc_sbgp_t **_sbgps,
         sbgps[i].rank_map = node_ranks;
         sbgps[i].status = UCC_SBGP_ENABLED;
         sbgps[i].map = ucc_ep_map_from_array(&node_ranks, node_size,
-                                            ucc_subset_size(&topo->set), 1);
+                                            ucc_subset_size(&topo->set), 0);
     }
 
     *_sbgps = sbgps;

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -50,6 +50,8 @@ typedef struct ucc_topo {
     int         n_sockets;
     ucc_sbgp_t *all_numas;            /*< array of numa sbgps, init on demand */
     int         n_numas;
+    ucc_sbgp_t *all_nodes;            /*< array of node sbgps, init on demand */
+    int         n_nodes;
     ucc_rank_t  node_leader_rank_id;  /*< defines which rank on a node will be
                                           node leader. Similar to local node rank.
                                           currently set to 0, can be selected differently
@@ -93,6 +95,10 @@ ucc_status_t ucc_topo_get_all_sockets(ucc_topo_t *topo, ucc_sbgp_t **sbgps,
 
 /* Returns the array of ALL existing numa subgroups of given topo */
 ucc_status_t ucc_topo_get_all_numas(ucc_topo_t *topo, ucc_sbgp_t **sbgps,
+                                    int *n_sbgps);
+
+/* Returns the array of ALL existing node subgroups of given topo */
+ucc_status_t ucc_topo_get_all_nodes(ucc_topo_t *topo, ucc_sbgp_t **sbgps,
                                     int *n_sbgps);
 
 static inline int ucc_rank_on_local_node(ucc_rank_t team_rank, ucc_topo_t *topo)

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -58,6 +58,8 @@ typedef struct ucc_topo {
                                           in the future */
     ucc_rank_t   node_leader_rank;    /*< actual rank of the node leader in the original
                                           (ucc_team) ranking */
+    ucc_rank_t  *node_leaders;        /*< array mapping each rank to its node leader in the original
+                                          (ucc_team) ranking, initialized on demand */
     ucc_subset_t set;     /*< subset of procs from the ucc_context_topo.
                          for ucc_team topo it is team->ctx_map */
     ucc_rank_t   min_ppn; /*< min ppn across the nodes for a team */
@@ -250,5 +252,10 @@ static inline ucc_rank_t ucc_topo_nnodes(ucc_topo_t *topo)
     }
     return sbgp->group_size;
 }
+
+/* Returns an array mapping each rank to its node leader.
+   The array is cached in topo->node_leaders. */
+ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo,
+                                       ucc_rank_t **node_leaders_out);
 
 #endif

--- a/test/gtest/core/test_topo.cc
+++ b/test/gtest/core/test_topo.cc
@@ -628,6 +628,7 @@ UCC_TEST_F(test_topo, node_leaders)
     EXPECT_EQ(UCC_OK, ucc_context_topo_init(&s.storage, &ctx_topo));
     EXPECT_EQ(UCC_OK, ucc_topo_init(set, ctx_topo, &topo));
     topo->node_leader_rank_id = 0;
+    EXPECT_EQ(2, topo->topo->nnodes);
     EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders));
 
     /* Verify node leaders array */


### PR DESCRIPTION
This is a followup PR to https://github.com/openucx/ucc/pull/1050.

It adds two fields to `ucc_topo_t`, `node_leaders` and `all_nodes` and corresponding functions to calculate them on demand. `all_nodes` is the node-sbgp equivalent of `all_sockets`, i.e. it's an array of every node subgroup in the comm.

Knowing the node subgroup mapping on other nodes than the one I'm on is useful in the allgatherv unpack stage from my PR. For example, say you ran with `mpirun --map-by node ...`. Then the node/rank mapping might look like:

```
node0: {rank0, rank2}
node1: {rank1, rank3}
```

Then the destination buffer after the allgatherv is done on each node will look like `{0,2,1,3}`, when it really should be in order of the ranks in the team, like `{0,1,2,3}`. To fix this, I will unpack the elements according to their node-level rank mapping from `all_nodes` once this PR goes in.

My justification for adding `topo->node_leaders` is that the topo is a much better place to calculate and store what each rank's node leader is. In my allgatherv PR, I was doing it in `ucc_cl_hier_allgatherv_init`. I will remove that and use this once it goes in.

