### PR TITLE
CL/HIER: Remove per node leader, fix double free

### DIFF
--- a/src/components/cl/hier/allgatherv/unpack.c
+++ b/src/components/cl/hier/allgatherv/unpack.c
@@ -70,7 +70,6 @@ ucc_status_t ucc_cl_hier_allgatherv_unpack_start(ucc_coll_task_t *task)
     size_t                      dst_dt_size       = ucc_dt_size(
                                                     args->dst.info_v.datatype);
     ucc_rank_t                 *node_leaders      = NULL;
-    ucc_rank_t                 *per_node_leaders  = NULL;
     ucc_sbgp_t                 *all_nodes         = NULL;
     ucc_sbgp_t                 *node_leaders_sbgp = NULL;
     ucc_topo_t                 *topo              = task->team->params.team->topo;
@@ -93,7 +92,7 @@ ucc_status_t ucc_cl_hier_allgatherv_unpack_start(ucc_coll_task_t *task)
 
     // Get the node leaders
     UCC_CHECK_GOTO(
-        ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders),
+        ucc_topo_get_node_leaders(topo, &node_leaders),
         out, status);
     
     // Get the node leaders subgroup for proper rank mapping
@@ -125,7 +124,6 @@ ucc_status_t ucc_cl_hier_allgatherv_unpack_start(ucc_coll_task_t *task)
         src_rank_disp = ucc_coll_args_get_displacement(
             args, args->src.info_v.displacements, node_leader_idx);
 
-        ucc_assert(per_node_leaders[node_leader_idx] == leader_team_rank);
         for (ucc_rank_t j = 0; j < all_nodes[node_leader_idx].group_size; j++) {
             if (all_nodes[node_leader_idx].group_size == 1) {
                 // Node sbgp wont exist for just a single rank on a node

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -60,7 +60,6 @@ typedef struct ucc_topo {
                                           (ucc_team) ranking */
     ucc_rank_t  *node_leaders;        /*< array mapping each rank to its node leader in the original
                                           (ucc_team) ranking, initialized on demand */
-    ucc_rank_t  *per_node_leaders;    /*< array of node leaders per node, initialized on demand */
     ucc_subset_t set;     /*< subset of procs from the ucc_context_topo.
                          for ucc_team topo it is team->ctx_map */
     ucc_rank_t   min_ppn; /*< min ppn across the nodes for a team */
@@ -262,7 +261,6 @@ static inline ucc_rank_t ucc_topo_nnodes(ucc_topo_t *topo)
 /* Returns node leaders array - array that maps each rank to the TEAM RANK that 
    is the leader of that rank's node. Also returns per-node leaders array - array
    mapping node_id to the TEAM RANK of that node's leader */
-ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leaders_out,
-                                      ucc_rank_t **per_node_leaders_out);
+ucc_status_t ucc_topo_get_node_leaders(ucc_topo_t *topo, ucc_rank_t **node_leaders_out);
 
 #endif

--- a/test/gtest/core/test_topo.cc
+++ b/test/gtest/core/test_topo.cc
@@ -619,7 +619,6 @@ UCC_TEST_F(test_topo, node_leaders)
     ucc_subset_t     set;
     ucc_rank_t       i;
     ucc_rank_t      *node_leaders;
-    ucc_rank_t      *per_node_leaders;
     /* simulates world proc array: 2 nodes, 4 ranks per node */
     SET_PI(s, 0, 0xaaa, 0, 0);  // Node 0, rank 0
     SET_PI(s, 1, 0xaaa, 1, 1);  // Node 0, rank 1
@@ -640,7 +639,7 @@ UCC_TEST_F(test_topo, node_leaders)
     EXPECT_EQ(UCC_OK, ucc_topo_init(set, ctx_topo, &topo));
     topo->node_leader_rank_id = 0;
     EXPECT_EQ(2, topo->topo->nnodes);
-    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders));
+    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders));
 
     /* Verify node leaders array */
     // Node 0 ranks should point to rank 0 (first rank on node 0)
@@ -652,15 +651,11 @@ UCC_TEST_F(test_topo, node_leaders)
         EXPECT_EQ(4, node_leaders[i]);
     }
 
-    /* Verify per_node_leaders array */
-    EXPECT_EQ(0, per_node_leaders[0]); // Node 0 leader
-    EXPECT_EQ(4, per_node_leaders[1]); // Node 1 leader
-
     /* Test with node_leader_rank_id = 1 */
     ucc_topo_cleanup(topo);
     EXPECT_EQ(UCC_OK, ucc_topo_init(set, ctx_topo, &topo));
     topo->node_leader_rank_id = 1;
-    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders));
+    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders));
 
     /* Verify node leaders array */
     // Node 0 ranks should point to rank 1 (second rank on node 0)
@@ -671,10 +666,6 @@ UCC_TEST_F(test_topo, node_leaders)
     for (i = 4; i < 8; i++) {
         EXPECT_EQ(5, node_leaders[i]);
     }
-
-    /* Verify per_node_leaders array */
-    EXPECT_EQ(1, per_node_leaders[0]); // Node 0 leader
-    EXPECT_EQ(5, per_node_leaders[1]); // Node 1 leader
 
     /* Test with a subset of ranks */
     ucc_topo_cleanup(topo);
@@ -688,7 +679,7 @@ UCC_TEST_F(test_topo, node_leaders)
     /* Test subset with node_leader_rank_id = 0 */
     EXPECT_EQ(UCC_OK, ucc_topo_init(set, ctx_topo, &topo));
     topo->node_leader_rank_id = 0;
-    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders));
+    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders));
 
     /* Verify node leaders array for subset */
     // Ranks 0,1 (from node 0) should point to rank 0 (first rank on node 0)
@@ -698,15 +689,11 @@ UCC_TEST_F(test_topo, node_leaders)
     EXPECT_EQ(2, node_leaders[2]);
     EXPECT_EQ(2, node_leaders[3]);
 
-    /* Verify per_node_leaders array */
-    EXPECT_EQ(0, per_node_leaders[0]); // Node 0 leader
-    EXPECT_EQ(2, per_node_leaders[1]); // Node 1 leader
-
     /* Test subset with node_leader_rank_id = 1 */
     ucc_topo_cleanup(topo);
     EXPECT_EQ(UCC_OK, ucc_topo_init(set, ctx_topo, &topo));
     topo->node_leader_rank_id = 1;
-    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders, &per_node_leaders));
+    EXPECT_EQ(UCC_OK, ucc_topo_get_node_leaders(topo, &node_leaders));
 
     /* Verify node leaders array for subset */
     // Ranks 0,1 (from node 0) should point to rank 1 (second rank on node 0)
@@ -715,8 +702,4 @@ UCC_TEST_F(test_topo, node_leaders)
     // Ranks 2,3 (from node 1) should point to rank 3 (second rank on node 1)
     EXPECT_EQ(3, node_leaders[2]);
     EXPECT_EQ(3, node_leaders[3]);
-
-    /* Verify per_node_leaders array */
-    EXPECT_EQ(1, per_node_leaders[0]); // Node 0 leader
-    EXPECT_EQ(3, per_node_leaders[1]); // Node 1 leader
 }


### PR DESCRIPTION
This PR removes the per_node_leaders field on the topo since after updating the unpack function, it isn't used anymore. It also fixes a double-free issue with `all_nodes->[my_rank]->rank_map` being the same pointer as `(ucc_topo_get_sbgp(topo, UCC_SBGP_NODE)).rank_map`.