### PR TITLE
CI: Update versions

### DIFF
--- a/.github/workflows/asan-test.yaml
+++ b/.github/workflows/asan-test.yaml
@@ -1,4 +1,4 @@
-name: Linter
+name: ASAN Tests
 
 on: [push, pull_request]
 
@@ -6,8 +6,9 @@ env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
   CLANG_VER: 12
+
 jobs:
-  clang-tidy:
+  gtest-asan:
     runs-on: ubuntu-22.04
     steps:
     - name: Install dependencies
@@ -16,7 +17,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
         sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VER} main"
-        sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear
+        sudo apt-get install -y --no-install-recommends clang-${CLANG_VER}
     - name: Get UCX
       run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
     - name: Build UCX
@@ -25,17 +26,11 @@ jobs:
         CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./contrib/configure-release --without-java --without-go --disable-numa --prefix $PWD/install
         make -j install
     - uses: actions/checkout@v1
-    - name: Build UCC
+    - name: Run gtest ASAN
       run: |
+        export ASAN_OPTIONS=fast_unwind_on_malloc=0:detect_leaks=1:print_suppressions=0
+        export LSAN_OPTIONS=report_objects=1
         ./autogen.sh
-        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --enable-assert
-        bear --output /tmp/compile_commands.json -- make -j
-    - name: Run clang-tidy
-      run: |
-        echo "Workspace: ${GITHUB_WORKSPACE}"
-        cd ${GITHUB_WORKSPACE}
-        run-clang-tidy-${CLANG_VER} -p /tmp/ 2>&1 | tee /tmp/clang_tidy.log
-        nerrors=$(grep 'error:' /tmp/clang_tidy.log | wc -l)
-        if [ $nerrors -ne 0 ]; then
-            exit 125;
-        fi
+        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure CFLAGS="-fsanitize=address" --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --enable-gtest
+        make -j install
+        ./test/gtest/gtest 

--- a/.github/workflows/asan-test.yaml
+++ b/.github/workflows/asan-test.yaml
@@ -20,7 +20,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
         echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends clang-${CLANG_VER}
+        sudo apt-get install -y --no-install-recommends clang-${CLANG_VER} clang++-${CLANG_VER} libclang-rt-${CLANG_VER}-dev
     - name: Get UCX
       run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
     - name: Build UCX
@@ -34,6 +34,6 @@ jobs:
         export ASAN_OPTIONS=fast_unwind_on_malloc=0:detect_leaks=1:print_suppressions=0
         export LSAN_OPTIONS=report_objects=1
         ./autogen.sh
-        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure CFLAGS="-fsanitize=address" --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --enable-gtest
+        CFLAGS="-fsanitize=address" CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --enable-gtest
         make -j install
         ./test/gtest/gtest

--- a/.github/workflows/asan-test.yaml
+++ b/.github/workflows/asan-test.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
-  CLANG_VER: 12
+  CLANG_VER: 17
 
 jobs:
   gtest-asan:
@@ -14,9 +14,12 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
-        sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VER} main"
+        sudo apt-get install -y --no-install-recommends wget gpg
+        # Setup LLVM repository
+        sudo mkdir -p /etc/apt/keyrings
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+        sudo apt-get update
         sudo apt-get install -y --no-install-recommends clang-${CLANG_VER}
     - name: Get UCX
       run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
@@ -33,4 +36,4 @@ jobs:
         ./autogen.sh
         CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure CFLAGS="-fsanitize=address" --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --enable-gtest
         make -j install
-        ./test/gtest/gtest 
+        ./test/gtest/gtest

--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -59,7 +59,7 @@ jobs:
         echo "Workspace: ${GITHUB_WORKSPACE}"
         cd ${GITHUB_WORKSPACE}
         run-clang-tidy-${CLANG_VER} -p /tmp/ -header-filter='.*' \
-          -ignore="${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/*,${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/*" \
+          -line-filter='[{"name":".*cuda/kernel/.*","lines":[[1,1000000]]}]' \
           2>&1 | tee /tmp/clang_tidy.log
         nerrors=$(grep 'error:' /tmp/clang_tidy.log | wc -l)
         if [ $nerrors -ne 0 ]; then

--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -6,7 +6,7 @@ env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
   HPCX_LINK: https://content.mellanox.com/hpc/hpc-x/v2.17.1rc2/hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz
-  CLANG_VER: 15
+  CLANG_VER: 17
   MLNX_OFED_VER: 23.10-1.1.9.0
   CUDA_VER: 12-8
   LIBRARY_PATH: /tmp/ucx/install/lib
@@ -18,9 +18,11 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common gpg
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
-        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+        sudo apt-get install -y --no-install-recommends wget gpg
+        # Setup LLVM repository
+        sudo mkdir -p /etc/apt/keyrings
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear clang-${CLANG_VER} clang++-${CLANG_VER}
     - name: Install extra rdma dependencies

--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -5,33 +5,34 @@ on: [push, pull_request]
 env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
-  HPCX_LINK: https://content.mellanox.com/hpc/hpc-x/v2.17.1rc2/hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64.tbz
+  HPCX_LINK: https://content.mellanox.com/hpc/hpc-x/v2.17.1rc2/hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz
   CLANG_VER: 12
-  MLNX_OFED_VER: 5.9-0.5.6.0
+  MLNX_OFED_VER: 23.10-1.1.9.0
   CUDA_VER: 11-4
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
 jobs:
   clang-tidy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
-        sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VER} main"
+        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common gpg
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+        sudo apt-get update
         sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear
     - name: Install extra rdma dependencies
       run: |
-        wget --no-verbose http://content.mellanox.com/ofed/MLNX_OFED-${MLNX_OFED_VER}/MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu20.04-x86_64.tgz
-        sudo tar -xvzf MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu20.04-x86_64.tgz
-        sudo chmod -R a+rwx MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu20.04-x86_64
-        sudo MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu20.04-x86_64/mlnxofedinstall --skip-unsupported-devices-check --user-space-only --without-fw-update --force --basic -vvv
+        wget --no-verbose http://content.mellanox.com/ofed/MLNX_OFED-${MLNX_OFED_VER}/MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu22.04-x86_64.tgz
+        sudo tar -xvzf MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu22.04-x86_64.tgz
+        sudo chmod -R a+rwx MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu22.04-x86_64
+        sudo MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu22.04-x86_64/mlnxofedinstall --skip-unsupported-devices-check --user-space-only --without-fw-update --force --basic -vvv
     - name: Install extra cuda dependencies
       run: |
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-        sudo dpkg -i cuda-keyring_1.0-1_all.deb
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+        sudo dpkg -i cuda-keyring_1.1-1_all.deb
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends cuda-cudart-dev-${CUDA_VER} cuda-nvcc-${CUDA_VER} cuda-nvml-dev-${CUDA_VER}
     - name: Get UCX
@@ -45,8 +46,8 @@ jobs:
       run: |
         cd /tmp
         wget ${HPCX_LINK}
-        tar xjf hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64.tbz
-        mv hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64 hpcx
+        tar xjf hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz
+        mv hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64 hpcx
     - uses: actions/checkout@v1
     - name: Build UCC
       run: |

--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Download HPCX
       run: |
         cd /tmp
-        wget ${HPCX_LINK}
+        wget --no-verbose ${HPCX_LINK}
         tar xjf hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz
         mv hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64 hpcx
     - uses: actions/checkout@v1
@@ -53,15 +53,15 @@ jobs:
       run: |
         ./autogen.sh
         CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --with-tls=ucp,mlx5,cuda,self,sharp --with-sharp=/tmp/hpcx/sharp --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-cuda=/usr/local/cuda --with-nvcc-gencode="-gencode=arch=compute_80,code=sm_80" --enable-assert
-        bear --output /tmp/compile_commands.json --exclude ${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/ --exclude ${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/ -- make
+        bear --output /tmp/compile_commands.json -- make -j
     - name: Run clang-tidy
       run: |
         echo "Workspace: ${GITHUB_WORKSPACE}"
         cd ${GITHUB_WORKSPACE}
-        run-clang-tidy-${CLANG_VER} -p /tmp/ 2>&1 | tee /tmp/clang_tidy.log
+        run-clang-tidy-${CLANG_VER} -p /tmp/ -header-filter='.*' \
+          -ignore="${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/*,${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/*" \
+          2>&1 | tee /tmp/clang_tidy.log
         nerrors=$(grep 'error:' /tmp/clang_tidy.log | wc -l)
         if [ $nerrors -ne 0 ]; then
             exit 125;
         fi
-        make clean
-        rm -rf /tmp/ucc

--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -8,7 +8,7 @@ env:
   HPCX_LINK: https://content.mellanox.com/hpc/hpc-x/v2.17.1rc2/hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz
   CLANG_VER: 15
   MLNX_OFED_VER: 23.10-1.1.9.0
-  CUDA_VER: 11-4
+  CUDA_VER: 12-8
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
 jobs:

--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -6,7 +6,7 @@ env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
   HPCX_LINK: https://content.mellanox.com/hpc/hpc-x/v2.17.1rc2/hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz
-  CLANG_VER: 12
+  CLANG_VER: 15
   MLNX_OFED_VER: 23.10-1.1.9.0
   CUDA_VER: 11-4
   LIBRARY_PATH: /tmp/ucx/install/lib
@@ -20,9 +20,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common gpg
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
-        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear
+        sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear clang-${CLANG_VER} clang++-${CLANG_VER}
     - name: Install extra rdma dependencies
       run: |
         wget --no-verbose http://content.mellanox.com/ofed/MLNX_OFED-${MLNX_OFED_VER}/MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu22.04-x86_64.tgz
@@ -53,7 +53,7 @@ jobs:
       run: |
         ./autogen.sh
         CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --with-tls=ucp,mlx5,cuda,self,sharp --with-sharp=/tmp/hpcx/sharp --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-cuda=/usr/local/cuda --with-nvcc-gencode="-gencode=arch=compute_80,code=sm_80" --enable-assert
-        bear --exclude ${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/ --exclude ${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/ --cdb /tmp/compile_commands.json make
+        bear --output /tmp/compile_commands.json --exclude ${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/ --exclude ${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/ -- make
     - name: Run clang-tidy
       run: |
         echo "Workspace: ${GITHUB_WORKSPACE}"

--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -5,9 +5,9 @@ on: [push, pull_request]
 env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
-  HPCX_LINK: https://content.mellanox.com/hpc/hpc-x/v2.17.1rc2/hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz
+  HPCX_LINK: https://content.mellanox.com/hpc/hpc-x/v2.22.1rc4/hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64.tbz
   CLANG_VER: 17
-  MLNX_OFED_VER: 23.10-1.1.9.0
+  MLNX_OFED_VER: 24.10-2.1.8.0
   CUDA_VER: 12-8
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
@@ -24,7 +24,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
         echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear clang-${CLANG_VER} clang++-${CLANG_VER}
+        sudo apt-get install -y --no-install-recommends clang-tidy-${CLANG_VER} bear clang-${CLANG_VER} clang++-${CLANG_VER}
     - name: Install extra rdma dependencies
       run: |
         wget --no-verbose http://content.mellanox.com/ofed/MLNX_OFED-${MLNX_OFED_VER}/MLNX_OFED_LINUX-${MLNX_OFED_VER}-ubuntu22.04-x86_64.tgz
@@ -48,8 +48,8 @@ jobs:
       run: |
         cd /tmp
         wget --no-verbose ${HPCX_LINK}
-        tar xjf hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz
-        mv hpcx-v2.17.1-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64 hpcx
+        tar xjf hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64.tbz
+        mv hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64 hpcx
     - uses: actions/checkout@v1
     - name: Build UCC
       run: |

--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -58,7 +58,7 @@ jobs:
       run: |
         echo "Workspace: ${GITHUB_WORKSPACE}"
         cd ${GITHUB_WORKSPACE}
-        run-clang-tidy-${CLANG_VER} -p /tmp/ -header-filter='^(?!.*(${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/.*|${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/.*)).*$' 2>&1 | tee /tmp/clang_tidy.log
+        run-clang-tidy-${CLANG_VER} -p /tmp/ -header-filter='^(?!.*(${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/.*|${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/.*)).*$' "^(?!.*\.cu$).*$" 2>&1 | tee /tmp/clang_tidy.log
         nerrors=$(grep 'error:' /tmp/clang_tidy.log | wc -l)
         if [ $nerrors -ne 0 ]; then
             exit 125;

--- a/.github/workflows/clang-tidy-nvidia.yaml
+++ b/.github/workflows/clang-tidy-nvidia.yaml
@@ -58,9 +58,7 @@ jobs:
       run: |
         echo "Workspace: ${GITHUB_WORKSPACE}"
         cd ${GITHUB_WORKSPACE}
-        run-clang-tidy-${CLANG_VER} -p /tmp/ -header-filter='.*' \
-          -line-filter='[{"name":".*cuda/kernel/.*","lines":[[1,1000000]]}]' \
-          2>&1 | tee /tmp/clang_tidy.log
+        run-clang-tidy-${CLANG_VER} -p /tmp/ -header-filter='^(?!.*(${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/.*|${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/.*)).*$' 2>&1 | tee /tmp/clang_tidy.log
         nerrors=$(grep 'error:' /tmp/clang_tidy.log | wc -l)
         if [ $nerrors -ne 0 ]; then
             exit 125;

--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -5,8 +5,8 @@ on: [push, pull_request]
 env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
-  CLANG_VER: 12
-  ROCM_VER: 5.7.1
+  CLANG_VER: 17
+  ROCM_VER: 6.0
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
 jobs:
@@ -18,12 +18,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common gpg curl
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
-        sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VER} main"
+        sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main"
         sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear
     - name: Install extra dependencies
       run: |
-        curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/rocm-keyring.gpg
-        echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VER} jammy main" | sudo tee /etc/apt/sources.list.d/rocm.list
+        sudo mkdir -p /etc/apt/keyrings
+        curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/rocm.gpg
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VER} jammy main" | sudo tee /etc/apt/sources.list.d/rocm.list
+        echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
         echo 'export PATH=$PATH:/opt/rocm/bin' | sudo tee -a /etc/profile.d/rocm.sh
         sudo apt-get update
         sudo apt-get install -y rocm-hip-sdk
@@ -44,7 +46,7 @@ jobs:
       run: |
         echo "Workspace: ${GITHUB_WORKSPACE}"
         cd ${GITHUB_WORKSPACE}
-        run-clang-tidy-${CLANG_VER} -p /tmp/ -header-filter='^(?!.*(${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/.*|${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/.*|${GITHUB_WORKSPACE}/src/components/ec/rocm/kernel/.*|${GITHUB_WORKSPACE}/src/components/mc/rocm/kernel/.*)).*$' 2>&1 | tee /tmp/clang_tidy.log
+        run-clang-tidy-${CLANG_VER} -p /tmp/ -header-filter='^(?!.*(${GITHUB_WORKSPACE}/src/components/ec/rocm/kernel/.*|${GITHUB_WORKSPACE}/src/components/mc/rocm/kernel/.*)).*$' "^(?!.*\.cu$).*$" 2>&1 | tee /tmp/clang_tidy.log
         nerrors=$(grep 'error:' /tmp/clang_tidy.log | wc -l)
         if [ $nerrors -ne 0 ]; then
             exit 125;

--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -11,7 +11,7 @@ env:
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
 jobs:
   clang-tidy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install dependencies
       run: |

--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -6,7 +6,7 @@ env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
   CLANG_VER: 12
-  ROCM_VER: 5.6.1
+  ROCM_VER: 5.7.1
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
 jobs:
@@ -23,7 +23,8 @@ jobs:
     - name: Install extra dependencies
       run: |
         curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/rocm-keyring.gpg
-        echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/5.6.1 focal main' | sudo tee /etc/apt/sources.list.d/rocm.list
+        echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VER} jammy main" | sudo tee /etc/apt/sources.list.d/rocm.list
+        echo 'export PATH=$PATH:/opt/rocm/bin' | sudo tee -a /etc/profile.d/rocm.sh
         sudo apt-get update
         sudo apt-get install -y rocm-hip-sdk
     - name: Get UCX
@@ -38,15 +39,13 @@ jobs:
       run: |
         ./autogen.sh
         CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-rocm=/opt/rocm --with-rccl=/opt/rocm --enable-assert
-        bear --exclude ${GITHUB_WORKSPACE}/src/components/ec/rocm/kernel/ --exclude ${GITHUB_WORKSPACE}/src/components/mc/rocm/kernel/ --cdb /tmp/compile_commands.json make
+        bear --output /tmp/compile_commands.json -- make -j
     - name: Run clang-tidy
       run: |
         echo "Workspace: ${GITHUB_WORKSPACE}"
         cd ${GITHUB_WORKSPACE}
-        run-clang-tidy-${CLANG_VER} -p /tmp/ 2>&1 | tee /tmp/clang_tidy.log
+        run-clang-tidy-${CLANG_VER} -p /tmp/ -header-filter='^(?!.*(${GITHUB_WORKSPACE}/src/components/ec/cuda/kernel/.*|${GITHUB_WORKSPACE}/src/components/mc/cuda/kernel/.*|${GITHUB_WORKSPACE}/src/components/ec/rocm/kernel/.*|${GITHUB_WORKSPACE}/src/components/mc/rocm/kernel/.*)).*$' 2>&1 | tee /tmp/clang_tidy.log
         nerrors=$(grep 'error:' /tmp/clang_tidy.log | wc -l)
         if [ $nerrors -ne 0 ]; then
             exit 125;
         fi
-        make clean
-        rm -rf /tmp/ucc

--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -5,12 +5,10 @@ on: [push, pull_request]
 env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
-  CLANG_VER: 17
+  CLANG_VER: 20
   ROCM_VER: 5.6.1
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
-  ROCM_PATH: /opt/rocm
-  ROCM_DEVICE_LIB_PATH: /opt/rocm/amdgcn/bitcode
 jobs:
   clang-tidy:
     runs-on: ubuntu-22.04

--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -6,9 +6,11 @@ env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
   CLANG_VER: 17
-  ROCM_VER: 6.3
+  ROCM_VER: 5.6.1
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
+  ROCM_PATH: /opt/rocm
+  ROCM_DEVICE_LIB_PATH: /opt/rocm/amdgcn/bitcode
 jobs:
   clang-tidy:
     runs-on: ubuntu-22.04
@@ -16,22 +18,25 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common gpg curl
+        # Install basic dependencies
+        sudo apt-get install -y --no-install-recommends wget gpg
+        # Setup LLVM repository
         sudo mkdir -p /etc/apt/keyrings
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
         echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear
-    - name: Install extra dependencies
-      run: |
-        sudo mkdir -p /etc/apt/keyrings
+        # Setup ROCm repository
         wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | sudo gpg --dearmor -o /etc/apt/keyrings/rocm.gpg
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VER} jammy main" | sudo tee /etc/apt/sources.list.d/rocm.list
         echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
+        # Update PATH for ROCm
         echo 'export PATH=$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin' | sudo tee -a /etc/profile.d/rocm.sh
         source /etc/profile.d/rocm.sh
+        # Install all required packages
         sudo apt-get update
-        sudo apt-get install -y hip-base hip-runtime-amd hip-dev rocm-device-libs rccl-dev
+        sudo apt-get install -y --no-install-recommends \
+          clang-tidy-${CLANG_VER} \
+          bear \
+          rocm-hip-sdk
         sudo ln -sf /opt/rocm-${ROCM_VER} /opt/rocm
     - name: Get UCX
       run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
@@ -45,8 +50,9 @@ jobs:
       run: |
         ./autogen.sh
         # gfx1102 is the latest RDNA3 architecture
-        export HIPFLAGS="--offload-arch=gfx1102"
-        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-rocm=/opt/rocm --with-rccl=/opt/rocm --enable-assert CXXFLAGS="$HIPFLAGS" CFLAGS="$HIPFLAGS"
+        # export HIPFLAGS="--offload-arch=gfx1102"
+        # export HIPCC_COMPILE_FLAGS_APPEND="$HIPFLAGS"
+        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-rocm=/opt/rocm --with-rccl=/opt/rocm --enable-assert
         bear --output /tmp/compile_commands.json -- make -j
     - name: Run clang-tidy
       run: |

--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -28,9 +28,11 @@ jobs:
         wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | sudo gpg --dearmor -o /etc/apt/keyrings/rocm.gpg
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VER} jammy main" | sudo tee /etc/apt/sources.list.d/rocm.list
         echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
-        echo 'export PATH=$PATH:/opt/rocm/bin' | sudo tee -a /etc/profile.d/rocm.sh
+        echo 'export PATH=$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin' | sudo tee -a /etc/profile.d/rocm.sh
+        source /etc/profile.d/rocm.sh
         sudo apt-get update
-        sudo apt-get install -y rocm-hip-sdk
+        sudo apt-get install -y hip-base hip-runtime-amd hip-dev rocm-device-libs rccl-dev
+        sudo ln -sf /opt/rocm-${ROCM_VER} /opt/rocm
     - name: Get UCX
       run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
     - name: Build UCX
@@ -42,7 +44,9 @@ jobs:
     - name: Build UCC
       run: |
         ./autogen.sh
-        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-rocm=/opt/rocm --with-rccl=/opt/rocm --enable-assert
+        # gfx1102 is the latest RDNA3 architecture
+        export HIPFLAGS="--offload-arch=gfx1102"
+        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-rocm=/opt/rocm --with-rccl=/opt/rocm --enable-assert CXXFLAGS="$HIPFLAGS" CFLAGS="$HIPFLAGS"
         bear --output /tmp/compile_commands.json -- make -j
     - name: Run clang-tidy
       run: |

--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -6,7 +6,7 @@ env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
   CLANG_VER: 17
-  ROCM_VER: 6.0
+  ROCM_VER: 6.3
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
 jobs:
@@ -17,13 +17,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common gpg curl
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
-        sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main"
+        sudo mkdir -p /etc/apt/keyrings
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+        sudo apt-get update
         sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear
     - name: Install extra dependencies
       run: |
         sudo mkdir -p /etc/apt/keyrings
-        curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/rocm.gpg
+        wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | sudo gpg --dearmor -o /etc/apt/keyrings/rocm.gpg
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VER} jammy main" | sudo tee /etc/apt/sources.list.d/rocm.list
         echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
         echo 'export PATH=$PATH:/opt/rocm/bin' | sudo tee -a /etc/profile.d/rocm.sh

--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
-  CLANG_VER: 20
+  CLANG_VER: 17
   ROCM_VER: 5.6.1
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
@@ -47,9 +47,6 @@ jobs:
     - name: Build UCC
       run: |
         ./autogen.sh
-        # gfx1102 is the latest RDNA3 architecture
-        # export HIPFLAGS="--offload-arch=gfx1102"
-        # export HIPCC_COMPILE_FLAGS_APPEND="$HIPFLAGS"
         CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --with-rocm=/opt/rocm --with-rccl=/opt/rocm --enable-assert
         bear --output /tmp/compile_commands.json -- make -j
     - name: Run clang-tidy

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
-  CLANG_VER: 12
+  CLANG_VER: 17
 jobs:
   clang-tidy:
     runs-on: ubuntu-22.04
@@ -13,10 +13,13 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends wget lsb-core software-properties-common
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| sudo apt-key add -
-        sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VER} main"
-        sudo apt-get install -y --no-install-recommends doxygen doxygen-latex clang-tidy-${CLANG_VER} bear
+        sudo apt-get install -y --no-install-recommends wget gpg
+        # Setup LLVM repository
+        sudo mkdir -p /etc/apt/keyrings
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends clang-tidy-${CLANG_VER} bear
     - name: Get UCX
       run: git clone ${OPEN_UCX_LINK} -b ${OPEN_UCX_BRANCH} /tmp/ucx
     - name: Build UCX

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         ./autogen.sh
         CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./configure --prefix=/tmp/ucc/install --with-ucx=/tmp/ucx/install --enable-assert
-        bear --cdb /tmp/compile_commands.json make
+        bear --output /tmp/compile_commands.json -- make -j
     - name: Run clang-tidy
       run: |
         echo "Workspace: ${GITHUB_WORKSPACE}"

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -8,7 +8,7 @@ env:
   CLANG_VER: 12
 jobs:
   clang-tidy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install dependencies
       run: |

--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -6,7 +6,7 @@ env:
   GIT_CF: https://raw.githubusercontent.com/llvm/llvm-project/release/11.x/clang/tools/clang-format/git-clang-format
 jobs:
   check-codestyle:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Check code style
     steps:
     - name: Install dependencies

--- a/.github/workflows/hpcsdk.yaml
+++ b/.github/workflows/hpcsdk.yaml
@@ -1,17 +1,17 @@
-name: HPC_SDK
+name: NVIDIA HPC SDK
 
 on: [push, pull_request]
 
 env:
-  HPCXDIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2023/comm_libs/12.2/hpcx/latest/
-  NCCLDIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2023/comm_libs/12.2/nccl/
-  CUDADIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2023/cuda/12.2/
+  HPCXDIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2025/comm_libs/12.8/hpcx/latest/
+  NCCLDIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2025/comm_libs/12.8/nccl/
+  CUDADIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2025/cuda/12.8/
 
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: nvcr.io/nvidia/nvhpc:23.9-devel-cuda12.2-ubuntu22.04
+      image: nvcr.io/nvidia/nvhpc:25.3-devel-cuda12.8-ubuntu24.04
     steps:
     - name: Install dependencies
       run: |

--- a/.github/workflows/hpcsdk.yaml
+++ b/.github/workflows/hpcsdk.yaml
@@ -3,15 +3,15 @@ name: NVIDIA HPC SDK
 on: [push, pull_request]
 
 env:
-  HPCXDIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2025/comm_libs/12.8/hpcx/latest/
-  NCCLDIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2025/comm_libs/12.8/nccl/
-  CUDADIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2025/cuda/12.8/
+  HPCXDIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2025/comm_libs/12.6/hpcx/latest/
+  NCCLDIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2025/comm_libs/12.6/nccl/
+  CUDADIR: /opt/nvidia/hpc_sdk/Linux_x86_64/2025/cuda/12.6/
 
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: nvcr.io/nvidia/nvhpc:25.3-devel-cuda12.8-ubuntu24.04
+      image: nvcr.io/nvidia/nvhpc:25.1-devel-cuda12.6-ubuntu24.04
     steps:
     - name: Install dependencies
       run: |

--- a/.github/workflows/hpcsdk.yaml
+++ b/.github/workflows/hpcsdk.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update
-        apt-get install -y --no-install-recommends libiberty-dev
+        apt-get install -y --no-install-recommends libiberty-dev libibverbs-dev libumad-dev
     - uses: actions/checkout@v1
     - name: Build UCC
       run: |

--- a/.github/workflows/hpcsdk.yaml
+++ b/.github/workflows/hpcsdk.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update
-        apt-get install -y --no-install-recommends libiberty-dev libibverbs-dev libumad-dev
+        apt-get install -y --no-install-recommends libiberty-dev libibverbs-dev libibumad-dev
     - uses: actions/checkout@v1
     - name: Build UCC
       run: |

--- a/.github/workflows/hpcsdk.yaml
+++ b/.github/workflows/hpcsdk.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: nvcr.io/nvidia/nvhpc:23.9-devel-cuda12.2-ubuntu22.04
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: OpenMPI tests
 
 on: [push, pull_request]
 


### PR DESCRIPTION
## What
Updated:
- runner ubuntu versions to 22.04 
- clang to 17 both for compilation and tidy 
- nvhpc:25.1-devel-cuda12.6-ubuntu24.04 (latest requires more disk size)
- moved ASAN gtest out of clang tidy job
- hpcx-v2.22.1
- MLNX_OFED 24.10-2.1.8.0

## Why ?
According to https://github.com/actions/runner-images/issues/11101 ubuntu 20.04 deprecated and will be removed
