### PR TITLE
UTIL: Support for NVC in ucc_assume macro

### DIFF
--- a/src/utils/ucc_compiler_def.h
+++ b/src/utils/ucc_compiler_def.h
@@ -127,6 +127,8 @@ static inline ucs_status_t ucc_status_to_ucs_status(ucc_status_t status)
 
 #if defined(__clang__)
     #define ucc_assume(x) __builtin_assume(x)
+#elif defined(__NVCOMPILER)
+    #define ucc_assume(x) __builtin_assume(x)
 #elif defined(__GNUC__)
     #if (__GNUC__ >= 13)
         /* GCC 13+ has __attribute__((assume)) */


### PR DESCRIPTION
## What
Add support NVC in assume macro

## Why ?
Latest HPC SDK (nvcr.io/nvidia/nvhpc:25.1-devel-cuda12.6-ubuntu24.04) reports error 
`unknown attribute "assume" [unrecognized_attribute]`
