### PR TITLE
TL/CUDA: NVLink SHARP (NVLS) Allreduce

### DIFF
--- a/src/coll_score/ucc_coll_score.c
+++ b/src/coll_score/ucc_coll_score.c
@@ -688,7 +688,7 @@ static ucc_status_t ucc_coll_score_parse_str(const char *str,
         }
         /* if we get there then we could not match token to any field */
         status = UCC_ERR_INVALID_PARAM;
-
+        ucc_error("failed to parse token \'%s\' in \'%s\'", tokens[i], str);
         //TODO add parsing of msg ranges and team size ranges
         goto out;
     }

--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -48,7 +48,12 @@ reduce_scatterv =                            \
 	reduce_scatterv/reduce_scatterv.h        \
 	reduce_scatterv/reduce_scatterv.c        \
 	reduce_scatterv/reduce_scatterv_ring.c   \
-	reduce_scatterv/reduce_scatterv_linear.c	
+	reduce_scatterv/reduce_scatterv_linear.c
+
+allreduce =                    \
+	allreduce/allreduce.h      \
+	allreduce/allreduce.c      \
+	allreduce/allreduce_nvls.c
 
 sources =               \
 	tl_cuda.h           \
@@ -65,6 +70,7 @@ sources =               \
 	$(alltoall)         \
 	$(alltoallv)        \
 	$(bcast)            \
+	$(allreduce)        \
 	$(reduce_scatter)   \
 	$(reduce_scatterv)
 

--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -53,7 +53,7 @@ allreduce =                    \
 if TL_CUDA_NVLS_ENABLED
 reduce_scatter += reduce_scatter/reduce_scatter_nvls.c
 
-allreduce += llreduce/allreduce_nvls.c
+allreduce += allreduce/allreduce_nvls.c
 endif
 
 sources =               \

--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -40,20 +40,21 @@ reduce_scatter =                           \
 	reduce_scatter/reduce_scatter_ring.c   \
 	reduce_scatter/reduce_scatter_linear.c
 
-if TL_CUDA_NVLS_ENABLED
-reduce_scatter += reduce_scatter/reduce_scatter_nvls.c
-endif
-
 reduce_scatterv =                            \
 	reduce_scatterv/reduce_scatterv.h        \
 	reduce_scatterv/reduce_scatterv.c        \
 	reduce_scatterv/reduce_scatterv_ring.c   \
 	reduce_scatterv/reduce_scatterv_linear.c
 
+if TL_CUDA_NVLS_ENABLED
+reduce_scatter += reduce_scatter/reduce_scatter_nvls.c
+
 allreduce =                    \
 	allreduce/allreduce.h      \
 	allreduce/allreduce.c      \
 	allreduce/allreduce_nvls.c
+
+endif
 
 sources =               \
 	tl_cuda.h           \

--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -46,14 +46,14 @@ reduce_scatterv =                            \
 	reduce_scatterv/reduce_scatterv_ring.c   \
 	reduce_scatterv/reduce_scatterv_linear.c
 
+allreduce =                    \
+	allreduce/allreduce.h      \
+	allreduce/allreduce.c
+
 if TL_CUDA_NVLS_ENABLED
 reduce_scatter += reduce_scatter/reduce_scatter_nvls.c
 
-allreduce =                    \
-	allreduce/allreduce.h      \
-	allreduce/allreduce.c      \
-	allreduce/allreduce_nvls.c
-
+allreduce += llreduce/allreduce_nvls.c
 endif
 
 sources =               \

--- a/src/components/tl/cuda/allreduce/allreduce.c
+++ b/src/components/tl/cuda/allreduce/allreduce.c
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "allreduce.h"
+#include "tl_cuda.h"
+#include "utils/ucc_coll_utils.h"
+
+ucc_base_coll_alg_info_t
+    ucc_tl_cuda_allreduce_algs[UCC_TL_CUDA_ALLREDUCE_ALG_LAST + 1] = {
+        [UCC_TL_CUDA_ALLREDUCE_ALG_NVLS] = {.id =
+                                                UCC_TL_CUDA_ALLREDUCE_ALG_NVLS,
+                                            .name = "nvls",
+                                            .desc = "NVLINK SHARP allreduce"},
+        [UCC_TL_CUDA_ALLREDUCE_ALG_LAST] = {
+            .id = 0, .name = NULL, .desc = NULL}};
+
+ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
+                                        ucc_base_team_t      *team,
+                                        ucc_coll_task_t     **task_h)
+{
+    ucc_tl_cuda_team_t *tl_team = ucc_derived_of(team, ucc_tl_cuda_team_t);
+    ucc_tl_cuda_task_t *task;
+    ucc_status_t        status;
+
+    task = ucc_tl_cuda_task_get(tl_team);
+    if (ucc_unlikely(!task)) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    status = ucc_coll_task_init(&task->super, coll_args, &tl_team->super.super);
+    if (ucc_unlikely(status != UCC_OK)) {
+        ucc_tl_cuda_task_put(task);
+        return status;
+    }
+
+    /* Use NVLS algorithm as default */
+    status = ucc_tl_cuda_allreduce_nvls_init(coll_args, team, task_h);
+    if (ucc_unlikely(status != UCC_OK)) {
+        ucc_tl_cuda_task_put(task);
+    }
+
+    return status;
+}
+
+

--- a/src/components/tl/cuda/allreduce/allreduce.c
+++ b/src/components/tl/cuda/allreduce/allreduce.c
@@ -42,6 +42,8 @@ ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
     if (ucc_unlikely(status != UCC_OK)) {
         ucc_tl_cuda_task_put(task);
     }
+#else
+    (void) task;
 #endif /* ENABLE_NVLS */
 
     return status;

--- a/src/components/tl/cuda/allreduce/allreduce.c
+++ b/src/components/tl/cuda/allreduce/allreduce.c
@@ -44,5 +44,3 @@ ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
 
     return status;
 }
-
-

--- a/src/components/tl/cuda/allreduce/allreduce.c
+++ b/src/components/tl/cuda/allreduce/allreduce.c
@@ -22,8 +22,8 @@ ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
                                         ucc_coll_task_t     **task_h)
 {
     ucc_tl_cuda_team_t *tl_team = ucc_derived_of(team, ucc_tl_cuda_team_t);
+    ucc_status_t        status  = UCC_ERR_NOT_IMPLEMENTED;
     ucc_tl_cuda_task_t *task;
-    ucc_status_t        status;
 
     task = ucc_tl_cuda_task_get(tl_team);
     if (ucc_unlikely(!task)) {
@@ -36,11 +36,13 @@ ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
         return status;
     }
 
+#ifdef ENABLE_NVLS
     /* Use NVLS algorithm as default */
     status = ucc_tl_cuda_allreduce_nvls_init(coll_args, team, task_h);
     if (ucc_unlikely(status != UCC_OK)) {
         ucc_tl_cuda_task_put(task);
     }
+#endif /* ENABLE_NVLS */
 
     return status;
 }

--- a/src/components/tl/cuda/allreduce/allreduce.c
+++ b/src/components/tl/cuda/allreduce/allreduce.c
@@ -43,7 +43,7 @@ ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
         ucc_tl_cuda_task_put(task);
     }
 #else
-    (void) task;
+    (void) task_h;
 #endif /* ENABLE_NVLS */
 
     return status;

--- a/src/components/tl/cuda/allreduce/allreduce.c
+++ b/src/components/tl/cuda/allreduce/allreduce.c
@@ -21,8 +21,9 @@ ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
                                         ucc_base_team_t      *team,
                                         ucc_coll_task_t     **task_h)
 {
-    ucc_tl_cuda_team_t *tl_team = ucc_derived_of(team, ucc_tl_cuda_team_t);
     ucc_status_t        status  = UCC_ERR_NOT_IMPLEMENTED;
+#ifdef ENABLE_NVLS
+    ucc_tl_cuda_team_t *tl_team = ucc_derived_of(team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_task_t *task;
 
     task = ucc_tl_cuda_task_get(tl_team);
@@ -36,13 +37,14 @@ ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
         return status;
     }
 
-#ifdef ENABLE_NVLS
     /* Use NVLS algorithm as default */
     status = ucc_tl_cuda_allreduce_nvls_init(coll_args, team, task_h);
     if (ucc_unlikely(status != UCC_OK)) {
         ucc_tl_cuda_task_put(task);
     }
 #else
+    (void) coll_args;
+    (void) team;
     (void) task_h;
 #endif /* ENABLE_NVLS */
 

--- a/src/components/tl/cuda/allreduce/allreduce.c
+++ b/src/components/tl/cuda/allreduce/allreduce.c
@@ -6,16 +6,17 @@
 
 #include "allreduce.h"
 #include "tl_cuda.h"
+#include "utils/arch/cuda_def.h"
 #include "utils/ucc_coll_utils.h"
 
 ucc_base_coll_alg_info_t
     ucc_tl_cuda_allreduce_algs[UCC_TL_CUDA_ALLREDUCE_ALG_LAST + 1] = {
-#ifdef ENABLE_NVLS
+#ifdef HAVE_NVLS
         [UCC_TL_CUDA_ALLREDUCE_ALG_NVLS] = {.id =
                                                 UCC_TL_CUDA_ALLREDUCE_ALG_NVLS,
                                             .name = "nvls",
                                             .desc = "NVLINK SHARP allreduce"},
-#endif /* ENABLE_NVLS */
+#endif /* HAVE_NVLS */
         [UCC_TL_CUDA_ALLREDUCE_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 
@@ -24,7 +25,7 @@ ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
                                         ucc_coll_task_t     **task_h)
 {
     ucc_status_t        status  = UCC_ERR_NOT_IMPLEMENTED;
-#ifdef ENABLE_NVLS
+#ifdef HAVE_NVLS
     ucc_tl_cuda_team_t *tl_team = ucc_derived_of(team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_task_t *task;
 
@@ -48,7 +49,7 @@ ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
     (void) coll_args;
     (void) team;
     (void) task_h;
-#endif /* ENABLE_NVLS */
+#endif /* HAVE_NVLS */
 
     return status;
 }

--- a/src/components/tl/cuda/allreduce/allreduce.c
+++ b/src/components/tl/cuda/allreduce/allreduce.c
@@ -10,10 +10,12 @@
 
 ucc_base_coll_alg_info_t
     ucc_tl_cuda_allreduce_algs[UCC_TL_CUDA_ALLREDUCE_ALG_LAST + 1] = {
+#ifdef ENABLE_NVLS
         [UCC_TL_CUDA_ALLREDUCE_ALG_NVLS] = {.id =
                                                 UCC_TL_CUDA_ALLREDUCE_ALG_NVLS,
                                             .name = "nvls",
                                             .desc = "NVLINK SHARP allreduce"},
+#endif /* ENABLE_NVLS */
         [UCC_TL_CUDA_ALLREDUCE_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 

--- a/src/components/tl/cuda/allreduce/allreduce.h
+++ b/src/components/tl/cuda/allreduce/allreduce.h
@@ -11,7 +11,9 @@
 #include "tl_cuda_coll.h"
 
 enum {
+#ifdef ENABLE_NVLS
     UCC_TL_CUDA_ALLREDUCE_ALG_NVLS,
+#endif /* ENABLE_NVLS */
     UCC_TL_CUDA_ALLREDUCE_ALG_LAST
 };
 

--- a/src/components/tl/cuda/allreduce/allreduce.h
+++ b/src/components/tl/cuda/allreduce/allreduce.h
@@ -11,20 +11,20 @@
 #include "tl_cuda_coll.h"
 
 enum {
-#ifdef ENABLE_NVLS
+#ifdef HAVE_NVLS
     UCC_TL_CUDA_ALLREDUCE_ALG_NVLS,
-#endif /* ENABLE_NVLS */
+#endif /* HAVE_NVLS */
     UCC_TL_CUDA_ALLREDUCE_ALG_LAST
 };
 
 extern ucc_base_coll_alg_info_t
     ucc_tl_cuda_allreduce_algs[UCC_TL_CUDA_ALLREDUCE_ALG_LAST + 1];
 
-#ifdef ENABLE_NVLS
+#ifdef HAVE_NVLS
 #define UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR "allreduce:nvls:@0"
 #else
 #define UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR ""
-#endif /* ENABLE_NVLS */
+#endif /* HAVE_NVLS */
 
 ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
                                         ucc_base_team_t      *team,

--- a/src/components/tl/cuda/allreduce/allreduce.h
+++ b/src/components/tl/cuda/allreduce/allreduce.h
@@ -21,7 +21,7 @@ extern ucc_base_coll_alg_info_t
     ucc_tl_cuda_allreduce_algs[UCC_TL_CUDA_ALLREDUCE_ALG_LAST + 1];
 
 #ifdef HAVE_NVLS
-#define UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR "allreduce:nvls:@0"
+#define UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR "allreduce:cuda:@0"
 #else
 #define UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR ""
 #endif /* HAVE_NVLS */

--- a/src/components/tl/cuda/allreduce/allreduce.h
+++ b/src/components/tl/cuda/allreduce/allreduce.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef ALLREDUCE_H_
+#define ALLREDUCE_H_
+
+#include "tl_cuda.h"
+#include "tl_cuda_coll.h"
+
+enum {
+    UCC_TL_CUDA_ALLREDUCE_ALG_NVLS,
+    UCC_TL_CUDA_ALLREDUCE_ALG_LAST
+};
+
+extern ucc_base_coll_alg_info_t
+    ucc_tl_cuda_allreduce_algs[UCC_TL_CUDA_ALLREDUCE_ALG_LAST + 1];
+
+#define UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR "allreduce:cuda:@0"
+
+ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
+                                        ucc_base_team_t      *team,
+                                        ucc_coll_task_t     **task_h);
+
+ucc_status_t ucc_tl_cuda_allreduce_nvls_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t      *team,
+                                             ucc_coll_task_t     **task_h);
+
+static inline int ucc_tl_cuda_allreduce_alg_from_str(const char *str)
+{
+    int i;
+    for (i = 0; i < UCC_TL_CUDA_ALLREDUCE_ALG_LAST; i++) {
+        if (0 == strcasecmp(str, ucc_tl_cuda_allreduce_algs[i].name)) {
+            break;
+        }
+    }
+    return i;
+}
+
+#endif

--- a/src/components/tl/cuda/allreduce/allreduce.h
+++ b/src/components/tl/cuda/allreduce/allreduce.h
@@ -18,7 +18,11 @@ enum {
 extern ucc_base_coll_alg_info_t
     ucc_tl_cuda_allreduce_algs[UCC_TL_CUDA_ALLREDUCE_ALG_LAST + 1];
 
-#define UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR "allreduce:cuda:@0"
+#ifdef ENABLE_NVLS
+#define UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR "allreduce:nvls:@0"
+#else
+#define UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR ""
+#endif /* ENABLE_NVLS */
 
 ucc_status_t ucc_tl_cuda_allreduce_init(ucc_base_coll_args_t *coll_args,
                                         ucc_base_team_t      *team,

--- a/src/components/tl/cuda/allreduce/allreduce_nvls.c
+++ b/src/components/tl/cuda/allreduce/allreduce_nvls.c
@@ -226,24 +226,26 @@ ucc_status_t ucc_tl_cuda_allreduce_nvls_init(ucc_base_coll_args_t *coll_args,
 
     if (coll_args->args.op != UCC_OP_SUM ||
         coll_args->args.dst.info.datatype != UCC_DT_FLOAT32) {
-        ucc_debug("NVLS allreduce is supported only with SUM operation "
+        ucc_error("NVLS allreduce is supported only with SUM operation "
                   "and float32 datatype");
         return UCC_ERR_NOT_SUPPORTED;
     }
 
     if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_connected(team->topo))) {
-        ucc_debug("NVLS allreduce is supported only on fully connected "
+        ucc_error("NVLS allreduce is supported only on fully connected "
                   "NVLINK systems");
         return UCC_ERR_NOT_SUPPORTED;
     }
 
     status = ucc_tl_cuda_task_init(coll_args, team, &task);
     if (ucc_unlikely(status != UCC_OK)) {
+        ucc_error("failed to initialize CUDA task");
         return status;
     }
 
     status = ucc_ec_create_event(&task->allreduce_nvls.evtCompletion, UCC_EE_CUDA_STREAM);
     if (ucc_unlikely(status != UCC_OK)) {
+        ucc_error("failed to create CUDA event");
         ucc_tl_cuda_task_put(task);
         return status;
     }

--- a/src/components/tl/cuda/allreduce/allreduce_nvls.c
+++ b/src/components/tl/cuda/allreduce/allreduce_nvls.c
@@ -6,6 +6,7 @@
 
 #include "allreduce/allreduce.h"
 #include "ucc/api/ucc.h"
+#include "core/ucc_ee.h"
 #include "utils/arch/cuda_def.h"
 #include "tl_cuda_nvls.h"
 #include "../kernels/allreduce_kernel.h"
@@ -31,7 +32,8 @@ ucc_status_t ucc_tl_cuda_allreduce_nvls_start(ucc_coll_task_t *coll_task)
     ucc_tl_cuda_team_t *team   = TASK_TEAM(task);
     ucc_coll_args_t    *args   = &TASK_ARGS(task);
     ucc_tl_cuda_nvls_t *nvls   = &team->nvls;
-    cudaStream_t        stream = team->stream;
+    ucc_ee_h            ee     = task->super.ee;
+    cudaStream_t        stream = (ee) ? (cudaStream_t)ee->ee_context : team->stream;
     ucc_datatype_t      dt     = task->allreduce_nvls.dt;
 
     size_t buf_size_bytes = args->src.info.count * ucc_dt_size(dt);
@@ -66,7 +68,8 @@ void ucc_tl_cuda_allreduce_nvls_progress(ucc_coll_task_t *coll_task)
     ucc_rank_t          trank  = UCC_TL_TEAM_RANK(team);
     cudaEvent_t         evt    = task->allreduce_nvls.evtCompletion;
     ucc_tl_cuda_nvls_t *nvls   = &team->nvls;
-    cudaStream_t        stream = team->stream;
+    ucc_ee_h            ee     = task->super.ee;
+    cudaStream_t        stream = (ee) ? (cudaStream_t)ee->ee_context : team->stream;
 
     ucc_status_t        status;
     cudaError_t         cuda_status;

--- a/src/components/tl/cuda/allreduce/allreduce_nvls.c
+++ b/src/components/tl/cuda/allreduce/allreduce_nvls.c
@@ -10,8 +10,6 @@
 #include "tl_cuda_nvls.h"
 #include "../kernels/allreduce_kernel.h"
 
-#include <cuda_runtime.h>
-#include <cuda.h>
 
 enum {
     STAGE_COPY,                /*< Copy src buffer to symmetric memory */

--- a/src/components/tl/cuda/allreduce/allreduce_nvls.c
+++ b/src/components/tl/cuda/allreduce/allreduce_nvls.c
@@ -38,21 +38,21 @@ ucc_status_t ucc_tl_cuda_allreduce_nvls_start(ucc_coll_task_t *coll_task)
 
     size_t buf_size_bytes = args->src.info.count * ucc_dt_size(dt);
 
-    ucc_debug("allreduce_nvls_start symmetric uc addr: %lld mc addr: "
-              "%lld buf_size_bytes: %zu",
-              nvls->uc_va, nvls->mc_va, buf_size_bytes);
+    ucc_debug("allreduce_nvls_start symmetric uc addr: %p mc addr: %p "
+              "buf_size_bytes: %zu",
+              (void *)nvls->uc_va, (void *)nvls->mc_va, buf_size_bytes);
 
     task->allreduce_nvls.rbuf           = args->dst.info.buffer;
     task->allreduce_nvls.sbuf           = args->src.info.buffer;
     task->allreduce_nvls.buf_size_bytes = buf_size_bytes;
-
-    task->allreduce_nvls.stage = STAGE_COPY;
 
     // copy src buffer to symmetric memory first
     CUDA_CHECK(cudaMemcpyAsync((void *)nvls->uc_va, args->src.info.buffer,
                                buf_size_bytes, cudaMemcpyDeviceToDevice,
                                stream));
     CUDA_CHECK(cudaEventRecord(task->allreduce_nvls.evtCompletion, stream));
+
+    task->allreduce_nvls.stage = STAGE_COPY;
 
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }

--- a/src/components/tl/cuda/allreduce/allreduce_nvls.c
+++ b/src/components/tl/cuda/allreduce/allreduce_nvls.c
@@ -24,8 +24,6 @@ enum {
     STAGE_BARRIER_TEST,        /*< Test barrier after kernel */
     STAGE_COPY_POST,           /*< Copy result buffer from symmetric memory to dst buffer */
     STAGE_COPY_POST_WAIT,      /*< Wait for the copy to complete */
-    STAGE_COPY_POST_BAR_START, /*< Start barrier after copy */
-    STAGE_COPY_POST_BAR_TEST   /*< Test barrier after copy */
 };
 
 ucc_status_t ucc_tl_cuda_allreduce_nvls_start(ucc_coll_task_t *coll_task)
@@ -182,25 +180,7 @@ void ucc_tl_cuda_allreduce_nvls_progress(ucc_coll_task_t *coll_task)
             task->super.status = UCC_INPROGRESS;
             return;
         }
-        task->allreduce_nvls.stage = STAGE_COPY_POST_BAR_START;
-        // fallthrough
-    case STAGE_COPY_POST_BAR_START:
-        status = ucc_tl_cuda_shm_barrier_start(trank, task->bar);
-        if (status != UCC_OK) {
-            ucc_error("allreduce barrier start failed");
-            task->super.status = status;
-            return;
-        }
-        task->allreduce_nvls.stage = STAGE_COPY_POST_BAR_TEST;
-        // fallthrough
-    case STAGE_COPY_POST_BAR_TEST:
-        status = ucc_tl_cuda_shm_barrier_test(trank, task->bar);
-        if (status != UCC_OK) {
-            task->super.status = status;
-            return;
-        }
         task->super.status = UCC_OK;
-        ucc_trace("allreduce kernel is completed");
         break;
     }
     return;

--- a/src/components/tl/cuda/allreduce/allreduce_nvls.c
+++ b/src/components/tl/cuda/allreduce/allreduce_nvls.c
@@ -4,84 +4,78 @@
  * See file LICENSE for terms.
  */
 
-#include "reduce_scatter/reduce_scatter.h"
-#include <ucc/api/ucc.h>
-
+#include "allreduce/allreduce.h"
+#include "ucc/api/ucc.h"
 #include "utils/arch/cuda_def.h"
 
 #include <cuda_runtime.h>
 #include <cuda.h>
 
 enum {
-    STAGE_COPY,          /*< Copy src buffer to symmetric memory */
+    STAGE_COPY, /*< Copy src buffer to symmetric memory */
     STAGE_COPY_BAR_START,
     STAGE_COPY_BAR_TEST,
     STAGE_KERNEL_START,
     STAGE_KERNEL,        /*< Kernel is running */
     STAGE_BARRIER_START, /*< Kernel is done, waiting for other ranks to finish */
-    STAGE_BARRIER_TEST, /*< Kernel is done, waiting for other ranks to finish */
+    STAGE_BARRIER_TEST,  /*< Kernel is done, waiting for other ranks to finish */
+    STAGE_COPY_POST,
+    STAGE_COPY_POST_WAIT,
+    STAGE_COPY_POST_BAR_START,
+    STAGE_COPY_POST_BAR_TEST
 };
 
-// Kernel is defined in src/components/tl/cuda/kernels/reduce_scatter_kernel.cu
-ucc_status_t post_reduce_scatter_kernel(cudaStream_t stream,
-                                        CUdeviceptr  src_addr,
-                                        CUdeviceptr  dst_addr,
-                                        size_t       src_size_bytes,
-                                        uint32_t     rank,
-                                        uint32_t     tsize);
+// Kernel is defined in src/components/tl/cuda/kernels/allreduce_kernel.cu
+ucc_status_t post_allreduce_kernel(cudaStream_t stream, CUdeviceptr src_addr,
+                                   size_t src_size_bytes, uint32_t rank,
+                                   uint32_t tsize);
 
-ucc_status_t ucc_tl_cuda_reduce_scatterv_nvls_start(ucc_coll_task_t *coll_task)
+ucc_status_t ucc_tl_cuda_allreduce_nvls_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task   = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team   = TASK_TEAM(task);
     ucc_coll_args_t    *args   = &TASK_ARGS(task);
     ucc_tl_cuda_nvls_t *nvls   = &team->nvls;
     cudaStream_t        stream = team->stream;
-    ucc_datatype_t      dt     = task->reduce_scatterv_nvls.dt;
+    ucc_datatype_t      dt     = task->allreduce_nvls.dt;
 
     size_t src_size_bytes = args->src.info.count * ucc_dt_size(dt);
     size_t dst_size_bytes = args->dst.info.count * ucc_dt_size(dt);
 
-    ucc_debug("reduce_scatterv_nvls_start symmetric uc addr: %lld mc addr: "
+    ucc_debug("allreduce_nvls_start symmetric uc addr: %lld mc addr: "
               "%lld src_size_bytes: %zu dst_size_bytes: %zu",
               nvls->uc_va, nvls->mc_va, src_size_bytes, dst_size_bytes);
 
-    if (args->coll_type == UCC_COLL_TYPE_REDUCE_SCATTER) {
-        task->reduce_scatterv_nvls.rbuf = args->dst.info.buffer;
-    } else {
-        task->reduce_scatterv_nvls.rbuf = args->dst.info_v.buffer;
-    }
+    task->allreduce_nvls.rbuf           = args->dst.info.buffer;
+    task->allreduce_nvls.sbuf           = args->src.info.buffer;
+    task->allreduce_nvls.src_size_bytes = src_size_bytes;
+    task->allreduce_nvls.dst_size_bytes = dst_size_bytes;
 
-    task->reduce_scatterv_nvls.sbuf = args->src.info.buffer;
-    task->reduce_scatterv_nvls.src_size_bytes = src_size_bytes;
-    task->reduce_scatterv_nvls.dst_size_bytes = dst_size_bytes;
+    task->allreduce_nvls.stage = STAGE_COPY;
 
-    task->reduce_scatterv_nvls.stage = STAGE_COPY;
-   
     // copy src buffer to symmetric memory first
     CUDA_CHECK(cudaMemcpyAsync((void *)nvls->uc_va, args->src.info.buffer,
                                src_size_bytes, cudaMemcpyDeviceToDevice,
                                stream));
-    CUDA_CHECK(cudaEventRecord(task->reduce_scatterv_nvls.evtCopy, stream));
+    CUDA_CHECK(cudaEventRecord(task->allreduce_nvls.evtCompletion, stream));
 
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
-void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
+void ucc_tl_cuda_allreduce_nvls_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_cuda_task_t *task   = ucc_derived_of(coll_task, ucc_tl_cuda_task_t);
     ucc_tl_cuda_team_t *team   = TASK_TEAM(task);
     ucc_rank_t          trank  = UCC_TL_TEAM_RANK(team);
-    cudaEvent_t         evt    = task->reduce_scatterv_nvls.evtCompletion;
+    cudaEvent_t         evt    = task->allreduce_nvls.evtCompletion;
     ucc_tl_cuda_nvls_t *nvls   = &team->nvls;
     cudaStream_t        stream = team->stream;
 
     ucc_status_t        status;
-    cudaError_t cuda_status;
-
-    switch (task->reduce_scatterv_nvls.stage) {
+    cudaError_t         cuda_status;
+    switch (task->allreduce_nvls.stage) {
     case STAGE_COPY:
-        cuda_status = cudaEventQuery(task->reduce_scatterv_nvls.evtCopy);
+        cuda_status = cudaEventQuery(evt);
         if (cuda_status == cudaErrorNotReady) {
             task->super.status = UCC_INPROGRESS;
             return;
@@ -92,7 +86,7 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
             task->super.status = UCC_ERR_NO_RESOURCE;
             return;
         }
-        task->reduce_scatterv_nvls.stage = STAGE_COPY_BAR_START;
+        task->allreduce_nvls.stage = STAGE_COPY_BAR_START;
         // fallthrough
     case STAGE_COPY_BAR_START:
         status = ucc_tl_cuda_shm_barrier_start(trank, task->bar);
@@ -101,7 +95,7 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
             task->super.status = UCC_ERR_NO_RESOURCE;
             return;
         }
-        task->reduce_scatterv_nvls.stage = STAGE_COPY_BAR_TEST;
+        task->allreduce_nvls.stage = STAGE_COPY_BAR_TEST;
         // fallthrough
     case STAGE_COPY_BAR_TEST:
         status = ucc_tl_cuda_shm_barrier_test(trank, task->bar);
@@ -109,26 +103,25 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
             task->super.status = status;
             return;
         }
-        task->reduce_scatterv_nvls.stage = STAGE_KERNEL_START;
+        task->allreduce_nvls.stage = STAGE_KERNEL_START;
         // fallthrough
     case STAGE_KERNEL_START:
-        status = post_reduce_scatter_kernel(stream, nvls->mc_va,
-                                            (CUdeviceptr) task->reduce_scatterv_nvls.rbuf,
-                                            task->reduce_scatterv_nvls.src_size_bytes, trank,
-                                            UCC_TL_TEAM_SIZE(team));
+        status = post_allreduce_kernel(stream, nvls->mc_va,
+                                       task->allreduce_nvls.src_size_bytes,
+                                       trank, UCC_TL_TEAM_SIZE(team));
         if (status != UCC_OK) {
-            ucc_error("failed to post reduce scatter kernel");
+            ucc_error("failed to post allreduce kernel");
             task->super.status = status;
             return;
         }
-        ucc_debug("reduce scatter kernel posted");
-        cuda_status = cudaEventRecord(task->reduce_scatterv_nvls.evtCompletion, stream);
+        ucc_debug("allreduce kernel posted");
+        cuda_status = cudaEventRecord(evt, stream);
         if (cuda_status != cudaSuccess) {
             ucc_error("cudaEventRecord failed: %s", cudaGetErrorString(cuda_status));
             task->super.status = UCC_ERR_NO_RESOURCE;
             return;
         }
-        task->reduce_scatterv_nvls.stage = STAGE_KERNEL;
+        task->allreduce_nvls.stage = STAGE_KERNEL;
         // fallthrough
     case STAGE_KERNEL:
         cuda_status = cudaEventQuery(evt);
@@ -142,7 +135,7 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
             task->super.status = UCC_ERR_NO_RESOURCE;
             return;
         }
-        task->reduce_scatterv_nvls.stage = STAGE_BARRIER_START;
+        task->allreduce_nvls.stage = STAGE_BARRIER_START;
         // fallthrough
     case STAGE_BARRIER_START:
         status = ucc_tl_cuda_shm_barrier_start(trank, task->bar);
@@ -151,7 +144,7 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
             task->super.status = UCC_ERR_NO_RESOURCE;
             return;
         }
-        task->reduce_scatterv_nvls.stage = STAGE_BARRIER_TEST;
+        task->allreduce_nvls.stage = STAGE_BARRIER_TEST;
         // fallthrough
     case STAGE_BARRIER_TEST:
         status = ucc_tl_cuda_shm_barrier_test(trank, task->bar);
@@ -159,28 +152,66 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
             task->super.status = status;
             return;
         }
+        ucc_debug("allreduce kernel is completed");
+        task->allreduce_nvls.stage = STAGE_COPY_POST;
+        // fallthrough        
+    case STAGE_COPY_POST:
+        cudaMemcpyAsync((void *)task->allreduce_nvls.rbuf,
+                        (void *)nvls->uc_va,
+                        task->allreduce_nvls.dst_size_bytes,
+                        cudaMemcpyDeviceToDevice,
+                        stream);
+        cuda_status = cudaEventRecord(evt, stream);
+        if (cuda_status != cudaSuccess) {
+            ucc_error("cudaEventRecord failed: %s", cudaGetErrorString(cuda_status));
+            task->super.status = UCC_ERR_NO_RESOURCE;
+            return;
+        }
+        task->allreduce_nvls.stage = STAGE_COPY_POST_WAIT;
+        // fallthrough
+    case STAGE_COPY_POST_WAIT:
+        cuda_status = cudaEventQuery(evt);
+        if (cuda_status == cudaErrorNotReady) {
+            task->super.status = UCC_INPROGRESS;
+            return;
+        }
+        task->allreduce_nvls.stage = STAGE_COPY_BAR_START;
+        // fallthrough
+    case STAGE_COPY_POST_BAR_START:
+        status = ucc_tl_cuda_shm_barrier_start(trank, task->bar);
+        if (status != UCC_OK) {
+            ucc_error("reduce scatter barrier start failed");
+            task->super.status = UCC_ERR_NO_RESOURCE;
+            return;
+        }
+        task->allreduce_nvls.stage = STAGE_COPY_POST_BAR_TEST;
+        // fallthrough
+    case STAGE_COPY_POST_BAR_TEST:
+        status = ucc_tl_cuda_shm_barrier_test(trank, task->bar);
+        if (status != UCC_OK) {
+            task->super.status = status;
+            return;
+        }
         task->super.status = UCC_OK;
-        ucc_debug("reduce scatter kernel is completed");
+        ucc_debug("allreduce kernel is completed");
         break;
     }
     return;
 }
 
-ucc_status_t ucc_tl_cuda_reduce_scatterv_nvls_finalize(ucc_coll_task_t *task)
+ucc_status_t ucc_tl_cuda_allreduce_nvls_finalize(ucc_coll_task_t *task)
 {
     ucc_tl_cuda_task_t *tl_task = ucc_derived_of(task, ucc_tl_cuda_task_t);
-    
-    CUDA_CHECK(cudaEventDestroy(tl_task->reduce_scatterv_nvls.evtCompletion));
-    CUDA_CHECK(cudaEventDestroy(tl_task->reduce_scatterv_nvls.evtCopy));
+
+    CUDA_CHECK(cudaEventDestroy(tl_task->allreduce_nvls.evtCompletion));
 
     ucc_tl_cuda_task_put(tl_task);
     return UCC_OK;
 }
 
-ucc_status_t
-ucc_tl_cuda_reduce_scatter_nvls_init(ucc_base_coll_args_t *coll_args,
-                                     ucc_base_team_t      *tl_team,
-                                     ucc_coll_task_t     **task_p)
+ucc_status_t ucc_tl_cuda_allreduce_nvls_init(ucc_base_coll_args_t *coll_args,
+                                             ucc_base_team_t      *tl_team,
+                                             ucc_coll_task_t     **task_p)
 {
     ucc_tl_cuda_team_t *team = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
     ucc_tl_cuda_task_t *task;
@@ -188,13 +219,13 @@ ucc_tl_cuda_reduce_scatter_nvls_init(ucc_base_coll_args_t *coll_args,
 
     if (coll_args->args.op != UCC_OP_SUM ||
         coll_args->args.dst.info.datatype != UCC_DT_FLOAT32) {
-        ucc_error("NVLS reduce scatter is supported only with SUM operation "
+        ucc_error("NVLS allreduce is supported only with SUM operation "
                   "and float32 datatype");
         return UCC_ERR_NOT_SUPPORTED;
     }
 
     if (ucc_unlikely(!ucc_tl_cuda_team_topo_is_fully_connected(team->topo))) {
-        ucc_error("NVLS reduce scatter is supported only on fully connected "
+        ucc_error("NVLS allreduce is supported only on fully connected "
                   "NVLINK systems");
         return UCC_ERR_NOT_SUPPORTED;
     }
@@ -204,18 +235,14 @@ ucc_tl_cuda_reduce_scatter_nvls_init(ucc_base_coll_args_t *coll_args,
         return status;
     }
 
-    CUDA_CHECK(cudaEventCreateWithFlags(
-        &task->reduce_scatterv_nvls.evtCompletion, cudaEventDisableTiming));
-    CUDA_CHECK(cudaEventCreateWithFlags(
-        &task->reduce_scatterv_nvls.evtCopy, cudaEventDisableTiming));
+    CUDA_CHECK(cudaEventCreateWithFlags(&task->allreduce_nvls.evtCompletion,
+                                        cudaEventDisableTiming));
 
-    task->reduce_scatterv_nvls.get_count  = ucc_tl_cuda_reduce_scatter_get_count;
-    task->reduce_scatterv_nvls.get_offset = ucc_tl_cuda_reduce_scatter_get_offset;
-    task->reduce_scatterv_nvls.dt         = coll_args->args.dst.info.datatype;
+    task->allreduce_nvls.dt = coll_args->args.dst.info.datatype;
 
-    task->super.post     = ucc_tl_cuda_reduce_scatterv_nvls_start;
-    task->super.progress = ucc_tl_cuda_reduce_scatterv_nvls_progress;
-    task->super.finalize = ucc_tl_cuda_reduce_scatterv_nvls_finalize;
+    task->super.post     = ucc_tl_cuda_allreduce_nvls_start;
+    task->super.progress = ucc_tl_cuda_allreduce_nvls_progress;
+    task->super.finalize = ucc_tl_cuda_allreduce_nvls_finalize;
 
     task->bar = TASK_BAR(task);
 

--- a/src/components/tl/cuda/kernels/Makefile.am
+++ b/src/components/tl/cuda/kernels/Makefile.am
@@ -22,7 +22,7 @@ LINK = $(LIBTOOL) --mode=link $(CC) -o $@
 comp_noinst = libucc_tl_cuda_kernels.la
 
 if TL_CUDA_NVLS_ENABLED
-libucc_tl_cuda_kernels_la_SOURCES  = reduce_scatter_kernel.cu
+libucc_tl_cuda_kernels_la_SOURCES  = reduce_scatter_kernel.cu allreduce_kernel.cu
 else
 libucc_tl_cuda_kernels_la_SOURCES  = 
 endif

--- a/src/components/tl/cuda/kernels/allreduce_kernel.cu
+++ b/src/components/tl/cuda/kernels/allreduce_kernel.cu
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "utils/arch/cuda_def.h"
+#include "../tl_cuda.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#define MAX_THREADS 1024
+#define MAX_BLOCKS 4
+
+#define MULTIMEM_ST(val, ptr)                                                  \
+    asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};" ::"l"(ptr),  \
+                 "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w)                \
+                 : "memory");
+
+#define MULTIMEM_LD(val, ptr)                                                  \
+    asm("multimem.ld_reduce.global.add.v4.f32 {%0,%1,%2,%3}, [%4];"            \
+        : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)                   \
+        : "l"(ptr)                                                             \
+        : "memory");
+
+__global__ void __launch_bounds__(MAX_THREADS)
+    allreduce_kernel(float *src_addr, size_t src_count, uint32_t rank,
+                     uint32_t tsize)
+{
+    size_t chunk_start = ((int64_t)src_count * (int64_t)rank) / (int64_t)tsize;
+    size_t chunk_end =
+        ((int64_t)src_count * (int64_t)(rank + 1)) / (int64_t)tsize;
+
+    size_t thread_offset = (threadIdx.x + blockIdx.x * blockDim.x) * 4;
+    size_t stride        = blockDim.x * gridDim.x * 4;
+
+    for (size_t idx = chunk_start + thread_offset; idx < chunk_end;
+         idx += stride) {
+        uint4 val;
+        MULTIMEM_LD(val, src_addr + idx);
+        MULTIMEM_ST(val, src_addr + idx);
+    }
+
+    return;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ucc_status_t post_allreduce_kernel(cudaStream_t stream, CUdeviceptr src_addr,
+                                   size_t src_size_bytes, uint32_t rank,
+                                   uint32_t tsize)
+{
+    allreduce_kernel<<<MAX_BLOCKS, MAX_THREADS, 0, stream>>>(
+        (float *)src_addr, src_size_bytes / sizeof(float),
+        rank, tsize);
+    CUDA_CHECK(cudaGetLastError());
+
+    return UCC_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/components/tl/cuda/kernels/allreduce_kernel.cu
+++ b/src/components/tl/cuda/kernels/allreduce_kernel.cu
@@ -11,23 +11,14 @@ extern "C" {
 #include "utils/arch/cuda_def.h"
 #include "../tl_cuda.h"
 
+#include "nvls.cuh"
+
 #ifdef __cplusplus
 }
 #endif
 
 #define MAX_THREADS 1024
 #define MAX_BLOCKS 4
-
-#define MULTIMEM_ST(val, ptr)                                                  \
-    asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};" ::"l"(ptr),  \
-                 "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w)                \
-                 : "memory");
-
-#define MULTIMEM_LD(val, ptr)                                                  \
-    asm("multimem.ld_reduce.global.add.v4.f32 {%0,%1,%2,%3}, [%4];"            \
-        : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)                   \
-        : "l"(ptr)                                                             \
-        : "memory");
 
 __global__ void __launch_bounds__(MAX_THREADS)
     allreduce_kernel(float *src_addr, size_t src_count, uint32_t rank,

--- a/src/components/tl/cuda/kernels/allreduce_kernel.h
+++ b/src/components/tl/cuda/kernels/allreduce_kernel.h
@@ -7,7 +7,6 @@
 #ifndef UCC_TL_CUDA_ALLREDUCE_KERNEL_H_
 #define UCC_TL_CUDA_ALLREDUCE_KERNEL_H_
 
-#include <cuda_runtime.h>
 #include <cuda.h>
 #include "ucc/api/ucc.h"
 
@@ -24,4 +23,4 @@ ucc_status_t post_allreduce_kernel(cudaStream_t stream, CUdeviceptr src_addr,
 }
 #endif
 
-#endif // UCC_TL_CUDA_ALLREDUCE_KERNEL_H_ 
+#endif // UCC_TL_CUDA_ALLREDUCE_KERNEL_H_

--- a/src/components/tl/cuda/kernels/allreduce_kernel.h
+++ b/src/components/tl/cuda/kernels/allreduce_kernel.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_ALLREDUCE_KERNEL_H_
+#define UCC_TL_CUDA_ALLREDUCE_KERNEL_H_
+
+#include <cuda_runtime.h>
+#include <cuda.h>
+#include "ucc/api/ucc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Kernel function declaration
+ucc_status_t post_allreduce_kernel(cudaStream_t stream, CUdeviceptr src_addr,
+                                   size_t src_size_bytes, uint32_t rank,
+                                   uint32_t tsize);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // UCC_TL_CUDA_ALLREDUCE_KERNEL_H_ 

--- a/src/components/tl/cuda/kernels/nvls.cuh
+++ b/src/components/tl/cuda/kernels/nvls.cuh
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_NVLS_CUH_
+#define UCC_TL_CUDA_NVLS_CUH_
+
+#include <cuda.h>
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#define MULTIMEM_ST(val, ptr)                                                  \
+    asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};" ::"l"(ptr),  \
+                 "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w)                \
+                 : "memory");
+
+#define MULTIMEM_LD(val, ptr)                                                  \
+    asm("multimem.ld_reduce.global.add.v4.f32 {%0,%1,%2,%3}, [%4];"            \
+        : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)                   \
+        : "l"(ptr)                                                             \
+        : "memory");
+#else
+    #error "NVLS is supported only on CUDA ARCH 9.0 and higher"
+#endif // __CUDA_ARCH__
+
+#endif // UCC_TL_CUDA_NVLS_CUH_

--- a/src/components/tl/cuda/kernels/nvls.cuh
+++ b/src/components/tl/cuda/kernels/nvls.cuh
@@ -9,7 +9,6 @@
 
 #include <cuda.h>
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
 #define MULTIMEM_ST(val, ptr)                                                  \
     asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};" ::"l"(ptr),  \
                  "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w)                \
@@ -20,8 +19,5 @@
         : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)                   \
         : "l"(ptr)                                                             \
         : "memory");
-#else
-    #error "NVLS is supported only on CUDA ARCH 9.0 and higher"
-#endif // __CUDA_ARCH__
 
 #endif // UCC_TL_CUDA_NVLS_CUH_

--- a/src/components/tl/cuda/kernels/reduce_scatter_kernel.cu
+++ b/src/components/tl/cuda/kernels/reduce_scatter_kernel.cu
@@ -11,23 +11,14 @@ extern "C" {
 #include "utils/arch/cuda_def.h"
 #include "../tl_cuda.h"
 
+#include "nvls.cuh"
+
 #ifdef __cplusplus
 }
 #endif
 
 #define MAX_THREADS 1024
 #define MAX_BLOCKS 10
-
-#define MULTIMEM_ST(val, ptr)                                                  \
-    asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};" ::"l"(ptr),  \
-                 "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w)                \
-                 : "memory");
-
-#define MULTIMEM_LD(val, ptr)                                                  \
-    asm("multimem.ld_reduce.global.add.v4.f32 {%0,%1,%2,%3}, [%4];"            \
-        : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)                   \
-        : "l"(ptr)                                                             \
-        : "memory");
 
 __global__ void __launch_bounds__(MAX_THREADS)
     reduce_scatter_kernel(float *src_addr, float *dst_addr, size_t src_count,

--- a/src/components/tl/cuda/kernels/reduce_scatter_kernel.h
+++ b/src/components/tl/cuda/kernels/reduce_scatter_kernel.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_CUDA_REDUCE_SCATTER_KERNEL_H_
+#define UCC_TL_CUDA_REDUCE_SCATTER_KERNEL_H_
+
+#include <cuda.h>
+#include "ucc/api/ucc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Kernel function declaration
+ucc_status_t post_reduce_scatter_kernel(cudaStream_t stream,
+                                        CUdeviceptr  src_addr,
+                                        CUdeviceptr  dst_addr,
+                                        size_t src_size_bytes, uint32_t rank,
+                                        uint32_t tsize);
+#ifdef __cplusplus
+}
+#endif
+
+#endif // UCC_TL_CUDA_REDUCE_SCATTER_KERNEL_H_

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter.c
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter.c
@@ -21,12 +21,12 @@ ucc_tl_cuda_reduce_scatter_algs[UCC_TL_CUDA_REDUCE_SCATTER_ALG_LAST + 1] = {
             {.id   = UCC_TL_CUDA_REDUCE_SCATTER_ALG_LINEAR,
              .name = "linear",
              .desc = "linear reduce scatter algorithm"},
-#ifdef ENABLE_NVLS
+#ifdef HAVE_NVLS
         [UCC_TL_CUDA_REDUCE_SCATTER_ALG_NVLS] =
             {.id   = UCC_TL_CUDA_REDUCE_SCATTER_ALG_NVLS,
              .name = "nvls",
              .desc = "nvls reduce scatter algorithm"},
-#endif /* ENABLE_NVLS */
+#endif /* HAVE_NVLS */
         [UCC_TL_CUDA_REDUCE_SCATTER_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter.c
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter.c
@@ -21,10 +21,12 @@ ucc_tl_cuda_reduce_scatter_algs[UCC_TL_CUDA_REDUCE_SCATTER_ALG_LAST + 1] = {
             {.id   = UCC_TL_CUDA_REDUCE_SCATTER_ALG_LINEAR,
              .name = "linear",
              .desc = "linear reduce scatter algorithm"},
+#ifdef ENABLE_NVLS
         [UCC_TL_CUDA_REDUCE_SCATTER_ALG_NVLS] =
             {.id   = UCC_TL_CUDA_REDUCE_SCATTER_ALG_NVLS,
              .name = "nvls",
              .desc = "nvls reduce scatter algorithm"},
+#endif /* ENABLE_NVLS */
         [UCC_TL_CUDA_REDUCE_SCATTER_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter.h
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter.h
@@ -15,9 +15,9 @@ enum
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_AUTO,
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_RING,
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_LINEAR,
-#ifdef ENABLE_NVLS
+#ifdef HAVE_NVLS
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_NVLS,
-#endif /* ENABLE_NVLS */
+#endif /* HAVE_NVLS */
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_LAST
 };
 
@@ -43,11 +43,11 @@ ucc_status_t ucc_tl_cuda_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_arg
 ucc_status_t ucc_tl_cuda_reduce_scatter_linear_init(ucc_base_coll_args_t *coll_args,
                                                     ucc_base_team_t *     tl_team,
                                                     ucc_coll_task_t **    task_p);
-#ifdef ENABLE_NVLS
+#ifdef HAVE_NVLS
 ucc_status_t ucc_tl_cuda_reduce_scatter_nvls_init(ucc_base_coll_args_t *coll_args,
                                                   ucc_base_team_t *     tl_team,
                                                   ucc_coll_task_t **    task_p);
-#endif /* ENABLE_NVLS */
+#endif /* HAVE_NVLS */
 
 static inline int ucc_tl_cuda_reduce_scatter_alg_from_str(const char *str)
 {

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter.h
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter.h
@@ -15,7 +15,9 @@ enum
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_AUTO,
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_RING,
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_LINEAR,
+#ifdef ENABLE_NVLS
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_NVLS,
+#endif /* ENABLE_NVLS */
     UCC_TL_CUDA_REDUCE_SCATTER_ALG_LAST
 };
 
@@ -41,10 +43,11 @@ ucc_status_t ucc_tl_cuda_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_arg
 ucc_status_t ucc_tl_cuda_reduce_scatter_linear_init(ucc_base_coll_args_t *coll_args,
                                                     ucc_base_team_t *     tl_team,
                                                     ucc_coll_task_t **    task_p);
-
+#ifdef ENABLE_NVLS
 ucc_status_t ucc_tl_cuda_reduce_scatter_nvls_init(ucc_base_coll_args_t *coll_args,
                                                   ucc_base_team_t *     tl_team,
                                                   ucc_coll_task_t **    task_p);
+#endif /* ENABLE_NVLS */
 
 static inline int ucc_tl_cuda_reduce_scatter_alg_from_str(const char *str)
 {

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter_nvls.c
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter_nvls.c
@@ -91,7 +91,7 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
         status = ucc_tl_cuda_shm_barrier_start(trank, task->bar);
         if (status != UCC_OK) {
             ucc_error("reduce scatter barrier start failed");
-            task->super.status = UCC_ERR_NO_RESOURCE;
+            task->super.status = status;
             return;
         }
         task->reduce_scatterv_nvls.stage = STAGE_COPY_BAR_TEST;
@@ -141,7 +141,7 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
         status = ucc_tl_cuda_shm_barrier_start(trank, task->bar);
         if (status != UCC_OK) {
             ucc_error("reduce scatter barrier start failed");
-            task->super.status = UCC_ERR_NO_RESOURCE;
+            task->super.status = status;
             return;
         }
         task->reduce_scatterv_nvls.stage = STAGE_BARRIER_TEST;

--- a/src/components/tl/cuda/reduce_scatter/reduce_scatter_nvls.c
+++ b/src/components/tl/cuda/reduce_scatter/reduce_scatter_nvls.c
@@ -8,6 +8,7 @@
 #include <ucc/api/ucc.h>
 
 #include "utils/arch/cuda_def.h"
+#include "kernels/reduce_scatter_kernel.h"
 
 #include <cuda_runtime.h>
 #include <cuda.h>
@@ -21,14 +22,6 @@ enum {
     STAGE_BARRIER_START, /*< Kernel is done, waiting for other ranks to finish */
     STAGE_BARRIER_TEST, /*< Kernel is done, waiting for other ranks to finish */
 };
-
-// Kernel is defined in src/components/tl/cuda/kernels/reduce_scatter_kernel.cu
-ucc_status_t post_reduce_scatter_kernel(cudaStream_t stream,
-                                        CUdeviceptr  src_addr,
-                                        CUdeviceptr  dst_addr,
-                                        size_t       src_size_bytes,
-                                        uint32_t     rank,
-                                        uint32_t     tsize);
 
 ucc_status_t ucc_tl_cuda_reduce_scatterv_nvls_start(ucc_coll_task_t *coll_task)
 {
@@ -57,7 +50,7 @@ ucc_status_t ucc_tl_cuda_reduce_scatterv_nvls_start(ucc_coll_task_t *coll_task)
     task->reduce_scatterv_nvls.dst_size_bytes = dst_size_bytes;
 
     task->reduce_scatterv_nvls.stage = STAGE_COPY;
-   
+
     // copy src buffer to symmetric memory first
     CUDA_CHECK(cudaMemcpyAsync((void *)nvls->uc_va, args->src.info.buffer,
                                src_size_bytes, cudaMemcpyDeviceToDevice,
@@ -85,7 +78,7 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
         if (cuda_status == cudaErrorNotReady) {
             task->super.status = UCC_INPROGRESS;
             return;
-        }   
+        }
         if (cuda_status != cudaSuccess) {
             ucc_error("cudaEventQuery failed %s",
                       cudaGetErrorString(cuda_status));
@@ -169,7 +162,7 @@ void ucc_tl_cuda_reduce_scatterv_nvls_progress(ucc_coll_task_t *coll_task)
 ucc_status_t ucc_tl_cuda_reduce_scatterv_nvls_finalize(ucc_coll_task_t *task)
 {
     ucc_tl_cuda_task_t *tl_task = ucc_derived_of(task, ucc_tl_cuda_task_t);
-    
+
     CUDA_CHECK(cudaEventDestroy(tl_task->reduce_scatterv_nvls.evtCompletion));
     CUDA_CHECK(cudaEventDestroy(tl_task->reduce_scatterv_nvls.evtCopy));
 

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -29,11 +29,19 @@
 #define UCC_TL_CUDA_MAX_PEERS 8
 #define UCC_TL_CUDA_MAX_RING_CHUNKS 8
 
+#ifdef HAVE_NVLS
 #define UCC_TL_CUDA_SUPPORTED_COLLS                                            \
     (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                        \
      UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                      \
      UCC_COLL_TYPE_BCAST | UCC_COLL_TYPE_ALLREDUCE |                           \
      UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE_SCATTERV)
+#else
+#define UCC_TL_CUDA_SUPPORTED_COLLS                                            \
+    (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                        \
+     UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                      \
+     UCC_COLL_TYPE_BCAST | UCC_COLL_TYPE_REDUCE_SCATTER |                      \
+     UCC_COLL_TYPE_REDUCE_SCATTERV)
+#endif /* HAVE_NVLS */
 
 #define UCC_TL_CUDA_TEAM_LIB(_team)                                            \
     (ucc_derived_of((_team)->super.super.context->lib, ucc_tl_cuda_lib_t))

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -32,7 +32,7 @@
 #define UCC_TL_CUDA_SUPPORTED_COLLS                                            \
     (UCC_COLL_TYPE_ALLTOALL | UCC_COLL_TYPE_ALLTOALLV |                        \
      UCC_COLL_TYPE_ALLGATHER | UCC_COLL_TYPE_ALLGATHERV |                      \
-     UCC_COLL_TYPE_BCAST |                                                     \
+     UCC_COLL_TYPE_BCAST | UCC_COLL_TYPE_ALLREDUCE |                           \
      UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE_SCATTERV)
 
 #define UCC_TL_CUDA_TEAM_LIB(_team)                                            \
@@ -294,6 +294,15 @@ struct ucc_tl_cuda_task {
             cudaEvent_t             evtCopy;
             cudaEvent_t             evtCompletion;
         } reduce_scatterv_nvls;
+        struct {
+            int            stage;
+            ucc_datatype_t dt;
+            void          *sbuf;
+            void          *rbuf;
+            size_t         src_size_bytes;
+            size_t         dst_size_bytes;
+            cudaEvent_t    evtCompletion;
+        } allreduce_nvls;
     };
 };
 

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -91,7 +91,7 @@ typedef struct ucc_tl_cuda_lib_config {
     unsigned long       allgather_ring_max_rings;
     uint32_t            allgather_ring_num_chunks;
     unsigned long       reduce_scatter_ring_max_rings;
-    uint32_t            topo_cache_enable;
+    int                 topo_cache_enable;
 } ucc_tl_cuda_lib_config_t;
 
 typedef struct ucc_tl_cuda_context_config {

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -299,8 +299,7 @@ struct ucc_tl_cuda_task {
             ucc_datatype_t dt;
             void          *sbuf;
             void          *rbuf;
-            size_t         src_size_bytes;
-            size_t         dst_size_bytes;
+            size_t         buf_size_bytes;
             cudaEvent_t    evtCompletion;
         } allreduce_nvls;
     };

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -300,7 +300,7 @@ struct ucc_tl_cuda_task {
             void          *sbuf;
             void          *rbuf;
             size_t         buf_size_bytes;
-            cudaEvent_t    evtCompletion;
+            void          *evtCompletion;
         } allreduce_nvls;
     };
 };

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -224,7 +224,7 @@ ucc_status_t ucc_tl_cuda_alg_id_to_init(int alg_id, const char *alg_id_str,
         break;
     case UCC_COLL_TYPE_ALLREDUCE:
         switch (alg_id) {
-#ifdef ENABLE_NVLS
+#ifdef HAVE_NVLS
         case UCC_TL_CUDA_ALLREDUCE_ALG_NVLS:
             *init = ucc_tl_cuda_allreduce_nvls_init;
             break;
@@ -235,7 +235,7 @@ ucc_status_t ucc_tl_cuda_alg_id_to_init(int alg_id, const char *alg_id_str,
         default:
             status = UCC_ERR_NOT_SUPPORTED;
             break;
-#endif /* ENABLE_NVLS */
+#endif /* HAVE_NVLS */
         };
         break;
     case UCC_COLL_TYPE_REDUCE_SCATTER:
@@ -249,11 +249,11 @@ ucc_status_t ucc_tl_cuda_alg_id_to_init(int alg_id, const char *alg_id_str,
         case UCC_TL_CUDA_REDUCE_SCATTER_ALG_LINEAR:
             *init = ucc_tl_cuda_reduce_scatter_linear_init;
             break;
-#ifdef ENABLE_NVLS
+#ifdef HAVE_NVLS
         case UCC_TL_CUDA_REDUCE_SCATTER_ALG_NVLS:
             *init = ucc_tl_cuda_reduce_scatter_nvls_init;
             break;
-#endif /* ENABLE_NVLS */
+#endif /* HAVE_NVLS */
         default:
             status = UCC_ERR_INVALID_PARAM;
             break;

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -224,12 +224,18 @@ ucc_status_t ucc_tl_cuda_alg_id_to_init(int alg_id, const char *alg_id_str,
         break;
     case UCC_COLL_TYPE_ALLREDUCE:
         switch (alg_id) {
+#ifdef ENABLE_NVLS
         case UCC_TL_CUDA_ALLREDUCE_ALG_NVLS:
             *init = ucc_tl_cuda_allreduce_nvls_init;
             break;
         default:
             status = UCC_ERR_INVALID_PARAM;
             break;
+#else
+        default:
+            status = UCC_ERR_NOT_SUPPORTED;
+            break;
+#endif /* ENABLE_NVLS */
         };
         break;
     case UCC_COLL_TYPE_REDUCE_SCATTER:
@@ -243,9 +249,11 @@ ucc_status_t ucc_tl_cuda_alg_id_to_init(int alg_id, const char *alg_id_str,
         case UCC_TL_CUDA_REDUCE_SCATTER_ALG_LINEAR:
             *init = ucc_tl_cuda_reduce_scatter_linear_init;
             break;
+#ifdef ENABLE_NVLS
         case UCC_TL_CUDA_REDUCE_SCATTER_ALG_NVLS:
             *init = ucc_tl_cuda_reduce_scatter_nvls_init;
             break;
+#endif /* ENABLE_NVLS */
         default:
             status = UCC_ERR_INVALID_PARAM;
             break;

--- a/src/components/tl/cuda/tl_cuda_coll.c
+++ b/src/components/tl/cuda/tl_cuda_coll.c
@@ -12,6 +12,7 @@
 #include "bcast/bcast.h"
 #include "reduce_scatter/reduce_scatter.h"
 #include "reduce_scatterv/reduce_scatterv.h"
+#include "allreduce/allreduce.h"
 #include "utils/arch/cpu.h"
 #include "utils/arch/cuda_def.h"
 
@@ -37,6 +38,7 @@ const char *
         UCC_TL_CUDA_ALLGATHER_DEFAULT_ALG_SELECT_STR,
         UCC_TL_CUDA_ALLGATHERV_DEFAULT_ALG_SELECT_STR,
         UCC_TL_CUDA_BCAST_DEFAULT_ALG_SELECT_STR,
+        UCC_TL_CUDA_ALLREDUCE_DEFAULT_ALG_SELECT_STR,
         UCC_TL_CUDA_REDUCE_SCATTER_DEFAULT_ALG_SELECT_STR,
         UCC_TL_CUDA_REDUCE_SCATTERV_DEFAULT_ALG_SELECT_STR};
 
@@ -86,6 +88,8 @@ ucc_status_t ucc_tl_cuda_coll_init(ucc_base_coll_args_t *coll_args,
         return ucc_tl_cuda_reduce_scatter_init(coll_args, team, task_h);
     case UCC_COLL_TYPE_REDUCE_SCATTERV:
         return ucc_tl_cuda_reduce_scatterv_init(coll_args, team, task_h);
+    case UCC_COLL_TYPE_ALLREDUCE:
+        return ucc_tl_cuda_allreduce_init(coll_args, team, task_h);
     case UCC_COLL_TYPE_ALLTOALLV:
         return ucc_tl_cuda_alltoallv_init(coll_args, team, task_h);
     default:
@@ -153,6 +157,8 @@ static inline int alg_id_from_str(ucc_coll_type_t coll_type, const char *str)
         return ucc_tl_cuda_allgatherv_alg_from_str(str);
     case UCC_COLL_TYPE_BCAST:
         return ucc_tl_cuda_bcast_alg_from_str(str);
+    case UCC_COLL_TYPE_ALLREDUCE:
+        return ucc_tl_cuda_allreduce_alg_from_str(str);
     default:
         break;
     }
@@ -210,6 +216,16 @@ ucc_status_t ucc_tl_cuda_alg_id_to_init(int alg_id, const char *alg_id_str,
         switch (alg_id) {
         case UCC_TL_CUDA_BCAST_ALG_LINEAR:
             *init = ucc_tl_cuda_bcast_linear_init;
+            break;
+        default:
+            status = UCC_ERR_INVALID_PARAM;
+            break;
+        };
+        break;
+    case UCC_COLL_TYPE_ALLREDUCE:
+        switch (alg_id) {
+        case UCC_TL_CUDA_ALLREDUCE_ALG_NVLS:
+            *init = ucc_tl_cuda_allreduce_nvls_init;
             break;
         default:
             status = UCC_ERR_INVALID_PARAM;

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -10,7 +10,7 @@
 #include "tl_cuda.h"
 #include "components/mc/ucc_mc.h"
 
-#define UCC_TL_CUDA_N_DEFAULT_ALG_SELECT_STR 5
+#define UCC_TL_CUDA_N_DEFAULT_ALG_SELECT_STR 6
 extern const char
     *ucc_tl_cuda_default_alg_select_str[UCC_TL_CUDA_N_DEFAULT_ALG_SELECT_STR];
 

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -28,16 +28,16 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
 {
     ucc_tl_cuda_context_config_t *tl_cuda_config =
         ucc_derived_of(config, ucc_tl_cuda_context_config_t);
-    ucc_tl_cuda_lib_t *lib =
-        ucc_derived_of(params->context->lib, ucc_tl_cuda_lib_t);
-    ucc_status_t status;
-    int num_devices;
-    cudaError_t cuda_st;
-    CUcontext cu_ctx;
-    CUresult cu_st;
+    ucc_status_t       status;
+    ucc_tl_cuda_lib_t *lib;
+    int                num_devices;
+    cudaError_t        cuda_st;
+    CUcontext          cu_ctx;
+    CUresult           cu_st;
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_cuda_config->super,
                               params->context);
+    lib = ucc_derived_of(self->super.super.lib, ucc_tl_cuda_lib_t);
     memcpy(&self->cfg, tl_cuda_config, sizeof(*tl_cuda_config));
 
     cuda_st = cudaGetDeviceCount(&num_devices);
@@ -130,14 +130,14 @@ ucc_status_t ucc_tl_cuda_memh_pack(const ucc_base_context_t *context, /* NOLINT 
 
 /**
  * @brief Cleanup function for CUDA TL context
- * 
+ *
  * This function is responsible for cleaning up resources associated with a CUDA TL context.
  * It performs the following operations:
  * 1. Logs the context finalization with debug information
  * 2. Destroys the IPC cache hash table if it exists
  * 3. Cleans up topology if it's context-specific (not cached)
  * 4. Cleans up the request memory pool
- * 
+ *
  * @param self Pointer to the CUDA TL context structure to be cleaned up
  */
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_context_t)

--- a/src/components/tl/cuda/tl_cuda_lib.c
+++ b/src/components/tl/cuda/tl_cuda_lib.c
@@ -10,7 +10,7 @@
 UCC_CLASS_INIT_FUNC(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *params,
                     const ucc_base_config_t *config)
 {
-    const ucc_tl_cuda_lib_config_t *tl_config     =
+    const ucc_tl_cuda_lib_config_t *tl_config =
         ucc_derived_of(config, ucc_tl_cuda_lib_config_t);
     size_t min_scratch_size;
 

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -147,7 +147,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_team_t)
     if (self->topo) {
         ucc_tl_cuda_team_topo_destroy(self->topo);
     }
-    
+
 #ifdef HAVE_TL_CUDA_NVLS
     // destroy the nvls context
     ucc_tl_cuda_nvls_destroy(self, self->super.super.context);
@@ -363,6 +363,8 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
     int                 i;
     ucc_coll_score_team_info_t team_info;
 
+    ucc_print("ucc_tl_cuda_team_get_scores");
+
     team_info.alg_fn              = ucc_tl_cuda_alg_id_to_init;
     team_info.default_score       = UCC_TL_CUDA_DEFAULT_SCORE;
     team_info.init                = ucc_tl_cuda_coll_init;
@@ -379,6 +381,7 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
     if (UCC_OK != status) {
         return status;
     }
+
 
     for (i = 0; i < UCC_TL_CUDA_N_DEFAULT_ALG_SELECT_STR; i++) {
         status = ucc_coll_score_update_from_str(

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -363,8 +363,6 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
     int                 i;
     ucc_coll_score_team_info_t team_info;
 
-    ucc_print("ucc_tl_cuda_team_get_scores");
-
     team_info.alg_fn              = ucc_tl_cuda_alg_id_to_init;
     team_info.default_score       = UCC_TL_CUDA_DEFAULT_SCORE;
     team_info.init                = ucc_tl_cuda_coll_init;
@@ -381,7 +379,6 @@ ucc_status_t ucc_tl_cuda_team_get_scores(ucc_base_team_t *tl_team,
     if (UCC_OK != status) {
         return status;
     }
-
 
     for (i = 0; i < UCC_TL_CUDA_N_DEFAULT_ALG_SELECT_STR; i++) {
         status = ucc_coll_score_update_from_str(


### PR DESCRIPTION
## What
UCC now supports the latest NVLink SHARP (NVLS) technology, unlocking advanced hardware features on modern GPUs (H100+). NVLS enables offloading collective operations to in-network hardware (NVSwitch), reducing SM usage and improving compute resource efficiency compared to traditional GPU-based implementations. 
Allreduce initial implementation with NVLS. (NVLS related initialization you could find in #1144 )

## Why ?
![image](https://github.com/user-attachments/assets/a3393fef-3d2f-4e39-8998-4c76dd325b2b)
Command line:
```
mpirun --mca coll ^hcoll --mca coll_ucc_enable 0 -x LD_LIBRARY_PATH=/.autodirect/swgwork/ikryukov/ucc_build/install/lib:$LD_LIBRARY_PATH -x UCC_TLS=cuda,ucp -x UCC_LOG_LEVEL=info -x UCC_TL_CUDA_TUNE=allreduce:cuda:@0 -np 8 /.autodirect/swgwork/ikryukov/ucc_build/install/bin/ucc_perftest -c allreduce -F -m cuda -b 1k -e 16M -d float32 -o sum
```

