### PR TITLE
UTIL: ucc_assume macro

### DIFF
--- a/src/coll_patterns/bruck_alltoall.h
+++ b/src/coll_patterns/bruck_alltoall.h
@@ -23,7 +23,7 @@ static inline ucc_rank_t get_bruck_step_start(uint32_t pow, uint32_t d)
 static inline ucc_rank_t get_bruck_step_finish(ucc_rank_t n, uint32_t radix,
                                                uint32_t d, uint32_t pow)
 {
-    UCC_ASSUME(pow > 0 && radix > 0);
+    ucc_assume(pow > 0 && radix > 0);
     return ucc_min(n + pow - 1 - (n - d * pow) % (pow * radix), n);
 }
 

--- a/src/coll_patterns/bruck_alltoall.h
+++ b/src/coll_patterns/bruck_alltoall.h
@@ -23,6 +23,7 @@ static inline ucc_rank_t get_bruck_step_start(uint32_t pow, uint32_t d)
 static inline ucc_rank_t get_bruck_step_finish(ucc_rank_t n, uint32_t radix,
                                                uint32_t d, uint32_t pow)
 {
+    UCC_ASSUME(pow > 0 && radix > 0);
     return ucc_min(n + pow - 1 - (n - d * pow) % (pow * radix), n);
 }
 

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -124,4 +124,19 @@ static inline ucs_status_t ucc_status_to_ucs_status(ucc_status_t status)
         }                                                                      \
     } while (0)
 
+
+#if defined(__clang__)
+    #define UCC_ASSUME(x) __builtin_assume(x)
+#elif defined(__GNUC__)
+    #if (__GNUC__ >= 13)
+        /* GCC 13+ has __attribute__((assume)) */
+        #define UCC_ASSUME(x) __attribute__((assume(x)))
+    #else
+        /* For older GCC versions, we can use __builtin_unreachable() as a fallback */
+        #define UCC_ASSUME(x) ((x) ? (void)0 : __builtin_unreachable())
+    #endif
+#else
+    #define UCC_ASSUME(x) do {} while (0)  /* No-op for unsupported compilers */
+#endif    
+
 #endif

--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -126,17 +126,17 @@ static inline ucs_status_t ucc_status_to_ucs_status(ucc_status_t status)
 
 
 #if defined(__clang__)
-    #define UCC_ASSUME(x) __builtin_assume(x)
+    #define ucc_assume(x) __builtin_assume(x)
 #elif defined(__GNUC__)
     #if (__GNUC__ >= 13)
         /* GCC 13+ has __attribute__((assume)) */
-        #define UCC_ASSUME(x) __attribute__((assume(x)))
+        #define ucc_assume(x) __attribute__((assume(x)))
     #else
         /* For older GCC versions, we can use __builtin_unreachable() as a fallback */
-        #define UCC_ASSUME(x) ((x) ? (void)0 : __builtin_unreachable())
+        #define ucc_assume(x) ((x) ? (void)0 : __builtin_unreachable())
     #endif
 #else
-    #define UCC_ASSUME(x) do {} while (0)  /* No-op for unsupported compilers */
+    #define ucc_assume(x) do {} while (0)  /* No-op for unsupported compilers */
 #endif    
 
 #endif


### PR DESCRIPTION
## What
Introduce `ucc_assume` macro to fix clang tidy warnings
## Why ?
clang tidy reports errors division by zero, compiler unable to ensure that some variables couldn't be 0
