### PR TITLE
TL/CUDA: Topology Cache

### DIFF
--- a/src/components/tl/cuda/tl_cuda.c
+++ b/src/components/tl/cuda/tl_cuda.c
@@ -42,6 +42,11 @@ static ucc_config_field_t ucc_tl_cuda_lib_config_table[] = {
      "reduce_scatterv ring algorithms",
      ucc_offsetof(ucc_tl_cuda_lib_config_t, reduce_scatter_ring_max_rings),
      UCC_CONFIG_TYPE_ULUNITS},
+    
+    {"USE_TOPO_CACHE", "y",
+     "Use the NVLINK topology cache",
+     ucc_offsetof(ucc_tl_cuda_lib_config_t, use_topo_cache),
+     UCC_CONFIG_TYPE_BOOL},
 
     {NULL}};
 

--- a/src/components/tl/cuda/tl_cuda.c
+++ b/src/components/tl/cuda/tl_cuda.c
@@ -43,9 +43,9 @@ static ucc_config_field_t ucc_tl_cuda_lib_config_table[] = {
      ucc_offsetof(ucc_tl_cuda_lib_config_t, reduce_scatter_ring_max_rings),
      UCC_CONFIG_TYPE_ULUNITS},
     
-    {"USE_TOPO_CACHE", "y",
-     "Use the NVLINK topology cache",
-     ucc_offsetof(ucc_tl_cuda_lib_config_t, use_topo_cache),
+    {"TOPO_CACHE_ENABLE", "y",
+     "Enable NVLINK topology cache",
+     ucc_offsetof(ucc_tl_cuda_lib_config_t, topo_cache_enable),
      UCC_CONFIG_TYPE_BOOL},
 
     {NULL}};

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -83,7 +83,7 @@ typedef struct ucc_tl_cuda_lib_config {
     unsigned long       allgather_ring_max_rings;
     uint32_t            allgather_ring_num_chunks;
     unsigned long       reduce_scatter_ring_max_rings;
-    uint32_t            use_topo_cache;
+    uint32_t            topo_cache_enable;
 } ucc_tl_cuda_lib_config_t;
 
 typedef struct ucc_tl_cuda_context_config {

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -92,6 +92,7 @@ typedef struct ucc_tl_cuda_context_config {
 typedef struct ucc_tl_cuda_lib {
     ucc_tl_lib_t             super;
     ucc_tl_cuda_lib_config_t cfg;
+    ucc_tl_cuda_topo_t      *topo;  /* Shared topology information */
 } ucc_tl_cuda_lib_t;
 UCC_CLASS_DECLARE(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -83,6 +83,7 @@ typedef struct ucc_tl_cuda_lib_config {
     unsigned long       allgather_ring_max_rings;
     uint32_t            allgather_ring_num_chunks;
     unsigned long       reduce_scatter_ring_max_rings;
+    uint32_t            use_topo_cache;
 } ucc_tl_cuda_lib_config_t;
 
 typedef struct ucc_tl_cuda_context_config {

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -128,24 +128,6 @@ ucc_status_t ucc_tl_cuda_memh_pack(const ucc_base_context_t *context, /* NOLINT 
     return UCC_ERR_NOT_IMPLEMENTED;
 }
 
-ucc_status_t ucc_tl_cuda_mem_map(const ucc_base_context_t *context, /* NOLINT */
-                                 int type, void *memh, void *tl_h) /* NOLINT */
-{
-    return UCC_ERR_NOT_IMPLEMENTED;
-}
-
-ucc_status_t ucc_tl_cuda_mem_unmap(const ucc_base_context_t *context, /* NOLINT */
-                                   int type, void *tl_h) /* NOLINT */
-{
-    return UCC_ERR_NOT_IMPLEMENTED;
-}
-
-ucc_status_t ucc_tl_cuda_memh_pack(const ucc_base_context_t *context, /* NOLINT */
-                                   int type, void *memh, void **pack_buffer) /* NOLINT */
-{
-    return UCC_ERR_NOT_IMPLEMENTED;
-}
-
 /**
  * @brief Cleanup function for CUDA TL context
  * 
@@ -174,8 +156,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_context_t)
 
     // Only destroy topology if it's context-specific (not cached)
     // For cached topology, it will be destroyed when the library is cleaned up
-    if (self->topo != NULL &&
-        (!lib->cfg.use_topo_cache || self->topo != lib->topo)) {
+    if (self->topo != NULL && !lib->cfg.use_topo_cache) {
         ucc_tl_cuda_topo_destroy(self->topo);
         self->topo = NULL;
     }

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -63,7 +63,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
                             &ucc_coll_task_mpool_ops, params->thread_mode,
                             "tl_cuda_req_mp");
     if (status != UCC_OK) {
-        tl_error(self->super.super.lib, 
+        tl_error(self->super.super.lib,
                  "failed to initialize tl_cuda_req mpool");
         return status;
     }

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -71,7 +71,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
     CUDA_CHECK_GOTO(cudaGetDevice(&self->device), free_mpool, status);
 
     /* Handle CUDA topology initialization based on caching configuration */
-    if (lib->cfg.use_topo_cache && lib->topo != NULL) {
+    if (lib->cfg.topo_cache_enable && lib->topo != NULL) {
         /* If topology caching is enabled and a cached topology exists,
            reuse the existing topology from the library */
         self->topo = lib->topo;
@@ -80,7 +80,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
            - If caching is enabled: store in lib->topo for reuse
            - If caching is disabled: store in self->topo (context-specific) */
         ucc_tl_cuda_topo_t **topo_ptr =
-            lib->cfg.use_topo_cache ? &lib->topo : &self->topo;
+            lib->cfg.topo_cache_enable ? &lib->topo : &self->topo;
 
         /* Create new topology instance and store it in the appropriate location */
         status = ucc_tl_cuda_topo_create((const ucc_base_lib_t *)&lib->super,
@@ -156,7 +156,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_context_t)
 
     // Only destroy topology if it's context-specific (not cached)
     // For cached topology, it will be destroyed when the library is cleaned up
-    if (self->topo != NULL && !lib->cfg.use_topo_cache) {
+    if (self->topo != NULL && !lib->cfg.topo_cache_enable) {
         ucc_tl_cuda_topo_destroy(self->topo);
         self->topo = NULL;
     }

--- a/src/components/tl/cuda/tl_cuda_lib.c
+++ b/src/components/tl/cuda/tl_cuda_lib.c
@@ -32,12 +32,19 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *params,
     if (self->cfg.scratch_size < min_scratch_size) {
         self->cfg.scratch_size = min_scratch_size;
     }
+
+    /* Initialize topology pointer to NULL - will be lazily initialized */
+    self->topo = NULL;
+
     tl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_lib_t)
 {
+    if (self->topo) {
+        ucc_tl_cuda_topo_destroy(self->topo);
+    }
     tl_debug(&self->super, "finalizing lib object: %p", self);
 }
 


### PR DESCRIPTION
## What
  - Store topology in lib and reuse for context creation.
  - Fixed IPC cache leak. 
  - Improved logging. 
  - Added comments. 

  The topology information includes:
    - PCI device IDs
    - NVLink connections between GPUs
    - Device types (GPU or switch)
    - Link widths and counts

## Why ?
- Topology discovery is expensive (requires NVML calls)
- The topology rarely changes during runtime
- Multiple contexts can share the same topology information

## How ?

- When use_topo_cache is enabled (default):
  - The topology information is stored in `lib->topo` (library level)
  - If a cached topology exists `(lib->topo != NULL)`, it is reused for new contexts
  - If no cached topology exists, a new one is created and stored in lib->topo
- When use_topo_cache is disabled:
  - Each context gets its own topology instance stored in `self->topo`
  - No sharing/reuse of topology information between contexts