### PR TITLE
CL/HIER: Add flag for nonroot info

### DIFF
--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -163,7 +163,9 @@ typedef struct ucc_base_team_iface {
 } ucc_base_team_iface_t;
 
 enum {
-    UCC_BASE_CARGS_MAX_FRAG_COUNT = UCC_BIT(0)
+    UCC_BASE_CARGS_MAX_FRAG_COUNT = UCC_BIT(0),
+    /* Info is available on nonroot ranks */
+    UCC_BASE_CARGS_NONROOT_INFO   = UCC_BIT(1)
 };
 
 typedef struct ucc_buffer_info_asymmetric_memtype {
@@ -179,6 +181,7 @@ typedef struct ucc_base_coll_args {
     ucc_coll_args_t                      args;
     ucc_team_t                          *team;
     size_t                               max_frag_count;
+    /* For asymmetric mem types across ranks */
     ucc_buffer_info_asymmetric_memtype_t asymmetric_save_info;
 } ucc_base_coll_args_t;
 

--- a/src/components/cl/hier/allgatherv/allgatherv.c
+++ b/src/components/cl/hier/allgatherv/allgatherv.c
@@ -304,6 +304,8 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
             args.args.dst.info_v.displacements = node_disps;
             args.args.dst.info_v.counts        = node_counts;
             args.args.dst.info_v.buffer        = node_gathered_data;
+            /* Indicate to gatherv it can read the dst counts on nonroots */
+            args.mask                         |= UCC_BASE_CARGS_NONROOT_INFO;
         }
         UCC_CHECK_GOTO(
             ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]),


### PR DESCRIPTION
Adds flag for cl/hier to tell tl/shm gatherv nonroots they can check coll_args->dst.info_v to determine max msg size