### PR TITLE
TL/MLX5: recover from ipoib issue in mcast init

### DIFF
--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_team.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_team.c
@@ -121,7 +121,6 @@ ucc_status_t ucc_tl_mlx5_mcast_team_init(ucc_base_context_t *base_context,
 
     comm->mcast.rcq = ibv_create_cq(mcast_context->ctx, comm->params.rx_depth, NULL, NULL, 0);
     if (!comm->mcast.rcq) {
-        ibv_dereg_mr(comm->grh_mr);
         tl_error(mcast_context->lib, "could not create recv cq, rx_depth %d, errno %d",
                   comm->params.rx_depth, errno);
         status = UCC_ERR_NO_RESOURCE;
@@ -130,7 +129,6 @@ ucc_status_t ucc_tl_mlx5_mcast_team_init(ucc_base_context_t *base_context,
 
     comm->mcast.scq = ibv_create_cq(mcast_context->ctx, comm->params.sx_depth, NULL, NULL, 0);
     if (!comm->mcast.scq) {
-        ibv_dereg_mr(comm->grh_mr);
         ibv_destroy_cq(comm->mcast.rcq);
         tl_error(mcast_context->lib, "could not create send cq, sx_depth %d, errno %d",
                   comm->params.sx_depth, errno);

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -196,11 +196,6 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
 
                 if (tl_team->local_mcast_team_ready) {
                     comm = tl_team->mcast->mcast_comm;
-                    /* release the resources */
-                    if (ibv_dereg_mr(comm->grh_mr)) {
-                        tl_warn(UCC_TL_TEAM_LIB(tl_team),
-                                "ibv_dereg_mr failed");
-                    }
                     if (ibv_destroy_cq(comm->mcast.rcq)) {
                         tl_warn(UCC_TL_TEAM_LIB(tl_team),
                                 "ibv_destroy_cq failed");


### PR DESCRIPTION
TL/MLX5: Recover from ipoib failure in mcast init and it avoids a segfault. It removes the unnecessary dereg function as registration has not happened before we fail here.