### PR TITLE
TL/SHARP: enable AG and RS after 16k

### DIFF
--- a/src/components/tl/sharp/tl_sharp_coll.c
+++ b/src/components/tl/sharp/tl_sharp_coll.c
@@ -12,6 +12,20 @@
 #include <sharp/api/version.h>
 #include <sharp/api/sharp_coll.h>
 
+/* Disable allgather and reduce_scatter for message sizes 0-16k since SHARP SAT is only enabled by default for messages larger than 16k.
+ * TODO: update with precise threshold once SHARP query can return SAT threshold.
+ */
+#define UCC_TL_SHARP_ALLGATHER_DEFAULT_ALG_SELECT_STR                          \
+    "allgather:0-16k:0"
+
+#define UCC_TL_SHARP_REDUCE_SCATTER_DEFAULT_ALG_SELECT_STR                     \
+    "reduce_scatter:0-16k:0"
+
+const char
+    *ucc_tl_sharp_default_alg_select_str[UCC_TL_SHARP_N_DEFAULT_ALG_SELECT_STR] = {
+        UCC_TL_SHARP_ALLGATHER_DEFAULT_ALG_SELECT_STR,
+        UCC_TL_SHARP_REDUCE_SCATTER_DEFAULT_ALG_SELECT_STR};
+
 enum sharp_datatype ucc_to_sharp_dtype[] = {
     [UCC_DT_PREDEFINED_ID(UCC_DT_INT16)]            = SHARP_DTYPE_SHORT,
     [UCC_DT_PREDEFINED_ID(UCC_DT_INT32)]            = SHARP_DTYPE_INT,

--- a/src/components/tl/sharp/tl_sharp_coll.h
+++ b/src/components/tl/sharp/tl_sharp_coll.h
@@ -12,6 +12,10 @@
 /* need to query for datatype support at runtime */
 #define SHARP_DTYPE_UNKNOWN 0xFFFF
 
+#define UCC_TL_SHARP_N_DEFAULT_ALG_SELECT_STR 2
+extern const char
+    *ucc_tl_sharp_default_alg_select_str[UCC_TL_SHARP_N_DEFAULT_ALG_SELECT_STR];
+
 extern enum sharp_datatype ucc_to_sharp_dtype[];
 
 ucc_status_t ucc_tl_sharp_allreduce_init(ucc_tl_sharp_task_t *task);

--- a/src/components/tl/sharp/tl_sharp_team.c
+++ b/src/components/tl/sharp/tl_sharp_team.c
@@ -279,6 +279,7 @@ ucc_status_t ucc_tl_sharp_team_get_scores(ucc_base_team_t  *tl_team,
     ucc_coll_score_t    *score;
     ucc_status_t         status;
     ucc_coll_score_team_info_t team_info;
+    int i;
 
     team_info.alg_fn              = NULL;
     team_info.default_score       = UCC_TL_SHARP_DEFAULT_SCORE;
@@ -296,6 +297,18 @@ ucc_status_t ucc_tl_sharp_team_get_scores(ucc_base_team_t  *tl_team,
                                      NULL, 0, &score);
     if (UCC_OK != status) {
         return status;
+    }
+
+    for (i = 0; i < UCC_TL_SHARP_N_DEFAULT_ALG_SELECT_STR; i++) {
+        status = ucc_coll_score_update_from_str(
+            ucc_tl_sharp_default_alg_select_str[i], &team_info,
+            &team->super.super, score);
+        if (UCC_OK != status) {
+            tl_error(tl_team->context->lib,
+                     "failed to apply default coll select setting: %s",
+                     ucc_tl_sharp_default_alg_select_str[i]);
+            goto err;
+        }
     }
 
     if (strlen(ctx->score_str) > 0) {


### PR DESCRIPTION
## What
- Added default algorithm selection strings for allgather and reduce_scatter .
- Updated the team score retrieval function to apply these default settings.

## Why ?
SHARP SAT by default is enabled only for msg size > 16k.
