### PR TITLE
EC/ROCM: Include stdbool.h for new versions of ROCM

### DIFF
--- a/src/components/ec/rocm/ec_rocm_executor_interruptible.c
+++ b/src/components/ec/rocm/ec_rocm_executor_interruptible.c
@@ -5,6 +5,7 @@
  * See file LICENSE for terms.
  */
 
+#include <stdbool.h>
 #include "ec_rocm_executor.h"
 #include "components/mc/ucc_mc.h"
 #include "components/ec/ucc_ec.h"


### PR DESCRIPTION
## What
This PR includes stdbool.h in a rocm file.

## Why ?
In ROCM 7.0 Hip is removing some library inclusions. This will allow usage of `bool`
