### PR TITLE
TL/UCP: Split single and multithreaded send/receive

### DIFF
--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -269,15 +269,12 @@ static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {
      "during collective execution",
      ucc_offsetof(ucc_tl_ucp_context_config_t, local_copy_type),
      UCC_CONFIG_TYPE_ENUM(ucc_tl_ucp_local_copy_names)},
-<<<<<<< HEAD
 
     {"MEMTYPE_COPY_ENABLE", "y",
      "Allows memory type copies. This option influences protocol selection in UCX. "
      "See https://github.com/openucx/ucx/pull/10490 for more details.",
      ucc_offsetof(ucc_tl_ucp_context_config_t, memtype_copy_enable),
      UCC_CONFIG_TYPE_BOOL},
-=======
->>>>>>> 8fb286e (TL/UCP: completion callback st/mt)
 
     {NULL}};
 

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -269,12 +269,15 @@ static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {
      "during collective execution",
      ucc_offsetof(ucc_tl_ucp_context_config_t, local_copy_type),
      UCC_CONFIG_TYPE_ENUM(ucc_tl_ucp_local_copy_names)},
+<<<<<<< HEAD
 
     {"MEMTYPE_COPY_ENABLE", "y",
      "Allows memory type copies. This option influences protocol selection in UCX. "
      "See https://github.com/openucx/ucx/pull/10490 for more details.",
      ucc_offsetof(ucc_tl_ucp_context_config_t, memtype_copy_enable),
      UCC_CONFIG_TYPE_BOOL},
+=======
+>>>>>>> 8fb286e (TL/UCP: completion callback st/mt)
 
     {NULL}};
 

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -166,13 +166,18 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
 typedef ucc_status_t (*ucc_tl_ucp_send_nb_fn_t)(void *buffer, size_t msglen, ucc_memory_type_t mtype,
                     ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
                     ucc_tl_ucp_task_t *task);
-
+typedef ucc_status_t (*ucc_tl_ucp_recv_nb_fn_t)(void *buffer, size_t msglen, ucc_memory_type_t mtype,
+                    ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
+                    ucc_tl_ucp_task_t *task);
 typedef struct ucc_tl_ucp_context {
     ucc_tl_context_t            super;
     ucc_tl_ucp_context_config_t cfg;
     ucc_tl_ucp_worker_t         worker;
     ucc_tl_ucp_worker_t         service_worker;
-    ucc_tl_ucp_send_nb_fn_t     ucc_tl_send_fn;
+    struct {
+        ucc_tl_ucp_send_nb_fn_t     ucc_tl_ucp_send_nb;
+        ucc_tl_ucp_recv_nb_fn_t     ucc_tl_ucp_recv_nb;
+    } callbacks;
     uint32_t                    service_worker_throttling_count;
     ucc_mpool_t                 req_mp;
     ucc_tl_ucp_remote_info_t *  remote_info;

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -161,22 +161,38 @@ typedef struct ucc_tl_ucp_team {
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
 
-typedef ucc_status_t (*ucc_tl_ucp_send_nb_fn_t)(void *buffer, size_t msglen, ucc_memory_type_t mtype,
-                    ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
-                    ucc_tl_ucp_task_t *task);
+typedef ucc_status_t (*ucc_tl_ucp_send_nb_fn_t)(void *buffer, size_t msglen,
+                                                ucc_memory_type_t mtype,
+                                                ucc_rank_t dest_group_rank,
+                                                ucc_tl_ucp_team_t *team,
+                                                ucc_tl_ucp_task_t *task);
+typedef ucc_status_t (*ucc_tl_ucp_recv_nb_fn_t)(void *buffer, size_t msglen,
+                                                ucc_memory_type_t mtype,
+                                                ucc_rank_t dest_group_rank,
+                                                ucc_tl_ucp_team_t *team,
+                                                ucc_tl_ucp_task_t *task);
 
-typedef ucc_status_t (*ucc_tl_ucp_recv_nb_fn_t)(void *buffer, size_t msglen, ucc_memory_type_t mtype,
-                    ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
-                    ucc_tl_ucp_task_t *task);
+typedef ucc_status_t (*ucc_tl_ucp_recv_nz_fn_t)(void *buffer, size_t msglen,
+                                                ucc_memory_type_t mtype,
+                                                ucc_rank_t dest_group_rank,
+                                                ucc_tl_ucp_team_t *team,
+                                                ucc_tl_ucp_task_t *task);
 
+typedef ucc_status_t (*ucc_tl_ucp_send_nz_fn_t)(void *buffer, size_t msglen,
+                                                ucc_memory_type_t mtype,
+                                                ucc_rank_t dest_group_rank,
+                                                ucc_tl_ucp_team_t *team,
+                                                ucc_tl_ucp_task_t *task);
 typedef struct ucc_tl_ucp_context {
     ucc_tl_context_t            super;
     ucc_tl_ucp_context_config_t cfg;
     ucc_tl_ucp_worker_t         worker;
     ucc_tl_ucp_worker_t         service_worker;
     struct {
-        ucc_tl_ucp_send_nb_fn_t     ucc_tl_ucp_send_nb;
-        ucc_tl_ucp_recv_nb_fn_t     ucc_tl_ucp_recv_nb;
+        ucc_tl_ucp_send_nb_fn_t ucc_tl_ucp_send_nb;
+        ucc_tl_ucp_recv_nb_fn_t ucc_tl_ucp_recv_nb;
+        ucc_tl_ucp_send_nz_fn_t ucc_tl_ucp_send_nz;
+        ucc_tl_ucp_recv_nz_fn_t ucc_tl_ucp_recv_nz;
     } callbacks;
     uint32_t                    service_worker_throttling_count;
     ucc_mpool_t                 req_mp;

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -148,6 +148,7 @@ typedef struct ucc_tl_ucp_context {
     ucc_tl_ucp_context_config_t cfg;
     ucc_tl_ucp_worker_t         worker;
     ucc_tl_ucp_worker_t         service_worker;
+    ucp_send_nbx_callback_t     completion_cb;
     uint32_t                    service_worker_throttling_count;
     ucc_mpool_t                 req_mp;
     ucc_tl_ucp_remote_info_t *  remote_info;

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -143,8 +143,6 @@ typedef ucc_status_t (*ucc_tl_ucp_copy_test_fn_t)(ucc_tl_ucp_context_t *ctx,
                                                   ucc_tl_ucp_copy_task_t *copy_task);
 typedef ucc_status_t (*ucc_tl_ucp_copy_finalize_fn_t)(ucc_tl_ucp_copy_task_t *copy_task);
 
-
-
 typedef struct ucc_tl_ucp_team {
     ucc_tl_team_t              super;
     ucc_status_t               status;
@@ -166,9 +164,11 @@ UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
 typedef ucc_status_t (*ucc_tl_ucp_send_nb_fn_t)(void *buffer, size_t msglen, ucc_memory_type_t mtype,
                     ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
                     ucc_tl_ucp_task_t *task);
+
 typedef ucc_status_t (*ucc_tl_ucp_recv_nb_fn_t)(void *buffer, size_t msglen, ucc_memory_type_t mtype,
                     ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
                     ucc_tl_ucp_task_t *task);
+
 typedef struct ucc_tl_ucp_context {
     ucc_tl_context_t            super;
     ucc_tl_ucp_context_config_t cfg;

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -143,27 +143,7 @@ typedef ucc_status_t (*ucc_tl_ucp_copy_test_fn_t)(ucc_tl_ucp_context_t *ctx,
                                                   ucc_tl_ucp_copy_task_t *copy_task);
 typedef ucc_status_t (*ucc_tl_ucp_copy_finalize_fn_t)(ucc_tl_ucp_copy_task_t *copy_task);
 
-typedef struct ucc_tl_ucp_context {
-    ucc_tl_context_t            super;
-    ucc_tl_ucp_context_config_t cfg;
-    ucc_tl_ucp_worker_t         worker;
-    ucc_tl_ucp_worker_t         service_worker;
-    ucp_send_nbx_callback_t     completion_cb;
-    uint32_t                    service_worker_throttling_count;
-    ucc_mpool_t                 req_mp;
-    ucc_tl_ucp_remote_info_t *  remote_info;
-    ucp_rkey_h *                rkeys;
-    uint64_t                    n_rinfo_segs;
-    uint64_t                    ucp_memory_types;
-    int                         topo_required;
-    struct {
-        ucc_tl_ucp_copy_post_fn_t     post;
-        ucc_tl_ucp_copy_test_fn_t     test;
-        ucc_tl_ucp_copy_finalize_fn_t finalize;
-    } copy;
-} ucc_tl_ucp_context_t;
-UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
-                  const ucc_base_config_t *);
+
 
 typedef struct ucc_tl_ucp_team {
     ucc_tl_team_t              super;
@@ -183,6 +163,32 @@ typedef struct ucc_tl_ucp_team {
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
 
+typedef ucc_status_t (*ucc_tl_ucp_send_nb_fn_t)(void *buffer, size_t msglen, ucc_memory_type_t mtype,
+                    ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
+                    ucc_tl_ucp_task_t *task);
+
+typedef struct ucc_tl_ucp_context {
+    ucc_tl_context_t            super;
+    ucc_tl_ucp_context_config_t cfg;
+    ucc_tl_ucp_worker_t         worker;
+    ucc_tl_ucp_worker_t         service_worker;
+    ucc_tl_ucp_send_nb_fn_t     ucc_tl_send_fn;
+    uint32_t                    service_worker_throttling_count;
+    ucc_mpool_t                 req_mp;
+    ucc_tl_ucp_remote_info_t *  remote_info;
+    ucp_rkey_h *                rkeys;
+    uint64_t                    n_rinfo_segs;
+    uint64_t                    ucp_memory_types;
+    int                         topo_required;
+    struct {
+        ucc_tl_ucp_copy_post_fn_t     post;
+        ucc_tl_ucp_copy_test_fn_t     test;
+        ucc_tl_ucp_copy_finalize_fn_t finalize;
+    } copy;
+} ucc_tl_ucp_context_t;
+UCC_CLASS_DECLARE(ucc_tl_ucp_context_t, const ucc_base_context_params_t *,
+                    const ucc_base_config_t *);
+  
 extern ucc_config_field_t ucc_tl_ucp_lib_config_table[];
 
 #define UCC_TL_UCP_SUPPORTED_COLLS                                             \

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -166,6 +166,7 @@ typedef ucc_status_t (*ucc_tl_ucp_send_nb_fn_t)(void *buffer, size_t msglen,
                                                 ucc_rank_t dest_group_rank,
                                                 ucc_tl_ucp_team_t *team,
                                                 ucc_tl_ucp_task_t *task);
+
 typedef ucc_status_t (*ucc_tl_ucp_recv_nb_fn_t)(void *buffer, size_t msglen,
                                                 ucc_memory_type_t mtype,
                                                 ucc_rank_t dest_group_rank,
@@ -183,6 +184,7 @@ typedef ucc_status_t (*ucc_tl_ucp_send_nz_fn_t)(void *buffer, size_t msglen,
                                                 ucc_rank_t dest_group_rank,
                                                 ucc_tl_ucp_team_t *team,
                                                 ucc_tl_ucp_task_t *task);
+
 typedef struct ucc_tl_ucp_context {
     ucc_tl_context_t            super;
     ucc_tl_ucp_context_config_t cfg;
@@ -193,7 +195,7 @@ typedef struct ucc_tl_ucp_context {
         ucc_tl_ucp_recv_nb_fn_t ucc_tl_ucp_recv_nb;
         ucc_tl_ucp_send_nz_fn_t ucc_tl_ucp_send_nz;
         ucc_tl_ucp_recv_nz_fn_t ucc_tl_ucp_recv_nz;
-    } callbacks;
+    } sendrecv_cbs;
     uint32_t                    service_worker_throttling_count;
     ucc_mpool_t                 req_mp;
     ucc_tl_ucp_remote_info_t *  remote_info;

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -97,8 +97,21 @@ void ucc_tl_ucp_team_default_score_str_free(
     }
 }
 
-void ucc_tl_ucp_send_completion_cb(void *request, ucs_status_t status,
-                                   void *user_data)
+void ucc_tl_ucp_send_completion_cb_st(void *request, ucs_status_t status,
+                                      void *user_data)
+{
+    ucc_tl_ucp_task_t *task = (ucc_tl_ucp_task_t *)user_data;
+    if (ucc_unlikely(UCS_OK != status)) {
+        tl_error(UCC_TASK_LIB(task), "failure in send completion %s",
+                 ucs_status_string(status));
+        task->super.status = ucs_status_to_ucc_status(status);
+    }
+    ++task->tagged.send_completed;
+    ucp_request_free(request);
+}
+
+void ucc_tl_ucp_send_completion_cb_mt(void *request, ucs_status_t status,
+                                      void *user_data)
 {
     ucc_tl_ucp_task_t *task = (ucc_tl_ucp_task_t *)user_data;
     if (ucc_unlikely(UCS_OK != status)) {

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -149,9 +149,9 @@ void ucc_tl_ucp_get_completion_cb(void *request, ucs_status_t status,
     ucp_request_free(request);
 }
 
-void ucc_tl_ucp_recv_completion_cb(void *request, ucs_status_t status,
-                                   const ucp_tag_recv_info_t *info, /* NOLINT */
-                                   void *user_data)
+void ucc_tl_ucp_recv_completion_cb_mt(void *request, ucs_status_t status,
+                                      const ucp_tag_recv_info_t *info, /* NOLINT */
+                                      void *user_data)
 {
     ucc_tl_ucp_task_t *task = (ucc_tl_ucp_task_t *)user_data;
     if (ucc_unlikely(UCS_OK != status)) {
@@ -160,6 +160,20 @@ void ucc_tl_ucp_recv_completion_cb(void *request, ucs_status_t status,
         task->super.status = ucs_status_to_ucc_status(status);
     }
     ucc_atomic_add32(&task->tagged.recv_completed, 1);
+    ucp_request_free(request);
+}
+
+void ucc_tl_ucp_recv_completion_cb_st(void *request, ucs_status_t status,
+                                      const ucp_tag_recv_info_t *info, /* NOLINT */
+                                      void *user_data)
+{
+    ucc_tl_ucp_task_t *task = (ucc_tl_ucp_task_t *)user_data;
+    if (ucc_unlikely(UCS_OK != status)) {
+        tl_error(UCC_TASK_LIB(task), "failure in recv completion %s",
+                 ucs_status_string(status));
+        task->super.status = ucs_status_to_ucc_status(status);
+    }
+    ++task->tagged.recv_completed;
     ucp_request_free(request);
 }
 

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -217,11 +217,11 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     case UCC_THREAD_SINGLE:
     case UCC_THREAD_FUNNELED:
         worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
-        self->completion_cb = ucc_tl_ucp_send_completion_cb_st;
+        self->ucc_tl_send_fn = ucc_tl_ucp_send_nb_st;
         break;
     case UCC_THREAD_MULTIPLE:
         worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
-        self->completion_cb = ucc_tl_ucp_send_completion_cb_mt;
+        self->ucc_tl_send_fn = ucc_tl_ucp_send_nb_mt;
         break;
     default:
         /* unreachable */

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -217,11 +217,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     case UCC_THREAD_SINGLE:
     case UCC_THREAD_FUNNELED:
         worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
-        self->ucc_tl_send_fn = ucc_tl_ucp_send_nb_st;
+        self->callbacks.ucc_tl_ucp_send_nb = ucc_tl_ucp_send_nb_st;
+        self->callbacks.ucc_tl_ucp_recv_nb = ucc_tl_ucp_recv_nb_st;
         break;
     case UCC_THREAD_MULTIPLE:
         worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
-        self->ucc_tl_send_fn = ucc_tl_ucp_send_nb_mt;
+        self->callbacks.ucc_tl_ucp_send_nb = ucc_tl_ucp_send_nb_mt;
+        self->callbacks.ucc_tl_ucp_recv_nb = ucc_tl_ucp_recv_nb_mt;        
         break;
     default:
         /* unreachable */

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -15,6 +15,8 @@
 #include "tl_ucp_copy.h"
 #include <limits.h>
 
+#include "tl_ucp_sendrecv.h"
+
 #define UCP_CHECK(function, msg, go, ctx)                                      \
     status = function;                                                         \
     if (UCS_OK != status) {                                                    \
@@ -215,9 +217,11 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     case UCC_THREAD_SINGLE:
     case UCC_THREAD_FUNNELED:
         worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
+        self->completion_cb = ucc_tl_ucp_send_completion_cb_st;
         break;
     case UCC_THREAD_MULTIPLE:
         worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
+        self->completion_cb = ucc_tl_ucp_send_completion_cb_mt;
         break;
     default:
         /* unreachable */
@@ -293,7 +297,6 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     }
     ucc_free(prefix);
     prefix = NULL;
-
 
     switch (self->cfg.local_copy_type) {
     case UCC_TL_UCP_LOCAL_COPY_TYPE_MC:

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -219,11 +219,15 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
         worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
         self->callbacks.ucc_tl_ucp_send_nb = ucc_tl_ucp_send_nb_st;
         self->callbacks.ucc_tl_ucp_recv_nb = ucc_tl_ucp_recv_nb_st;
+        self->callbacks.ucc_tl_ucp_send_nz = ucc_tl_ucp_send_nz_st;
+        self->callbacks.ucc_tl_ucp_recv_nz = ucc_tl_ucp_recv_nz_st;
         break;
     case UCC_THREAD_MULTIPLE:
         worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
         self->callbacks.ucc_tl_ucp_send_nb = ucc_tl_ucp_send_nb_mt;
-        self->callbacks.ucc_tl_ucp_recv_nb = ucc_tl_ucp_recv_nb_mt;        
+        self->callbacks.ucc_tl_ucp_recv_nb = ucc_tl_ucp_recv_nb_mt;
+        self->callbacks.ucc_tl_ucp_send_nz = ucc_tl_ucp_send_nz_mt;
+        self->callbacks.ucc_tl_ucp_recv_nz = ucc_tl_ucp_recv_nz_mt;        
         break;
     default:
         /* unreachable */

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -217,17 +217,17 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
     case UCC_THREAD_SINGLE:
     case UCC_THREAD_FUNNELED:
         worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
-        self->callbacks.ucc_tl_ucp_send_nb = ucc_tl_ucp_send_nb_st;
-        self->callbacks.ucc_tl_ucp_recv_nb = ucc_tl_ucp_recv_nb_st;
-        self->callbacks.ucc_tl_ucp_send_nz = ucc_tl_ucp_send_nz_st;
-        self->callbacks.ucc_tl_ucp_recv_nz = ucc_tl_ucp_recv_nz_st;
+        self->sendrecv_cbs.ucc_tl_ucp_send_nb = ucc_tl_ucp_send_nb_st;
+        self->sendrecv_cbs.ucc_tl_ucp_recv_nb = ucc_tl_ucp_recv_nb_st;
+        self->sendrecv_cbs.ucc_tl_ucp_send_nz = ucc_tl_ucp_send_nz_st;
+        self->sendrecv_cbs.ucc_tl_ucp_recv_nz = ucc_tl_ucp_recv_nz_st;
         break;
     case UCC_THREAD_MULTIPLE:
         worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
-        self->callbacks.ucc_tl_ucp_send_nb = ucc_tl_ucp_send_nb_mt;
-        self->callbacks.ucc_tl_ucp_recv_nb = ucc_tl_ucp_recv_nb_mt;
-        self->callbacks.ucc_tl_ucp_send_nz = ucc_tl_ucp_send_nz_mt;
-        self->callbacks.ucc_tl_ucp_recv_nz = ucc_tl_ucp_recv_nz_mt;        
+        self->sendrecv_cbs.ucc_tl_ucp_send_nb = ucc_tl_ucp_send_nb_mt;
+        self->sendrecv_cbs.ucc_tl_ucp_recv_nb = ucc_tl_ucp_recv_nb_mt;
+        self->sendrecv_cbs.ucc_tl_ucp_send_nz = ucc_tl_ucp_send_nz_mt;
+        self->sendrecv_cbs.ucc_tl_ucp_recv_nz = ucc_tl_ucp_recv_nz_mt;        
         break;
     default:
         /* unreachable */

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -15,9 +15,12 @@
 #include "utils/ucc_compiler_def.h"
 #include "components/mc/base/ucc_mc_base.h"
 
-void ucc_tl_ucp_send_completion_cb(void *request, ucs_status_t status,
+void ucc_tl_ucp_send_completion_cb_st(void *request, ucs_status_t status,
                                    void *user_data);
+void ucc_tl_ucp_send_completion_cb_mt(void *request, ucs_status_t status,
+                                    void *user_data);
 
+                                    
 void ucc_tl_ucp_put_completion_cb(void *request, ucs_status_t status,
                                    void *user_data);
 
@@ -102,7 +105,7 @@ ucc_tl_ucp_send_nb(void *buffer, size_t msglen, ucc_memory_type_t mtype,
     ucs_status_ptr_t ucp_status;
 
     ucp_status = ucc_tl_ucp_send_common(buffer, msglen, mtype, dest_group_rank,
-                                        team, task, ucc_tl_ucp_send_completion_cb,
+                                        team, task, UCC_TL_UCP_TEAM_CTX(team)->completion_cb,
                                         (void *)task);
     if (UCS_OK != ucp_status) {
         UCC_TL_UCP_CHECK_REQ_STATUS();

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -253,35 +253,87 @@ ucc_tl_ucp_recv_cb(void *buffer, size_t msglen, ucc_memory_type_t mtype,
 }
 
 /* Non-Zero recv: if msglen == 0 then it is a no-op */
-static inline ucc_status_t ucc_tl_ucp_recv_nz(void *buffer, size_t msglen,
-                                              ucc_memory_type_t mtype,
-                                              ucc_rank_t dest_group_rank,
-                                              ucc_tl_ucp_team_t *team,
-                                              ucc_tl_ucp_task_t *task)
+static inline ucc_status_t ucc_tl_ucp_recv_nz_mt(void *buffer, size_t msglen,
+                                                 ucc_memory_type_t mtype,
+                                                 ucc_rank_t dest_group_rank,
+                                                 ucc_tl_ucp_team_t *team,
+                                                 ucc_tl_ucp_task_t *task)
 {
     if (msglen == 0) {
         task->tagged.recv_posted++;
         ucc_atomic_add32(&task->tagged.recv_completed, 1);
         return UCC_OK;
     }
-    return ucc_tl_ucp_recv_nb(buffer, msglen, mtype,
-                              dest_group_rank, team, task);
+    return ucc_tl_ucp_recv_nb_mt(buffer, msglen, mtype, dest_group_rank, team,
+                                 task);
+}
+
+/* Non-Zero recv: if msglen == 0 then it is a no-op */
+static inline ucc_status_t ucc_tl_ucp_recv_nz_st(void *buffer, size_t msglen,
+                                                 ucc_memory_type_t mtype,
+                                                 ucc_rank_t dest_group_rank,
+                                                 ucc_tl_ucp_team_t *team,
+                                                 ucc_tl_ucp_task_t *task)
+{
+    if (msglen == 0) {
+        task->tagged.recv_posted++;
+        task->tagged.recv_completed++;
+        return UCC_OK;
+    }
+    return ucc_tl_ucp_recv_nb_st(buffer, msglen, mtype, dest_group_rank, team,
+                                 task);
 }
 
 /* Non-Zero send: if msglen == 0 then it is a no-op */
-static inline ucc_status_t ucc_tl_ucp_send_nz(void *buffer, size_t msglen,
-                                              ucc_memory_type_t mtype,
-                                              ucc_rank_t dest_group_rank,
-                                              ucc_tl_ucp_team_t *team,
-                                              ucc_tl_ucp_task_t *task)
+static inline ucc_status_t ucc_tl_ucp_send_nz_mt(void *buffer, size_t msglen,
+                                                 ucc_memory_type_t mtype,
+                                                 ucc_rank_t dest_group_rank,
+                                                 ucc_tl_ucp_team_t *team,
+                                                 ucc_tl_ucp_task_t *task)
 {
     if (msglen == 0) {
         task->tagged.send_posted++;
         ucc_atomic_add32(&task->tagged.send_completed, 1);
         return UCC_OK;
     }
-    return ucc_tl_ucp_send_nb(buffer, msglen, mtype,
-                              dest_group_rank, team, task);
+    return ucc_tl_ucp_send_nb_mt(buffer, msglen, mtype, dest_group_rank, team,
+                                 task);
+}
+
+/* Non-Zero send: if msglen == 0 then it is a no-op */
+static inline ucc_status_t ucc_tl_ucp_send_nz_st(void *buffer, size_t msglen,
+                                                 ucc_memory_type_t mtype,
+                                                 ucc_rank_t dest_group_rank,
+                                                 ucc_tl_ucp_team_t *team,
+                                                 ucc_tl_ucp_task_t *task)
+{
+    if (msglen == 0) {
+        task->tagged.send_posted++;
+        task->tagged.send_completed++;
+        return UCC_OK;
+    }
+    return ucc_tl_ucp_send_nb_st(buffer, msglen, mtype, dest_group_rank, team,
+                                 task);
+}
+
+static inline ucc_status_t ucc_tl_ucp_send_nz(void *buffer, size_t msglen,
+                                              ucc_memory_type_t mtype,
+                                              ucc_rank_t        dest_group_rank,
+                                              ucc_tl_ucp_team_t *team,
+                                              ucc_tl_ucp_task_t *task)
+{
+    return UCC_TL_UCP_TEAM_CTX(team)->callbacks.ucc_tl_ucp_send_nz(
+        buffer, msglen, mtype, dest_group_rank, team, task);
+}
+
+static inline ucc_status_t ucc_tl_ucp_recv_nz(void *buffer, size_t msglen,
+                                              ucc_memory_type_t mtype,
+                                              ucc_rank_t        dest_group_rank,
+                                              ucc_tl_ucp_team_t *team,
+                                              ucc_tl_ucp_task_t *task)
+{
+    return UCC_TL_UCP_TEAM_CTX(team)->callbacks.ucc_tl_ucp_recv_nz(
+        buffer, msglen, mtype, dest_group_rank, team, task);
 }
 
 static inline ucc_status_t

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -100,16 +100,17 @@ ucc_tl_ucp_send_common(void *buffer, size_t msglen, ucc_memory_type_t mtype,
     return ucp_tag_send_nbx(ep, buffer, 1, ucp_tag, &req_param);
 }
 
-static inline ucc_status_t
-ucc_tl_ucp_send_nb_st(void *buffer, size_t msglen, ucc_memory_type_t mtype,
-                   ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
-                   ucc_tl_ucp_task_t *task)
+static inline ucc_status_t ucc_tl_ucp_send_nb_st(void *buffer, size_t msglen,
+                                                 ucc_memory_type_t mtype,
+                                                 ucc_rank_t dest_group_rank,
+                                                 ucc_tl_ucp_team_t *team,
+                                                 ucc_tl_ucp_task_t *task)
 {
     ucs_status_ptr_t ucp_status;
 
-    ucp_status = ucc_tl_ucp_send_common(buffer, msglen, mtype, dest_group_rank,
-                                        team, task, ucc_tl_ucp_send_completion_cb_st,
-                                        (void *)task);
+    ucp_status = ucc_tl_ucp_send_common(
+        buffer, msglen, mtype, dest_group_rank, team, task,
+        ucc_tl_ucp_send_completion_cb_st, (void *)task);
     if (UCS_OK != ucp_status) {
         UCC_TL_UCP_CHECK_REQ_STATUS();
     } else {
@@ -118,16 +119,17 @@ ucc_tl_ucp_send_nb_st(void *buffer, size_t msglen, ucc_memory_type_t mtype,
     return UCC_OK;
 }
 
-static inline ucc_status_t
-ucc_tl_ucp_send_nb_mt(void *buffer, size_t msglen, ucc_memory_type_t mtype,
-                   ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
-                   ucc_tl_ucp_task_t *task)
+static inline ucc_status_t ucc_tl_ucp_send_nb_mt(void *buffer, size_t msglen,
+                                                 ucc_memory_type_t mtype,
+                                                 ucc_rank_t dest_group_rank,
+                                                 ucc_tl_ucp_team_t *team,
+                                                 ucc_tl_ucp_task_t *task)
 {
     ucs_status_ptr_t ucp_status;
 
-    ucp_status = ucc_tl_ucp_send_common(buffer, msglen, mtype, dest_group_rank,
-                                        team, task, ucc_tl_ucp_send_completion_cb_mt,
-                                        (void *)task);
+    ucp_status = ucc_tl_ucp_send_common(
+        buffer, msglen, mtype, dest_group_rank, team, task,
+        ucc_tl_ucp_send_completion_cb_mt, (void *)task);
     if (UCS_OK != ucp_status) {
         UCC_TL_UCP_CHECK_REQ_STATUS();
     } else {
@@ -136,13 +138,14 @@ ucc_tl_ucp_send_nb_mt(void *buffer, size_t msglen, ucc_memory_type_t mtype,
     return UCC_OK;
 }
 
-static inline ucc_status_t
-ucc_tl_ucp_send_nb(void *buffer, size_t msglen, ucc_memory_type_t mtype,
-                   ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
-                   ucc_tl_ucp_task_t *task)
+static inline ucc_status_t ucc_tl_ucp_send_nb(void *buffer, size_t msglen,
+                                              ucc_memory_type_t mtype,
+                                              ucc_rank_t        dest_group_rank,
+                                              ucc_tl_ucp_team_t *team,
+                                              ucc_tl_ucp_task_t *task)
 {
-    return UCC_TL_UCP_TEAM_CTX(team)->callbacks.ucc_tl_ucp_send_nb(buffer, msglen, mtype,
-        dest_group_rank, team, task);
+    return UCC_TL_UCP_TEAM_CTX(team)->sendrecv_cbs.ucc_tl_ucp_send_nb(
+        buffer, msglen, mtype, dest_group_rank, team, task);
 }
 
 static inline ucc_status_t
@@ -190,16 +193,17 @@ ucc_tl_ucp_recv_common(void *buffer, size_t msglen, ucc_memory_type_t mtype,
                             ucp_tag_mask, &req_param);
 }
 
-static inline ucc_status_t
-ucc_tl_ucp_recv_nb_mt(void *buffer, size_t msglen, ucc_memory_type_t mtype,
-                   ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
-                   ucc_tl_ucp_task_t *task)
+static inline ucc_status_t ucc_tl_ucp_recv_nb_mt(void *buffer, size_t msglen,
+                                                 ucc_memory_type_t mtype,
+                                                 ucc_rank_t dest_group_rank,
+                                                 ucc_tl_ucp_team_t *team,
+                                                 ucc_tl_ucp_task_t *task)
 {
     ucs_status_ptr_t ucp_status;
 
-    ucp_status = ucc_tl_ucp_recv_common(buffer, msglen, mtype, dest_group_rank,
-                                        team, task, ucc_tl_ucp_recv_completion_cb_mt,
-                                        (void *)task);
+    ucp_status = ucc_tl_ucp_recv_common(
+        buffer, msglen, mtype, dest_group_rank, team, task,
+        ucc_tl_ucp_recv_completion_cb_mt, (void *)task);
     if (UCS_OK != ucp_status) {
         UCC_TL_UCP_CHECK_REQ_STATUS();
     } else {
@@ -208,16 +212,17 @@ ucc_tl_ucp_recv_nb_mt(void *buffer, size_t msglen, ucc_memory_type_t mtype,
     return UCC_OK;
 }
 
-static inline ucc_status_t
-ucc_tl_ucp_recv_nb_st(void *buffer, size_t msglen, ucc_memory_type_t mtype,
-                   ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
-                   ucc_tl_ucp_task_t *task)
+static inline ucc_status_t ucc_tl_ucp_recv_nb_st(void *buffer, size_t msglen,
+                                                 ucc_memory_type_t mtype,
+                                                 ucc_rank_t dest_group_rank,
+                                                 ucc_tl_ucp_team_t *team,
+                                                 ucc_tl_ucp_task_t *task)
 {
     ucs_status_ptr_t ucp_status;
 
-    ucp_status = ucc_tl_ucp_recv_common(buffer, msglen, mtype, dest_group_rank,
-                                        team, task, ucc_tl_ucp_recv_completion_cb_st,
-                                        (void *)task);
+    ucp_status = ucc_tl_ucp_recv_common(
+        buffer, msglen, mtype, dest_group_rank, team, task,
+        ucc_tl_ucp_recv_completion_cb_st, (void *)task);
     if (UCS_OK != ucp_status) {
         UCC_TL_UCP_CHECK_REQ_STATUS();
     } else {
@@ -226,19 +231,21 @@ ucc_tl_ucp_recv_nb_st(void *buffer, size_t msglen, ucc_memory_type_t mtype,
     return UCC_OK;
 }
 
-static inline ucc_status_t
-ucc_tl_ucp_recv_nb(void *buffer, size_t msglen, ucc_memory_type_t mtype,
-                   ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
-                   ucc_tl_ucp_task_t *task)
+static inline ucc_status_t ucc_tl_ucp_recv_nb(void *buffer, size_t msglen,
+                                              ucc_memory_type_t mtype,
+                                              ucc_rank_t        dest_group_rank,
+                                              ucc_tl_ucp_team_t *team,
+                                              ucc_tl_ucp_task_t *task)
 {
-    return UCC_TL_UCP_TEAM_CTX(team)->callbacks.ucc_tl_ucp_recv_nb(buffer, msglen, mtype,
-        dest_group_rank, team, task);
+    return UCC_TL_UCP_TEAM_CTX(team)->sendrecv_cbs.ucc_tl_ucp_recv_nb(
+        buffer, msglen, mtype, dest_group_rank, team, task);
 }
 
 static inline ucc_status_t
 ucc_tl_ucp_recv_cb(void *buffer, size_t msglen, ucc_memory_type_t mtype,
                    ucc_rank_t dest_group_rank, ucc_tl_ucp_team_t *team,
-                   ucc_tl_ucp_task_t *task, ucp_tag_recv_nbx_callback_t cb, void *user_data)
+                   ucc_tl_ucp_task_t *task, ucp_tag_recv_nbx_callback_t cb,
+                   void *user_data)
 {
     ucs_status_ptr_t ucp_status;
 
@@ -322,7 +329,7 @@ static inline ucc_status_t ucc_tl_ucp_send_nz(void *buffer, size_t msglen,
                                               ucc_tl_ucp_team_t *team,
                                               ucc_tl_ucp_task_t *task)
 {
-    return UCC_TL_UCP_TEAM_CTX(team)->callbacks.ucc_tl_ucp_send_nz(
+    return UCC_TL_UCP_TEAM_CTX(team)->sendrecv_cbs.ucc_tl_ucp_send_nz(
         buffer, msglen, mtype, dest_group_rank, team, task);
 }
 
@@ -332,7 +339,7 @@ static inline ucc_status_t ucc_tl_ucp_recv_nz(void *buffer, size_t msglen,
                                               ucc_tl_ucp_team_t *team,
                                               ucc_tl_ucp_task_t *task)
 {
-    return UCC_TL_UCP_TEAM_CTX(team)->callbacks.ucc_tl_ucp_recv_nz(
+    return UCC_TL_UCP_TEAM_CTX(team)->sendrecv_cbs.ucc_tl_ucp_recv_nz(
         buffer, msglen, mtype, dest_group_rank, team, task);
 }
 


### PR DESCRIPTION
## What
This change introduces two separate code paths for single-threaded and multi-threaded scenarios. During context creation, a specific set of functions and callbacks is selected based on the threading mode, avoiding branching in performance-critical (hot) paths. The single-threaded implementation avoids the use of atomics, which are unnecessary in that context and have been shown to impact performance on ARM systems (3–7% regression on small messages).

## Why ?
Recent performance analysis has revealed regressions in TL/UCP, particularly noticeable on ARM platforms. The atomics introduced in #932 addressed correctness in multi-threaded environments but introduced overhead even in single-threaded use cases. This PR mitigates that overhead for single-threaded configurations. A future update will address multi-threaded performance by revising atomic operations to use appropriate memory models for ARM.

OSU Allgather benchmark on AMD x86, 100k iterations for better stability in results on small messages, Optimized - code from this PR.
```
Size(B)    Master(us)   1.3.2(us)    Optimized(us)  M vs 1.3.2(%)  O vs 1.3.2(%)  O vs M(%)   
------------------------------------------------------------------------------------------
1          94.34        98.67        75.71                 +4.58        +23.27        +19.75
2          83.13        80.98        76.41                 -2.59         +5.65         +8.09
4          84.19        83.67        75.83                 -0.61         +9.37         +9.92
8          645.81       663.58       634.07                +2.75         +4.45         +1.82
16         642.60       667.64       640.89                +3.90         +4.01         +0.27
32         664.89       745.26       667.67               +12.09        +10.41         -0.42
```
Grace (arm) 8 nodes 1ppn OSU alltoall cuda memory 100k iterations (before diff was 3-7%):
```
Size      1.3.2(us)    Current(us)    % Difference
----------------------------------------------------
1         9.79         9.83         +0.41%
2         9.78         9.82         +0.41%
4         9.76         9.81         +0.51%
8         9.77         9.82         +0.51%
16        9.76         9.80         +0.41%
32        9.89         9.92         +0.30%
```