### PR TITLE
TOPO: Node ldr ordered by team

### DIFF
--- a/src/components/cl/hier/allgatherv/allgatherv.c
+++ b/src/components/cl/hier/allgatherv/allgatherv.c
@@ -69,53 +69,48 @@ static inline ucc_status_t find_leader_rank(ucc_base_team_t *team,
    dst buffer is contiguous */
 static inline ucc_status_t is_block_ordered(ucc_cl_hier_team_t *cl_team, int *ordered)
 {
-    ucc_topo_t *topo = cl_team->super.super.params.team->topo;
-    ucc_sbgp_t *sbgp;
-    int         is_block_ordered;
+    ucc_topo_t  *topo             = cl_team->super.super.params.team->topo;
+    ucc_sbgp_t  *all_nodes        = NULL;
+    int          is_block_ordered = 1;
+    int          n_nodes;
+    ucc_status_t status;
+    ucc_rank_t   prev_rank, curr_rank;
+    ucc_rank_t   i, j;
 
     if (cl_team->is_block_ordered != -1) {
         is_block_ordered = cl_team->is_block_ordered;
     } else {
-        sbgp = ucc_topo_get_sbgp(topo, UCC_SBGP_FULL_HOST_ORDERED);
-        is_block_ordered = ucc_ep_map_is_identity(&sbgp->map) ? 1 : 0;
+        status = ucc_topo_get_all_nodes(topo, &all_nodes, &n_nodes);
+        if (status != UCC_OK) {
+            return status;
+        }
+
+        // For each node, check if its ranks are consecutive in team order
+        for (i = 0; i < n_nodes; i++) {
+            if (all_nodes[i].status == UCC_SBGP_ENABLED
+                && all_nodes[i].group_size > 1) {
+                // Get first rank in this node
+                prev_rank = ucc_ep_map_eval(all_nodes[i].map, 0);
+
+                // Check if all other ranks are consecutive
+                for (j = 1; j < all_nodes[i].group_size; j++) {
+                    curr_rank = ucc_ep_map_eval(all_nodes[i].map, j);
+
+                    // If ranks are not consecutive, not block ordered
+                    if (curr_rank != prev_rank + 1) {
+                        is_block_ordered = 0;
+                        break;
+                    }
+                    prev_rank = curr_rank;
+                }
+            }
+        }
+
+        // Save for next time
         cl_team->is_block_ordered = is_block_ordered;
     }
 
     *ordered = is_block_ordered;
-
-    return UCC_OK;
-}
-
-/* Node leader subgroup is always ordered by ascending host_id. If the team's ranks are
-   not in the same order, then node leader subgroup allgatherv won't be enough, we'll
-   have to use a staging buffer and unpack to reorder each leader's contribution.
-   So, this func will check that the team ranks in the ldr sbgp are ascending */
-static inline ucc_status_t is_host_ordered(ucc_cl_hier_team_t *cl_team, int *ordered)
-{
-    int         is_host_ordered;
-    ucc_rank_t  max_rank, i, team_rank;
-
-    if (cl_team->is_host_ordered != -1) {
-        is_host_ordered = cl_team->is_host_ordered;
-    } else {
-        if (SBGP_EXISTS(cl_team, NODE_LEADERS)) {
-            is_host_ordered = 1;
-            max_rank = ucc_ep_map_eval(SBGP_MAP(cl_team, NODE_LEADERS), 0);
-            for (i = 1; i < SBGP_SIZE(cl_team, NODE_LEADERS); i++) {
-                team_rank = ucc_ep_map_eval(SBGP_MAP(cl_team, NODE_LEADERS), i);
-                if (team_rank < max_rank) {
-                    is_host_ordered = 0;
-                    break;
-                }
-                max_rank = team_rank;
-            }
-        } else {
-            is_host_ordered = 1;
-        }
-        cl_team->is_host_ordered = is_host_ordered;
-    }
-
-    *ordered = is_host_ordered;
 
     return UCC_OK;
 }
@@ -161,7 +156,7 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
     ucc_rank_t              team_rank;
     size_t                  leader_old_count;
     size_t                  add_count, new_count;
-    int                     block_ordered, host_ordered;
+    int                     block_ordered;
     int                     ldr_sbgp_only;
 
     memcpy(&args,     coll_args, sizeof(args));
@@ -183,8 +178,8 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
 
     n_tasks   = 0;
     UCC_CHECK_GOTO(is_block_ordered(cl_team, &block_ordered), free_sched, status);
-    UCC_CHECK_GOTO(is_host_ordered(cl_team, &host_ordered), free_sched, status);
-    is_contig = block_ordered && host_ordered && ucc_coll_args_is_disp_contig(&args.args, team_size);
+    is_contig = block_ordered && ucc_coll_args_is_disp_contig(&args.args, team_size);
+
     /* handle the case where this rank may be the only one on this node */
     ldr_sbgp_only = !SBGP_ENABLED(cl_team, NODE) && SBGP_ENABLED(cl_team, NODE_LEADERS);
     

--- a/src/components/cl/hier/allgatherv/allgatherv.c
+++ b/src/components/cl/hier/allgatherv/allgatherv.c
@@ -99,13 +99,14 @@ static inline ucc_status_t is_block_ordered(ucc_cl_hier_team_t *cl_team, int *or
                     // If ranks are not consecutive, not block ordered
                     if (curr_rank != prev_rank + 1) {
                         is_block_ordered = 0;
-                        break;
+                        goto break_outer;
                     }
                     prev_rank = curr_rank;
                 }
             }
         }
 
+break_outer:
         // Save for next time
         cl_team->is_block_ordered = is_block_ordered;
     }

--- a/src/components/cl/hier/allgatherv/allgatherv.h
+++ b/src/components/cl/hier/allgatherv/allgatherv.h
@@ -17,7 +17,7 @@ enum
 extern ucc_base_coll_alg_info_t
     ucc_cl_hier_allgatherv_algs[UCC_CL_HIER_ALLGATHERV_ALG_LAST + 1];
 
-#define UCC_CL_HIER_ALLGATHERV_DEFAULT_ALG_SELECT_STR "allgatherv:0-2k:host:@gab"
+#define UCC_CL_HIER_ALLGATHERV_DEFAULT_ALG_SELECT_STR "allgatherv:0-7864320:host:@gab"
 
 ucc_status_t ucc_cl_hier_allgatherv_init(ucc_base_coll_args_t *coll_args,
                                         ucc_base_team_t       *team,

--- a/src/components/cl/hier/allgatherv/allgatherv.h
+++ b/src/components/cl/hier/allgatherv/allgatherv.h
@@ -17,7 +17,7 @@ enum
 extern ucc_base_coll_alg_info_t
     ucc_cl_hier_allgatherv_algs[UCC_CL_HIER_ALLGATHERV_ALG_LAST + 1];
 
-#define UCC_CL_HIER_ALLGATHERV_DEFAULT_ALG_SELECT_STR "allgatherv:0-7864320:host:@gab"
+#define UCC_CL_HIER_ALLGATHERV_DEFAULT_ALG_SELECT_STR "allgatherv:0-8m:host:@gab"
 
 ucc_status_t ucc_cl_hier_allgatherv_init(ucc_base_coll_args_t *coll_args,
                                         ucc_base_team_t       *team,

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -107,7 +107,6 @@ typedef struct ucc_cl_hier_team {
     ucc_hier_sbgp_t          sbgps[UCC_HIER_SBGP_LAST];
     ucc_hier_sbgp_type_t     top_sbgp;
     int                      is_block_ordered;
-    int                      is_host_ordered;
 } ucc_cl_hier_team_t;
 UCC_CLASS_DECLARE(ucc_cl_hier_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -263,7 +263,6 @@ ucc_status_t ucc_cl_hier_team_create_test(ucc_base_team_t *cl_team)
     }
 
     team->is_block_ordered = -1;
-    team->is_host_ordered  = -1;
     team->n_tl_teams       =  0;
 
     /* TL teams are created: get scores and merge them to produce

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -174,6 +174,22 @@ ucc_status_t ucc_sbgp_create_node(ucc_topo_t *topo, ucc_sbgp_t *sbgp)
     return UCC_OK;
 }
 
+static int ucc_compare_nl_ranks(const void *a, const void *b)
+{
+    ucc_rank_t *r1 = (ucc_rank_t *)a;
+    ucc_rank_t *r2 = (ucc_rank_t *)b;
+
+    if(*r1 > *r2) {
+        return 1;
+    }
+    else if(*r1 == *r2) {
+        return 0;
+    }
+    else {
+        return -1;
+    }
+}
+
 static ucc_status_t sbgp_create_node_leaders(ucc_topo_t *topo, ucc_sbgp_t *sbgp,
                                              int ctx_nlr)
 {
@@ -294,6 +310,10 @@ static ucc_status_t sbgp_create_node_leaders(ucc_topo_t *topo, ucc_sbgp_t *sbgp,
             nl_array_1[n_node_leaders++] = nl_array_2[i];
         }
     }
+
+    /* order the node leader sbgp by team rank instead of host id */
+    qsort(nl_array_1, n_node_leaders, sizeof(ucc_rank_t), ucc_compare_nl_ranks);
+
 skip:
     ucc_free(nl_array_2);
 

--- a/src/components/topo/ucc_sbgp.c
+++ b/src/components/topo/ucc_sbgp.c
@@ -313,6 +313,15 @@ static ucc_status_t sbgp_create_node_leaders(ucc_topo_t *topo, ucc_sbgp_t *sbgp,
 
     /* order the node leader sbgp by team rank instead of host id */
     qsort(nl_array_1, n_node_leaders, sizeof(ucc_rank_t), ucc_compare_nl_ranks);
+    if (i_am_node_leader) {
+        for (i = 0; i < n_node_leaders; i++) {
+            // my index in nl_array_1 was swapped, find where it was swapped to
+            if (nl_array_1[i] == comm_rank) {
+                sbgp->group_rank = i;
+                break;
+            }
+        }
+    }
 
 skip:
     ucc_free(nl_array_2);


### PR DESCRIPTION
## What

This PR sorts the node leader subgroup rank mapping by team rank to avoid unnecessary unpacking in allgatherv. It also removes the `is_host_ordered` function in the allgatherv code, because it was previously checking whether or not the leaders were sorted by team rank. Now it always will be.

## Why ?

Previously the node leader subgroup was sorted by hostid, meaning that if a hostname happened to be lower than another hostname by the comparator that UCC uses, the node leader allgatherv step in my cl/hier allgatherv might actually be incorrect and need the extra unpack step to rearrange the buffer to have the right order.

Previous PR for reference here: https://github.com/openucx/ucc/pull/1103

## How ?
Sorts the rank mapping and updates group_rank. In addition to removing `is_host_ordered`, I also updated `is_block_ordered`, which previously checked if the FULL_ORDERED subgroup was the same as the current team. This  was a tighter restriction than it needed to be, since FULL_ORDERED also sorts by the socket, and the allgatherv only cares whether ranks are block ordered on each node.

## Data

https://docs.google.com/spreadsheets/d/1icnHUZFCYvThZ_bsZ3PS3fCL5HLG58fGrpViF25dHDY/edit?usp=sharing
