### PR TITLE
TEST: build sm70 only in CI

### DIFF
--- a/.ci/scripts/build_ucc.sh
+++ b/.ci/scripts/build_ucc.sh
@@ -9,7 +9,8 @@ mkdir -p "${UCC_SRC_DIR}/build"
 cd "${UCC_SRC_DIR}/build"
 "${UCC_SRC_DIR}/configure" --with-ucx="${UCX_INSTALL_DIR}" --with-cuda="${CUDA_HOME}" \
     --prefix="${UCC_INSTALL_DIR}" --enable-gtest --with-mpi \
-    --with-tls=cuda,nccl,self,sharp,shm,ucp,mlx5
+    --with-tls=cuda,nccl,self,sharp,shm,ucp,mlx5 \
+    --with-nvcc-gencode="-gencode=arch=compute_70,code=sm_70"
 make -j install
 echo "${UCC_INSTALL_DIR}/lib" > /etc/ld.so.conf.d/ucc.conf
 ldconfig

--- a/.ci/scripts/coverity.sh
+++ b/.ci/scripts/coverity.sh
@@ -25,7 +25,7 @@ module load dev/cuda12.1.1
 module load dev/nccl_2.18.3-1_cuda12.1.1_"$(uname -i)"
 module load tools/cov-2021.12
 ./autogen.sh
-./configure --with-nccl --with-tls=cuda,nccl,self,sharp,shm,ucp,mlx5 --with-ucx="${HPCX_UCX_DIR}" --with-sharp="${HPCX_SHARP_DIR}"
+./configure --with-nccl --with-tls=cuda,nccl,self,sharp,shm,ucp,mlx5 --with-ucx="${HPCX_UCX_DIR}" --with-sharp="${HPCX_SHARP_DIR}" --with-nvcc-gencode="-gencode=arch=compute_70,code=sm_70"
 make_opt="-j$(($(nproc) / 2 + 1))"
 COV_BUILD_DIR=$(dirname "$0")/cov-build
 mkdir -p "$COV_BUILD_DIR"


### PR DESCRIPTION
## What
This PR modifies the CI build script to specifically build UCC for NVIDIA Volta (sm70) architecture only, by adding the --with-nvcc-gencode flag to the configure command.

## Why ?
This change is needed to ensure consistent CI builds targeting a specific GPU architecture (Volta/sm70). This helps in reducing build time in CI by compiling for a single architecture

## How ?
The change is implemented by adding the --with-nvcc-gencode="-gencode=arch=compute_70,code=sm_70" flag to the configure command in .ci/scripts/build_ucc.sh. This flag tells NVCC to generate code specifically for the Volta architecture (compute capability 7.0).