### PR TITLE
TL/MLX5: gdr checks and support for CUDA mt

### DIFF
--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -1,11 +1,12 @@
 /**
- * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
 
 #ifndef UCC_TL_MLX5_H_
 #define UCC_TL_MLX5_H_
+
 #include "components/tl/ucc_tl.h"
 #include "components/tl/ucc_tl_log.h"
 #include "core/ucc_service_coll.h"
@@ -88,6 +89,7 @@ typedef struct ucc_tl_mlx5_context {
     int                          sock;
     ucc_mpool_t                  req_mp;
     ucc_tl_mlx5_mcast_context_t  mcast;
+    uint16_t                     supported_mem_types;
 } ucc_tl_mlx5_context_t;
 UCC_CLASS_DECLARE(ucc_tl_mlx5_context_t, const ucc_base_context_params_t*,
                   const ucc_base_config_t*);

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -304,21 +304,23 @@ initial_sync_post:
     return UCC_INPROGRESS;
 }
 
-ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
+ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *tl_team,
                                          ucc_coll_score_t **score_p)
 {
-    ucc_tl_mlx5_team_t *team  = ucc_derived_of(tl_team, ucc_tl_mlx5_team_t);
-    ucc_base_context_t *ctx   = UCC_TL_TEAM_CTX(team);
-    ucc_base_lib_t     *lib   = UCC_TL_TEAM_LIB(team);
-    ucc_memory_type_t   mt[2] = {UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA};
+    ucc_tl_mlx5_team_t    *team   = ucc_derived_of(tl_team, ucc_tl_mlx5_team_t);
+    ucc_base_context_t    *ctx    = UCC_TL_TEAM_CTX(team);
+    ucc_tl_mlx5_context_t *tl_ctx = ucc_derived_of(ctx, ucc_tl_mlx5_context_t);
+    ucc_base_lib_t        *lib    = UCC_TL_TEAM_LIB(team);
+    ucc_memory_type_t      mt[2]  = {UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA};
     ucc_coll_score_t          *score;
     ucc_status_t               status;
     ucc_coll_score_team_info_t team_info;
 
+
     team_info.alg_fn              = NULL;
     team_info.default_score       = UCC_TL_MLX5_DEFAULT_SCORE;
     team_info.init                = ucc_tl_mlx5_coll_init;
-    team_info.num_mem_types       = 2;
+    team_info.num_mem_types       = tl_ctx->supported_mem_types & UCC_BIT(UCC_MEMORY_TYPE_CUDA) ? 2 : 1;
     team_info.supported_mem_types = mt;
     team_info.supported_colls =
         (UCC_COLL_TYPE_ALLTOALL * (team->a2a_state == TL_MLX5_TEAM_STATE_ALLTOALL_READY)) |


### PR DESCRIPTION
## What
- Introduced functions to check for GPU Direct driver availability.
- Enhanced context initialization to support CUDA memory types if the GPU Direct driver is present.
- Adjusted memory type handling in team score retrieval and multicast team initialization to reflect CUDA support.

## Why ?
Fixes following CI issue in MLX5 Alltoall
```
tl_mlx5_rcache.c:28   TL_MLX5 ERROR failed to register memory
alltoall_coll.c:150  TL_MLX5 ERROR Failed to register send_bf memory (errno=14)
ucc_coll.c:301  UCC_COLL INFO  coll_init: Alltoall: src={0x7f2325a00000, 8, uint8, Cuda}, dst={0x7f2325b00000, 8, uint8, Cuda}; CL_BASIC {TL_MLX5}, team_id 1
tl_mlx5_rcache.c:28   TL_MLX5 ERROR failed to register memory
alltoall_coll.c:150  TL_MLX5 ERROR Failed to register send_bf memory (errno=14)
```