### PR TITLE
UTIL: Optimized ucc_round_up_power2 function

### DIFF
--- a/src/components/tl/mlx5/alltoall/alltoall_coll.c
+++ b/src/components/tl/mlx5/alltoall/alltoall_coll.c
@@ -788,9 +788,9 @@ static inline int block_size_fits(size_t msgsize, int height, int width)
         width > MAX_BLOCK_SIZE) {
         return false;
     }
-    t = ucc_lowest_greater_power2(ucc_max(msgsize, 8));
+    t = ucc_round_up_power2(ucc_max(msgsize, 8));
     return height *
-               ucc_max(ucc_lowest_greater_power2(width) * t, MAX_MSG_SIZE) <=
+               ucc_max(ucc_round_up_power2(width) * t, MAX_MSG_SIZE) <=
            MAX_TRANSPOSE_SIZE;
 }
 

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -146,7 +146,7 @@ static inline int ucc_lowest_greater_power2(int value)
     if (value <= 1) {
         return 1;
     }
-    return 1 << (32 - ucc_count_leading_zero_bits(value));
+    return 1 << (32 - ucc_count_leading_zero_bits(value - 1));
 }
 
 #endif

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -141,7 +141,7 @@ static inline uint32_t ucc_ilog2_ceil(uint32_t n)
 }
 
 /* return the lowest greater or equal power of 2 */
-static inline int ucc_lowest_greater_power2(int value)
+static inline int ucc_round_up_power2(int value)
 {
     if (value <= 1) {
         return 1;

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -143,11 +143,22 @@ static inline uint32_t ucc_ilog2_ceil(uint32_t n)
 /* return the lowest greater or equal power of 2 */
 static inline int ucc_lowest_greater_power2(int value)
 {
-    int p = 1;
-    while (p < value) {
-        p *= 2;
+    if (value <= 1) {
+        return 1;
     }
-    return p;
+
+    // Handle integer overflow case
+    if (value > (INT32_MAX / 2)) {
+        return INT32_MAX;  
+    }
+
+    --value;  // pow2 case
+    value |= value >> 1;
+    value |= value >> 2;
+    value |= value >> 4;
+    value |= value >> 8;
+    value |= value >> 16;
+    return value + 1;
 }
 
 #endif

--- a/src/utils/ucc_math.h
+++ b/src/utils/ucc_math.h
@@ -146,19 +146,7 @@ static inline int ucc_lowest_greater_power2(int value)
     if (value <= 1) {
         return 1;
     }
-
-    // Handle integer overflow case
-    if (value > (INT32_MAX / 2)) {
-        return INT32_MAX;  
-    }
-
-    --value;  // pow2 case
-    value |= value >> 1;
-    value |= value >> 2;
-    value |= value >> 4;
-    value |= value >> 8;
-    value |= value >> 16;
-    return value + 1;
+    return 1 << (32 - ucc_count_leading_zero_bits(value));
 }
 
 #endif


### PR DESCRIPTION
## What
Optimized version of `ucc_lowest_greater_power2()` using bitwise operations

## Why ?

- constant time
- mul free only bitwise ops
- prevent overflow

References: 
https://stackoverflow.com/questions/364985/algorithm-for-finding-the-smallest-power-of-two-thats-greater-or-equal-to-a-giv 
https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2 
