### PR TITLE
CL/HIER: Allgatherv node sbgp unpack

### DIFF
--- a/src/components/cl/hier/allgatherv/allgatherv.c
+++ b/src/components/cl/hier/allgatherv/allgatherv.c
@@ -52,7 +52,7 @@ static inline ucc_status_t find_leader_rank(ucc_base_team_t *team,
     ucc_status_t        status;
 
     ucc_assert(team_rank >= 0 && team_rank < UCC_CL_TEAM_SIZE(cl_team));
-    ucc_assert(SBGP_ENABLED(cl_team, NODE_LEADERS));
+    ucc_assert(SBGP_EXISTS(cl_team, NODE_LEADERS));
 
     status = ucc_topo_get_node_leaders(core_team->topo, &node_leaders, NULL);
     if (UCC_OK != status) {
@@ -151,10 +151,10 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
     }
     node_gathered_data = NULL;
 
-    /* If I'm a node leader, calculate leader_counts, leader_disps, and set the
+    /* If node ldr sbgp, calculate leader_counts, leader_disps, and set the
        dst buffer of the gatherv to the right displacements for the in-place
-       node-leader allgatherv */
-    if(SBGP_ENABLED(cl_team, NODE) && SBGP_ENABLED(cl_team, NODE_LEADERS)) {
+       node-leader allgatherv, even on non-node-leader ranks */
+    if(SBGP_ENABLED(cl_team, NODE) && SBGP_EXISTS(cl_team, NODE_LEADERS)) {
         /* Sum up the counts on each node to get the count for each node leader */
         for (i = 0; i < team_size; i++) {
             UCC_CHECK_GOTO(

--- a/src/components/cl/hier/allgatherv/allgatherv.c
+++ b/src/components/cl/hier/allgatherv/allgatherv.c
@@ -101,8 +101,10 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
     void                   *buffer;
     void                   *node_gathered_data;
     ucc_rank_t              leader_team_rank;
-    ucc_rank_t              leader_sgbp_rank;
+    ucc_rank_t              leader_sbgp_rank;
     ucc_rank_t              team_rank;
+    size_t                  leader_old_count;
+    size_t                  add_count, new_count;
 
     if (coll_args->args.src.info.mem_type != UCC_MEMORY_TYPE_HOST ||
         coll_args->args.dst.info_v.mem_type != UCC_MEMORY_TYPE_HOST) {
@@ -158,16 +160,16 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
             UCC_CHECK_GOTO(
                 find_leader_rank(team, i, &leader_team_rank),
                 free_scratch, status);
-            ucc_rank_t leader_sbgp_rank = ucc_ep_map_local_rank(
+            leader_sbgp_rank = ucc_ep_map_local_rank(
                                             SBGP_MAP(cl_team, NODE_LEADERS),
                                             leader_team_rank);
-            size_t     leader_old_count = ucc_coll_args_get_count(
+            leader_old_count = ucc_coll_args_get_count(
                                             &args.args, leader_counts,
                                             leader_sbgp_rank);
-            size_t     add_count        = ucc_coll_args_get_count(
+            add_count        = ucc_coll_args_get_count(
                                             &args.args,
                                             args.args.dst.info_v.counts, i);
-            size_t     new_count        = add_count + leader_old_count;
+            new_count        = add_count + leader_old_count;
             ucc_coll_args_set_count(&args.args, leader_counts,
                                     leader_sbgp_rank, new_count);
         }
@@ -176,17 +178,12 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
            a contiguous chunk */
         disp_counter = 0;
         for (i = 0; i < leader_sbgp_size; i++) {
-            //NOLINTNEXTLINE
-            leader_team_rank = ucc_ep_map_eval(
-                                          SBGP_MAP(cl_team, NODE_LEADERS), i);
-            leader_sgbp_rank = ucc_ep_map_local_rank(
-                                          SBGP_MAP(cl_team, NODE_LEADERS),
-                                          leader_team_rank);
+
             ucc_coll_args_set_displacement(&args.args, leader_disps,
-                                            leader_sgbp_rank, disp_counter);
+                                            i, disp_counter);
             disp_counter += ucc_coll_args_get_count(&args.args,
                                                     leader_counts,
-                                                    leader_sgbp_rank);
+                                                    i);
         }
 
         node_gathered_data = PTR_OFFSET(buffer,

--- a/src/components/cl/hier/allgatherv/allgatherv.c
+++ b/src/components/cl/hier/allgatherv/allgatherv.c
@@ -279,8 +279,14 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
 
         if (!is_contig) {
             args                        = args_old;
-            args.args.src.info_v        = args.args.dst.info_v;
+            args.args.src.info_v.datatype = args.args.dst.info_v.datatype;
+            args.args.src.info_v.mem_type = args.args.dst.info_v.mem_type;
             args.args.src.info_v.buffer = buffer;
+            
+            // Pass leader_disps and leader_counts through src.info_v
+            args.args.src.info_v.displacements = leader_disps;
+            args.args.src.info_v.counts = leader_counts;
+            
             UCC_CHECK_GOTO(
                 ucc_cl_hier_allgatherv_unpack_init(&args, team, &tasks[n_tasks]),
                 free_scratch, status);

--- a/src/components/cl/hier/allgatherv/unpack.c
+++ b/src/components/cl/hier/allgatherv/unpack.c
@@ -68,6 +68,7 @@ ucc_status_t ucc_cl_hier_allgatherv_unpack_start(ucc_coll_task_t *task)
                                                 args->src.info_v.datatype);
     size_t                      dst_dt_size = ucc_dt_size(
                                                 args->dst.info_v.datatype);
+    ucc_topo_t                 *topo = task->team->params.team->topo;
     ucc_ee_executor_t          *exec;
     ucc_status_t                status;
     ucc_rank_t                  i;
@@ -75,41 +76,83 @@ ucc_status_t ucc_cl_hier_allgatherv_unpack_start(ucc_coll_task_t *task)
     size_t                      dst_rank_count;
     size_t                      src_rank_disp;
     size_t                      dst_rank_disp;
+    ucc_rank_t                 *node_leaders = NULL;
+    ucc_rank_t                 *per_node_leaders = NULL;
+    ucc_sbgp_t                 *all_nodes = NULL;
+    int                         n_nodes;
+    ucc_rank_t                  node_id;
+    ucc_rank_t                  node_rank_offset;
+    ucc_rank_t                  team_rank;
 
     UCC_CHECK_GOTO(
         ucc_coll_task_get_executor(&schedule->super, &exec),
         out, status);
     eargs.task_type = UCC_EE_EXECUTOR_TASK_COPY;
 
-    *n_tasks        = 0;
-    src_rank_disp   = 0;
+    *n_tasks = 0;
+
+    // Get the node leaders and all nodes information
+    UCC_CHECK_GOTO(
+        ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders),
+        out, status);
+    
+    UCC_CHECK_GOTO(
+        ucc_topo_get_all_nodes(topo, &all_nodes, &n_nodes),
+        out, status);
 
     for (i = 0; i < team_size; i++) {
-        src_rank_count = ucc_coll_args_get_count(args, args->src.info_v.counts,
-                                                 i);
-        dst_rank_count = ucc_coll_args_get_count(args, args->dst.info_v.counts,
-                                                 i);
-        dst_rank_disp  = ucc_coll_args_get_displacement(
-                                args, args->dst.info_v.displacements, i);
-        ucc_assert(src_rank_count * src_dt_size ==
-                   dst_rank_count * dst_dt_size);
-        eargs.copy.src  = PTR_OFFSET(
-                            args->src.info_v.buffer,
-                            src_rank_disp * src_dt_size);
-        eargs.copy.dst  = PTR_OFFSET(
-                            args->dst.info_v.buffer,
-                            dst_rank_disp * dst_dt_size);
-        eargs.copy.len  = dst_rank_count * dst_dt_size;
+        // Find which node this rank belongs to
+        for (node_id = 0; node_id < n_nodes; node_id++) {
+            if (all_nodes[node_id].status == UCC_SBGP_ENABLED) {
+                for (node_rank_offset = 0; node_rank_offset < all_nodes[node_id].group_size; node_rank_offset++) {
+                    team_rank = ucc_ep_map_eval(all_nodes[node_id].map, node_rank_offset);
+                    if (team_rank == i) {
+                        // Found the node and position for this team rank
+                        goto found_rank;
+                    }
+                }
+            }
+        }
+found_rank:
+        // Get counts and displacements for destination (team order)
+        dst_rank_count = ucc_coll_args_get_count(args, args->dst.info_v.counts, i);
+        dst_rank_disp = ucc_coll_args_get_displacement(args, args->dst.info_v.displacements, i);
+        
+        // Source displacement needs to account for node-based ordering
+        // Calculate offset in source buffer based on node_id and rank's position within node
+        src_rank_disp = 0;
+        // Add up counts for all preceding nodes
+        for (ucc_rank_t prev_node = 0; prev_node < node_id; prev_node++) {
+            if (all_nodes[prev_node].status == UCC_SBGP_ENABLED) {
+                for (ucc_rank_t prev_node_rank = 0; prev_node_rank < all_nodes[prev_node].group_size; prev_node_rank++) {
+                    ucc_rank_t prev_team_rank = ucc_ep_map_eval(all_nodes[prev_node].map, prev_node_rank);
+                    src_rank_disp += ucc_coll_args_get_count(args, args->dst.info_v.counts, prev_team_rank);
+                }
+            }
+        }
+        
+        // Add offset within current node
+        for (ucc_rank_t j = 0; j < node_rank_offset; j++) {
+            ucc_rank_t curr_team_rank = ucc_ep_map_eval(all_nodes[node_id].map, j);
+            src_rank_disp += ucc_coll_args_get_count(args, args->dst.info_v.counts, curr_team_rank);
+        }
+        
+        src_rank_count = dst_rank_count;
+        ucc_assert(src_rank_count * src_dt_size == dst_rank_count * dst_dt_size);
+        
+        eargs.copy.src = PTR_OFFSET(args->src.info_v.buffer, src_rank_disp * src_dt_size);
+        eargs.copy.dst = PTR_OFFSET(args->dst.info_v.buffer, dst_rank_disp * dst_dt_size);
+        eargs.copy.len = dst_rank_count * dst_dt_size;
+        
         if (eargs.copy.src != eargs.copy.dst) {
             UCC_CHECK_GOTO(
                 ucc_ee_executor_task_post(exec, &eargs, &tasks[*n_tasks]),
                 out, status);
             (*n_tasks)++;
         }
-        src_rank_disp += src_rank_count;
     }
 
-    schedule->super.status       = UCC_INPROGRESS;
+    schedule->super.status = UCC_INPROGRESS;
 
     ucc_progress_queue_enqueue(cl_team->super.super.context->ucc_context->pq,
                                task);

--- a/src/components/cl/hier/allgatherv/unpack.c
+++ b/src/components/cl/hier/allgatherv/unpack.c
@@ -115,11 +115,7 @@ ucc_status_t ucc_cl_hier_allgatherv_unpack_start(ucc_coll_task_t *task)
         ucc_rank_t leader_team_rank = node_leaders[i];
         
         // Find the position of this leader in the node_leaders_sbgp
-        for (node_leader_idx = 0; node_leader_idx < node_leaders_sbgp->group_size; node_leader_idx++) {
-            if (ucc_ep_map_eval(node_leaders_sbgp->map, node_leader_idx) == leader_team_rank) {
-                break;
-            }
-        }
+        node_leader_idx = ucc_ep_map_local_rank(node_leaders_sbgp->map, leader_team_rank);
         
         // Get source displacement from leader_displacements (passed in src.info_v)
         src_rank_disp = ucc_coll_args_get_displacement(

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -106,15 +106,6 @@ typedef struct ucc_cl_hier_team {
     ucc_coll_score_t        *score;
     ucc_hier_sbgp_t          sbgps[UCC_HIER_SBGP_LAST];
     ucc_hier_sbgp_type_t     top_sbgp;
-    /* Array of size team_size, where node_leaders[i] = the rank of i's node
-       leader */
-    ucc_rank_t              *node_leaders;
-    /* Array of size node_leader_sbgp_size, with ranks in terms of the
-       team, sorted lowest to highest. This is useful for allgatherv.
-       The reason is the iterating through the node leader sbgp and map eval'ing
-       the ranks can yield unsorted ranks, e.g. 2n2ppn with ranks 0 and 2 as
-       leaders, leader 0 could map to rank 2 and leader 1 could map to rank 0 */
-    ucc_rank_t              *leader_list;
 } ucc_cl_hier_team_t;
 UCC_CLASS_DECLARE(ucc_cl_hier_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -47,9 +47,6 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
     ucc_tl_lib_t              *tl_lib;
     ucc_base_lib_attr_t        attr;
 
-    self->node_leaders = NULL;
-    self->leader_list  = NULL;
-
     if (!params->team->topo) {
         cl_debug(cl_context->lib,
                 "can't create hier team without topology data");
@@ -204,13 +201,6 @@ ucc_status_t ucc_cl_hier_team_destroy(ucc_base_team_t *cl_team)
     int                        i, j;
     ucc_hier_sbgp_t           *hs;
     struct ucc_team_team_desc *d;
-
-    if (team->node_leaders) {
-        ucc_free(team->node_leaders);
-        ucc_free(team->leader_list);
-        team->node_leaders = NULL;
-        team->leader_list  = NULL;
-    }
 
     if (NULL == team->team_create_req) {
         status = ucc_team_multiple_req_alloc(&team->team_create_req,

--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -186,6 +186,7 @@ ucc_status_t ucc_topo_init(ucc_subset_t set, ucc_context_topo_t *ctx_topo,
     topo->all_numas           = NULL;
     topo->all_nodes           = NULL;
     topo->node_leaders        = NULL;
+    topo->per_node_leaders    = NULL;
 
     *_topo = topo;
     return UCC_OK;
@@ -227,6 +228,9 @@ void ucc_topo_cleanup(ucc_topo_t *topo)
         }
         if (topo->node_leaders) {
             ucc_free(topo->node_leaders);
+        }
+        if (topo->per_node_leaders) {
+            ucc_free(topo->per_node_leaders);
         }
         ucc_free(topo);
     }
@@ -380,7 +384,8 @@ ucc_status_t ucc_topo_get_all_nodes(ucc_topo_t *topo, ucc_sbgp_t **sbgps,
     return status;
 }
 
-ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leaders_out)
+ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leaders_out,
+                                      ucc_rank_t **per_node_leaders_out)
 {
     ucc_subset_t *set    = &topo->set;
     ucc_rank_t    size   = ucc_subset_size(set);
@@ -392,6 +397,17 @@ ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leade
 
     if (topo->node_leaders) {
         *node_leaders_out = topo->node_leaders;
+        if (per_node_leaders_out) {
+            *per_node_leaders_out = topo->per_node_leaders;
+        }
+        return UCC_OK;
+    }
+
+    // If we just want the per_node_leaders, return them
+    if (!node_leaders_out && topo->per_node_leaders) {
+        ucc_assert(topo->per_node_leaders);
+        ucc_assert(per_node_leaders_out);
+        *per_node_leaders_out = topo->per_node_leaders;
         return UCC_OK;
     }
 
@@ -445,8 +461,11 @@ ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leade
     }
 
     topo->node_leaders = node_leaders;
+    topo->per_node_leaders = per_node_leaders;
     *node_leaders_out = node_leaders;
+    if (per_node_leaders_out) {
+        *per_node_leaders_out = per_node_leaders;
+    }
     ucc_free(ranks_seen_per_node);
-    ucc_free(per_node_leaders);
     return UCC_OK;
 }

--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -405,8 +405,8 @@ ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leade
 
     // If we just want the per_node_leaders, return them
     if (!node_leaders_out && topo->per_node_leaders) {
-        ucc_assert(topo->per_node_leaders);
-        ucc_assert(per_node_leaders_out);
+        ucc_assert(topo->per_node_leaders != NULL);
+        ucc_assert(per_node_leaders_out != NULL);
         *per_node_leaders_out = topo->per_node_leaders;
         return UCC_OK;
     }

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -60,6 +60,7 @@ typedef struct ucc_topo {
                                           (ucc_team) ranking */
     ucc_rank_t  *node_leaders;        /*< array mapping each rank to its node leader in the original
                                           (ucc_team) ranking, initialized on demand */
+    ucc_rank_t  *per_node_leaders;    /*< array of node leaders per node, initialized on demand */
     ucc_subset_t set;     /*< subset of procs from the ucc_context_topo.
                          for ucc_team topo it is team->ctx_map */
     ucc_rank_t   min_ppn; /*< min ppn across the nodes for a team */
@@ -253,9 +254,10 @@ static inline ucc_rank_t ucc_topo_nnodes(ucc_topo_t *topo)
     return sbgp->group_size;
 }
 
-/* Returns an array mapping each rank to its node leader.
-   The array is cached in topo->node_leaders. */
-ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo,
-                                       ucc_rank_t **node_leaders_out);
+/* Returns node leaders array - array that maps each rank to the TEAM RANK that 
+   is the leader of that rank's node. Also returns per-node leaders array - array
+   mapping node_id to the TEAM RANK of that node's leader */
+ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leaders_out,
+                                      ucc_rank_t **per_node_leaders_out);
 
 #endif

--- a/test/gtest/core/test_topo.cc
+++ b/test/gtest/core/test_topo.cc
@@ -619,6 +619,7 @@ UCC_TEST_F(test_topo, node_leaders)
     ucc_subset_t     set;
     ucc_rank_t       i;
     ucc_rank_t      *node_leaders;
+    ucc_rank_t      *per_node_leaders;
     /* simulates world proc array: 2 nodes, 4 ranks per node */
     SET_PI(s, 0, 0xaaa, 0, 0);  // Node 0, rank 0
     SET_PI(s, 1, 0xaaa, 1, 1);  // Node 0, rank 1
@@ -639,7 +640,7 @@ UCC_TEST_F(test_topo, node_leaders)
     EXPECT_EQ(UCC_OK, ucc_topo_init(set, ctx_topo, &topo));
     topo->node_leader_rank_id = 0;
     EXPECT_EQ(2, topo->topo->nnodes);
-    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders));
+    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders));
 
     /* Verify node leaders array */
     // Node 0 ranks should point to rank 0 (first rank on node 0)
@@ -651,11 +652,15 @@ UCC_TEST_F(test_topo, node_leaders)
         EXPECT_EQ(4, node_leaders[i]);
     }
 
+    /* Verify per_node_leaders array */
+    EXPECT_EQ(0, per_node_leaders[0]); // Node 0 leader
+    EXPECT_EQ(4, per_node_leaders[1]); // Node 1 leader
+
     /* Test with node_leader_rank_id = 1 */
     ucc_topo_cleanup(topo);
     EXPECT_EQ(UCC_OK, ucc_topo_init(set, ctx_topo, &topo));
     topo->node_leader_rank_id = 1;
-    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders));
+    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders));
 
     /* Verify node leaders array */
     // Node 0 ranks should point to rank 1 (second rank on node 0)
@@ -666,6 +671,10 @@ UCC_TEST_F(test_topo, node_leaders)
     for (i = 4; i < 8; i++) {
         EXPECT_EQ(5, node_leaders[i]);
     }
+
+    /* Verify per_node_leaders array */
+    EXPECT_EQ(1, per_node_leaders[0]); // Node 0 leader
+    EXPECT_EQ(5, per_node_leaders[1]); // Node 1 leader
 
     /* Test with a subset of ranks */
     ucc_topo_cleanup(topo);
@@ -679,7 +688,7 @@ UCC_TEST_F(test_topo, node_leaders)
     /* Test subset with node_leader_rank_id = 0 */
     EXPECT_EQ(UCC_OK, ucc_topo_init(set, ctx_topo, &topo));
     topo->node_leader_rank_id = 0;
-    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders));
+    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders));
 
     /* Verify node leaders array for subset */
     // Ranks 0,1 (from node 0) should point to rank 0 (first rank on node 0)
@@ -689,11 +698,15 @@ UCC_TEST_F(test_topo, node_leaders)
     EXPECT_EQ(2, node_leaders[2]);
     EXPECT_EQ(2, node_leaders[3]);
 
+    /* Verify per_node_leaders array */
+    EXPECT_EQ(0, per_node_leaders[0]); // Node 0 leader
+    EXPECT_EQ(2, per_node_leaders[1]); // Node 1 leader
+
     /* Test subset with node_leader_rank_id = 1 */
     ucc_topo_cleanup(topo);
     EXPECT_EQ(UCC_OK, ucc_topo_init(set, ctx_topo, &topo));
     topo->node_leader_rank_id = 1;
-    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders));
+    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders));
 
     /* Verify node leaders array for subset */
     // Ranks 0,1 (from node 0) should point to rank 1 (second rank on node 0)
@@ -702,4 +715,8 @@ UCC_TEST_F(test_topo, node_leaders)
     // Ranks 2,3 (from node 1) should point to rank 3 (second rank on node 1)
     EXPECT_EQ(3, node_leaders[2]);
     EXPECT_EQ(3, node_leaders[3]);
+
+    /* Verify per_node_leaders array */
+    EXPECT_EQ(1, per_node_leaders[0]); // Node 0 leader
+    EXPECT_EQ(3, per_node_leaders[1]); // Node 1 leader
 }


### PR DESCRIPTION
This PR is a followup to https://github.com/openucx/ucc/pull/1098 and https://github.com/openucx/ucc/pull/1050.

In my previous allgatherv PR, there was an issue in the case that the ranks in each node subgroup are not contiguous in the team rank order. For example, say you ran with mpirun --map-by node .... Then the node/rank mapping might look like:

```
node0: {rank0, rank2}
node1: {rank1, rank3}
```

Then the destination buffer after the allgatherv is done on each node will look like {0,2,1,3}, when it really should be in order of the ranks in the team, like {0,1,2,3}.

To fix this, in this PR, I unpack the elements according to their node-level rank mapping from all_nodes.