### PR TITLE
TL/UCP: fix allreduce knomial data consistency

### DIFF
--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -213,6 +213,17 @@ ucc_knomial_pattern_get_base_rank(ucc_knomial_pattern_t *p, ucc_rank_t rank)
     }
 }
 
+/* return the index of rank in the loop assuming smallest rank has index 0 */
+static inline ucc_kn_radix_t
+ucc_knomial_pattern_get_loop_index(ucc_knomial_pattern_t *p, ucc_rank_t rank)
+{
+    ucc_rank_t base_rank = ucc_knomial_pattern_get_base_rank(p, rank);
+    ucc_rank_t rank0 = ucc_knomial_pattern_loop_rank(p, base_rank);
+    ucc_rank_t cur_rank = ucc_knomial_pattern_loop_rank(p, rank);
+
+    return (cur_rank - rank0) / p->radix_pow;
+}
+
 static inline void
 ucc_knomial_pattern_next_iteration(ucc_knomial_pattern_t *p)
 {

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -125,6 +125,7 @@ typedef struct ucc_tl_ucp_task {
             int                     phase;
             ucc_knomial_pattern_t   p;
             void                   *scratch;
+            void                   *reduce_bufs[UCC_EE_EXECUTOR_NUM_BUFS];
             ucc_mc_buffer_header_t *scratch_mc_header;
             ucc_ee_executor_task_t *etask;
             ucc_ee_executor_t      *executor;

--- a/src/utils/ucc_dt_reduce.h
+++ b/src/utils/ucc_dt_reduce.h
@@ -6,6 +6,7 @@
 #ifndef UCC_DT_REDUCE_H_
 #define UCC_DT_REDUCE_H_
 
+#include "components/ec/base/ucc_ec_base.h"
 #include "components/mc/ucc_mc.h"
 #include "components/ec/ucc_ec.h"
 
@@ -67,6 +68,44 @@ static inline ucc_status_t ucc_dt_reduce(void *src1, void *src2, void *dst,
 {
     return ucc_dt_reduce_strided(src1, src2, dst, 1, count, 0, dt, args, flags,
                                  alpha, exec, task);
+}
+
+static inline ucc_status_t ucc_dt_reduce_multi(void **srcs, void *dst,
+                                               size_t n_srcs,
+                                               size_t count, ucc_datatype_t dt,
+                                               ucc_coll_args_t *args,
+                                               uint16_t flags, double alpha,
+                                               ucc_ee_executor_t *exec,
+                                               ucc_ee_executor_task_t **task)
+{
+    ucc_ee_executor_task_args_t eargs;
+
+    ucc_assert(n_srcs <= UCC_EE_EXECUTOR_NUM_BUFS);
+    if (count == 0 || n_srcs == 0) {
+        *task = NULL;
+        return UCC_OK;
+    }
+
+    if (!UCC_DT_IS_PREDEFINED(dt)) {
+        ucc_assert(UCC_DT_HAS_REDUCE(dt));
+        *task = NULL;
+        return ucc_dt_reduce_userdefined(srcs, NULL, dst, n_srcs, count, 0,
+                                         ucc_dt_to_generic(dt));
+    } else {
+        eargs.task_type = UCC_EE_EXECUTOR_TASK_REDUCE;
+        eargs.flags = flags;
+        eargs.reduce.alpha = alpha;
+        eargs.reduce.count = count;
+        eargs.reduce.dt = dt;
+        eargs.reduce.op = args->op;
+        eargs.reduce.dst = dst;
+        eargs.reduce.n_srcs = n_srcs;
+        for (size_t i = 0; i < n_srcs; i++) {
+            eargs.reduce.srcs[i] = srcs[i];
+        }
+
+        return ucc_ee_executor_task_post(exec, &eargs, task);
+    }
 }
 
 #endif


### PR DESCRIPTION
## What
Allreduce knomial relies on  associativity property of reduce operations, however it does different reduction order on different ranks which is not allowed according to MPI standard. This PR fixes this issues

## How ?
Sort reduce buffers by their knomial group index at every iteration before doing reduce operation.