### PR TITLE
TL/CUDA: Alltoall(v) copy engine 

### DIFF
--- a/src/components/tl/cuda/alltoall/alltoall.c
+++ b/src/components/tl/cuda/alltoall/alltoall.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -36,6 +36,7 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
     ucc_coll_args_t    *args = &TASK_ARGS(task);
     ucc_status_t        status;
     size_t              data_len;
+    int                 i;
 
     task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
 
@@ -68,10 +69,14 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
     }
 
     if (lib->cfg.alltoall_use_copy_engine) {
-        ucc_debug("ucc_tl_cuda_alltoall_ce_init: using cuda copy engine");
+        ucc_debug("ucc_tl_cuda_alltoallv_ce_init: copy engine");
         task->alltoallv_ce.copy_post = cuda_copy_post;
+        task->alltoallv_ce.evtCompletions = (cudaEvent_t*)ucc_malloc(team->num_streams * sizeof(cudaEvent_t), "alltoallv_ce.evtCompletions");
+        for (i = 0; i < team->num_streams; i++) {
+            CUDA_CHECK_GOTO(cudaEventCreateWithFlags(&task->alltoallv_ce.evtCompletions[i], cudaEventDisableTiming), exit_err, status);
+        }
     } else {
-        ucc_debug("ucc_tl_cuda_alltoall_ce_init: executor");
+        ucc_debug("ucc_tl_cuda_alltoallv_ce_init: executor");
         task->alltoallv_ce.copy_post = ee_copy_post;
         task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
     }

--- a/src/components/tl/cuda/alltoall/alltoall_ce.c
+++ b/src/components/tl/cuda/alltoall/alltoall_ce.c
@@ -32,6 +32,7 @@ size_t ucc_tl_cuda_alltoall_get_offset(const ucc_tl_cuda_task_t *task,
 ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_tl_cuda_lib_t  *lib  = UCC_TL_CUDA_TEAM_LIB(team);
     ucc_coll_args_t    *args = &TASK_ARGS(task);
     ucc_status_t        status;
     size_t              data_len;
@@ -64,6 +65,15 @@ ucc_status_t ucc_tl_cuda_alltoall_ce_init(ucc_tl_cuda_task_t *task)
         if (ucc_unlikely(status != UCC_OK)) {
             goto exit_err;
         }
+    }
+
+    if (lib->cfg.alltoall_use_copy_engine) {
+        ucc_debug("ucc_tl_cuda_alltoall_ce_init: using cuda copy engine");
+        task->alltoallv_ce.copy_post = cuda_copy_post;
+    } else {
+        ucc_debug("ucc_tl_cuda_alltoall_ce_init: executor");
+        task->alltoallv_ce.copy_post = ee_copy_post;
+        task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
     }
 
     task->super.post           = ucc_tl_cuda_alltoallv_ce_start;

--- a/src/components/tl/cuda/alltoallv/alltoallv.h
+++ b/src/components/tl/cuda/alltoallv/alltoallv.h
@@ -24,4 +24,11 @@ ucc_status_t ucc_tl_cuda_alltoallv_init(ucc_base_coll_args_t *coll_args,
                                         ucc_base_team_t      *tl_team,
                                         ucc_coll_task_t     **task_p);
 
+ucc_status_t cuda_copy_post(void *dst, void *src, size_t len,
+                       ucc_ee_executor_t       *executor,
+                       ucc_ee_executor_task_t **task, cudaStream_t stream);
+
+ucc_status_t ee_copy_post(void *dst, void *src, size_t len,
+                       ucc_ee_executor_t       *executor,
+                       ucc_ee_executor_task_t **task, cudaStream_t stream);
 #endif

--- a/src/components/tl/cuda/alltoallv/alltoallv.h
+++ b/src/components/tl/cuda/alltoallv/alltoallv.h
@@ -24,11 +24,42 @@ ucc_status_t ucc_tl_cuda_alltoallv_init(ucc_base_coll_args_t *coll_args,
                                         ucc_base_team_t      *tl_team,
                                         ucc_coll_task_t     **task_p);
 
+/**
+ * @brief Post a copy operation using CUDA copy engine
+ * 
+ * This function posts a copy operation to be executed directly by the CUDA copy engine.
+ * The executor and task parameters are unused as the operation is handled by CUDA.
+ * The stream parameter is used to specify which CUDA stream should execute the copy.
+ *
+ * @param dst Destination buffer for the copy operation
+ * @param src Source buffer for the copy operation
+ * @param len Length of data to copy in bytes
+ * @param executor Unused - operation handled by CUDA copy engine
+ * @param task Unused - operation handled by CUDA copy engine
+ * @param stream CUDA stream to execute the copy operation
+ * @return UCC_OK on success, error code otherwise
+ */
 ucc_status_t cuda_copy_post(void *dst, void *src, size_t len,
                        ucc_ee_executor_t       *executor,
                        ucc_ee_executor_task_t **task, cudaStream_t stream);
 
+/**
+ * @brief Post a copy operation using the UCC executor
+ * 
+ * This function posts a copy operation to be executed by the UCC executor.
+ * The executor and task parameters are used to track the operation's progress.
+ * The stream parameter is unused as the executor manages its own execution context.
+ *
+ * @param dst Destination buffer for the copy operation
+ * @param src Source buffer for the copy operation
+ * @param len Length of data to copy in bytes
+ * @param executor UCC executor to handle the copy operation
+ * @param task Pointer to store the executor task handle
+ * @param stream Unused - executor manages its own execution context
+ * @return UCC_OK on success, error code otherwise
+ */
 ucc_status_t ee_copy_post(void *dst, void *src, size_t len,
                        ucc_ee_executor_t       *executor,
                        ucc_ee_executor_task_t **task, cudaStream_t stream);
+
 #endif

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Meta Platforms, Inc. and affiliates. 2022.
  *
  * See file LICENSE for terms.
@@ -20,29 +20,29 @@ enum {
     ALLTOALL_CE_STAGE_BAR,  /*< Wait for other ranks to finish */
 };
 
-//NOLINTNEXTLINE: stream is unused
+//NOLINTNEXTLINE(misc-unused-parameters): stream parameter unused as executor manages execution
 ucc_status_t ee_copy_post(void *dst, void *src, size_t len,
                        ucc_ee_executor_t       *executor,
                        ucc_ee_executor_task_t **task, cudaStream_t stream)
 {
     ucc_ee_executor_task_args_t exec_args = {0};
-    exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
-    exec_args.copy.dst  = dst;
-    exec_args.copy.src  = src;
-    exec_args.copy.len  = len;
+    exec_args.task_type                   = UCC_EE_EXECUTOR_TASK_COPY;
+    exec_args.copy.dst                    = dst;
+    exec_args.copy.src                    = src;
+    exec_args.copy.len                    = len;
     return ucc_ee_executor_task_post(executor, &exec_args, task);
 }
 
-//NOLINTNEXTLINE: executor, task, is unused
+//NOLINTNEXTLINE(misc-unused-parameters): executor and task unused as operation handled by CUDA
 ucc_status_t cuda_copy_post(void *dst, void *src, size_t len,
                        ucc_ee_executor_t       *executor,
                        ucc_ee_executor_task_t **task, cudaStream_t stream)
 {
     ucc_status_t status;
-
-    CUDA_CHECK_GOTO(cudaMemcpyAsync(dst, src, len, cudaMemcpyDeviceToDevice, stream), exit_err, status);
+    CUDA_CHECK_GOTO(
+        cudaMemcpyAsync(dst, src, len, cudaMemcpyDeviceToDevice, stream),
+        exit_err, status);
     return UCC_OK;
-
 exit_err:
     return status;
 }
@@ -175,11 +175,9 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
     ucc_tl_cuda_lib_t          *lib  = UCC_TL_CUDA_TEAM_LIB(team);
     ucc_rank_t                  rank = UCC_TL_TEAM_RANK(team);
     ucc_tl_cuda_sync_t         *sync = TASK_SYNC(task, rank);
-    // ucc_ee_executor_task_args_t exec_args = {0};
     ucc_tl_cuda_sync_t         *peer_sync;
     ucc_ee_executor_t          *exec;
     void                       *src, *dst;
-    // ucc_ee_executor_task_t    **exec_task;
     size_t                      data_size, data_displ;
     ucc_rank_t                  i, peer, psrc, pdst;
     ucc_status_t                status;
@@ -233,16 +231,10 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
             task, sync->alltoallv_ce.rdispl_bytes, peer);
         dst = PTR_OFFSET(task->alltoallv_ce.rbuf, data_displ);
 
-        // exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
-        // exec_args.copy.dst  = dst;
-        // exec_args.copy.src  = src;
-        // exec_args.copy.len  = data_size;
-        // exec_task =
-        //     &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
-        // status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
-
-        status = task->alltoallv_ce.copy_post(dst, src, data_size, exec, &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted], stream);
-        
+        status = task->alltoallv_ce.copy_post(
+            dst, src, data_size, exec,
+            &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted],
+            stream);
 
         if (ucc_unlikely(status != UCC_OK)) {
             goto exit;
@@ -270,16 +262,11 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
         data_displ = task->alltoallv_ce.get_offset(
             task, peer_sync->alltoallv_ce.rdispl_bytes, psrc);
         dst                 = PTR_OFFSET(dst, data_displ);
-        
-        // exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
-        // exec_args.copy.dst  = dst;
-        // exec_args.copy.src  = src;
-        // exec_args.copy.len  = data_size;
-        // exec_task =
-        //     &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
-        // status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
 
-        status = task->alltoallv_ce.copy_post(dst, src, data_size, exec, &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted], stream);
+        status = task->alltoallv_ce.copy_post(
+            dst, src, data_size, exec,
+            &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted],
+            stream);
 
         if (ucc_unlikely(status != UCC_OK)) {
             goto exit;
@@ -376,7 +363,6 @@ void ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task)
         task->alltoallv_ce.stage = ALLTOALL_CE_STAGE_COPY;
         /* fall through */
     case ALLTOALL_CE_STAGE_COPY:
-        
         if (lib->cfg.alltoall_use_copy_engine) {
             cudaError_t cuda_status =
                 cudaEventQuery(task->alltoallv_ce.evtCompletion);
@@ -413,7 +399,6 @@ void ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task)
                 task->alltoallv_ce.exec_task[i] = NULL;
             }
         }
-
         status =
             ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
         if (ucc_unlikely(status != UCC_OK)) {

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -171,17 +171,17 @@ exit_err:
 
 ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t         *team = TASK_TEAM(task);
-    ucc_tl_cuda_lib_t          *lib  = UCC_TL_CUDA_TEAM_LIB(team);
-    ucc_rank_t                  rank = UCC_TL_TEAM_RANK(team);
-    ucc_tl_cuda_sync_t         *sync = TASK_SYNC(task, rank);
-    ucc_tl_cuda_sync_t         *peer_sync;
-    ucc_ee_executor_t          *exec;
-    void                       *src, *dst;
-    size_t                      data_size, data_displ;
-    ucc_rank_t                  i, peer, psrc, pdst;
-    ucc_status_t                status;
-    cudaStream_t                stream;
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_tl_cuda_lib_t  *lib  = UCC_TL_CUDA_TEAM_LIB(team);
+    ucc_rank_t          rank = UCC_TL_TEAM_RANK(team);
+    ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
+    ucc_tl_cuda_sync_t *peer_sync;
+    ucc_ee_executor_t  *exec;
+    void               *src, *dst;
+    size_t              data_size, data_displ;
+    ucc_rank_t          i, peer, psrc, pdst;
+    ucc_status_t        status;
+    cudaStream_t        stream;
 
     if (task->alltoallv_ce.evtCompletion) {
         CUDA_CHECK_GOTO(cudaEventDestroy(task->alltoallv_ce.evtCompletion),

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -20,6 +20,33 @@ enum {
     ALLTOALL_CE_STAGE_BAR,  /*< Wait for other ranks to finish */
 };
 
+//NOLINTNEXTLINE: stream is unused
+ucc_status_t ee_copy_post(void *dst, void *src, size_t len,
+                       ucc_ee_executor_t       *executor,
+                       ucc_ee_executor_task_t **task, cudaStream_t stream)
+{
+    ucc_ee_executor_task_args_t exec_args = {0};
+    exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
+    exec_args.copy.dst  = dst;
+    exec_args.copy.src  = src;
+    exec_args.copy.len  = len;
+    return ucc_ee_executor_task_post(executor, &exec_args, task);
+}
+
+//NOLINTNEXTLINE: executor, task, is unused
+ucc_status_t cuda_copy_post(void *dst, void *src, size_t len,
+                       ucc_ee_executor_t       *executor,
+                       ucc_ee_executor_task_t **task, cudaStream_t stream)
+{
+    ucc_status_t status;
+
+    CUDA_CHECK_GOTO(cudaMemcpyAsync(dst, src, len, cudaMemcpyDeviceToDevice, stream), exit_err, status);
+    return UCC_OK;
+
+exit_err:
+    return status;
+}
+
 ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
@@ -104,7 +131,6 @@ ucc_status_t ucc_tl_cuda_alltoallv_setup_test(ucc_tl_cuda_task_t *task)
             status = UCC_ERR_NO_MESSAGE;
             goto exit_err;
         }
-
         status = ucc_tl_cuda_map_memhandle(
             peer_sync->mem_info_src.ptr, peer_sync->mem_info_src.length,
             peer_sync->mem_info_src.handle,
@@ -127,7 +153,6 @@ ucc_status_t ucc_tl_cuda_alltoallv_setup_test(ucc_tl_cuda_task_t *task)
             status = UCC_ERR_NO_MESSAGE;
             goto exit_err;
         }
-
         status = ucc_tl_cuda_map_memhandle(
             peer_sync->mem_info_dst.ptr, peer_sync->mem_info_dst.length,
             peer_sync->mem_info_dst.handle,
@@ -146,23 +171,42 @@ exit_err:
 
 ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t         *team      = TASK_TEAM(task);
-    ucc_rank_t                  rank      = UCC_TL_TEAM_RANK(team);
-    ucc_tl_cuda_sync_t         *sync      = TASK_SYNC(task, rank);
-    ucc_ee_executor_task_args_t exec_args = {0};
+    ucc_tl_cuda_team_t         *team = TASK_TEAM(task);
+    ucc_tl_cuda_lib_t          *lib  = UCC_TL_CUDA_TEAM_LIB(team);
+    ucc_rank_t                  rank = UCC_TL_TEAM_RANK(team);
+    ucc_tl_cuda_sync_t         *sync = TASK_SYNC(task, rank);
+    // ucc_ee_executor_task_args_t exec_args = {0};
     ucc_tl_cuda_sync_t         *peer_sync;
     ucc_ee_executor_t          *exec;
     void                       *src, *dst;
-    ucc_ee_executor_task_t    **exec_task;
+    // ucc_ee_executor_task_t    **exec_task;
     size_t                      data_size, data_displ;
     ucc_rank_t                  i, peer, psrc, pdst;
     ucc_status_t                status;
+    cudaStream_t                stream;
+
+    if (task->alltoallv_ce.evtCompletion) {
+        CUDA_CHECK_GOTO(cudaEventDestroy(task->alltoallv_ce.evtCompletion),
+                        exit, status);
+    }
+
+    CUDA_CHECK_GOTO(cudaEventCreateWithFlags(&task->alltoallv_ce.evtCompletion,
+                                             cudaEventDisableTiming),
+                    exit, status);
+
+    if (lib->cfg.alltoall_use_copy_engine) {
+        // copy engine is used, so no executor is needed
+        exec   = NULL;
+        stream = team->stream;
+    } else {
+        stream = 0;
+        status = ucc_coll_task_get_executor(&task->super, &exec);
+        if (ucc_unlikely(status != UCC_OK)) {
+            goto exit;
+        }
+    }
 
     task->alltoallv_ce.num_posted = 0;
-    status = ucc_coll_task_get_executor(&task->super, &exec);
-    if (ucc_unlikely(status != UCC_OK)) {
-        goto exit;
-    }
 
     for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
         peer = (rank + i) % UCC_TL_TEAM_SIZE(team);
@@ -189,13 +233,17 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
             task, sync->alltoallv_ce.rdispl_bytes, peer);
         dst = PTR_OFFSET(task->alltoallv_ce.rbuf, data_displ);
 
-        exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
-        exec_args.copy.dst  = dst;
-        exec_args.copy.src  = src;
-        exec_args.copy.len  = data_size;
-        exec_task =
-            &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
-        status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
+        // exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
+        // exec_args.copy.dst  = dst;
+        // exec_args.copy.src  = src;
+        // exec_args.copy.len  = data_size;
+        // exec_task =
+        //     &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
+        // status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
+
+        status = task->alltoallv_ce.copy_post(dst, src, data_size, exec, &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted], stream);
+        
+
         if (ucc_unlikely(status != UCC_OK)) {
             goto exit;
         }
@@ -222,18 +270,30 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
         data_displ = task->alltoallv_ce.get_offset(
             task, peer_sync->alltoallv_ce.rdispl_bytes, psrc);
         dst                 = PTR_OFFSET(dst, data_displ);
-        exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
-        exec_args.copy.dst  = dst;
-        exec_args.copy.src  = src;
-        exec_args.copy.len  = data_size;
-        exec_task =
-            &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
-        status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
+        
+        // exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
+        // exec_args.copy.dst  = dst;
+        // exec_args.copy.src  = src;
+        // exec_args.copy.len  = data_size;
+        // exec_task =
+        //     &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted];
+        // status = ucc_ee_executor_task_post(exec, &exec_args, exec_task);
+
+        status = task->alltoallv_ce.copy_post(dst, src, data_size, exec, &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted], stream);
+
         if (ucc_unlikely(status != UCC_OK)) {
             goto exit;
         }
         task->alltoallv_ce.num_posted++;
     }
+
+    if (lib->cfg.alltoall_use_copy_engine) {
+        // for copy engine, we need to record the event to the stream that would mark the completion of the copy 
+        CUDA_CHECK_GOTO(
+            cudaEventRecord(task->alltoallv_ce.evtCompletion, stream), exit,
+            status);
+    }
+
 exit:
     return status;
 }
@@ -283,6 +343,7 @@ void ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_tl_cuda_lib_t  *lib  = UCC_TL_CUDA_TEAM_LIB(team);
     ucc_status_t        status;
     int                 i;
 
@@ -315,21 +376,44 @@ void ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task)
         task->alltoallv_ce.stage = ALLTOALL_CE_STAGE_COPY;
         /* fall through */
     case ALLTOALL_CE_STAGE_COPY:
-        for (i = 0; i < task->alltoallv_ce.num_posted; i++) {
-            if (!task->alltoallv_ce.exec_task[i]) {
-                continue;
-            }
-            status = ucc_ee_executor_task_test(task->alltoallv_ce.exec_task[i]);
-            if (status != UCC_OK) {
-                if (status == UCC_OPERATION_INITIALIZED) {
-                    status = UCC_INPROGRESS;
-                }
-                task->super.status = status;
+        
+        if (lib->cfg.alltoall_use_copy_engine) {
+            cudaError_t cuda_status =
+                cudaEventQuery(task->alltoallv_ce.evtCompletion);
+            if (cuda_status == cudaSuccess) {
+                ucc_debug("cuda copy finished");
+                task->super.status = UCC_OK;
+            } else if (cuda_status == cudaErrorNotReady) {
+                // still in progress
+                task->super.status = UCC_INPROGRESS;
+                return;
+            } else {
+                ucc_error("error cudaEventQuery %s!",
+                          cudaGetErrorString(cuda_status));
+                task->super.status = UCC_ERR_NO_MESSAGE;
+                ucc_assert(0);
                 return;
             }
-            ucc_ee_executor_task_finalize(task->alltoallv_ce.exec_task[i]);
-            task->alltoallv_ce.exec_task[i] = NULL;
+        } else {
+            // copy engine scenario
+            for (i = 0; i < task->alltoallv_ce.num_posted; i++) {
+                if (!task->alltoallv_ce.exec_task[i]) {
+                    continue;
+                }
+                status =
+                    ucc_ee_executor_task_test(task->alltoallv_ce.exec_task[i]);
+                if (status != UCC_OK) {
+                    if (status == UCC_OPERATION_INITIALIZED) {
+                        status = UCC_INPROGRESS;
+                    }
+                    task->super.status = status;
+                    return;
+                }
+                ucc_ee_executor_task_finalize(task->alltoallv_ce.exec_task[i]);
+                task->alltoallv_ce.exec_task[i] = NULL;
+            }
         }
+
         status =
             ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), task->bar);
         if (ucc_unlikely(status != UCC_OK)) {
@@ -412,6 +496,7 @@ size_t ucc_tl_cuda_alltoallv_get_offset(const ucc_tl_cuda_task_t *task,
 ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
 {
     ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    ucc_tl_cuda_lib_t  *lib  = UCC_TL_CUDA_TEAM_LIB(team);
     ucc_coll_args_t    *args = &TASK_ARGS(task);
     ucc_status_t        status;
     size_t              data_len;
@@ -453,14 +538,22 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
         }
     }
 
-    task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
+    if (lib->cfg.alltoall_use_copy_engine) {
+        ucc_debug("ucc_tl_cuda_alltoallv_ce_init: copy engine");
+        task->alltoallv_ce.copy_post = cuda_copy_post;
+    } else {
+        ucc_debug("ucc_tl_cuda_alltoallv_ce_init: executor");
+        task->alltoallv_ce.copy_post = ee_copy_post;
+        task->super.flags |= UCC_COLL_TASK_FLAG_EXECUTOR;
+    }
+
     task->super.post           = ucc_tl_cuda_alltoallv_ce_start;
     task->super.triggered_post_setup =
-        ucc_tl_cuda_alltoallv_ce_triggered_post_setup;
+    ucc_tl_cuda_alltoallv_ce_triggered_post_setup;
+
     task->super.progress = ucc_tl_cuda_alltoallv_ce_progress;
     task->super.finalize = ucc_tl_cuda_alltoallv_ce_finalize;
     task->bar            = TASK_BAR(task);
-
     return UCC_OK;
 
 exit_err:

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -50,8 +50,21 @@ exit_err:
 ucc_status_t ucc_tl_cuda_alltoallv_ce_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
+    ucc_tl_cuda_team_t *team = TASK_TEAM(task);
+    int i;
 
     tl_trace(UCC_TASK_LIB(task), "finalizing task %p", task);
+    
+    // Clean up completion events
+    if (task->alltoallv_ce.evtCompletions) {
+        for (i = 0; i < team->num_streams; i++) {
+            if (task->alltoallv_ce.evtCompletions[i]) {
+                cudaEventDestroy(task->alltoallv_ce.evtCompletions[i]);
+            }
+        }
+        ucc_free(task->alltoallv_ce.evtCompletions);
+        task->alltoallv_ce.evtCompletions = NULL;
+    }
     ucc_tl_cuda_task_put(task);
     return UCC_OK;
 }
@@ -63,7 +76,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_setup_start(ucc_tl_cuda_task_t *task)
     ucc_status_t        status;
     ucc_coll_args_t    *args    = &TASK_ARGS(task);
     ucc_ee_h            ee      = task->super.ee;
-    cudaStream_t        stream  = (ee) ? (cudaStream_t)ee->ee_context : team->stream;
+    cudaStream_t        stream  = (ee) ? (cudaStream_t)ee->ee_context : TASK_STREAM(task); // TODO: stream 0?
 
     // For Alltoallv: copy counts and displ. to SHM for remote GPUs to access (if required)
     if (UCC_COLL_TYPE_ALLTOALLV == args->coll_type) {
@@ -111,7 +124,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_setup_test(ucc_tl_cuda_task_t *task)
     ucc_status_t                 status;
     ucc_rank_t                   i, dst;
     ucc_ee_h                     ee     = task->super.ee;
-    cudaStream_t                 stream = (ee) ? (cudaStream_t)ee->ee_context : team->stream;
+    cudaStream_t                 stream = (ee) ? (cudaStream_t)ee->ee_context : TASK_STREAM(task);
 
     status = ucc_tl_cuda_shm_barrier_test(UCC_TL_TEAM_RANK(team), task->bar);
     if (status != UCC_OK) {
@@ -175,6 +188,8 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
     ucc_tl_cuda_lib_t  *lib  = UCC_TL_CUDA_TEAM_LIB(team);
     ucc_rank_t          rank = UCC_TL_TEAM_RANK(team);
     ucc_tl_cuda_sync_t *sync = TASK_SYNC(task, rank);
+    int stream_idx           = 0;
+    int num_streams          = UCC_TL_CUDA_TEAM_NUM_STREAMS(team);
     ucc_tl_cuda_sync_t *peer_sync;
     ucc_ee_executor_t  *exec;
     void               *src, *dst;
@@ -183,19 +198,23 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
     ucc_status_t        status;
     cudaStream_t        stream;
 
-    if (task->alltoallv_ce.evtCompletion) {
-        CUDA_CHECK_GOTO(cudaEventDestroy(task->alltoallv_ce.evtCompletion),
-                        exit, status);
-    }
-
-    CUDA_CHECK_GOTO(cudaEventCreateWithFlags(&task->alltoallv_ce.evtCompletion,
-                                             cudaEventDisableTiming),
-                    exit, status);
-
     if (lib->cfg.alltoall_use_copy_engine) {
         // copy engine is used, so no executor is needed
         exec   = NULL;
-        stream = team->stream;
+        // First clean up any existing completion events
+        for (i = 0; i < num_streams; i++) {
+            if (task->alltoallv_ce.evtCompletions[i]) {
+                CUDA_CHECK_GOTO(cudaEventDestroy(task->alltoallv_ce.evtCompletions[i]),
+                                exit, status);
+                task->alltoallv_ce.evtCompletions[i] = NULL;
+            }
+        }
+        // Create new events for each stream
+        for (i = 0; i < num_streams; i++) {
+            CUDA_CHECK_GOTO(cudaEventCreateWithFlags(&task->alltoallv_ce.evtCompletions[i],
+                                                   cudaEventDisableTiming),
+                           exit, status);
+        }
     } else {
         stream = 0;
         status = ucc_coll_task_get_executor(&task->super, &exec);
@@ -231,6 +250,13 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
             task, sync->alltoallv_ce.rdispl_bytes, peer);
         dst = PTR_OFFSET(task->alltoallv_ce.rbuf, data_displ);
 
+        if (lib->cfg.alltoall_use_copy_engine) {
+            // Get the current stream
+            stream = UCC_TL_CUDA_TEAM_STREAM_IDX(team, stream_idx);
+            // Round-robin across available streams
+            stream_idx = (stream_idx + 1) % team->num_streams;
+        }
+        
         status = task->alltoallv_ce.copy_post(
             dst, src, data_size, exec,
             &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted],
@@ -263,6 +289,13 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
             task, peer_sync->alltoallv_ce.rdispl_bytes, psrc);
         dst                 = PTR_OFFSET(dst, data_displ);
 
+        if (lib->cfg.alltoall_use_copy_engine) {
+            // Get the current stream
+            stream = team->streams[stream_idx];
+            // Round-robin across available streams
+            stream_idx = (stream_idx + 1) % team->num_streams;
+        }
+
         status = task->alltoallv_ce.copy_post(
             dst, src, data_size, exec,
             &task->alltoallv_ce.exec_task[task->alltoallv_ce.num_posted],
@@ -275,10 +308,12 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
     }
 
     if (lib->cfg.alltoall_use_copy_engine) {
-        // for copy engine, we need to record the event to the stream that would mark the completion of the copy 
-        CUDA_CHECK_GOTO(
-            cudaEventRecord(task->alltoallv_ce.evtCompletion, stream), exit,
-            status);
+        // Record completion events for each stream
+        for (i = 0; i < team->num_streams; i++) {
+            CUDA_CHECK_GOTO(
+                cudaEventRecord(task->alltoallv_ce.evtCompletions[i], team->streams[i]), exit,
+                status);
+        }
     }
 
 exit:
@@ -364,24 +399,36 @@ void ucc_tl_cuda_alltoallv_ce_progress(ucc_coll_task_t *coll_task)
         /* fall through */
     case ALLTOALL_CE_STAGE_COPY:
         if (lib->cfg.alltoall_use_copy_engine) {
-            cudaError_t cuda_status =
-                cudaEventQuery(task->alltoallv_ce.evtCompletion);
-            if (cuda_status == cudaSuccess) {
-                ucc_debug("cuda copy finished");
+            int all_completed = 1;
+            int num_streams = team->num_streams;
+            for (i = 0; i < num_streams; i++) {
+                cudaError_t cuda_status =
+                    cudaEventQuery(task->alltoallv_ce.evtCompletions[i]);
+                if (cuda_status == cudaSuccess) {
+                    // This event is completed
+                    continue;
+                } else if (cuda_status == cudaErrorNotReady) {
+                    // This event is still in progress
+                    all_completed = 0;
+                    break;
+                } else {
+                    // Error occurred
+                    ucc_error("error cudaEventQuery %s!",
+                              cudaGetErrorString(cuda_status));
+                    task->super.status = UCC_ERR_NO_MESSAGE;
+                    ucc_assert(0);
+                    return;
+                }
+            }
+
+            if (all_completed) {
+                ucc_debug("all cuda copies finished");
                 task->super.status = UCC_OK;
-            } else if (cuda_status == cudaErrorNotReady) {
-                // still in progress
-                task->super.status = UCC_INPROGRESS;
-                return;
             } else {
-                ucc_error("error cudaEventQuery %s!",
-                          cudaGetErrorString(cuda_status));
-                task->super.status = UCC_ERR_NO_MESSAGE;
-                ucc_assert(0);
+                task->super.status = UCC_INPROGRESS;
                 return;
             }
         } else {
-            // copy engine scenario
             for (i = 0; i < task->alltoallv_ce.num_posted; i++) {
                 if (!task->alltoallv_ce.exec_task[i]) {
                     continue;
@@ -485,6 +532,7 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
     ucc_coll_args_t    *args = &TASK_ARGS(task);
     ucc_status_t        status;
     size_t              data_len;
+    int                 i;
 
     if (!UCC_COLL_ARGS_CONTIG_BUFFER(args)) {
         tl_debug(UCC_TL_TEAM_LIB(team), "Do not support non-contiguous buffer");
@@ -526,6 +574,10 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_init(ucc_tl_cuda_task_t *task)
     if (lib->cfg.alltoall_use_copy_engine) {
         ucc_debug("ucc_tl_cuda_alltoallv_ce_init: copy engine");
         task->alltoallv_ce.copy_post = cuda_copy_post;
+        task->alltoallv_ce.evtCompletions = (cudaEvent_t*)ucc_malloc(team->num_streams * sizeof(cudaEvent_t), "alltoallv_ce.evtCompletions");
+        for (i = 0; i < team->num_streams; i++) {
+            CUDA_CHECK_GOTO(cudaEventCreateWithFlags(&task->alltoallv_ce.evtCompletions[i], cudaEventDisableTiming), exit_err, status);
+        }
     } else {
         ucc_debug("ucc_tl_cuda_alltoallv_ce_init: executor");
         task->alltoallv_ce.copy_post = ee_copy_post;

--- a/src/components/tl/cuda/tl_cuda.c
+++ b/src/components/tl/cuda/tl_cuda.c
@@ -43,6 +43,11 @@ static ucc_config_field_t ucc_tl_cuda_lib_config_table[] = {
      ucc_offsetof(ucc_tl_cuda_lib_config_t, reduce_scatter_ring_max_rings),
      UCC_CONFIG_TYPE_ULUNITS},
 
+    {"ALLTOALL_USE_COPY_ENGINE", "y",
+     "Use copy engine for alltoallv",
+     ucc_offsetof(ucc_tl_cuda_lib_config_t, alltoall_use_copy_engine),
+     UCC_CONFIG_TYPE_BOOL},
+
     {NULL}};
 
 UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_cuda_lib_t, ucc_base_lib_t,

--- a/src/components/tl/cuda/tl_cuda.c
+++ b/src/components/tl/cuda/tl_cuda.c
@@ -48,6 +48,11 @@ static ucc_config_field_t ucc_tl_cuda_lib_config_table[] = {
      ucc_offsetof(ucc_tl_cuda_lib_config_t, alltoall_use_copy_engine),
      UCC_CONFIG_TYPE_BOOL},
 
+    {"NUM_STREAMS", "1",
+     "Number of CUDA streams to create per team",
+     ucc_offsetof(ucc_tl_cuda_lib_config_t, num_streams),
+     UCC_CONFIG_TYPE_UINT},
+
     {NULL}};
 
 UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_cuda_lib_t, ucc_base_lib_t,

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -37,6 +37,16 @@
 #define UCC_TL_CUDA_TEAM_CTX(_team)                                            \
     (ucc_derived_of((_team)->super.super.context, ucc_tl_cuda_context_t))
 
+/* For backward compatibility, map stream reference to the first stream */
+#define UCC_TL_CUDA_TEAM_STREAM(_team) ((_team)->streams[0])
+
+/* Get stream by index, or first stream if index is beyond num_streams */
+#define UCC_TL_CUDA_TEAM_STREAM_IDX(_team, _idx) \
+    ((_idx) < (_team)->num_streams ? (_team)->streams[_idx] : (_team)->streams[0])
+
+/* Get number of streams in the team */
+#define UCC_TL_CUDA_TEAM_NUM_STREAMS(_team) ((_team)->num_streams)
+
 #define UCC_TL_CUDA_TEAM_SYNC(_team, _rank, _id)                               \
     ({                                                                         \
         size_t _ctrl_size_rank =                                               \
@@ -80,6 +90,7 @@ typedef struct ucc_tl_cuda_lib_config {
     uint32_t            allgather_ring_num_chunks;
     unsigned long       reduce_scatter_ring_max_rings;
     int                 alltoall_use_copy_engine;
+    uint32_t            num_streams;    // Number of CUDA streams to create per team
 } ucc_tl_cuda_lib_config_t;
 
 typedef struct ucc_tl_cuda_context_config {
@@ -168,7 +179,8 @@ typedef struct ucc_tl_cuda_team {
     ucc_tl_cuda_sync_state_t  *sync_state;         // Tracks the task currently using the sync segment of shared memory, if free - 0
     ucc_tl_cuda_shm_barrier_t *bar;                // Pointer to the first barrier in an array of size [0; 2 * max_concurrent]. First max_concurrent barriers are for normal mode, the second one for active set mode
     ucc_tl_cuda_scratch_t      scratch;
-    cudaStream_t               stream;
+    cudaStream_t              *streams;            // Array of CUDA streams
+    uint32_t                   num_streams;        // Number of streams in the array
     ucc_tl_cuda_rank_id_t     *ids;
     ucc_team_oob_coll_t        oob;
     void                      *oob_req;
@@ -211,7 +223,7 @@ struct ucc_tl_cuda_task {
                                       ucc_ee_executor_t       *executor,
                                       ucc_ee_executor_task_t **task,
                                       cudaStream_t             stream);
-            cudaEvent_t          evtCompletion;
+            cudaEvent_t*          evtCompletions; // Array of CUDA events for each stream
         } alltoallv_ce;
         struct {
             int                     stage;

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -79,6 +79,7 @@ typedef struct ucc_tl_cuda_lib_config {
     unsigned long       allgather_ring_max_rings;
     uint32_t            allgather_ring_num_chunks;
     unsigned long       reduce_scatter_ring_max_rings;
+    int                 alltoall_use_copy_engine;
 } ucc_tl_cuda_lib_config_t;
 
 typedef struct ucc_tl_cuda_context_config {
@@ -206,6 +207,11 @@ struct ucc_tl_cuda_task {
                                ucc_rank_t block);
             size_t (*get_offset)(const ucc_tl_cuda_task_t *task,
                                  size_t *displ_bytes, ucc_rank_t block);
+            ucc_status_t (*copy_post)(void *dst, void *src, size_t len,
+                                      ucc_ee_executor_t       *executor,
+                                      ucc_ee_executor_task_t **task,
+                                      cudaStream_t             stream);
+            cudaEvent_t          evtCompletion;
         } alltoallv_ce;
         struct {
             int                     stage;

--- a/src/components/tl/cuda/tl_cuda_cache.h
+++ b/src/components/tl/cuda/tl_cuda_cache.h
@@ -23,7 +23,7 @@ typedef struct ucc_tl_cuda_cache_region {
 } ucc_tl_cuda_cache_region_t;
 
 typedef struct ucc_tl_cuda_cache {
-    pthread_rwlock_t  lock;       /**< protests the page table */
+    pthread_rwlock_t  lock;       /**< Protects the page table */
     ucs_pgtable_t     pgtable;    /**< Page table to hold the regions */
     char             *name;       /**< Name */
 } ucc_tl_cuda_cache_t;

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -31,6 +31,12 @@ extern const char
         UCC_TL_CUDA_TEAM_BARRIER(_team, (_task)->coll_id);                     \
     })
 
+#define TASK_STREAM(_task)                                                     \
+    ({                                                                         \
+        ucc_tl_cuda_team_t *_team = TASK_TEAM(_task);                          \
+        UCC_TL_CUDA_TEAM_STREAM_IDX(_team, (_task)->coll_id % _team->num_streams); \
+    })
+
 #define TASK_SCRATCH(_task, _rank)                                             \
     ({                                                                         \
         ucc_tl_cuda_team_t *_team = TASK_TEAM(_task);                          \

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -252,13 +252,15 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
                                            team->ids[i].scratch_info.handle,
                                            &team->scratch.rem[i],
                                            ucc_tl_cuda_get_cache(team, i));
-        memcpy(&team->scratch.rem_info[i], &team->ids[i].scratch_info,
-               sizeof(ucc_tl_cuda_mem_info_t));
         if (status != UCC_OK) {
+            tl_error(tl_team->context->lib, "failed to map memhandle");
             goto exit_err;
         }
+        ucc_print("map memhandle done %d", i);
+        memcpy(&team->scratch.rem_info[i], &team->ids[i].scratch_info,
+               sizeof(ucc_tl_cuda_mem_info_t));
     }
-
+    
     if (UCC_TL_TEAM_LIB(team)->log_component.log_level >= UCC_LOG_LEVEL_DEBUG) {
         ucc_tl_cuda_team_topo_print_proxies(&team->super, team->topo);
         ucc_tl_cuda_team_topo_print_rings(&team->super, team->topo);

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -31,7 +31,8 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_team_t, ucc_base_context_t *tl_context,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
 
     self->oob         = params->params.oob;
-    self->stream      = NULL;
+    self->streams     = NULL;
+    self->num_streams = lib->cfg.num_streams;
     self->topo        = NULL;
     self->scratch.loc = NULL;
 
@@ -173,12 +174,15 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_team_t)
         }
         ucc_free(self->ids);
     }
-    if (self->stream) {
-        st = cudaStreamDestroy(self->stream);
-        if (st != cudaSuccess) {
-            tl_warn(UCC_TL_TEAM_LIB(self), "cudaStreamDestroy failed: %d (%s)",
-                    st, cudaGetErrorName(st));
+    if (self->streams) {
+        for (i = 0; i < self->num_streams; i++) {
+            st = cudaStreamDestroy(self->streams[i]);
+            if (st != cudaSuccess) {
+                tl_warn(UCC_TL_TEAM_LIB(self), "cudaStreamDestroy failed: %d (%s)",
+                        st, cudaGetErrorName(st));
+            }
         }
+        ucc_free(self->streams);
     }
     for (i = 0; i < UCC_TL_TEAM_SIZE(self); i++) {
         if (self->scratch.rem[i]) {
@@ -232,7 +236,7 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
     team->oob_req = (void*)0x1;
 
     for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
-           team->scratch.rem[i] = NULL;
+        team->scratch.rem[i] = NULL;
     }
 
     status = ucc_tl_cuda_team_topo_create(&team->super, &team->topo);
@@ -286,14 +290,27 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
     team->sync_state = (ucc_tl_cuda_sync_state_t*)PTR_OFFSET(team->bar,
                             sizeof(ucc_tl_cuda_shm_barrier_t) *
                             resource_num);
-    CUDA_CHECK_GOTO(cudaStreamCreateWithFlags(&team->stream,
-                    cudaStreamNonBlocking), exit_err, status);
+    
+    /* Allocate memory for the array of CUDA streams */
+    team->streams = ucc_malloc(team->num_streams * sizeof(cudaStream_t), "cuda_streams");
+    if (!team->streams) {
+        tl_error(tl_team->context->lib, "failed to allocate memory for CUDA streams");
+        status = UCC_ERR_NO_MEMORY;
+        goto exit_err;
+    }
+    
+    /* Create all CUDA streams */
+    for (i = 0; i < team->num_streams; i++) {
+        CUDA_CHECK_GOTO(cudaStreamCreateWithFlags(&team->streams[i],
+                        cudaStreamNonBlocking), free_streams, status);
+    }
+    
     for (i = 0; i < resource_num; i++) {
         sync = UCC_TL_CUDA_TEAM_SYNC(team, UCC_TL_TEAM_RANK(team), i);
         CUDA_CHECK_GOTO(cudaEventCreateWithFlags(&sync->ipc_event_local,
                                                 cudaEventDisableTiming |
                                                 cudaEventInterprocess),
-                        exit_err, status);
+                        free_streams, status);
         CUDA_CHECK_GOTO(cudaIpcGetEventHandle(&sync->ev_handle,
                                              sync->ipc_event_local),
                         exit_err, status);
@@ -304,8 +321,21 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
     status = ucc_tl_cuda_shm_barrier_start(UCC_TL_TEAM_RANK(team), bar);
     if (status != UCC_OK) {
         tl_error(tl_team->context->lib, "failed to start shm barrier");
-        goto exit_err;
+        goto free_streams;
     }
+    
+    goto barrier;
+
+free_streams:
+    /* Error handling for stream creation failure */
+    if (team->streams) {
+        for (j = 0; j < team->num_streams; j++) {
+            cudaStreamDestroy(team->streams[j]);
+        }
+        ucc_free(team->streams);
+        team->streams = NULL;
+    }
+    goto exit_err;
 
 barrier:
     bar = UCC_TL_CUDA_TEAM_BARRIER(team, 0);
@@ -313,7 +343,7 @@ barrier:
     if (status == UCC_INPROGRESS) {
         return status;
     } else if (status != UCC_OK) {
-        goto exit_err;
+        goto free_streams;
     }
 
     for (i = 0; i < resource_num; i++) {
@@ -324,8 +354,8 @@ barrier:
             }
             peer_sync = UCC_TL_CUDA_TEAM_SYNC(team, j, i);
             CUDA_CHECK_GOTO(cudaIpcOpenEventHandle(&sync->data[j].ipc_event_remote,
-                                                   peer_sync->ev_handle),
-                            exit_err, status);
+                                                  peer_sync->ev_handle),
+                           free_streams, status);
         }
     }
     team->oob_req = NULL;


### PR DESCRIPTION
## What
Split all-to-all implementation into two flows:

- Executor (kernel-based)
- Copy engine (CUDA memcpyAsync)
Added ability to control the number of streams that UCC creates within the TL/CUDA teams, distributing copies among different streams in a round-robin fashion.

## Why ?
- executor is kernel based and consumes SM
- copy engine implementation is SM free (only query event status during progress)

## How ?
