### PR TITLE
CL/HIER: Allgatherv lone node leader

### DIFF
--- a/src/components/cl/hier/allgatherv/allgatherv.c
+++ b/src/components/cl/hier/allgatherv/allgatherv.c
@@ -169,10 +169,9 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
 
     in_place = UCC_IS_INPLACE(args.args);
 
-    if (coll_args->args.dst.info_v.mem_type != UCC_MEMORY_TYPE_HOST) {
-        return UCC_ERR_NOT_SUPPORTED;
-    }
-    if (!in_place && coll_args->args.src.info.mem_type != UCC_MEMORY_TYPE_HOST) {
+    if (args.args.dst.info_v.mem_type != UCC_MEMORY_TYPE_HOST ||
+        (!in_place && args.args.src.info.mem_type != UCC_MEMORY_TYPE_HOST) ||
+        UCC_IS_PERSISTENT(args.args)) {
         return UCC_ERR_NOT_SUPPORTED;
     }
 

--- a/src/components/cl/hier/allgatherv/unpack.c
+++ b/src/components/cl/hier/allgatherv/unpack.c
@@ -129,7 +129,6 @@ ucc_status_t ucc_cl_hier_allgatherv_unpack_start(ucc_coll_task_t *task)
         for (ucc_rank_t j = 0; j < all_nodes[node_leader_idx].group_size; j++) {
             if (all_nodes[node_leader_idx].group_size == 1) {
                 // Node sbgp wont exist for just a single rank on a node
-                curr_team_rank = leader_team_rank;
                 break;
             } else {
                 curr_team_rank = ucc_ep_map_eval(all_nodes[node_leader_idx].map, j);

--- a/src/components/cl/hier/allgatherv/unpack.c
+++ b/src/components/cl/hier/allgatherv/unpack.c
@@ -127,9 +127,15 @@ ucc_status_t ucc_cl_hier_allgatherv_unpack_start(ucc_coll_task_t *task)
 
         ucc_assert(per_node_leaders[node_leader_idx] == leader_team_rank);
         for (ucc_rank_t j = 0; j < all_nodes[node_leader_idx].group_size; j++) {
-            curr_team_rank = ucc_ep_map_eval(all_nodes[node_leader_idx].map, j);
-            if (curr_team_rank == i) {
-                break; // We found our position
+            if (all_nodes[node_leader_idx].group_size == 1) {
+                // Node sbgp wont exist for just a single rank on a node
+                curr_team_rank = leader_team_rank;
+                break;
+            } else {
+                curr_team_rank = ucc_ep_map_eval(all_nodes[node_leader_idx].map, j);
+                if (curr_team_rank == i) {
+                    break; // We found our position
+                }
             }
             // Add previous ranks' counts from the same node
             src_rank_disp += ucc_coll_args_get_count(


### PR DESCRIPTION
Follow up to https://github.com/openucx/ucc/pull/1103. This PR fixes the case where a node leader is the only rank on the node. In that case, the node subgroup wont exist and he'll have to memcpy the src buf to the scratch buffer.