### PR TITLE
TL/UCP: fix inplace checking in service allgather

### DIFF
--- a/src/components/tl/ucp/tl_ucp_service_coll.c
+++ b/src/components/tl/ucp/tl_ucp_service_coll.c
@@ -148,8 +148,7 @@ ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
     uint32_t             npolls   =
         UCC_TL_UCP_TEAM_CTX(tl_team)->cfg.oob_npolls;
     int                  in_place =
-        (sbuf == PTR_OFFSET(rbuf, msgsize * ucc_ep_map_eval(subset.map,
-                                                            subset.myrank)));
+        sbuf == PTR_OFFSET(rbuf, msgsize * subset.myrank);
     ucc_base_coll_args_t bargs    = {
         .args = {
             .coll_type = UCC_COLL_TYPE_ALLGATHER,


### PR DESCRIPTION
## What
Fix checking if allgather should use the in-place version or not, by checking the **logical ranks** of the team. (No need to remap to physical ranks.)
## Why ?
In situations involving team odd-even, this results in a problem where, for instance, the tl/cuda cannot communicate.
This issue starts to become visible after fixing another issue in #1089.
