### PR TITLE
TL/UCP: add support for onesided dynamic segments

### DIFF
--- a/src/components/tl/ucp/alltoall/alltoall_onesided.c
+++ b/src/components/tl/ucp/alltoall/alltoall_onesided.c
@@ -57,6 +57,18 @@ static inline void alltoall_onesided_wait_completion(ucc_tl_ucp_task_t *task,
 
 ucc_status_t ucc_tl_ucp_alltoall_onesided_sched_start(ucc_coll_task_t *ctask)
 {
+    ucc_schedule_t *schedule = ucc_derived_of(ctask, ucc_schedule_t);
+    int             i;
+
+    /* Re-arm each subtask's dependency counter so the schedule can be
+     * re-posted for a persistent collective.  The plain ucc_schedule_start()
+     * only re-emits SCHEDULE_STARTED; unlike the pipelined schedule it does
+     * not reset n_deps_satisfied, so without this the SCHEDULE_STARTED /
+     * COMPLETED dependencies would never fire again on the second post and
+     * the schedule would hang. */
+    for (i = 0; i < schedule->n_tasks; i++) {
+        schedule->tasks[i]->n_deps_satisfied = 0;
+    }
     return ucc_schedule_start(ctask);
 }
 
@@ -72,13 +84,20 @@ ucc_status_t ucc_tl_ucp_alltoall_onesided_sched_finalize(ucc_coll_task_t *ctask)
 
 ucc_status_t ucc_tl_ucp_alltoall_onesided_finalize(ucc_coll_task_t *coll_task)
 {
-    ucc_status_t status;
+    ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_status_t       destroy_status;
+    ucc_status_t       status;
 
+    destroy_status = ucc_tl_ucp_coll_dynamic_segment_destroy(task);
+    if (ucc_unlikely(UCC_OK != destroy_status)) {
+        tl_error(UCC_TASK_LIB(coll_task),
+                 "failed to destroy dynamic segment local handles");
+    }
     status = ucc_tl_ucp_coll_finalize(coll_task);
     if (ucc_unlikely(UCC_OK != status)) {
         tl_error(UCC_TASK_LIB(coll_task), "failed to finalize collective");
     }
-    return status;
+    return (destroy_status != UCC_OK) ? destroy_status : status;
 }
 
 void ucc_tl_ucp_alltoall_onesided_get_progress(ucc_coll_task_t *ctask)
@@ -92,27 +111,56 @@ void ucc_tl_ucp_alltoall_onesided_get_progress(ucc_coll_task_t *ctask)
     ucc_rank_t         gsize     = UCC_TL_TEAM_SIZE(team);
     uint32_t           ntokens   = task->alltoall_onesided.tokens;
     int64_t            npolls    = task->alltoall_onesided.npolls;
-    /* To resolve remote virtual addresses, the dst_memh is the one that must
-     * have the rkey information. For this algorithm, we need to swap the
-     * src and dst handles to operate correctly */
-    ucc_mem_map_mem_h *dst_memh  = TASK_ARGS(task).src_memh.global_memh;
-    uint32_t          *posted    = &task->onesided.get_posted;
-    uint32_t          *completed = &task->onesided.get_completed;
-    ucc_rank_t         peer      = (grank + *posted + 1) % gsize;
-    ucc_mem_map_mem_h  src_memh;
+    /* For GET, we read from each peer's src buffer into our local dst buffer.
+     * remote_rkeys is the per-rank array of src rkeys (what we GET from);
+     * local_h is our own dst buffer registration (where data lands). */
+    ucc_mem_map_mem_h *remote_rkeys = TASK_ARGS(task).src_memh.global_memh;
+    uint32_t          *posted       = &task->onesided.get_posted;
+    uint32_t          *completed    = &task->onesided.get_completed;
+    ucc_rank_t         peer         = (grank + *posted + 1) % gsize;
+    ucc_mem_map_mem_h  local_h;
     size_t             nelems;
+    ucc_status_t       status;
+    ucc_status_t       st;
+
+    if (task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG) {
+        status = ucc_tl_ucp_test_dynamic_segment(task);
+        if (status == UCC_INPROGRESS) {
+            return;
+        }
+        if (UCC_OK != status) {
+            task->super.status = status;
+            tl_error(UCC_TL_TEAM_LIB(team),
+                     "failed to exchange dynamic segments");
+            return;
+        }
+        local_h      = task->dynamic_segments.dst_local;
+        remote_rkeys = (ucc_mem_map_mem_h *)task->dynamic_segments.src_global;
+    } else {
+        local_h = ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
+                    (TASK_ARGS(task).flags &
+                     UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL))
+                   ? TASK_ARGS(task).dst_memh.global_memh[grank]
+                   : TASK_ARGS(task).dst_memh.local_memh;
+    }
+
+    if (ucc_unlikely((task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG) &&
+                     remote_rkeys == NULL)) {
+        task->super.status = UCC_OK;
+        goto out;
+    }
 
     nelems   = TASK_ARGS(task).src.info.count;
     nelems   = (nelems / gsize) * ucc_dt_size(TASK_ARGS(task).src.info.datatype);
-    src_memh = (TASK_ARGS(task).flags & UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL)
-                   ? TASK_ARGS(task).dst_memh.global_memh[grank]
-                   : TASK_ARGS(task).dst_memh.local_memh;
-
+    if (nelems == 0) {
+        task->super.status = UCC_OK;
+        goto out;
+    }
     for (; *posted < gsize; peer = (peer + 1) % gsize) {
         UCPCHECK_GOTO(ucc_tl_ucp_get_nb(PTR_OFFSET(dest, peer * nelems),
                                         PTR_OFFSET(src, grank * nelems),
-                                        nelems, mtype, peer, src_memh, dst_memh,
-                                        team, task),
+                                        nelems, mtype, peer, local_h,
+                                        remote_rkeys, team, task),
                       task, out);
 
         if (!alltoall_onesided_handle_completion(task, posted, completed,
@@ -123,7 +171,12 @@ void ucc_tl_ucp_alltoall_onesided_get_progress(ucc_coll_task_t *ctask)
 
     alltoall_onesided_wait_completion(task, npolls);
 out:
-    return;
+    st = task->super.status;
+    if (st != UCC_INPROGRESS &&
+        (task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG)) {
+        ucc_status_t fin = ucc_tl_ucp_coll_dynamic_segment_finalize(task);
+        task->super.status = (st != UCC_OK) ? st : fin;
+    }
 }
 
 void ucc_tl_ucp_alltoall_onesided_put_progress(ucc_coll_task_t *ctask)
@@ -143,13 +196,42 @@ void ucc_tl_ucp_alltoall_onesided_put_progress(ucc_coll_task_t *ctask)
     ucc_rank_t         peer      = (grank + *posted + 1) % gsize;
     ucc_mem_map_mem_h  src_memh;
     size_t             nelems;
+    ucc_status_t       status;
+    ucc_status_t       st;
 
-    nelems   = TASK_ARGS(task).src.info.count;
-    nelems   = (nelems / gsize) * ucc_dt_size(TASK_ARGS(task).src.info.datatype);
-    src_memh = (TASK_ARGS(task).flags & UCC_COLL_ARGS_FLAG_SRC_MEMH_GLOBAL)
+    nelems = TASK_ARGS(task).src.info.count;
+    nelems = (nelems / gsize) * ucc_dt_size(TASK_ARGS(task).src.info.datatype);
+    if (task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG) {
+        status = ucc_tl_ucp_test_dynamic_segment(task);
+        if (status == UCC_INPROGRESS) {
+            return;
+        }
+        if (UCC_OK != status) {
+            task->super.status = status;
+            tl_error(UCC_TL_TEAM_LIB(team),
+                     "failed to exchange dynamic segments");
+            return;
+        }
+        src_memh = task->dynamic_segments.src_local;
+        dst_memh = (ucc_mem_map_mem_h *)task->dynamic_segments.dst_global;
+    } else {
+        src_memh = ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
+                    (TASK_ARGS(task).flags &
+                     UCC_COLL_ARGS_FLAG_SRC_MEMH_GLOBAL))
                    ? TASK_ARGS(task).src_memh.global_memh[grank]
                    : TASK_ARGS(task).src_memh.local_memh;
+    }
 
+    if (ucc_unlikely((task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG) &&
+                     dst_memh == NULL)) {
+        task->super.status = UCC_OK;
+        goto out;
+    }
+
+    if (nelems == 0) {
+        task->super.status = UCC_OK;
+        goto out;
+    }
     for (; *posted < gsize; peer = (peer + 1) % gsize) {
         UCPCHECK_GOTO(
             ucc_tl_ucp_put_nb(PTR_OFFSET(src, peer * nelems),
@@ -166,10 +248,13 @@ void ucc_tl_ucp_alltoall_onesided_put_progress(ucc_coll_task_t *ctask)
 
     alltoall_onesided_wait_completion(task, npolls);
 out:
-    return;
+    st = task->super.status;
+    if (st != UCC_INPROGRESS &&
+        (task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG)) {
+        ucc_status_t fin = ucc_tl_ucp_coll_dynamic_segment_finalize(task);
+        task->super.status = (st != UCC_OK) ? st : fin;
+    }
 }
-
-static ucc_status_t ucc_tl_ucp_alltoall_onesided_start_ops(ucc_tl_ucp_task_t *task);
 
 ucc_status_t ucc_tl_ucp_alltoall_onesided_start(ucc_coll_task_t *ctask)
 {
@@ -180,65 +265,16 @@ ucc_status_t ucc_tl_ucp_alltoall_onesided_start(ucc_coll_task_t *ctask)
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
     if (task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG) {
         status = ucc_tl_ucp_coll_dynamic_segment_exchange_nb(task);
-        if (status == UCC_INPROGRESS) {
-            return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
-        }
-        if (UCC_OK != status) {
+        if (UCC_OK != status && UCC_INPROGRESS != status) {
             task->super.status = status;
+            tl_error(UCC_TL_TEAM_LIB(team),
+                     "failed to exchange dynamic segments");
             return task->super.status;
         }
     }
 
     /* Start the onesided operations */
-    return ucc_tl_ucp_alltoall_onesided_start_ops(task);
-}
-
-static ucc_status_t ucc_tl_ucp_alltoall_onesided_start_ops(ucc_tl_ucp_task_t *task)
-{
-    ucc_tl_ucp_team_t  *team     = TASK_TEAM(task);
-    ptrdiff_t           src      = (ptrdiff_t)TASK_ARGS(task).src.info.buffer;
-    ptrdiff_t           dest     = (ptrdiff_t)TASK_ARGS(task).dst.info.buffer;
-    size_t              nelems   = TASK_ARGS(task).src.info.count;
-    ucc_rank_t          grank    = UCC_TL_TEAM_RANK(team);
-    ucc_rank_t          gsize    = UCC_TL_TEAM_SIZE(team);
-    ucc_rank_t          start    = (grank + 1) % gsize;
-    long               *pSync    = TASK_ARGS(task).global_work_buffer;
-    ucc_mem_map_mem_h   src_memh = TASK_ARGS(task).src_memh.local_memh;
-    ucc_mem_map_mem_h  *dst_memh = TASK_ARGS(task).dst_memh.global_memh;
-    ucc_rank_t          peer;
-
-
-    if (task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG) {
-        status = ucc_tl_ucp_coll_dynamic_segment_exchange(task);
-        if (UCC_OK != status) {
-            task->super.status = status;
-            return task->super.status;
-        }
-        src_memh = task->dynamic_segments.src_global[grank];
-        dst_memh = (ucc_mem_map_mem_h *)task->dynamic_segments.dst_global;
-    } else {
-        if (TASK_ARGS(task).flags & UCC_COLL_ARGS_FLAG_SRC_MEMH_GLOBAL) {
-            src_memh = TASK_ARGS(task).src_memh.global_memh[grank];
-        }
-    }
-
-    /* TODO: change when support for library-based work buffers is complete */
-    nelems = (nelems / gsize) * ucc_dt_size(TASK_ARGS(task).src.info.datatype);
-    dest   = dest + grank * nelems;
-    for (peer = start; task->onesided.put_posted < gsize;
-         peer = (peer + 1) % gsize) {
-        UCPCHECK_GOTO(ucc_tl_ucp_put_nb((void *)(src + peer * nelems),
-                                        (void *)dest, nelems, peer, src_memh,
-                                        dst_memh, team, task),
-                      task, out);
-        UCPCHECK_GOTO(ucc_tl_ucp_atomic_inc(pSync, peer, dst_memh, team), task,
-                      out);
-    }
-
-    /* Operations posted, return UCC_INPROGRESS to let progress function set flag */
-    return UCC_INPROGRESS;
-out:
-    return task->super.status;
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
 ucc_status_t ucc_tl_ucp_alltoall_onesided_init(ucc_base_coll_args_t *coll_args,
@@ -254,7 +290,7 @@ ucc_status_t ucc_tl_ucp_alltoall_onesided_init(ucc_base_coll_args_t *coll_args,
     };
     size_t                       perc_bw     =
         UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.alltoall_onesided_percent_bw;
-    ucc_tl_ucp_alltoall_onesided_alg_t alg   =
+    ucc_tl_ucp_onesided_alg_type alg         =
         UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.alltoall_onesided_alg;
     ucc_tl_ucp_schedule_t       *tl_schedule = NULL;
     ucc_rank_t                   group_size  = 1;
@@ -276,7 +312,8 @@ ucc_status_t ucc_tl_ucp_alltoall_onesided_init(ucc_base_coll_args_t *coll_args,
     if (!(coll_args->args.mask & UCC_COLL_ARGS_FIELD_MEM_MAP_SRC_MEMH)) {
         coll_args->args.src_memh.global_memh = NULL;
     } else {
-        if (!(coll_args->args.flags & UCC_COLL_ARGS_FLAG_SRC_MEMH_GLOBAL)) {
+        if (!(coll_args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) ||
+            !(coll_args->args.flags & UCC_COLL_ARGS_FLAG_SRC_MEMH_GLOBAL)) {
             tl_error(UCC_TL_TEAM_LIB(tl_team),
                 "onesided alltoall requires global memory handles for src buffers");
             status = UCC_ERR_INVALID_PARAM;
@@ -286,19 +323,13 @@ ucc_status_t ucc_tl_ucp_alltoall_onesided_init(ucc_base_coll_args_t *coll_args,
     if (!(coll_args->args.mask & UCC_COLL_ARGS_FIELD_MEM_MAP_DST_MEMH)) {
         coll_args->args.dst_memh.global_memh = NULL;
     } else {
-        if (!(coll_args->args.flags & UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL)) {
+        if (!(coll_args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) ||
+            !(coll_args->args.flags & UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL)) {
             tl_error(UCC_TL_TEAM_LIB(tl_team),
                 "onesided alltoall requires global memory handles for dst buffers");
             status = UCC_ERR_INVALID_PARAM;
             return status;
         }
-    }
-
-    status = ucc_tl_ucp_coll_dynamic_segment_init(&coll_args->args, task);
-    if (UCC_OK != status) {
-        tl_error(UCC_TL_TEAM_LIB(tl_team),
-                "failed to initialize dynamic segments");
-        return status;
     }
 
     status = ucc_tl_ucp_get_schedule(tl_team, coll_args,
@@ -322,12 +353,35 @@ ucc_status_t ucc_tl_ucp_alltoall_onesided_init(ucc_base_coll_args_t *coll_args,
         group_size = sbgp->group_size;
     }
 
-    task                 = ucc_tl_ucp_init_task(coll_args, team);
+    task = ucc_tl_ucp_init_task(coll_args, team);
+    if (ucc_unlikely(!task)) {
+        status = UCC_ERR_NO_MEMORY;
+        goto out;
+    }
     task->super.finalize = ucc_tl_ucp_alltoall_onesided_finalize;
     a2a_task             = &task->super;
 
+    /* initialize dynamic segments */
+    if (alg == UCC_TL_UCP_ALLTOALL_ONESIDED_GET ||
+       (alg == UCC_TL_UCP_ALLTOALL_ONESIDED_AUTO &&
+        sbgp->group_size >= CONGESTION_THRESHOLD)) {
+        alg = UCC_TL_UCP_ALLTOALL_ONESIDED_GET;
+    } else if (alg == UCC_TL_UCP_ALLTOALL_ONESIDED_AUTO) {
+        alg = UCC_TL_UCP_ALLTOALL_ONESIDED_PUT;
+    }
+    status = ucc_tl_ucp_coll_dynamic_segment_init(&coll_args->args, alg, task);
+    if (UCC_OK != status) {
+        if (status != UCC_ERR_NOT_SUPPORTED) {
+            tl_error(UCC_TL_TEAM_LIB(tl_team),
+                     "failed to initialize dynamic segments");
+        }
+        ucc_tl_ucp_coll_finalize(&task->super);
+        goto out;
+    }
+
     status = ucc_tl_ucp_coll_init(&barrier_coll_args, team, &barrier_task);
     if (status != UCC_OK) {
+        task->super.finalize(&task->super);
         goto out;
     }
     if (perc_bw > 100) {
@@ -340,23 +394,25 @@ ucc_status_t ucc_tl_ucp_alltoall_onesided_init(ucc_base_coll_args_t *coll_args,
     nelems             = nelems / UCC_TL_TEAM_SIZE(tl_team);
     param.field_mask   = UCP_EP_PERF_PARAM_FIELD_MESSAGE_SIZE;
     attr.field_mask    = UCP_EP_PERF_ATTR_FIELD_ESTIMATED_TIME;
-    param.message_size = nelems * ucc_dt_size(TASK_ARGS(task).src.info.datatype);;
+    param.message_size = nelems * ucc_dt_size(TASK_ARGS(task).src.info.datatype);
     ucc_tl_ucp_get_ep(
         tl_team, (UCC_TL_TEAM_RANK(tl_team) + 1) % UCC_TL_TEAM_SIZE(tl_team),
         &ep);
     ucp_ep_evaluate_perf(ep, &param, &attr);
 
-    rate  = (1 / attr.estimated_time) * (double)(perc_bw / 100.0);
-    ratio = (nelems > 0) ? nelems * group_size : 1;
-    task->alltoall_onesided.tokens = rate / ratio;
+    if (attr.estimated_time > 0) {
+        rate  = (1 / attr.estimated_time) * (double)(perc_bw / 100.0);
+        ratio = (nelems > 0) ? nelems * group_size : 1;
+        task->alltoall_onesided.tokens = rate / ratio;
+    } else {
+        task->alltoall_onesided.tokens = 0;
+    }
     if (task->alltoall_onesided.tokens < 1) {
         task->alltoall_onesided.tokens = 1;
     }
     task->super.post = ucc_tl_ucp_alltoall_onesided_start;
     npolls           = task->n_polls;
-    if (alg == UCC_TL_UCP_ALLTOALL_ONESIDED_GET ||
-       (alg == UCC_TL_UCP_ALLTOALL_ONESIDED_AUTO &&
-                                    group_size >= CONGESTION_THRESHOLD)) {
+    if (alg == UCC_TL_UCP_ALLTOALL_ONESIDED_GET) {
         npolls = nelems * ucc_dt_size(TASK_ARGS(task).src.info.datatype);
         if (npolls < task->n_polls) {
             npolls = task->n_polls;

--- a/src/components/tl/ucp/alltoallv/alltoallv_onesided.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_onesided.c
@@ -11,6 +11,8 @@
 #include "utils/ucc_math.h"
 #include "tl_ucp_sendrecv.h"
 
+void ucc_tl_ucp_alltoallv_onesided_progress(ucc_coll_task_t *ctask);
+
 ucc_status_t ucc_tl_ucp_alltoallv_onesided_start(ucc_coll_task_t *ctask)
 {
     ucc_tl_ucp_task_t *task     = ucc_derived_of(ctask, ucc_tl_ucp_task_t);
@@ -29,22 +31,16 @@ ucc_status_t ucc_tl_ucp_alltoallv_onesided_start(ucc_coll_task_t *ctask)
     ucc_mem_map_mem_h *dst_memh = TASK_ARGS(task).dst_memh.global_memh;
     ucc_rank_t         peer;
     size_t             sd_disp, dd_disp, data_size;
-    ucc_status_t       status;
 
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
-    if (task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG) {
-        status = ucc_tl_ucp_coll_dynamic_segment_exchange(task);
-        if (UCC_OK != status) {
-            task->super.status = status;
-            goto out;
-        }
-        src_memh   = task->dynamic_segments.src_global[grank];
-        dst_memh   = (ucc_mem_map_mem_h *)task->dynamic_segments.dst_global;
-    } else {
+
+    if ((TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_MEM_MAP_SRC_MEMH) &&
+        (TASK_ARGS(task).mask & UCC_COLL_ARGS_FIELD_FLAGS)) {
         if (TASK_ARGS(task).flags & UCC_COLL_ARGS_FLAG_SRC_MEMH_GLOBAL) {
             src_memh = TASK_ARGS(task).src_memh.global_memh[grank];
         }
     }
+
     /* perform a put to each member peer using the peer's index in the
      * destination displacement. */
     for (peer = (grank + 1) % gsize; task->onesided.put_posted < gsize;
@@ -69,6 +65,7 @@ ucc_status_t ucc_tl_ucp_alltoallv_onesided_start(ucc_coll_task_t *ctask)
                                             dst_memh, team),
                       task, out);
     }
+
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 out:
     return task->super.status;
@@ -76,26 +73,25 @@ out:
 
 void ucc_tl_ucp_alltoallv_onesided_progress(ucc_coll_task_t *ctask)
 {
-    ucc_tl_ucp_task_t *task  = ucc_derived_of(ctask, ucc_tl_ucp_task_t);
-    ucc_tl_ucp_team_t *team  = TASK_TEAM(task);
-    ucc_rank_t         gsize = UCC_TL_TEAM_SIZE(team);
-    long              *pSync = TASK_ARGS(task).global_work_buffer;
+    ucc_tl_ucp_task_t *task     = ucc_derived_of(ctask, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team     = TASK_TEAM(task);
+    long              *pSync    = TASK_ARGS(task).global_work_buffer;
+    ucc_rank_t         gsize    = UCC_TL_TEAM_SIZE(team);
 
     if (ucc_tl_ucp_test_onesided(task, gsize) == UCC_INPROGRESS) {
         return;
     }
-
     pSync[0]           = 0;
-    task->super.status = ucc_tl_ucp_coll_dynamic_segment_finalize(task);
+    task->super.status = UCC_OK;
 }
 
 ucc_status_t ucc_tl_ucp_alltoallv_onesided_init(ucc_base_coll_args_t *coll_args,
                                                 ucc_base_team_t      *team,
                                                 ucc_coll_task_t     **task_h)
 {
-    ucc_tl_ucp_team_t  *tl_team  = ucc_derived_of(team, ucc_tl_ucp_team_t);
-    ucc_status_t        status   = UCC_OK;
-    ucc_tl_ucp_task_t  *task;
+    ucc_tl_ucp_team_t *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
+    ucc_status_t       status  = UCC_OK;
+    ucc_tl_ucp_task_t *task;
 
     ALLTOALLV_TASK_CHECK(coll_args->args, tl_team);
     if (!(coll_args->args.mask & UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER)) {
@@ -104,25 +100,38 @@ ucc_status_t ucc_tl_ucp_alltoallv_onesided_init(ucc_base_coll_args_t *coll_args,
         status = UCC_ERR_NOT_SUPPORTED;
         goto out;
     }
+    if (coll_args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) {
+        if (!(coll_args->args.flags & UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS)) {
+            tl_error(UCC_TL_TEAM_LIB(tl_team),
+                     "non memory mapped buffers are not supported");
+            status = UCC_ERR_NOT_SUPPORTED;
+            goto out;
+        }
+    }
     if (!(coll_args->args.mask & UCC_COLL_ARGS_FIELD_MEM_MAP_SRC_MEMH)) {
         coll_args->args.src_memh.global_memh = NULL;
     }
     if (!(coll_args->args.mask & UCC_COLL_ARGS_FIELD_MEM_MAP_DST_MEMH)) {
         coll_args->args.dst_memh.global_memh = NULL;
+    } else {
+        if (!(coll_args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) ||
+            !(coll_args->args.flags & UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL)) {
+            tl_error(UCC_TL_TEAM_LIB(tl_team),
+                     "onesided alltoallv requires global memory handles for dst "
+                     "buffers");
+            status = UCC_ERR_INVALID_PARAM;
+            goto out;
+        }
     }
 
-    task                 = ucc_tl_ucp_init_task(coll_args, team);
+    task = ucc_tl_ucp_init_task(coll_args, team);
+    if (ucc_unlikely(!task)) {
+        status = UCC_ERR_NO_MEMORY;
+        goto out;
+    }
     *task_h              = &task->super;
     task->super.post     = ucc_tl_ucp_alltoallv_onesided_start;
     task->super.progress = ucc_tl_ucp_alltoallv_onesided_progress;
-
-    status = ucc_tl_ucp_coll_dynamic_segment_init(
-        &coll_args->args, task);
-    if (UCC_OK != status) {
-        tl_error(UCC_TL_TEAM_LIB(tl_team),
-                 "failed to initialize dynamic segments");
-        goto out;
-    }
 out:
     return status;
 }

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -308,10 +308,10 @@ static ucs_config_field_t ucc_tl_ucp_context_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_context_config_t, memtype_copy_enable),
      UCC_CONFIG_TYPE_BOOL},
 
-    {"EXPORTED_MEMORY_HANDLE", "n",
-     "If set to yes, initialize UCP context with the exported memory handle "
-     "feature, which is useful for offload devices such as a DPU. Otherwise "
-     "disable the use of this feature.",
+    {"EXPORTED_MEMORY_HANDLE", "0",
+     "If set to 1, initialize UCP context with the exported memory handle "
+     "feature, which is useful for offload devices such as a DPU. Set to 0 "
+     "to disable this feature (default is 0).",
      ucc_offsetof(ucc_tl_ucp_context_config_t, exported_memory_handle),
      UCC_CONFIG_TYPE_BOOL},
 

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -43,12 +43,12 @@ typedef struct ucc_tl_ucp_iface {
 /* Extern iface should follow the pattern: ucc_tl_<tl_name> */
 extern ucc_tl_ucp_iface_t ucc_tl_ucp;
 
-typedef enum ucc_tl_ucp_alltoall_onesided_alg_type {
+typedef enum ucc_tl_ucp_onesided_alg_type {
     UCC_TL_UCP_ALLTOALL_ONESIDED_PUT,
     UCC_TL_UCP_ALLTOALL_ONESIDED_GET,
     UCC_TL_UCP_ALLTOALL_ONESIDED_AUTO,
     UCC_TL_UCP_ALLTOALL_ONESIDED_LAST
-} ucc_tl_ucp_alltoall_onesided_alg_t;
+} ucc_tl_ucp_onesided_alg_type;
 
 typedef struct ucc_tl_ucp_lib_config {
     ucc_tl_lib_config_t                super;
@@ -89,7 +89,7 @@ typedef struct ucc_tl_ucp_lib_config {
     ucc_ternary_auto_value_t           use_topo;
     int                                use_reordering;
     uint32_t                           alltoall_onesided_percent_bw;
-    ucc_tl_ucp_alltoall_onesided_alg_t alltoall_onesided_alg;
+    ucc_tl_ucp_onesided_alg_type       alltoall_onesided_alg;
 } ucc_tl_ucp_lib_config_t;
 
 typedef enum ucc_tl_ucp_local_copy_type {

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -169,8 +169,6 @@ typedef struct ucc_tl_ucp_team {
     ucc_status_t               status;
     uint32_t                   seq_num;
     ucc_tl_ucp_task_t         *preconnect_task;
-    void *                     va_base[MAX_NR_SEGMENTS];
-    size_t                     base_length[MAX_NR_SEGMENTS];
     ucc_tl_ucp_worker_t *      worker;
     ucc_tl_ucp_team_config_t   cfg;
     const char *               tuning_str;
@@ -316,4 +314,19 @@ void ucc_tl_ucp_pre_register_mem(ucc_tl_ucp_team_t *team, void *addr,
 ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t *ctx,
                                             ucc_mem_map_params_t  map,
                                             ucc_team_oob_coll_t   oob);
+
+ucc_status_t ucc_tl_ucp_mem_map(const ucc_base_context_t *context,
+                                ucc_mem_map_mode_t        mode,
+                                ucc_mem_map_memh_t       *memh,
+                                ucc_mem_map_tl_t         *tl_h);
+
+ucc_status_t ucc_tl_ucp_memh_pack(const ucc_base_context_t *context,
+                                  ucc_mem_map_mode_t        mode,
+                                  ucc_mem_map_tl_t         *tl_h,
+                                  void                    **pack_buffer);
+
+ucc_status_t ucc_tl_ucp_mem_unmap(const ucc_base_context_t *context,
+                                  ucc_mem_map_mode_t        mode,
+                                  ucc_mem_map_tl_t         *memh);
+
 #endif

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -8,6 +8,8 @@
 #include "tl_ucp_coll.h"
 #include "components/mc/ucc_mc.h"
 #include "core/ucc_team.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
 #include "barrier/barrier.h"
 #include "alltoall/alltoall.h"
 #include "alltoallv/alltoallv.h"
@@ -23,6 +25,19 @@
 #include "fanin/fanin.h"
 #include "fanout/fanout.h"
 #include "scatterv/scatterv.h"
+
+/* Constants for dynamic segment memory handle packing */
+#define IS_SRC 1
+#define IS_DST 0
+
+enum {
+    DYN_SEG_EXCHANGE_STEP_INIT,
+    DYN_SEG_EXCHANGE_STEP_SIZE_TEST,
+    DYN_SEG_EXCHANGE_STEP_DATA_ALLOC,
+    DYN_SEG_EXCHANGE_STEP_DATA_START,
+    DYN_SEG_EXCHANGE_STEP_DATA_TEST,
+    DYN_SEG_EXCHANGE_STEP_COMPLETE
+};
 
 const ucc_tl_ucp_default_alg_desc_t
     ucc_tl_ucp_default_alg_descs[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR] = {
@@ -104,6 +119,669 @@ ucc_status_t ucc_tl_ucp_coll_finalize(ucc_coll_task_t *coll_task)
     tl_trace(UCC_TASK_LIB(task), "finalizing task %p", task);
     ucc_tl_ucp_put_task(task);
     return UCC_OK;
+}
+
+static inline ucc_status_t dynamic_segment_map_memh(ucc_mem_map_memh_t **memh,
+                                                    ucc_coll_args_t *coll_args,
+                                                    int is_src,
+                                                    ucc_tl_ucp_task_t   *task)
+{
+    ucc_tl_ucp_team_t        *tl_team = UCC_TL_UCP_TASK_TEAM(task);
+    ucc_tl_ucp_context_t     *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_status_t              status  = UCC_OK;
+    ucc_mem_map_memh_t       *lmemh   = NULL;
+    void                     *buffer;
+    ucc_count_t               total_count;
+    ucc_datatype_t            datatype;
+    ucc_coll_buffer_info_v_t *info_v;
+
+    lmemh = ucc_calloc(1, sizeof(ucc_mem_map_memh_t), "dyn_memh");
+    if (lmemh == NULL) {
+        tl_error(UCC_TASK_LIB(task), "failed to allocate memh");
+        status = UCC_ERR_NO_MEMORY;
+        goto out;
+    }
+    lmemh->tl_h = ucc_calloc(1, sizeof(ucc_mem_map_tl_t), "dyn_tlh");
+    if (!lmemh->tl_h) {
+        tl_error(UCC_TASK_LIB(task), "failed to allocate memh");
+        ucc_free(lmemh);
+        status = UCC_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    /* Check if this is one of the *v collectives */
+    if (coll_args->coll_type == UCC_COLL_TYPE_ALLGATHERV ||
+        coll_args->coll_type == UCC_COLL_TYPE_ALLTOALLV ||
+        coll_args->coll_type == UCC_COLL_TYPE_GATHERV ||
+        coll_args->coll_type == UCC_COLL_TYPE_REDUCE_SCATTERV ||
+        coll_args->coll_type == UCC_COLL_TYPE_SCATTERV) {
+
+        if (is_src) {
+            info_v = &coll_args->src.info_v;
+        } else {
+            info_v = &coll_args->dst.info_v;
+        }
+
+        buffer   = info_v->buffer;
+        datatype = info_v->datatype;
+        /* Calculate total buffer size considering both counts and displacements */
+        total_count = ucc_coll_args_get_v_buffer_size(coll_args, info_v->counts,
+                                                      info_v->displacements,
+                                                      UCC_TL_TEAM_SIZE(tl_team));
+    } else {
+        /* Handle regular collectives - use info */
+        if (is_src) {
+            total_count = coll_args->src.info.count;
+            buffer      = coll_args->src.info.buffer;
+            datatype    = coll_args->src.info.datatype;
+        } else {
+            total_count = coll_args->dst.info.count;
+            buffer      = coll_args->dst.info.buffer;
+            datatype    = coll_args->dst.info.datatype;
+        }
+    }
+    lmemh->address = buffer;
+    lmemh->len     = total_count * ucc_dt_size(datatype);
+    lmemh->num_tls = 1;  /* Only one transport layer (UCP) */
+    strncpy(lmemh->tl_h->tl_name, "ucp", UCC_MEM_MAP_TL_NAME_LEN - 1);
+    status = ucc_tl_ucp_mem_map(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT,
+                                lmemh, lmemh->tl_h);
+    if (UCC_OK != status) {
+        tl_error(UCC_TASK_LIB(task), "failed to map memory for memh");
+        ucc_free(lmemh->tl_h);
+        ucc_free(lmemh);
+        goto out;
+    }
+    *memh = lmemh;
+out:
+    return status;
+}
+
+/*
+ * This function initializes dynamic memory segments for onesided collectives.
+ * It checks if user-provided memory handles are available, and if not,
+ * creates and maps local memory handles for source and destination buffers.
+ * These handles will be exchanged across ranks for remote memory access. */
+UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_init, (coll_args, task),
+                        ucc_coll_args_t *coll_args, ucc_tl_ucp_task_t *task)
+{
+    ucc_status_t        status = UCC_OK;
+    ucc_mem_map_memh_t *src_memh;
+    ucc_mem_map_memh_t *dst_memh;
+
+    if ((coll_args->mask & UCC_COLL_ARGS_FIELD_FLAGS)) {
+        if ((coll_args->flags & UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS)) {
+            return UCC_OK;
+        }
+    } else if ((coll_args->mask & UCC_COLL_ARGS_FIELD_MEM_MAP_SRC_MEMH) &&
+               (coll_args->mask & UCC_COLL_ARGS_FIELD_MEM_MAP_DST_MEMH)) {
+        return UCC_OK;
+    }
+    status = dynamic_segment_map_memh(&src_memh, coll_args, IS_SRC, task);
+    if (UCC_OK != status) {
+        return status;
+    }
+    status = dynamic_segment_map_memh(&dst_memh, coll_args, IS_DST, task);
+    if (UCC_OK != status) {
+        ucc_free(src_memh->tl_h);
+        ucc_free(src_memh);
+        return status;
+    }
+    memset(&task->dynamic_segments, 0, sizeof(task->dynamic_segments));
+    task->dynamic_segments.src_local = src_memh;
+    task->dynamic_segments.dst_local = dst_memh;
+    task->flags                     |= UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG;
+    return status;
+}
+
+static inline ucc_status_t dynamic_segment_alloc_seg(ucc_mem_map_memh_t **memh,
+                                                     size_t packed_size)
+{
+    ucc_mem_map_memh_t *lmemh;
+
+    lmemh = ucc_calloc(1, sizeof(ucc_mem_map_memh_t) + packed_size + sizeof(size_t) * 2, "packed_memh");
+    if (!lmemh) {
+        return UCC_ERR_NO_MEMORY;
+    }
+    lmemh->tl_h = ucc_calloc(1, sizeof(ucc_mem_map_tl_t), "packed_tl_h");
+    if (!lmemh->tl_h) {
+        ucc_free(lmemh);
+        return UCC_ERR_NO_MEMORY;
+    }
+    *memh = lmemh;
+    return UCC_OK;
+}
+
+static inline void dynamic_segment_memh_pack(ucc_context_h ctx,
+                                             ucc_tl_ucp_dyn_seg_args_t *args,
+                                             int is_src)
+{
+    ucc_mem_map_memh_t *memh;
+    void               *pack_buffer;
+    size_t              pack_size;
+    void               *address;
+    size_t              len;
+
+    if (is_src) {
+        pack_buffer = args->src_pack_buffer;
+        pack_size   = args->src_pack_size;
+        address     = args->src_memh_local->address;
+        len         = args->src_memh_local->len;
+        memh        = args->src_memh_pack;
+    } else {
+        pack_buffer = args->dst_pack_buffer;
+        pack_size   = args->dst_pack_size;
+        address     = args->dst_memh_local->address;
+        len         = args->dst_memh_local->len;
+        memh        = args->dst_memh_pack;
+    }
+    /* Pack local data into exchange buffer */
+    strncpy(memh->pack_buffer, "ucp", UCC_MEM_MAP_TL_NAME_LEN - 1);
+    memcpy(PTR_OFFSET(memh->pack_buffer, UCC_MEM_MAP_TL_NAME_LEN), &pack_size,
+           sizeof(size_t));
+    memcpy(PTR_OFFSET(memh->pack_buffer, UCC_MEM_MAP_TL_NAME_LEN + sizeof(size_t)),
+           pack_buffer, pack_size);
+    memh->mode    = UCC_MEM_MAP_MODE_EXPORT;
+    memh->context = ctx;
+    memh->address = address;
+    memh->len     = len;
+    memh->num_tls = 1;
+}
+
+static ucc_status_t dynamic_segment_pack_memory_handles(ucc_tl_ucp_dyn_seg_args_t *args)
+{
+    ucc_tl_ucp_team_t      *tl_team = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_tl_ucp_context_t   *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_status_t            status;
+
+    status = ucc_tl_ucp_memh_pack(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT,
+                                  args->src_memh_local->tl_h, &args->src_pack_buffer);
+    if (status != UCC_OK) {
+        tl_error(UCC_TASK_LIB(args->task), "failed to pack src memory handle");
+        return status;
+    }
+    args->src_pack_size = args->src_memh_local->tl_h->packed_size;
+
+    status = ucc_tl_ucp_memh_pack(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT,
+                                  args->dst_memh_local->tl_h, &args->dst_pack_buffer);
+    if (status != UCC_OK) {
+        tl_error(UCC_TASK_LIB(args->task), "failed to pack dst memory handle");
+        ucc_free(args->src_pack_buffer);
+        args->src_pack_buffer = NULL;
+        return status;
+    }
+    args->dst_pack_size = args->dst_memh_local->tl_h->packed_size;
+    return UCC_OK;
+}
+
+static ucc_status_t dynamic_segment_calculate_sizes_start(ucc_tl_ucp_dyn_seg_args_t *args,
+                                                          ucc_service_coll_req_t **scoll_req)
+{
+    ucc_tl_ucp_team_t *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_team_t        *core_team = UCC_TL_CORE_TEAM(tl_team);
+    ucc_subset_t       subset    = {.map = core_team->ctx_map,
+                                    .myrank = core_team->rank};
+    size_t            *global_sizes;
+    ucc_status_t       status;
+    size_t             local_pack_size;
+
+    /* Calculate total pack size for this rank */
+    local_pack_size = ucc_max(args->src_pack_size, args->dst_pack_size) + sizeof(size_t) * 2;
+
+    global_sizes = ucc_calloc(core_team->size, sizeof(size_t), "global sizes");
+    if (!global_sizes) {
+        tl_error(UCC_TASK_LIB(args->task), "failed to allocate global sizes buffer");
+        return UCC_ERR_NO_MEMORY;
+    }
+    args->global_sizes = global_sizes;
+
+    status = ucc_service_allgather(core_team, &local_pack_size, global_sizes,
+                                   sizeof(size_t), subset, scoll_req);
+    if (status != UCC_OK) {
+        tl_error(UCC_TASK_LIB(args->task),
+                 "failed to start service allgather for sizes");
+        ucc_free(global_sizes);
+        args->global_sizes = NULL;
+        return status;
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t dynamic_segment_calculate_sizes_test(ucc_tl_ucp_dyn_seg_args_t *args,
+                                                         ucc_service_coll_req_t **scoll_req)
+{
+    ucc_tl_ucp_team_t      *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_tl_ucp_context_t   *ctx       = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_team_t             *core_team = UCC_TL_CORE_TEAM(tl_team);
+    ucc_status_t            status;
+    int                     i;
+
+    status = ucc_collective_test(&(*scoll_req)->task->super);
+    if (status == UCC_INPROGRESS) {
+        if (ctx->cfg.service_worker) {
+            ucp_worker_progress(ctx->service_worker.ucp_worker);
+        }
+        return UCC_INPROGRESS;
+    } else if (status != UCC_OK) {
+        tl_error(UCC_TASK_LIB(args->task),
+                 "failed during service allgather for sizes %s", ucc_status_string(status));
+        ucc_service_coll_finalize(*scoll_req);
+        ucc_free(args->global_sizes);
+        args->global_sizes = NULL;
+        return status;
+    }
+    args->max_individual_pack_size = 0;
+    for (i = 0; i < core_team->size; i++) {
+        if (args->global_sizes[i] > args->max_individual_pack_size) {
+            args->max_individual_pack_size = args->global_sizes[i];
+        }
+    }
+    args->exchange_size = 2 * (sizeof(ucc_mem_map_memh_t) + args->max_individual_pack_size + sizeof(size_t) * 2);
+    if (args->exchange_size == 0) {
+        ucc_service_coll_finalize(*scoll_req);
+        ucc_free(args->global_sizes);
+        args->global_sizes = NULL;
+        return UCC_ERR_NO_MESSAGE;
+    }
+    ucc_service_coll_finalize(*scoll_req);
+    ucc_free(args->global_sizes);
+    args->global_sizes = NULL;
+    *scoll_req         = NULL;
+    return UCC_OK;
+}
+
+static ucc_status_t dynamic_segment_allocate_buffers(ucc_tl_ucp_dyn_seg_args_t *args)
+{
+    ucc_tl_ucp_team_t *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_team_t        *core_team = UCC_TL_CORE_TEAM(tl_team);
+    ucc_status_t       status;
+
+    status = dynamic_segment_alloc_seg(&args->src_memh_pack, args->max_individual_pack_size);
+    if (UCC_OK != status) {
+       tl_error(UCC_TASK_LIB(args->task), "failed to allocate src_memh_pack");
+       return status;
+    }
+    status = dynamic_segment_alloc_seg(&args->dst_memh_pack, args->max_individual_pack_size);
+    if (UCC_OK != status) {
+       tl_error(UCC_TASK_LIB(args->task), "failed to allocate dst_memh_pack");
+       ucc_free(args->src_memh_pack);
+       args->src_memh_pack = NULL;
+       return status;
+    }
+
+    args->exchange_buffer = ucc_malloc(args->exchange_size, "exchange buffer");
+    if (!args->exchange_buffer) {
+        tl_error(UCC_TASK_LIB(args->task), "failed to allocate exchange buffer");
+        ucc_free(args->src_memh_pack);
+        args->src_memh_pack = NULL;
+        ucc_free(args->dst_memh_pack);
+        args->dst_memh_pack = NULL;
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    args->task->dynamic_segments.global_buffer = ucc_malloc(args->exchange_size * core_team->size, "global buffer");
+    if (!args->task->dynamic_segments.global_buffer) {
+        tl_error(UCC_TASK_LIB(args->task), "failed to allocate global buffer");
+        ucc_free(args->exchange_buffer);
+        args->exchange_buffer = NULL;
+        ucc_free(args->src_memh_pack);
+        args->src_memh_pack = NULL;
+        ucc_free(args->dst_memh_pack);
+        args->dst_memh_pack = NULL;
+        return UCC_ERR_NO_MEMORY;
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t dynamic_segment_pack_and_exchange_data_start(ucc_tl_ucp_dyn_seg_args_t *args,
+                                                                ucc_service_coll_req_t **scoll_req)
+{
+    ucc_tl_ucp_team_t      *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_tl_ucp_context_t   *ctx       = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_team_t             *core_team = UCC_TL_CORE_TEAM(tl_team);
+    ucc_subset_t            subset    = {.map = core_team->ctx_map,
+                                         .myrank = core_team->rank};
+    ucc_status_t            status;
+
+    dynamic_segment_memh_pack((ucc_context_h)&ctx->super.super, args, IS_SRC);
+    dynamic_segment_memh_pack((ucc_context_h)&ctx->super.super, args, IS_DST);
+
+    memcpy(args->exchange_buffer, args->src_memh_pack, args->src_pack_size + 2 * sizeof(size_t) + sizeof(ucc_mem_map_memh_t));
+    memcpy(PTR_OFFSET(args->exchange_buffer, sizeof(ucc_mem_map_memh_t) + args->max_individual_pack_size + sizeof(size_t) * 2), args->dst_memh_pack,
+           args->dst_pack_size + 2 * sizeof(size_t) + sizeof(ucc_mem_map_memh_t));
+    /* Allgather the packed memory handles */
+    status = ucc_service_allgather(core_team, args->exchange_buffer, args->task->dynamic_segments.global_buffer,
+                                   args->exchange_size, subset, scoll_req);
+    if (status != UCC_OK) {
+        tl_error(UCC_TASK_LIB(args->task),
+                 "failed to start service allgather for memory handles");
+        return status;
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t dynamic_segment_pack_and_exchange_data_test(ucc_tl_ucp_dyn_seg_args_t *args,
+                                                                ucc_service_coll_req_t **scoll_req)
+{
+    ucc_tl_ucp_team_t      *tl_team = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_tl_ucp_context_t   *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_status_t            status;
+
+    status = ucc_collective_test(&(*scoll_req)->task->super);
+    if (status < UCC_OK) {
+        tl_error(UCC_TASK_LIB(args->task),
+                 "failed during service allgather for memory handles %s", ucc_status_string(status));
+        ucc_service_coll_finalize(*scoll_req);
+        return status;
+    } else if (status == UCC_INPROGRESS) {
+        if (ctx->cfg.service_worker) {
+            ucp_worker_progress(ctx->service_worker.ucp_worker);
+        }
+        return UCC_INPROGRESS;
+    }
+    ucc_service_coll_finalize(*scoll_req);
+    *scoll_req = NULL;
+    return UCC_OK;
+}
+
+static ucc_status_t dynamic_segment_import_memory_handles(ucc_tl_ucp_dyn_seg_args_t *args)
+{
+    ucc_tl_ucp_team_t      *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_tl_ucp_context_t   *ctx       = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_team_t             *core_team = UCC_TL_CORE_TEAM(tl_team);
+    size_t                  src_offset;
+    size_t                  dst_offset;
+    ucc_status_t            status;
+    int                     i;
+
+    args->task->dynamic_segments.src_global = ucc_calloc(core_team->size, sizeof(ucc_mem_map_memh_t *),
+                                                    "src_global");
+    if (!args->task->dynamic_segments.src_global) {
+         tl_error(UCC_TASK_LIB(args->task),
+                 "failed to allocate global src memory handles");
+        return UCC_ERR_NO_MEMORY;
+    }
+    args->task->dynamic_segments.dst_global = ucc_calloc(core_team->size, sizeof(ucc_mem_map_memh_t *),
+                                                    "dst_global");
+    if (!args->task->dynamic_segments.dst_global) {
+         tl_error(UCC_TASK_LIB(args->task),
+                 "failed to allocate global dst memory handles");
+        ucc_free(args->task->dynamic_segments.src_global);
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    /* Import memory handles for each rank using ucc_tl_ucp_mem_map */
+    for (i = 0; i < core_team->size; i++) {
+        /* Each rank's data in global buffer contains:
+           - src_memh_pack: sizeof(ucc_mem_map_memh_t) + max_individual_pack_size + sizeof(size_t) * 2
+           - dst_memh_pack: sizeof(ucc_mem_map_memh_t) + max_individual_pack_size + sizeof(size_t) * 2
+        */
+        src_offset = i * args->exchange_size;
+        dst_offset = i * args->exchange_size + args->exchange_size / 2;
+
+        args->task->dynamic_segments.src_global[i] = (ucc_mem_map_memh_t *)PTR_OFFSET(args->task->dynamic_segments.global_buffer, src_offset);
+        args->task->dynamic_segments.dst_global[i] = (ucc_mem_map_memh_t *)PTR_OFFSET(args->task->dynamic_segments.global_buffer, dst_offset);
+
+        args->task->dynamic_segments.src_global[i]->tl_h = ucc_calloc(1, sizeof(ucc_mem_map_tl_t), "global tl_h");
+        args->task->dynamic_segments.dst_global[i]->tl_h = ucc_calloc(1, sizeof(ucc_mem_map_tl_t), "global tl_h");
+
+        status = ucc_tl_ucp_mem_map(&ctx->super.super, UCC_MEM_MAP_MODE_IMPORT,
+                                   args->task->dynamic_segments.src_global[i],
+                                   args->task->dynamic_segments.src_global[i]->tl_h);
+        if (status != UCC_OK) {
+            tl_error(UCC_TASK_LIB(args->task),
+                     "failed to import src memory handle for rank %d", i);
+            return status;
+        }
+        status = ucc_tl_ucp_mem_map(&ctx->super.super, UCC_MEM_MAP_MODE_IMPORT,
+                                   args->task->dynamic_segments.dst_global[i],
+                                   args->task->dynamic_segments.dst_global[i]->tl_h);
+        if (status != UCC_OK) {
+            tl_error(UCC_TASK_LIB(args->task),
+                     "failed to import dst memory handle for rank %d", i);
+            return status;
+        }
+    }
+
+    return UCC_OK;
+}
+
+static void dynamic_segment_cleanup_buffers(ucc_tl_ucp_dyn_seg_args_t *args)
+{
+    if (!args) {
+        return;
+    }
+
+    if (args->src_pack_buffer) {
+        ucc_free(args->src_pack_buffer);
+        args->src_pack_buffer = NULL;
+    }
+    if (args->dst_pack_buffer) {
+        ucc_free(args->dst_pack_buffer);
+        args->dst_pack_buffer = NULL;
+    }
+    if (args->src_memh_pack) {
+        if (args->src_memh_pack->tl_h) {
+            ucc_free(args->src_memh_pack->tl_h);
+            args->src_memh_pack->tl_h = NULL;
+        }
+        ucc_free(args->src_memh_pack);
+        args->src_memh_pack = NULL;
+    }
+    if (args->dst_memh_pack) {
+        if (args->dst_memh_pack->tl_h) {
+            ucc_free(args->dst_memh_pack->tl_h);
+            args->dst_memh_pack->tl_h = NULL;
+        }
+        ucc_free(args->dst_memh_pack);
+        args->dst_memh_pack = NULL;
+    }
+    if (args->exchange_buffer) {
+        ucc_free(args->exchange_buffer);
+        args->exchange_buffer = NULL;
+    }
+    if (args->global_sizes) {
+        ucc_free(args->global_sizes);
+        args->global_sizes = NULL;
+    }
+
+}
+
+UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_exchange_nb, (task),
+                        ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t *tl_team   = UCC_TL_UCP_TASK_TEAM(task);
+    ucc_team_t        *core_team = UCC_TL_CORE_TEAM(tl_team);
+    ucc_status_t       status    = UCC_OK;
+
+    if (core_team->size == 0) {
+        tl_error(UCC_TASK_LIB(task), "unable to exchange segments with team size of 0");
+        return UCC_ERR_INVALID_PARAM;
+    }
+
+    /* Initialize on first call */
+    if (task->dynamic_segments.exchange_args == NULL) {
+        task->dynamic_segments.exchange_args = ucc_calloc(1, sizeof(ucc_tl_ucp_dyn_seg_args_t), "exchange_args");
+        if (!task->dynamic_segments.exchange_args) {
+            tl_error(UCC_TASK_LIB(task), "failed to allocate exchange_args");
+            return UCC_ERR_NO_MEMORY;
+        }
+        task->dynamic_segments.exchange_args->task           = task;
+        task->dynamic_segments.exchange_args->src_memh_local = task->dynamic_segments.src_local;
+        task->dynamic_segments.exchange_args->dst_memh_local = task->dynamic_segments.dst_local;
+        task->dynamic_segments.exchange_step                 = 0;
+        task->dynamic_segments.exchange_status               = UCC_OK;
+        task->dynamic_segments.scoll_req_sizes               = NULL;
+        task->dynamic_segments.scoll_req_data                = NULL;
+    }
+    switch (task->dynamic_segments.exchange_step) {
+    case DYN_SEG_EXCHANGE_STEP_INIT:
+        status = dynamic_segment_pack_memory_handles(task->dynamic_segments.exchange_args);
+        if (status != UCC_OK) {
+            goto err_cleanup;
+        }
+        task->dynamic_segments.exchange_step = DYN_SEG_EXCHANGE_STEP_SIZE_TEST;
+        return UCC_INPROGRESS;
+
+    case DYN_SEG_EXCHANGE_STEP_SIZE_TEST:
+        if (task->dynamic_segments.exchange_args->global_sizes == NULL) {
+
+            /* First call - start the allgather */
+            status = dynamic_segment_calculate_sizes_start(task->dynamic_segments.exchange_args,
+                                                         &task->dynamic_segments.scoll_req_sizes);
+            if (status != UCC_OK) {
+                tl_error(UCC_TASK_LIB(task), "failed to start allgather %s", ucc_status_string(status));
+                goto err_cleanup;
+            }
+            return UCC_INPROGRESS;
+        } else {
+            /* Subsequent calls - test for completion */
+            status = dynamic_segment_calculate_sizes_test(task->dynamic_segments.exchange_args,
+                                                        &task->dynamic_segments.scoll_req_sizes);
+            if (status == UCC_INPROGRESS) {
+                return UCC_INPROGRESS;
+            }
+            if (status != UCC_OK) {
+                tl_error(UCC_TASK_LIB(task), "failed to test allgather");
+                goto err_cleanup;
+            }
+            task->dynamic_segments.exchange_step = DYN_SEG_EXCHANGE_STEP_DATA_ALLOC;
+            return UCC_INPROGRESS;
+        }
+
+    case DYN_SEG_EXCHANGE_STEP_DATA_ALLOC:
+        status = dynamic_segment_allocate_buffers(task->dynamic_segments.exchange_args);
+        if (status != UCC_OK) {
+            tl_error(UCC_TASK_LIB(task), "failed to allocate buffers");
+            goto err_cleanup;
+        }
+        task->dynamic_segments.exchange_step = DYN_SEG_EXCHANGE_STEP_DATA_START;
+        return UCC_INPROGRESS;
+
+    case DYN_SEG_EXCHANGE_STEP_DATA_START:
+        if (task->dynamic_segments.scoll_req_data == NULL) {
+            /* First call - start the allgather */
+            status = dynamic_segment_pack_and_exchange_data_start(task->dynamic_segments.exchange_args,
+                                                                 &task->dynamic_segments.scoll_req_data);
+            if (status != UCC_OK) {
+                tl_error(UCC_TASK_LIB(task), "failed to start data exchange %s", ucc_status_string(status));
+                goto err_cleanup_global;
+            }
+            return UCC_INPROGRESS;
+        } else {
+            /* Subsequent calls - test for completion */
+            status = dynamic_segment_pack_and_exchange_data_test(task->dynamic_segments.exchange_args,
+                                                               &task->dynamic_segments.scoll_req_data);
+            if (status == UCC_INPROGRESS) {
+                return UCC_INPROGRESS;
+            }
+            if (status != UCC_OK) {
+                tl_error(UCC_TASK_LIB(task), "failed to test data exchange");
+                goto err_cleanup_global;
+            }
+        }
+    }
+    status = dynamic_segment_import_memory_handles(task->dynamic_segments.exchange_args);
+    if (status != UCC_OK) {
+        tl_error(UCC_TASK_LIB(task), "failed to import memory handles");
+        goto err_cleanup_global;
+    }
+
+    /* Cleanup and complete */
+    dynamic_segment_cleanup_buffers(task->dynamic_segments.exchange_args);
+    ucc_free(task->dynamic_segments.exchange_args);
+    task->dynamic_segments.exchange_args = NULL;
+    task->dynamic_segments.exchange_step = DYN_SEG_EXCHANGE_STEP_COMPLETE;
+    return UCC_OK;
+
+err_cleanup_global:
+    if (task->dynamic_segments.global_buffer) {
+        ucc_free(task->dynamic_segments.global_buffer);
+        task->dynamic_segments.global_buffer = NULL;
+    }
+err_cleanup:
+    if (task->dynamic_segments.exchange_args) {
+        dynamic_segment_cleanup_buffers(task->dynamic_segments.exchange_args);
+        ucc_free(task->dynamic_segments.exchange_args);
+        task->dynamic_segments.exchange_args = NULL;
+    }
+    return status;
+}
+
+UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_finalize, (task),
+                        ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t    *team      = UCC_TL_UCP_TASK_TEAM(task);
+    ucc_tl_ucp_context_t *ctx       = UCC_TL_UCP_TEAM_CTX(team);
+    ucc_status_t          status    = UCC_OK;
+    size_t                team_size = UCC_TL_TEAM_SIZE(team);
+    int                   i;
+
+    if (!(task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG)) {
+        return UCC_OK;
+    }
+    if (task->dynamic_segments.src_global) {
+        for (i = 0; i < team_size; i++) {
+            if (task->dynamic_segments.src_global[i] &&
+                task->dynamic_segments.src_global[i]->tl_h) {
+                status = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_IMPORT, task->dynamic_segments.src_global[i]->tl_h);
+                if (status != UCC_OK) {
+                    tl_error(UCC_TASK_LIB(task), "failed to unmap src global memory handle for rank %d", i);
+                }
+                ucc_free(task->dynamic_segments.src_global[i]->tl_h);
+                task->dynamic_segments.src_global[i]->tl_h = NULL;
+                task->dynamic_segments.src_global[i] = NULL;
+            }
+        }
+        ucc_free(task->dynamic_segments.src_global);
+        task->dynamic_segments.src_global = NULL;
+    }
+    if (task->dynamic_segments.dst_global) {
+        for (i = 0; i < team_size; i++) {
+            if (task->dynamic_segments.dst_global[i] && 
+                task->dynamic_segments.dst_global[i]->tl_h) {
+                status = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_IMPORT, task->dynamic_segments.dst_global[i]->tl_h);
+                if (status != UCC_OK) {
+                    tl_error(UCC_TASK_LIB(task), "failed to unmap dst global memory handle for rank %d", i);
+                }
+                ucc_free(task->dynamic_segments.dst_global[i]->tl_h);
+                task->dynamic_segments.dst_global[i]->tl_h = NULL;
+                task->dynamic_segments.dst_global[i] = NULL;
+            }
+        }
+        ucc_free(task->dynamic_segments.dst_global);
+        task->dynamic_segments.dst_global = NULL;
+    }
+    /* Free global buffer */
+    if (task->dynamic_segments.global_buffer) {
+        ucc_free(task->dynamic_segments.global_buffer);
+        task->dynamic_segments.global_buffer = NULL;
+    }
+    if (task->dynamic_segments.src_local) {
+        if (task->dynamic_segments.src_local->tl_h) {
+            status = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT, task->dynamic_segments.src_local->tl_h);
+            if (status != UCC_OK) {
+                tl_error(UCC_TASK_LIB(task), "failed to unmap src local memory handle");
+            }
+            ucc_free(task->dynamic_segments.src_local->tl_h);
+            task->dynamic_segments.src_local->tl_h = NULL;
+        }
+        ucc_free(task->dynamic_segments.src_local);
+        task->dynamic_segments.src_local = NULL;
+    }
+    if (task->dynamic_segments.dst_local) {
+        if (task->dynamic_segments.dst_local->tl_h) {
+            status = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT, task->dynamic_segments.dst_local->tl_h);
+            if (status != UCC_OK) {
+                tl_error(UCC_TASK_LIB(task), "failed to unmap dst local memory handle");
+            }
+            ucc_free(task->dynamic_segments.dst_local->tl_h);
+            task->dynamic_segments.dst_local->tl_h = NULL;
+        }
+        ucc_free(task->dynamic_segments.dst_local);
+        task->dynamic_segments.dst_local = NULL;
+    }
+    return status;
 }
 
 ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_args_t *coll_args,

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -6,6 +6,7 @@
 
 #include "tl_ucp.h"
 #include "tl_ucp_coll.h"
+#include "tl_ucp_ep.h"
 #include "components/mc/ucc_mc.h"
 #include "core/ucc_team.h"
 #include "utils/ucc_math.h"
@@ -26,18 +27,8 @@
 #include "fanout/fanout.h"
 #include "scatterv/scatterv.h"
 
-/* Constants for dynamic segment memory handle packing */
-#define IS_SRC 1
-#define IS_DST 0
-
-enum {
-    DYN_SEG_EXCHANGE_STEP_INIT,
-    DYN_SEG_EXCHANGE_STEP_SIZE_TEST,
-    DYN_SEG_EXCHANGE_STEP_DATA_ALLOC,
-    DYN_SEG_EXCHANGE_STEP_DATA_START,
-    DYN_SEG_EXCHANGE_STEP_DATA_TEST,
-    DYN_SEG_EXCHANGE_STEP_COMPLETE
-};
+/* Selects which buffer is mapped in dynamic_segment_map_memh */
+enum { DYN_SEG_DST = 0, DYN_SEG_SRC = 1 };
 
 const ucc_tl_ucp_default_alg_desc_t
     ucc_tl_ucp_default_alg_descs[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR] = {
@@ -122,8 +113,8 @@ ucc_status_t ucc_tl_ucp_coll_finalize(ucc_coll_task_t *coll_task)
 }
 
 static inline ucc_status_t dynamic_segment_map_memh(ucc_mem_map_memh_t **memh,
-                                                    ucc_coll_args_t *coll_args,
-                                                    int is_src,
+                                                    ucc_coll_args_t     *coll_args,
+                                                    int                  is_src,
                                                     ucc_tl_ucp_task_t   *task)
 {
     ucc_tl_ucp_team_t        *tl_team = UCC_TL_UCP_TASK_TEAM(task);
@@ -133,7 +124,6 @@ static inline ucc_status_t dynamic_segment_map_memh(ucc_mem_map_memh_t **memh,
     void                     *buffer;
     ucc_count_t               total_count;
     ucc_datatype_t            datatype;
-    ucc_coll_buffer_info_v_t *info_v;
 
     lmemh = ucc_calloc(1, sizeof(ucc_mem_map_memh_t), "dyn_memh");
     if (lmemh == NULL) {
@@ -149,37 +139,16 @@ static inline ucc_status_t dynamic_segment_map_memh(ucc_mem_map_memh_t **memh,
         goto out;
     }
 
-    /* Check if this is one of the *v collectives */
-    if (coll_args->coll_type == UCC_COLL_TYPE_ALLGATHERV ||
-        coll_args->coll_type == UCC_COLL_TYPE_ALLTOALLV ||
-        coll_args->coll_type == UCC_COLL_TYPE_GATHERV ||
-        coll_args->coll_type == UCC_COLL_TYPE_REDUCE_SCATTERV ||
-        coll_args->coll_type == UCC_COLL_TYPE_SCATTERV) {
-
-        if (is_src) {
-            info_v = &coll_args->src.info_v;
-        } else {
-            info_v = &coll_args->dst.info_v;
-        }
-
-        buffer   = info_v->buffer;
-        datatype = info_v->datatype;
-        /* Calculate total buffer size considering both counts and displacements */
-        total_count = ucc_coll_args_get_v_buffer_size(coll_args, info_v->counts,
-                                                      info_v->displacements,
-                                                      UCC_TL_TEAM_SIZE(tl_team));
+    if (is_src) {
+        total_count = coll_args->src.info.count;
+        buffer      = coll_args->src.info.buffer;
+        datatype    = coll_args->src.info.datatype;
     } else {
-        /* Handle regular collectives - use info */
-        if (is_src) {
-            total_count = coll_args->src.info.count;
-            buffer      = coll_args->src.info.buffer;
-            datatype    = coll_args->src.info.datatype;
-        } else {
-            total_count = coll_args->dst.info.count;
-            buffer      = coll_args->dst.info.buffer;
-            datatype    = coll_args->dst.info.datatype;
-        }
+        total_count = coll_args->dst.info.count;
+        buffer      = coll_args->dst.info.buffer;
+        datatype    = coll_args->dst.info.datatype;
     }
+
     lmemh->address = buffer;
     lmemh->len     = total_count * ucc_dt_size(datatype);
     lmemh->num_tls = 1;  /* Only one transport layer (UCP) */
@@ -202,135 +171,201 @@ out:
  * It checks if user-provided memory handles are available, and if not,
  * creates and maps local memory handles for source and destination buffers.
  * These handles will be exchanged across ranks for remote memory access. */
-UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_init, (coll_args, task),
-                        ucc_coll_args_t *coll_args, ucc_tl_ucp_task_t *task)
+UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_init,
+                        (coll_args, alg, task), ucc_coll_args_t *coll_args,
+                        ucc_tl_ucp_onesided_alg_type alg,
+                        ucc_tl_ucp_task_t *task)
 {
-    ucc_status_t        status = UCC_OK;
-    ucc_mem_map_memh_t *src_memh;
-    ucc_mem_map_memh_t *dst_memh;
+    ucc_tl_ucp_team_t    *tl_team = UCC_TL_UCP_TASK_TEAM(task);
+    ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_status_t          status  = UCC_OK;
+    ucc_mem_map_memh_t   *src_memh;
+    ucc_mem_map_memh_t   *dst_memh;
+    uint64_t              flags;
 
-    if ((coll_args->mask & UCC_COLL_ARGS_FIELD_FLAGS)) {
-        if ((coll_args->flags & UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS)) {
-            return UCC_OK;
-        }
-    } else if ((coll_args->mask & UCC_COLL_ARGS_FIELD_MEM_MAP_SRC_MEMH) &&
-               (coll_args->mask & UCC_COLL_ARGS_FIELD_MEM_MAP_DST_MEMH)) {
+    if ((coll_args->coll_type == UCC_COLL_TYPE_ALLTOALLV) ||
+        (coll_args->coll_type == UCC_COLL_TYPE_ALLGATHERV) ||
+        (coll_args->coll_type == UCC_COLL_TYPE_GATHERV) ||
+        (coll_args->coll_type == UCC_COLL_TYPE_REDUCE_SCATTERV) ||
+        (coll_args->coll_type == UCC_COLL_TYPE_SCATTERV)) {
+        tl_debug(UCC_TASK_LIB(task), "dynamic segments are not supported for %s",
+                 ucc_coll_type_str(coll_args->coll_type));
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    /* coll_args->flags is only valid when FIELD_FLAGS is set in the mask;
+     * treat it as zero otherwise to avoid reading indeterminate bits. */
+    flags = (coll_args->mask & UCC_COLL_ARGS_FIELD_FLAGS) ? coll_args->flags
+                                                          : 0;
+    if (flags & UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS) {
         return UCC_OK;
     }
-    status = dynamic_segment_map_memh(&src_memh, coll_args, IS_SRC, task);
+    /* Skip dynamic mapping when the user has already provided the handle that
+     * this algorithm needs: src for GET (peers pull from it), dst for PUT
+     * (peers push into it).  The non-DYN_SEG progress path will use it.
+     * This is independent of the MEM_MAPPED_BUFFERS bail-out above. */
+    if (alg == UCC_TL_UCP_ALLTOALL_ONESIDED_GET) {
+        if ((coll_args->mask & UCC_COLL_ARGS_FIELD_MEM_MAP_SRC_MEMH) &&
+            (flags & UCC_COLL_ARGS_FLAG_SRC_MEMH_GLOBAL)) {
+            return UCC_OK;
+        }
+    } else {
+        if ((coll_args->mask & UCC_COLL_ARGS_FIELD_MEM_MAP_DST_MEMH) &&
+            (flags & UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL)) {
+            return UCC_OK;
+        }
+    }
+    if (coll_args->src.info.count == 0) {
+        return UCC_OK;
+    }
+    /* Register both local buffers for RDMA.  Only the remotely-accessed side
+     * (src for GET, dst for PUT) is exported to peers during exchange; the
+     * other side is kept as the local UCP memh for the RDMA operation. */
+    status = dynamic_segment_map_memh(&src_memh, coll_args, DYN_SEG_SRC, task);
     if (UCC_OK != status) {
         return status;
     }
-    status = dynamic_segment_map_memh(&dst_memh, coll_args, IS_DST, task);
+    status = dynamic_segment_map_memh(&dst_memh, coll_args, DYN_SEG_DST, task);
     if (UCC_OK != status) {
+        /* Preserve the original mapping error: a failure of the cleanup
+         * unmap must not mask the root cause reported to the caller. */
+        ucc_status_t unmap_status;
+
+        unmap_status = ucc_tl_ucp_mem_unmap(&ctx->super.super,
+                                            UCC_MEM_MAP_MODE_EXPORT,
+                                            src_memh->tl_h);
+        if (UCC_OK != unmap_status) {
+            tl_warn(UCC_TASK_LIB(task),
+                    "failed to unmap src_memh during cleanup: %s",
+                    ucc_status_string(unmap_status));
+        }
         ucc_free(src_memh->tl_h);
         ucc_free(src_memh);
         return status;
     }
     memset(&task->dynamic_segments, 0, sizeof(task->dynamic_segments));
-    task->dynamic_segments.src_local = src_memh;
-    task->dynamic_segments.dst_local = dst_memh;
-    task->flags                     |= UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG;
+    task->dynamic_segments.src_local  = src_memh;
+    task->dynamic_segments.dst_local  = dst_memh;
+    task->dynamic_segments.src_global = NULL;
+    task->dynamic_segments.dst_global = NULL;
+    task->dynamic_segments.alg        = alg;
+    task->flags                      |= UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG;
+    task->dynamic_segments.exchange_step = UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_INIT;
     return status;
 }
 
-static inline ucc_status_t dynamic_segment_alloc_seg(ucc_mem_map_memh_t **memh,
-                                                     size_t packed_size)
-{
-    ucc_mem_map_memh_t *lmemh;
+/* Explicit on-wire representation of an exported dynamic segment.  Only
+ * serializable scalar fields cross the wire -- no process-local pointers
+ * (context/tl_h/tl_data), so the format is self-contained and unambiguous.
+ * The receiver reconstructs a full ucc_mem_map_memh_t from these bytes in
+ * dynamic_segment_import_memory_handles().
+ *
+ * payload[] mirrors the ucc_mem_map_memh_t pack_buffer layout that
+ * resolve_p2p_by_memh() consumes on the receiver:
+ *   [ TL name (UCC_MEM_MAP_TL_NAME_LEN) | packed rkey size | packed rkey ] */
+typedef struct ucc_tl_ucp_dyn_seg_wire_t {
+    uint64_t address;      /* base VA of the exported segment (sender-local) */
+    uint64_t len;          /* segment length in bytes                        */
+    uint64_t payload_size; /* number of payload bytes that follow            */
+    char     payload[0];
+} ucc_tl_ucp_dyn_seg_wire_t;
 
-    lmemh = ucc_calloc(1, sizeof(ucc_mem_map_memh_t) + packed_size + sizeof(size_t) * 2, "packed_memh");
-    if (!lmemh) {
-        return UCC_ERR_NO_MEMORY;
-    }
-    lmemh->tl_h = ucc_calloc(1, sizeof(ucc_mem_map_tl_t), "packed_tl_h");
-    if (!lmemh->tl_h) {
-        ucc_free(lmemh);
-        return UCC_ERR_NO_MEMORY;
-    }
-    *memh = lmemh;
-    return UCC_OK;
-}
+/* Fixed per-rank overhead of the wire payload (TL name + packed rkey size). */
+#define UCC_TL_UCP_DYN_SEG_PAYLOAD_HDR (UCC_MEM_MAP_TL_NAME_LEN + sizeof(size_t))
 
-static inline void dynamic_segment_memh_pack(ucc_context_h ctx,
-                                             ucc_tl_ucp_dyn_seg_args_t *args,
-                                             int is_src)
+static inline void dynamic_segment_memh_pack(ucc_tl_ucp_dyn_seg_args_t *args,
+                                             int                        is_src)
 {
-    ucc_mem_map_memh_t *memh;
-    void               *pack_buffer;
-    size_t              pack_size;
-    void               *address;
-    size_t              len;
+    ucc_tl_ucp_dyn_seg_wire_t *wire = args->exchange_buffer;
+    ucc_mem_map_memh_t        *local;
+    void                      *pack_buffer;
+    size_t                     pack_size;
+    char                      *payload;
 
     if (is_src) {
         pack_buffer = args->src_pack_buffer;
         pack_size   = args->src_pack_size;
-        address     = args->src_memh_local->address;
-        len         = args->src_memh_local->len;
-        memh        = args->src_memh_pack;
+        local       = args->src_memh_local;
     } else {
         pack_buffer = args->dst_pack_buffer;
         pack_size   = args->dst_pack_size;
-        address     = args->dst_memh_local->address;
-        len         = args->dst_memh_local->len;
-        memh        = args->dst_memh_pack;
+        local       = args->dst_memh_local;
     }
-    /* Pack local data into exchange buffer */
-    strncpy(memh->pack_buffer, "ucp", UCC_MEM_MAP_TL_NAME_LEN - 1);
-    memcpy(PTR_OFFSET(memh->pack_buffer, UCC_MEM_MAP_TL_NAME_LEN), &pack_size,
+
+    /* Serialize only scalar, address-space-independent fields. */
+    wire->address      = (uint64_t)local->address;
+    wire->len          = local->len;
+    wire->payload_size = UCC_TL_UCP_DYN_SEG_PAYLOAD_HDR + pack_size;
+
+    /* Serialize the packed rkey into the receiver-facing pack_buffer layout:
+     *   [0 .. TL_NAME_LEN)              : TL name (null-padded)
+     *   [TL_NAME_LEN .. +sizeof(size_t)): packed rkey size
+     *   [TL_NAME_LEN + sizeof(size_t).. ): packed rkey data             */
+    payload = wire->payload;
+    strncpy(payload, "ucp", UCC_MEM_MAP_TL_NAME_LEN - 1);
+    memcpy(PTR_OFFSET(payload, UCC_MEM_MAP_TL_NAME_LEN), &pack_size,
            sizeof(size_t));
-    memcpy(PTR_OFFSET(memh->pack_buffer, UCC_MEM_MAP_TL_NAME_LEN + sizeof(size_t)),
+    memcpy(PTR_OFFSET(payload, UCC_MEM_MAP_TL_NAME_LEN + sizeof(size_t)),
            pack_buffer, pack_size);
-    memh->mode    = UCC_MEM_MAP_MODE_EXPORT;
-    memh->context = ctx;
-    memh->address = address;
-    memh->len     = len;
-    memh->num_tls = 1;
 }
 
-static ucc_status_t dynamic_segment_pack_memory_handles(ucc_tl_ucp_dyn_seg_args_t *args)
+static ucc_status_t
+dynamic_segment_pack_memory_handles(ucc_tl_ucp_dyn_seg_args_t *args)
 {
-    ucc_tl_ucp_team_t      *tl_team = UCC_TL_UCP_TASK_TEAM(args->task);
-    ucc_tl_ucp_context_t   *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
-    ucc_status_t            status;
+    ucc_tl_ucp_team_t    *tl_team = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_status_t          status;
 
-    status = ucc_tl_ucp_memh_pack(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT,
-                                  args->src_memh_local->tl_h, &args->src_pack_buffer);
-    if (status != UCC_OK) {
-        tl_error(UCC_TASK_LIB(args->task), "failed to pack src memory handle");
-        return status;
+    if (args->src_memh_local) {
+        status = ucc_tl_ucp_memh_pack(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT,
+                                      args->src_memh_local->tl_h,
+                                      &args->src_pack_buffer);
+        if (status != UCC_OK) {
+            tl_error(UCC_TASK_LIB(args->task), "failed to pack src memory handle");
+            return status;
+        }
+        args->src_pack_size = args->src_memh_local->tl_h->packed_size;
     }
-    args->src_pack_size = args->src_memh_local->tl_h->packed_size;
-
-    status = ucc_tl_ucp_memh_pack(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT,
-                                  args->dst_memh_local->tl_h, &args->dst_pack_buffer);
-    if (status != UCC_OK) {
-        tl_error(UCC_TASK_LIB(args->task), "failed to pack dst memory handle");
-        ucc_free(args->src_pack_buffer);
-        args->src_pack_buffer = NULL;
-        return status;
+    if (args->dst_memh_local) {
+        status = ucc_tl_ucp_memh_pack(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT,
+                                      args->dst_memh_local->tl_h,
+                                      &args->dst_pack_buffer);
+        if (status != UCC_OK) {
+            tl_error(UCC_TASK_LIB(args->task), "failed to pack dst memory handle");
+            ucc_free(args->src_pack_buffer);
+            args->src_pack_buffer = NULL;
+            return status;
+        }
+        args->dst_pack_size = args->dst_memh_local->tl_h->packed_size;
     }
-    args->dst_pack_size = args->dst_memh_local->tl_h->packed_size;
     return UCC_OK;
 }
 
-static ucc_status_t dynamic_segment_calculate_sizes_start(ucc_tl_ucp_dyn_seg_args_t *args,
-                                                          ucc_service_coll_req_t **scoll_req)
+static ucc_status_t
+dynamic_segment_calculate_sizes_start(ucc_tl_ucp_dyn_seg_args_t *args,
+                                      ucc_service_coll_req_t   **scoll_req)
 {
     ucc_tl_ucp_team_t *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
     ucc_team_t        *core_team = UCC_TL_CORE_TEAM(tl_team);
-    ucc_subset_t       subset    = {.map = core_team->ctx_map,
-                                    .myrank = core_team->rank};
+    ucc_subset_t       subset;
     size_t            *global_sizes;
     ucc_status_t       status;
     size_t             local_pack_size;
 
-    /* Calculate total pack size for this rank */
-    local_pack_size = ucc_max(args->src_pack_size, args->dst_pack_size) + sizeof(size_t) * 2;
+    subset.map    = UCC_TL_TEAM_MAP(tl_team);
+    subset.myrank = UCC_TL_TEAM_RANK(tl_team);
 
-    global_sizes = ucc_calloc(core_team->size, sizeof(size_t), "global sizes");
+    /* Calculate total pack size for this rank - only destination handles
+     * Use inner packed TL size; exchange_size will add outer TL header. */
+    if (args->task->dynamic_segments.alg == UCC_TL_UCP_ALLTOALL_ONESIDED_GET) {
+        local_pack_size = args->src_pack_size;
+    } else {
+        local_pack_size = args->dst_pack_size;
+    }
+
+    global_sizes = ucc_calloc(UCC_TL_TEAM_SIZE(tl_team), sizeof(size_t), "global sizes");
     if (!global_sizes) {
-        tl_error(UCC_TASK_LIB(args->task), "failed to allocate global sizes buffer");
+        tl_error(UCC_TASK_LIB(args->task),
+                 "failed to allocate global sizes buffer");
         return UCC_ERR_NO_MEMORY;
     }
     args->global_sizes = global_sizes;
@@ -347,14 +382,14 @@ static ucc_status_t dynamic_segment_calculate_sizes_start(ucc_tl_ucp_dyn_seg_arg
     return UCC_OK;
 }
 
-static ucc_status_t dynamic_segment_calculate_sizes_test(ucc_tl_ucp_dyn_seg_args_t *args,
-                                                         ucc_service_coll_req_t **scoll_req)
+static ucc_status_t
+dynamic_segment_calculate_sizes_test(ucc_tl_ucp_dyn_seg_args_t *args,
+                                     ucc_service_coll_req_t   **scoll_req)
 {
-    ucc_tl_ucp_team_t      *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
-    ucc_tl_ucp_context_t   *ctx       = UCC_TL_UCP_TEAM_CTX(tl_team);
-    ucc_team_t             *core_team = UCC_TL_CORE_TEAM(tl_team);
-    ucc_status_t            status;
-    int                     i;
+    ucc_tl_ucp_team_t    *tl_team = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_status_t          status;
+    int                   i;
 
     status = ucc_collective_test(&(*scoll_req)->task->super);
     if (status == UCC_INPROGRESS) {
@@ -364,25 +399,23 @@ static ucc_status_t dynamic_segment_calculate_sizes_test(ucc_tl_ucp_dyn_seg_args
         return UCC_INPROGRESS;
     } else if (status != UCC_OK) {
         tl_error(UCC_TASK_LIB(args->task),
-                 "failed during service allgather for sizes %s", ucc_status_string(status));
+                 "failed during service allgather for sizes %s",
+                 ucc_status_string(status));
         ucc_service_coll_finalize(*scoll_req);
         ucc_free(args->global_sizes);
         args->global_sizes = NULL;
         return status;
     }
     args->max_individual_pack_size = 0;
-    for (i = 0; i < core_team->size; i++) {
+    for (i = 0; i < UCC_TL_TEAM_SIZE(tl_team); i++) {
         if (args->global_sizes[i] > args->max_individual_pack_size) {
             args->max_individual_pack_size = args->global_sizes[i];
         }
     }
-    args->exchange_size = 2 * (sizeof(ucc_mem_map_memh_t) + args->max_individual_pack_size + sizeof(size_t) * 2);
-    if (args->exchange_size == 0) {
-        ucc_service_coll_finalize(*scoll_req);
-        ucc_free(args->global_sizes);
-        args->global_sizes = NULL;
-        return UCC_ERR_NO_MESSAGE;
-    }
+    /* Total per-rank slot: wire header + TL name + packed-size field + rkey data. */
+    args->exchange_size = sizeof(ucc_tl_ucp_dyn_seg_wire_t) +
+                          UCC_TL_UCP_DYN_SEG_PAYLOAD_HDR +
+                          args->max_individual_pack_size;
     ucc_service_coll_finalize(*scoll_req);
     ucc_free(args->global_sizes);
     args->global_sizes = NULL;
@@ -390,67 +423,51 @@ static ucc_status_t dynamic_segment_calculate_sizes_test(ucc_tl_ucp_dyn_seg_args
     return UCC_OK;
 }
 
-static ucc_status_t dynamic_segment_allocate_buffers(ucc_tl_ucp_dyn_seg_args_t *args)
+static ucc_status_t
+dynamic_segment_allocate_buffers(ucc_tl_ucp_dyn_seg_args_t *args)
 {
-    ucc_tl_ucp_team_t *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
-    ucc_team_t        *core_team = UCC_TL_CORE_TEAM(tl_team);
-    ucc_status_t       status;
+    ucc_tl_ucp_team_t *tl_team = UCC_TL_UCP_TASK_TEAM(args->task);
 
-    status = dynamic_segment_alloc_seg(&args->src_memh_pack, args->max_individual_pack_size);
-    if (UCC_OK != status) {
-       tl_error(UCC_TASK_LIB(args->task), "failed to allocate src_memh_pack");
-       return status;
-    }
-    status = dynamic_segment_alloc_seg(&args->dst_memh_pack, args->max_individual_pack_size);
-    if (UCC_OK != status) {
-       tl_error(UCC_TASK_LIB(args->task), "failed to allocate dst_memh_pack");
-       ucc_free(args->src_memh_pack);
-       args->src_memh_pack = NULL;
-       return status;
-    }
-
-    args->exchange_buffer = ucc_malloc(args->exchange_size, "exchange buffer");
+    args->exchange_buffer = ucc_calloc(1, args->exchange_size, "exchange buffer");
     if (!args->exchange_buffer) {
         tl_error(UCC_TASK_LIB(args->task), "failed to allocate exchange buffer");
-        ucc_free(args->src_memh_pack);
-        args->src_memh_pack = NULL;
-        ucc_free(args->dst_memh_pack);
-        args->dst_memh_pack = NULL;
         return UCC_ERR_NO_MEMORY;
     }
-
-    args->task->dynamic_segments.global_buffer = ucc_malloc(args->exchange_size * core_team->size, "global buffer");
+    args->task->dynamic_segments.global_buffer =
+        ucc_calloc(UCC_TL_TEAM_SIZE(tl_team), args->exchange_size, "global buffer");
     if (!args->task->dynamic_segments.global_buffer) {
         tl_error(UCC_TASK_LIB(args->task), "failed to allocate global buffer");
         ucc_free(args->exchange_buffer);
         args->exchange_buffer = NULL;
-        ucc_free(args->src_memh_pack);
-        args->src_memh_pack = NULL;
-        ucc_free(args->dst_memh_pack);
-        args->dst_memh_pack = NULL;
         return UCC_ERR_NO_MEMORY;
     }
     return UCC_OK;
 }
 
-static ucc_status_t dynamic_segment_pack_and_exchange_data_start(ucc_tl_ucp_dyn_seg_args_t *args,
-                                                                ucc_service_coll_req_t **scoll_req)
+static ucc_status_t
+dynamic_segment_pack_and_exchange_data_start(ucc_tl_ucp_dyn_seg_args_t *args,
+                                             ucc_service_coll_req_t **scoll_req)
 {
-    ucc_tl_ucp_team_t      *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
-    ucc_tl_ucp_context_t   *ctx       = UCC_TL_UCP_TEAM_CTX(tl_team);
-    ucc_team_t             *core_team = UCC_TL_CORE_TEAM(tl_team);
-    ucc_subset_t            subset    = {.map = core_team->ctx_map,
-                                         .myrank = core_team->rank};
-    ucc_status_t            status;
+    ucc_tl_ucp_team_t    *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_team_t           *core_team = UCC_TL_CORE_TEAM(tl_team);
+    ucc_subset_t          subset;
+    ucc_status_t          status;
 
-    dynamic_segment_memh_pack((ucc_context_h)&ctx->super.super, args, IS_SRC);
-    dynamic_segment_memh_pack((ucc_context_h)&ctx->super.super, args, IS_DST);
+    subset.map    = UCC_TL_TEAM_MAP(tl_team);
+    subset.myrank = UCC_TL_TEAM_RANK(tl_team);
 
-    memcpy(args->exchange_buffer, args->src_memh_pack, args->src_pack_size + 2 * sizeof(size_t) + sizeof(ucc_mem_map_memh_t));
-    memcpy(PTR_OFFSET(args->exchange_buffer, sizeof(ucc_mem_map_memh_t) + args->max_individual_pack_size + sizeof(size_t) * 2), args->dst_memh_pack,
-           args->dst_pack_size + 2 * sizeof(size_t) + sizeof(ucc_mem_map_memh_t));
+    /* Serialize this rank's exported handle straight into the exchange buffer
+     * as an explicit wire struct (no in-memory memh pointers leak over). */
+    if (args->task->dynamic_segments.alg == UCC_TL_UCP_ALLTOALL_ONESIDED_GET) {
+        /* GET: each rank shares its src handle so peers can GET from it */
+        dynamic_segment_memh_pack(args, DYN_SEG_SRC);
+    } else {
+        /* PUT: each rank shares its dst handle so peers can PUT into it */
+        dynamic_segment_memh_pack(args, DYN_SEG_DST);
+    }
     /* Allgather the packed memory handles */
-    status = ucc_service_allgather(core_team, args->exchange_buffer, args->task->dynamic_segments.global_buffer,
+    status = ucc_service_allgather(core_team, args->exchange_buffer,
+                                   args->task->dynamic_segments.global_buffer,
                                    args->exchange_size, subset, scoll_req);
     if (status != UCC_OK) {
         tl_error(UCC_TASK_LIB(args->task),
@@ -460,98 +477,233 @@ static ucc_status_t dynamic_segment_pack_and_exchange_data_start(ucc_tl_ucp_dyn_
     return UCC_OK;
 }
 
-static ucc_status_t dynamic_segment_pack_and_exchange_data_test(ucc_tl_ucp_dyn_seg_args_t *args,
-                                                                ucc_service_coll_req_t **scoll_req)
+static ucc_status_t
+dynamic_segment_pack_and_exchange_data_test(ucc_tl_ucp_dyn_seg_args_t *args,
+                                            ucc_service_coll_req_t **scoll_req)
 {
-    ucc_tl_ucp_team_t      *tl_team = UCC_TL_UCP_TASK_TEAM(args->task);
-    ucc_tl_ucp_context_t   *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
-    ucc_status_t            status;
+    ucc_tl_ucp_team_t    *tl_team = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_status_t          status;
 
     status = ucc_collective_test(&(*scoll_req)->task->super);
-    if (status < UCC_OK) {
-        tl_error(UCC_TASK_LIB(args->task),
-                 "failed during service allgather for memory handles %s", ucc_status_string(status));
-        ucc_service_coll_finalize(*scoll_req);
-        return status;
-    } else if (status == UCC_INPROGRESS) {
+    if (status == UCC_INPROGRESS) {
         if (ctx->cfg.service_worker) {
             ucp_worker_progress(ctx->service_worker.ucp_worker);
         }
         return UCC_INPROGRESS;
+    } else if (status != UCC_OK) {
+        tl_error(UCC_TASK_LIB(args->task),
+                 "failed during service allgather for memory handles %s",
+                 ucc_status_string(status));
+        ucc_service_coll_finalize(*scoll_req);
+        return status;
     }
     ucc_service_coll_finalize(*scoll_req);
     *scoll_req = NULL;
     return UCC_OK;
 }
 
-static ucc_status_t dynamic_segment_import_memory_handles(ucc_tl_ucp_dyn_seg_args_t *args)
+/* Validate a remote rkey by unpacking it immediately so that failures are
+   reported at exchange time rather than lazily during data access. */
+static ucc_status_t
+validate_remote_rkey(ucc_tl_ucp_team_t *tl_team, ucc_tl_ucp_task_t *task,
+                     ucc_mem_map_memh_t *memh, int rank)
 {
-    ucc_tl_ucp_team_t      *tl_team   = UCC_TL_UCP_TASK_TEAM(args->task);
-    ucc_tl_ucp_context_t   *ctx       = UCC_TL_UCP_TEAM_CTX(tl_team);
-    ucc_team_t             *core_team = UCC_TL_CORE_TEAM(tl_team);
-    size_t                  src_offset;
-    size_t                  dst_offset;
-    ucc_status_t            status;
-    int                     i;
+    ucp_ep_h     ep;
+    ucp_rkey_h   test_rkey;
+    void        *packed_rkey;
+    ucs_status_t ucs_status;
+    ucc_status_t status;
 
-    args->task->dynamic_segments.src_global = ucc_calloc(core_team->size, sizeof(ucc_mem_map_memh_t *),
-                                                    "src_global");
-    if (!args->task->dynamic_segments.src_global) {
-         tl_error(UCC_TASK_LIB(args->task),
-                 "failed to allocate global src memory handles");
+    status = ucc_tl_ucp_get_ep(tl_team, rank, &ep);
+    if (status != UCC_OK) {
+        tl_error(UCC_TASK_LIB(task),
+                 "failed to get EP for rank %d during import validation", rank);
+        return status;
+    }
+    /* pack_buffer layout: [TL name | outer pack_size | UCC_TL_UCP_MEMH_TL_HEADER_SIZE | rkey]
+     * outer pack_size is sizeof(size_t); UCC_TL_UCP_MEMH_TL_HEADER_SIZE is 2*sizeof(size_t). */
+    packed_rkey = PTR_OFFSET(memh->pack_buffer,
+                             UCC_MEM_MAP_TL_NAME_LEN + sizeof(size_t) +
+                             UCC_TL_UCP_MEMH_TL_HEADER_SIZE);
+    ucs_status = ucp_ep_rkey_unpack(ep, packed_rkey, &test_rkey);
+    if (ucs_status != UCS_OK) {
+        tl_error(UCC_TASK_LIB(task), "rkey validation failed for rank %d: %s",
+                 rank, ucs_status_string(ucs_status));
+        return ucs_status_to_ucc_status(ucs_status);
+    }
+    ucp_rkey_destroy(test_rkey);
+    return UCC_OK;
+}
+
+/* Free an array of independently-allocated imported memory handles and their
+   owned tl_h.  The pointer array itself is freed by the caller. */
+static ucc_status_t
+free_imported_handles(ucc_tl_ucp_context_t *ctx, ucc_tl_ucp_task_t *task,
+                      ucc_mem_map_memh_t **handles, size_t n, const char *label)
+{
+    ucc_status_t status = UCC_OK;
+    ucc_status_t tmp;
+    size_t       i;
+
+    for (i = 0; i < n; i++) {
+        if (!handles[i]) {
+            continue;
+        }
+        if (handles[i]->tl_h) {
+            tmp = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_IMPORT,
+                                       handles[i]->tl_h);
+            if (tmp != UCC_OK) {
+                tl_error(UCC_TASK_LIB(task),
+                         "failed to unmap %s global memory handle for rank %zu",
+                         label, i);
+                if (status == UCC_OK) {
+                    status = tmp;
+                }
+            }
+            ucc_free(handles[i]->tl_h);
+            handles[i]->tl_h = NULL;
+        }
+        ucc_free(handles[i]);
+        handles[i] = NULL;
+    }
+    return status;
+}
+
+/* Unmap and free a single exported (local) memory handle. */
+static ucc_status_t
+free_local_memh(ucc_tl_ucp_context_t *ctx, ucc_tl_ucp_task_t *task,
+                ucc_mem_map_memh_t **memh_ptr, const char *label)
+{
+    ucc_mem_map_memh_t *memh = *memh_ptr;
+    ucc_status_t        status = UCC_OK;
+    ucc_status_t        tmp;
+
+    if (!memh) {
+        return UCC_OK;
+    }
+    if (memh->tl_h) {
+        tmp = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT,
+                                   memh->tl_h);
+        if (tmp != UCC_OK) {
+            tl_error(UCC_TASK_LIB(task), "failed to unmap %s local memory handle",
+                     label);
+            status = tmp;
+        }
+        ucc_free(memh->tl_h);
+        memh->tl_h = NULL;
+    }
+    ucc_free(memh);
+    *memh_ptr = NULL;
+    return status;
+}
+
+static ucc_status_t
+dynamic_segment_import_memory_handles(ucc_tl_ucp_dyn_seg_args_t *args)
+{
+    ucc_tl_ucp_team_t    *tl_team = UCC_TL_UCP_TASK_TEAM(args->task);
+    ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
+    ucc_mem_map_memh_t  **global;
+    size_t                offset;
+    ucc_status_t          status;
+    int                   i;
+    int                   j;
+
+    /* Only allocate destination handles for one-sided operations */
+    global =
+        ucc_calloc(UCC_TL_TEAM_SIZE(tl_team), sizeof(ucc_mem_map_memh_t *), "global");
+    if (!global) {
+        tl_error(UCC_TASK_LIB(args->task),
+                 "failed to allocate global memory handles");
         return UCC_ERR_NO_MEMORY;
     }
-    args->task->dynamic_segments.dst_global = ucc_calloc(core_team->size, sizeof(ucc_mem_map_memh_t *),
-                                                    "dst_global");
-    if (!args->task->dynamic_segments.dst_global) {
-         tl_error(UCC_TASK_LIB(args->task),
-                 "failed to allocate global dst memory handles");
-        ucc_free(args->task->dynamic_segments.src_global);
-        return UCC_ERR_NO_MEMORY;
+
+    /* Reconstruct a local memory handle for each rank from the serialized
+       wire bytes.  global[i] is an independently-allocated ucc_mem_map_memh_t
+       (NOT an interior pointer into global_buffer); it owns its tl_h and its
+       copy of the pack_buffer, and is released in finalize()/on error below. */
+    for (i = 0; i < UCC_TL_TEAM_SIZE(tl_team); i++) {
+        ucc_tl_ucp_dyn_seg_wire_t *wire;
+        ucc_mem_map_memh_t        *memh;
+
+        offset = i * args->exchange_size;
+        wire   = PTR_OFFSET(args->task->dynamic_segments.global_buffer, offset);
+
+        memh = ucc_calloc(1, sizeof(ucc_mem_map_memh_t) + wire->payload_size,
+                          "imported memh");
+        if (!memh) {
+            tl_error(UCC_TASK_LIB(args->task),
+                     "failed to allocate imported memh for rank %d", i);
+            status = UCC_ERR_NO_MEMORY;
+            goto out;
+        }
+        global[i] = memh;
+        /* Populate all pointer/scalar fields locally; nothing here is trusted
+           from the wire except the serialized address, length and rkey bytes. */
+        memh->mode    = UCC_MEM_MAP_MODE_IMPORT;
+        memh->context = (ucc_context_h)&ctx->super.super;
+        memh->address = (void *)wire->address;
+        memh->len     = wire->len;
+        memh->num_tls = 1;
+        memcpy(memh->pack_buffer, wire->payload, wire->payload_size);
+
+        memh->tl_h = ucc_calloc(1, sizeof(ucc_mem_map_tl_t), "global tl_h");
+        if (!memh->tl_h) {
+            tl_error(UCC_TASK_LIB(args->task),
+                    "failed to allocate global tl handles");
+            status = UCC_ERR_NO_MEMORY;
+            goto out;
+        }
+
+        status = ucc_tl_ucp_mem_map(
+            &ctx->super.super, UCC_MEM_MAP_MODE_IMPORT,
+            memh,
+            memh->tl_h);
+        if (status != UCC_OK) {
+            tl_error(UCC_TASK_LIB(args->task),
+                     "failed to import dst memory handle for rank %d ", i);
+            goto out;
+        }
+        /* Validate remote key by unpacking immediately, so exchange-phase
+           failures are reported here rather than lazily during data access. */
+        status = validate_remote_rkey(tl_team, args->task, memh, i);
+        if (status != UCC_OK) {
+            goto out;
+        }
     }
 
-    /* Import memory handles for each rank using ucc_tl_ucp_mem_map */
-    for (i = 0; i < core_team->size; i++) {
-        /* Each rank's data in global buffer contains:
-           - src_memh_pack: sizeof(ucc_mem_map_memh_t) + max_individual_pack_size + sizeof(size_t) * 2
-           - dst_memh_pack: sizeof(ucc_mem_map_memh_t) + max_individual_pack_size + sizeof(size_t) * 2
-        */
-        src_offset = i * args->exchange_size;
-        dst_offset = i * args->exchange_size + args->exchange_size / 2;
-
-        args->task->dynamic_segments.src_global[i] = (ucc_mem_map_memh_t *)PTR_OFFSET(args->task->dynamic_segments.global_buffer, src_offset);
-        args->task->dynamic_segments.dst_global[i] = (ucc_mem_map_memh_t *)PTR_OFFSET(args->task->dynamic_segments.global_buffer, dst_offset);
-
-        args->task->dynamic_segments.src_global[i]->tl_h = ucc_calloc(1, sizeof(ucc_mem_map_tl_t), "global tl_h");
-        args->task->dynamic_segments.dst_global[i]->tl_h = ucc_calloc(1, sizeof(ucc_mem_map_tl_t), "global tl_h");
-
-        status = ucc_tl_ucp_mem_map(&ctx->super.super, UCC_MEM_MAP_MODE_IMPORT,
-                                   args->task->dynamic_segments.src_global[i],
-                                   args->task->dynamic_segments.src_global[i]->tl_h);
-        if (status != UCC_OK) {
-            tl_error(UCC_TASK_LIB(args->task),
-                     "failed to import src memory handle for rank %d", i);
-            return status;
-        }
-        status = ucc_tl_ucp_mem_map(&ctx->super.super, UCC_MEM_MAP_MODE_IMPORT,
-                                   args->task->dynamic_segments.dst_global[i],
-                                   args->task->dynamic_segments.dst_global[i]->tl_h);
-        if (status != UCC_OK) {
-            tl_error(UCC_TASK_LIB(args->task),
-                     "failed to import dst memory handle for rank %d", i);
-            return status;
-        }
+    if (args->task->dynamic_segments.alg == UCC_TL_UCP_ALLTOALL_ONESIDED_GET) {
+        args->task->dynamic_segments.src_global = global;
+        args->task->dynamic_segments.dst_global = NULL;
+    } else {
+        args->task->dynamic_segments.src_global = NULL;
+        args->task->dynamic_segments.dst_global = global;
     }
 
     return UCC_OK;
+out:
+    /* Release every handle reconstructed so far, including the current partial
+       one at index i (global[i] is NULL if its allocation is what failed). */
+    for (j = 0; j <= i && j < (int)UCC_TL_TEAM_SIZE(tl_team); j++) {
+        if (!global[j]) {
+            continue;
+        }
+        if (global[j]->tl_h) {
+            /* tl_data is set only once mem_map succeeded; unmap needs it. */
+            if (global[j]->tl_h->tl_data) {
+                ucc_tl_ucp_mem_unmap(&ctx->super.super,
+                                     UCC_MEM_MAP_MODE_IMPORT, global[j]->tl_h);
+            }
+            ucc_free(global[j]->tl_h);
+        }
+        ucc_free(global[j]);
+    }
+    ucc_free(global);
+    return status;
 }
 
 static void dynamic_segment_cleanup_buffers(ucc_tl_ucp_dyn_seg_args_t *args)
 {
-    if (!args) {
-        return;
-    }
-
     if (args->src_pack_buffer) {
         ucc_free(args->src_pack_buffer);
         args->src_pack_buffer = NULL;
@@ -559,22 +711,6 @@ static void dynamic_segment_cleanup_buffers(ucc_tl_ucp_dyn_seg_args_t *args)
     if (args->dst_pack_buffer) {
         ucc_free(args->dst_pack_buffer);
         args->dst_pack_buffer = NULL;
-    }
-    if (args->src_memh_pack) {
-        if (args->src_memh_pack->tl_h) {
-            ucc_free(args->src_memh_pack->tl_h);
-            args->src_memh_pack->tl_h = NULL;
-        }
-        ucc_free(args->src_memh_pack);
-        args->src_memh_pack = NULL;
-    }
-    if (args->dst_memh_pack) {
-        if (args->dst_memh_pack->tl_h) {
-            ucc_free(args->dst_memh_pack->tl_h);
-            args->dst_memh_pack->tl_h = NULL;
-        }
-        ucc_free(args->dst_memh_pack);
-        args->dst_memh_pack = NULL;
     }
     if (args->exchange_buffer) {
         ucc_free(args->exchange_buffer);
@@ -584,10 +720,10 @@ static void dynamic_segment_cleanup_buffers(ucc_tl_ucp_dyn_seg_args_t *args)
         ucc_free(args->global_sizes);
         args->global_sizes = NULL;
     }
-
 }
 
-UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_exchange_nb, (task),
+UCC_TL_UCP_PROFILE_FUNC(ucc_status_t,
+                        ucc_tl_ucp_coll_dynamic_segment_exchange_nb, (task),
                         ucc_tl_ucp_task_t *task)
 {
     ucc_tl_ucp_team_t *tl_team   = UCC_TL_UCP_TASK_TEAM(task);
@@ -595,49 +731,63 @@ UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_exchange_n
     ucc_status_t       status    = UCC_OK;
 
     if (core_team->size == 0) {
-        tl_error(UCC_TASK_LIB(task), "unable to exchange segments with team size of 0");
+        tl_error(UCC_TASK_LIB(task),
+                 "unable to exchange segments with team size of 0");
         return UCC_ERR_INVALID_PARAM;
     }
 
     /* Initialize on first call */
     if (task->dynamic_segments.exchange_args == NULL) {
-        task->dynamic_segments.exchange_args = ucc_calloc(1, sizeof(ucc_tl_ucp_dyn_seg_args_t), "exchange_args");
+        task->dynamic_segments.exchange_args =
+            ucc_calloc(1, sizeof(ucc_tl_ucp_dyn_seg_args_t), "exchange_args");
         if (!task->dynamic_segments.exchange_args) {
             tl_error(UCC_TASK_LIB(task), "failed to allocate exchange_args");
             return UCC_ERR_NO_MEMORY;
         }
-        task->dynamic_segments.exchange_args->task           = task;
-        task->dynamic_segments.exchange_args->src_memh_local = task->dynamic_segments.src_local;
-        task->dynamic_segments.exchange_args->dst_memh_local = task->dynamic_segments.dst_local;
-        task->dynamic_segments.exchange_step                 = 0;
-        task->dynamic_segments.exchange_status               = UCC_OK;
-        task->dynamic_segments.scoll_req_sizes               = NULL;
-        task->dynamic_segments.scoll_req_data                = NULL;
+        task->dynamic_segments.exchange_args->task = task;
+        /* Only expose the exchanged side for packing; the other side is used
+         * locally by the RDMA operation and does not need to be shared. */
+        if (task->dynamic_segments.alg == UCC_TL_UCP_ALLTOALL_ONESIDED_GET) {
+            task->dynamic_segments.exchange_args->src_memh_local =
+                task->dynamic_segments.src_local;
+            task->dynamic_segments.exchange_args->dst_memh_local = NULL;
+        } else {
+            task->dynamic_segments.exchange_args->src_memh_local = NULL;
+            task->dynamic_segments.exchange_args->dst_memh_local =
+                task->dynamic_segments.dst_local;
+        }
+        task->dynamic_segments.exchange_step   = 0;
+        task->dynamic_segments.scoll_req_sizes = NULL;
+        task->dynamic_segments.scoll_req_data  = NULL;
     }
     switch (task->dynamic_segments.exchange_step) {
-    case DYN_SEG_EXCHANGE_STEP_INIT:
-        status = dynamic_segment_pack_memory_handles(task->dynamic_segments.exchange_args);
+    case UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_INIT:
+        status = dynamic_segment_pack_memory_handles(
+            task->dynamic_segments.exchange_args);
         if (status != UCC_OK) {
             goto err_cleanup;
         }
-        task->dynamic_segments.exchange_step = DYN_SEG_EXCHANGE_STEP_SIZE_TEST;
+        task->dynamic_segments.exchange_step = UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_SIZE_TEST;
         return UCC_INPROGRESS;
 
-    case DYN_SEG_EXCHANGE_STEP_SIZE_TEST:
+    case UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_SIZE_TEST:
         if (task->dynamic_segments.exchange_args->global_sizes == NULL) {
 
             /* First call - start the allgather */
-            status = dynamic_segment_calculate_sizes_start(task->dynamic_segments.exchange_args,
-                                                         &task->dynamic_segments.scoll_req_sizes);
+            status = dynamic_segment_calculate_sizes_start(
+                task->dynamic_segments.exchange_args,
+                &task->dynamic_segments.scoll_req_sizes);
             if (status != UCC_OK) {
-                tl_error(UCC_TASK_LIB(task), "failed to start allgather %s", ucc_status_string(status));
+                tl_error(UCC_TASK_LIB(task), "failed to start allgather %s",
+                         ucc_status_string(status));
                 goto err_cleanup;
             }
             return UCC_INPROGRESS;
         } else {
             /* Subsequent calls - test for completion */
-            status = dynamic_segment_calculate_sizes_test(task->dynamic_segments.exchange_args,
-                                                        &task->dynamic_segments.scoll_req_sizes);
+            status = dynamic_segment_calculate_sizes_test(
+                task->dynamic_segments.exchange_args,
+                &task->dynamic_segments.scoll_req_sizes);
             if (status == UCC_INPROGRESS) {
                 return UCC_INPROGRESS;
             }
@@ -645,33 +795,38 @@ UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_exchange_n
                 tl_error(UCC_TASK_LIB(task), "failed to test allgather");
                 goto err_cleanup;
             }
-            task->dynamic_segments.exchange_step = DYN_SEG_EXCHANGE_STEP_DATA_ALLOC;
+            task->dynamic_segments.exchange_step =
+                UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_DATA_ALLOC;
             return UCC_INPROGRESS;
         }
 
-    case DYN_SEG_EXCHANGE_STEP_DATA_ALLOC:
-        status = dynamic_segment_allocate_buffers(task->dynamic_segments.exchange_args);
+    case UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_DATA_ALLOC:
+        status = dynamic_segment_allocate_buffers(
+            task->dynamic_segments.exchange_args);
         if (status != UCC_OK) {
             tl_error(UCC_TASK_LIB(task), "failed to allocate buffers");
             goto err_cleanup;
         }
-        task->dynamic_segments.exchange_step = DYN_SEG_EXCHANGE_STEP_DATA_START;
+        task->dynamic_segments.exchange_step = UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_DATA_START;
         return UCC_INPROGRESS;
 
-    case DYN_SEG_EXCHANGE_STEP_DATA_START:
+    case UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_DATA_START:
         if (task->dynamic_segments.scoll_req_data == NULL) {
             /* First call - start the allgather */
-            status = dynamic_segment_pack_and_exchange_data_start(task->dynamic_segments.exchange_args,
-                                                                 &task->dynamic_segments.scoll_req_data);
+            status = dynamic_segment_pack_and_exchange_data_start(
+                task->dynamic_segments.exchange_args,
+                &task->dynamic_segments.scoll_req_data);
             if (status != UCC_OK) {
-                tl_error(UCC_TASK_LIB(task), "failed to start data exchange %s", ucc_status_string(status));
+                tl_error(UCC_TASK_LIB(task), "failed to start data exchange %s",
+                         ucc_status_string(status));
                 goto err_cleanup_global;
             }
             return UCC_INPROGRESS;
         } else {
             /* Subsequent calls - test for completion */
-            status = dynamic_segment_pack_and_exchange_data_test(task->dynamic_segments.exchange_args,
-                                                               &task->dynamic_segments.scoll_req_data);
+            status = dynamic_segment_pack_and_exchange_data_test(
+                task->dynamic_segments.exchange_args,
+                &task->dynamic_segments.scoll_req_data);
             if (status == UCC_INPROGRESS) {
                 return UCC_INPROGRESS;
             }
@@ -680,8 +835,10 @@ UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_exchange_n
                 goto err_cleanup_global;
             }
         }
+        /* falls through: data exchange complete, import handles below */
     }
-    status = dynamic_segment_import_memory_handles(task->dynamic_segments.exchange_args);
+    status = dynamic_segment_import_memory_handles(
+        task->dynamic_segments.exchange_args);
     if (status != UCC_OK) {
         tl_error(UCC_TASK_LIB(task), "failed to import memory handles");
         goto err_cleanup_global;
@@ -691,7 +848,7 @@ UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_exchange_n
     dynamic_segment_cleanup_buffers(task->dynamic_segments.exchange_args);
     ucc_free(task->dynamic_segments.exchange_args);
     task->dynamic_segments.exchange_args = NULL;
-    task->dynamic_segments.exchange_step = DYN_SEG_EXCHANGE_STEP_COMPLETE;
+    task->dynamic_segments.exchange_step = UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_COMPLETE;
     return UCC_OK;
 
 err_cleanup_global:
@@ -708,78 +865,79 @@ err_cleanup:
     return status;
 }
 
-UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_finalize, (task),
-                        ucc_tl_ucp_task_t *task)
+UCC_TL_UCP_PROFILE_FUNC(ucc_status_t, ucc_tl_ucp_coll_dynamic_segment_finalize,
+                        (task), ucc_tl_ucp_task_t *task)
 {
+    /* Idempotent: safe to call once per completed iteration. USE_DYN_SEG flag
+       is intentionally NOT cleared so destroy() and re-exchange paths still
+       function correctly. */
+
     ucc_tl_ucp_team_t    *team      = UCC_TL_UCP_TASK_TEAM(task);
     ucc_tl_ucp_context_t *ctx       = UCC_TL_UCP_TEAM_CTX(team);
     ucc_status_t          status    = UCC_OK;
+    ucc_status_t          tmp;
     size_t                team_size = UCC_TL_TEAM_SIZE(team);
-    int                   i;
 
     if (!(task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG)) {
         return UCC_OK;
     }
     if (task->dynamic_segments.src_global) {
-        for (i = 0; i < team_size; i++) {
-            if (task->dynamic_segments.src_global[i] &&
-                task->dynamic_segments.src_global[i]->tl_h) {
-                status = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_IMPORT, task->dynamic_segments.src_global[i]->tl_h);
-                if (status != UCC_OK) {
-                    tl_error(UCC_TASK_LIB(task), "failed to unmap src global memory handle for rank %d", i);
-                }
-                ucc_free(task->dynamic_segments.src_global[i]->tl_h);
-                task->dynamic_segments.src_global[i]->tl_h = NULL;
-                task->dynamic_segments.src_global[i] = NULL;
-            }
+        /* Each global[i] is an independently-allocated imported handle that
+           owns its tl_h and its copy of the packed rkey bytes; free both. */
+        tmp = free_imported_handles(ctx, task, task->dynamic_segments.src_global,
+                                    team_size, "src");
+        if (tmp != UCC_OK && status == UCC_OK) {
+            status = tmp;
         }
         ucc_free(task->dynamic_segments.src_global);
         task->dynamic_segments.src_global = NULL;
     }
     if (task->dynamic_segments.dst_global) {
-        for (i = 0; i < team_size; i++) {
-            if (task->dynamic_segments.dst_global[i] && 
-                task->dynamic_segments.dst_global[i]->tl_h) {
-                status = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_IMPORT, task->dynamic_segments.dst_global[i]->tl_h);
-                if (status != UCC_OK) {
-                    tl_error(UCC_TASK_LIB(task), "failed to unmap dst global memory handle for rank %d", i);
-                }
-                ucc_free(task->dynamic_segments.dst_global[i]->tl_h);
-                task->dynamic_segments.dst_global[i]->tl_h = NULL;
-                task->dynamic_segments.dst_global[i] = NULL;
-            }
+        tmp = free_imported_handles(ctx, task, task->dynamic_segments.dst_global,
+                                    team_size, "dst");
+        if (tmp != UCC_OK && status == UCC_OK) {
+            status = tmp;
         }
         ucc_free(task->dynamic_segments.dst_global);
         task->dynamic_segments.dst_global = NULL;
     }
-    /* Free global buffer */
+    /* Free the allgather receive buffer.  The imported handles no longer point
+       into it (each holds its own copy), so ordering here is not critical. */
     if (task->dynamic_segments.global_buffer) {
         ucc_free(task->dynamic_segments.global_buffer);
         task->dynamic_segments.global_buffer = NULL;
     }
-    if (task->dynamic_segments.src_local) {
-        if (task->dynamic_segments.src_local->tl_h) {
-            status = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT, task->dynamic_segments.src_local->tl_h);
-            if (status != UCC_OK) {
-                tl_error(UCC_TASK_LIB(task), "failed to unmap src local memory handle");
-            }
-            ucc_free(task->dynamic_segments.src_local->tl_h);
-            task->dynamic_segments.src_local->tl_h = NULL;
-        }
-        ucc_free(task->dynamic_segments.src_local);
-        task->dynamic_segments.src_local = NULL;
+    /* src_local and dst_local are kept alive for persistent collective reuse.
+     * They are released by ucc_tl_ucp_coll_dynamic_segment_destroy() when the
+     * task is truly destroyed.  On the next start(), exchange_nb will detect
+     * exchange_args == NULL and restart the exchange from scratch. */
+
+    /* Reset exchange state machine so that a subsequent start() restarts the
+       exchange from INIT, regardless of how exchange_args is handled. */
+    task->dynamic_segments.exchange_step = UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_INIT;
+    task->dynamic_segments.scoll_req_sizes = NULL;
+    task->dynamic_segments.scoll_req_data  = NULL;
+
+    return status;
+}
+
+ucc_status_t ucc_tl_ucp_coll_dynamic_segment_destroy(ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t    *team   = UCC_TL_UCP_TASK_TEAM(task);
+    ucc_tl_ucp_context_t *ctx    = UCC_TL_UCP_TEAM_CTX(team);
+    ucc_status_t          status = UCC_OK;
+    ucc_status_t          tmp;
+
+    if (!(task->flags & UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG)) {
+        return UCC_OK;
     }
-    if (task->dynamic_segments.dst_local) {
-        if (task->dynamic_segments.dst_local->tl_h) {
-            status = ucc_tl_ucp_mem_unmap(&ctx->super.super, UCC_MEM_MAP_MODE_EXPORT, task->dynamic_segments.dst_local->tl_h);
-            if (status != UCC_OK) {
-                tl_error(UCC_TASK_LIB(task), "failed to unmap dst local memory handle");
-            }
-            ucc_free(task->dynamic_segments.dst_local->tl_h);
-            task->dynamic_segments.dst_local->tl_h = NULL;
-        }
-        ucc_free(task->dynamic_segments.dst_local);
-        task->dynamic_segments.dst_local = NULL;
+    tmp = free_local_memh(ctx, task, &task->dynamic_segments.src_local, "src");
+    if (tmp != UCC_OK && status == UCC_OK) {
+        status = tmp;
+    }
+    tmp = free_local_memh(ctx, task, &task->dynamic_segments.dst_local, "dst");
+    if (tmp != UCC_OK && status == UCC_OK) {
+        status = tmp;
     }
     return status;
 }

--- a/src/components/tl/ucp/tl_ucp_coll.h
+++ b/src/components/tl/ucp/tl_ucp_coll.h
@@ -15,6 +15,14 @@
 #define UCC_UUNITS_AUTO_RADIX 4
 #define UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR 9
 
+enum ucc_tl_ucp_dyn_seg_exchange_step {
+    UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_INIT,
+    UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_SIZE_TEST,
+    UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_DATA_ALLOC,
+    UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_DATA_START,
+    UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_COMPLETE
+};
+
 ucc_status_t ucc_tl_ucp_team_default_score_str_alloc(ucc_tl_ucp_team_t *team,
     char *default_select_str[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR]);
 
@@ -79,251 +87,6 @@ typedef struct ucc_tl_ucp_default_alg_desc {
     ucc_tl_ucp_score_str_get_fn_t  str_get_fn;
 } ucc_tl_ucp_default_alg_desc_t;
 
-<<<<<<< HEAD
-=======
-enum ucc_tl_ucp_task_flags {
-    /*indicates whether subset field of tl_ucp_task is set*/
-    UCC_TL_UCP_TASK_FLAG_SUBSET      = UCC_BIT(0),
-    /* indicates usage of dynamic segments */
-    UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG = UCC_BIT(1),
-    /* indicates onesided operations have been started */
-    UCC_TL_UCP_TASK_FLAG_OPS_STARTED = UCC_BIT(2),
-};
-
-typedef struct ucc_tl_ucp_allreduce_sw_pipeline
-    ucc_tl_ucp_allreduce_sw_pipeline;
-typedef struct ucc_tl_ucp_allreduce_sw_host_allgather
-    ucc_tl_ucp_allreduce_sw_host_allgather;
-typedef struct ucc_tl_ucp_dpu_offload_buf_info
-    ucc_tl_ucp_dpu_offload_buf_info_t;
-
-/* Structure to hold dynamic segment exchange parameters and buffers */
-typedef struct {
-    ucc_tl_ucp_task_t  *task;
-    void               *src_pack_buffer;
-    void               *dst_pack_buffer;
-    size_t              src_pack_size;
-    size_t              dst_pack_size;
-    size_t              max_individual_pack_size;
-    size_t              exchange_size;
-    ucc_mem_map_memh_t *src_memh_pack;
-    ucc_mem_map_memh_t *dst_memh_pack;
-    void               *exchange_buffer;
-    ucc_mem_map_memh_t *src_memh_local;
-    ucc_mem_map_memh_t *dst_memh_local;
-    size_t             *global_sizes;
-} ucc_tl_ucp_dyn_seg_args_t;
-
-typedef struct ucc_tl_ucp_task {
-    ucc_coll_task_t super;
-    uint32_t        flags;
-    union {
-        struct {
-            uint32_t        send_posted;
-            uint32_t        send_completed;
-            uint32_t        recv_posted;
-            uint32_t        recv_completed;
-            uint32_t        tag;
-        } tagged;
-        struct {
-            uint32_t        put_posted;
-            uint32_t        put_completed;
-            uint32_t        get_posted;
-            uint32_t        get_completed;
-        } onesided;
-    };
-    uint32_t        n_polls;
-    ucc_subset_t    subset;
-    union {
-        struct {
-            int                     phase;
-            ucc_knomial_pattern_t   p;
-        } barrier;
-        struct {
-            int                     phase;
-            ucc_knomial_pattern_t   p;
-            void                   *scratch;
-            void                   *reduce_bufs[UCC_EE_EXECUTOR_NUM_BUFS];
-            ucc_mc_buffer_header_t *scratch_mc_header;
-            ucc_ee_executor_task_t *etask;
-            ucc_ee_executor_t      *executor;
-        } allreduce_kn;
-        struct {
-            ucc_tl_ucp_allreduce_sw_pipeline          *pipe;
-            ucs_status_ptr_t                          *put_requests;
-            ucc_tl_ucp_allreduce_sw_host_allgather    *allgather_data;
-            ucc_coll_task_t                           *allgather_task;
-            ucc_ee_executor_task_t                    *reduce_task;
-            ucc_tl_ucp_dpu_offload_buf_info_t         *bufs;
-        } allreduce_sliding_window;
-        struct {
-            int                     phase;
-            ucc_knomial_pattern_t   p;
-            void                   *scratch;
-            ucc_mc_buffer_header_t *scratch_mc_header;
-            ucc_ee_executor_task_t *etask;
-            ucc_ee_executor_t      *executor;
-            size_t                  max_seg;
-        } reduce_scatter_kn;
-        struct {
-            void                   *scratch;
-            size_t                  max_block_count;
-            ucc_ep_map_t            inv_map;
-            int                     n_frags;
-            int                     frag;
-            char                    s_scratch_busy[2];
-            ucc_ee_executor_task_t *etask;
-            ucc_ee_executor_t      *executor;
-        } reduce_scatter_ring;
-        struct {
-            void                   *scratch;
-            size_t                  max_block_count;
-            ucc_ep_map_t            inv_map;
-            int                     n_frags;
-            int                     frag;
-            char                    s_scratch_busy[2];
-            ucc_ee_executor_task_t *etask;
-            ucc_ee_executor_t      *executor;
-        } reduce_scatterv_ring;
-        struct {
-            int                     phase;
-            ucc_knomial_pattern_t   p;
-            ucc_rank_t              recv_dist;
-            ptrdiff_t               send_offset;
-            ptrdiff_t               recv_offset;
-            size_t                  recv_size;
-        } scatter_kn;
-        struct {
-            int                     phase;
-            ucc_knomial_pattern_t   p;
-            void                   *sbuf;
-            ucc_tl_ucp_copy_task_t *copy_task;
-            ucc_rank_t              recv_dist;
-        } allgather_kn;
-        struct {
-            /*
-             * get send/recv block depends on subset type being used.
-             * For service allgather we need to get context endpoints but keep
-             * subset numbering.
-             * For regular allgather with rank reordering both endpoints
-             * and blocks permutation are necessary.
-             */
-            ucc_rank_t (*get_send_block)(ucc_subset_t *subset,
-                                         ucc_rank_t trank,
-                                         ucc_rank_t tsize,
-                                         int step);
-            ucc_rank_t (*get_recv_block)(ucc_subset_t *subset,
-                                         ucc_rank_t trank,
-                                         ucc_rank_t tsize,
-                                         int step);
-        } allgather_ring;
-        struct {
-            int                     nreqs; // number of send/recv requests in progress
-            ucc_tl_ucp_copy_task_t *copy_task;
-        } allgather_linear;
-        struct {
-            ucc_mc_buffer_header_t *scratch_header;
-            size_t                  scratch_size;
-        } allgather_bruck;
-        struct {
-            uint32_t                i;
-            int                     data_expected;
-        } allgather_sparbit;
-        struct {
-            ucc_rank_t              dist;
-            uint32_t                radix;
-        } bcast_kn;
-        struct {
-            ucc_dbt_single_tree_t   t1;
-            ucc_dbt_single_tree_t   t2;
-            int                     state;
-        } bcast_dbt;
-        struct {
-            ucc_rank_t              dist;
-            ucc_rank_t              max_dist;
-            int                     children_per_cycle;
-            uint32_t                radix;
-            int                     phase;
-            void                   *scratch;
-            ucc_mc_buffer_header_t *scratch_mc_header;
-            ucc_ee_executor_task_t *etask;
-            ucc_ee_executor_t      *executor;
-        } reduce_kn;
-        struct {
-            int                     state;
-            ucc_dbt_single_tree_t   trees[2];
-            int                     reduction_comp[2];
-            int                     send_comp[2];
-            void                   *scratch;
-            ucc_mc_buffer_header_t *scratch_mc_header;
-            ucc_ee_executor_task_t *etask;
-            ucc_ee_executor_t      *executor;
-        } reduce_dbt;
-        struct {
-            int                     phase;
-            ucc_knomial_pattern_t   p;
-            ucc_rank_t              dist;
-            ucc_rank_t              max_dist;
-            uint32_t                radix;
-            void *                  scratch;
-            ucc_mc_buffer_header_t *scratch_mc_header;
-        } gather_kn;
-        struct {
-            size_t                  merge_buf_size;
-            ucc_mc_buffer_header_t *scratch_mc_header;
-            size_t                  byte_send_limit;
-            int                     phase;
-            uint32_t                radix;
-            uint32_t                cur_radix;
-            uint32_t                iteration;
-            ucc_rank_t              cur_out;
-            size_t                  traffic_in;
-            size_t                  traffic_out;
-            ucc_rank_t              num_in;
-            ucc_rank_t              num2send;
-            ucc_rank_t              num2recv;
-        } alltoallv_hybrid;
-        struct {
-            ucc_mc_buffer_header_t *scratch_mc_header;
-            ucc_ee_executor_task_t *etask;
-            void                   *src;
-            void                   *dst;
-            ucc_rank_t              iteration;
-            int                     phase;
-        } alltoall_bruck;
-        char                        plugin_data[UCC_TL_UCP_TASK_PLUGIN_MAX_DATA];
-    };
-    struct {
-        ucc_mem_map_memh_t        *src_local;
-        ucc_mem_map_memh_t        *dst_local;
-        ucc_mem_map_memh_t       **src_global;
-        ucc_mem_map_memh_t       **dst_global;
-        ucc_tl_ucp_dyn_seg_args_t *exchange_args;
-        void                      *global_buffer;
-        ucc_service_coll_req_t    *scoll_req_sizes; /* For sizes allgather */
-        ucc_service_coll_req_t    *scoll_req_data; /* For data ex allgather */
-        int                        exchange_step;
-        ucc_status_t               exchange_status;
-    } dynamic_segments;
-} ucc_tl_ucp_task_t;
-
-typedef struct ucc_tl_ucp_schedule {
-    ucc_schedule_pipelined_t super;
-    ucc_mc_buffer_header_t  *scratch_mc_header;
-    union {
-        ptrdiff_t frag_offset;
-    } reduce_srg_kn;
-} ucc_tl_ucp_schedule_t;
-
-#define TASK_TEAM(_task)                                                       \
-    (ucc_derived_of((_task)->super.team, ucc_tl_ucp_team_t))
-#define TASK_CTX(_task)                                                        \
-    (ucc_derived_of((_task)->super.team->context, ucc_tl_ucp_context_t))
-#define TASK_LIB(_task)                                                        \
-    (ucc_derived_of((_task)->super.team->context->lib, ucc_tl_ucp_lib_t))
-#define TASK_ARGS(_task) (_task)->super.bargs.args
-
->>>>>>> fc580dc2 (TL/UCP: enable nonblocking dynamic segments)
 #define AVG_ALPHA(_task) (1.0 / (double)UCC_TL_TEAM_SIZE(TASK_TEAM(_task)))
 
 ucc_status_t ucc_tl_ucp_coll_init(ucc_base_coll_args_t *coll_args,
@@ -522,12 +285,17 @@ static inline unsigned ucc_tl_ucp_get_knomial_radix(ucc_tl_ucp_team_t *team,
 }
 
 ucc_status_t ucc_tl_ucp_coll_dynamic_segment_init(ucc_coll_args_t *coll_args,
+                                                  ucc_tl_ucp_onesided_alg_type alg,
                                                   ucc_tl_ucp_task_t   *task);
 
-ucc_status_t ucc_tl_ucp_coll_dynamic_segment_exchange(ucc_tl_ucp_task_t *task);
 ucc_status_t ucc_tl_ucp_coll_dynamic_segment_exchange_nb(ucc_tl_ucp_task_t *task);
 
+/* Called at end of each iteration: releases imported/global handles and
+ * resets exchange state for the next start(). */
 ucc_status_t ucc_tl_ucp_coll_dynamic_segment_finalize(ucc_tl_ucp_task_t *task);
+
+/* Called once at task destroy: releases the locally exported handles. */
+ucc_status_t ucc_tl_ucp_coll_dynamic_segment_destroy(ucc_tl_ucp_task_t *task);
 
 static inline ucc_status_t ucc_tl_ucp_test_dynamic_segment(ucc_tl_ucp_task_t *task)
 {
@@ -535,7 +303,7 @@ static inline ucc_status_t ucc_tl_ucp_test_dynamic_segment(ucc_tl_ucp_task_t *ta
         return UCC_OK;
     }
 
-    if (task->dynamic_segments.exchange_step < 5) {
+    if (task->dynamic_segments.exchange_step < UCC_TL_UCP_DYN_SEG_EXCHANGE_STEP_COMPLETE) {
         return ucc_tl_ucp_coll_dynamic_segment_exchange_nb(task);
     }
 

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -547,8 +547,6 @@ ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t * ctx,
                                             ucc_mem_map_params_t   map,
                                             ucc_context_oob_coll_t oob)
 {
-    ucc_tl_ucp_lib_t *lib =
-        ucc_derived_of(ctx->super.super.lib, ucc_tl_ucp_lib_t);
     uint32_t             size  = oob.n_oob_eps;
     uint64_t             nsegs = map.n_segments;
     ucp_mem_map_params_t mmap_params;
@@ -568,13 +566,14 @@ ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t * ctx,
     }
 
     if (nsegs > MAX_NR_SEGMENTS) {
-        tl_error(lib, "cannot map more than %d segments", MAX_NR_SEGMENTS);
+        tl_error(ctx->super.super.lib, "cannot map more than %d segments",
+                 MAX_NR_SEGMENTS);
         return UCC_ERR_INVALID_PARAM;
     }
     ctx->rkeys = (ucp_rkey_h *)ucc_calloc(sizeof(ucp_rkey_h), nsegs * size,
                                           "ucp_ctx_rkeys");
     if (NULL == ctx->rkeys) {
-        tl_error(lib, "failed to allocated %zu bytes",
+        tl_error(ctx->super.super.lib, "failed to allocated %zu bytes",
                  sizeof(ucp_rkey_h) * nsegs * size);
         return UCC_ERR_NO_MEMORY;
     }
@@ -582,7 +581,7 @@ ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t * ctx,
     ctx->remote_info = (ucc_tl_ucp_remote_info_t *)ucc_calloc(
         nsegs, sizeof(ucc_tl_ucp_remote_info_t), "ucp_remote_info");
     if (NULL == ctx->remote_info) {
-        tl_error(lib, "failed to allocated %zu bytes",
+        tl_error(ctx->super.super.lib, "failed to allocated %zu bytes",
                  sizeof(ucc_tl_ucp_remote_info_t) * nsegs);
         ucc_status = UCC_ERR_NO_MEMORY;
         goto fail_alloc_remote_segs;
@@ -596,7 +595,8 @@ ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t * ctx,
 
         status = ucp_mem_map(ctx->worker.ucp_context, &mmap_params, &mh);
         if (UCS_OK != status) {
-            tl_error(lib, "ucp_mem_map failed with error code: %d", status);
+            tl_error(ctx->super.super.lib,
+                     "ucp_mem_map failed with error code: %d", status);
             ucc_status = ucs_status_to_ucc_status(status);
             goto fail_mem_map;
         }
@@ -606,7 +606,8 @@ ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t * ctx,
                                                   &ctx->remote_info[i].packed_key,
                                                   &ctx->remote_info[i].packed_key_len);
         if (UCS_OK != status) {
-            tl_error(lib, "failed to pack UCP key with error code: %d", status);
+            tl_error(ctx->super.super.lib,
+                     "failed to pack UCP key with error code: %d", status);
             ucc_status = ucs_status_to_ucc_status(status);
             goto fail_mem_map;
         }
@@ -835,20 +836,12 @@ ucc_status_t ucc_tl_ucp_mem_unmap(const ucc_base_context_t *context, ucc_mem_map
         if (data->rkey) {
             ucp_rkey_destroy(data->rkey);
         }
-        // Free the data structure itself
         ucc_free(data);
         memh->tl_data = NULL;
     } else {
         ucc_error("Unknown mem map mode entered: %d", mode);
         return UCC_ERR_INVALID_PARAM;
     }
-
-    /* Free the TL data structure */
-    if (data) {
-        ucc_free(data);
-        memh->tl_data = NULL;
-    }
-
     return UCC_OK;
 }
 
@@ -868,6 +861,17 @@ ucc_status_t ucc_tl_ucp_memh_pack(const ucc_base_context_t *context,
     if (!data || !data->rinfo.mem_h) {
         tl_error(ctx->super.super.lib, "unable to pack memory handle without TL handles");
         return UCC_ERR_INVALID_PARAM;
+    }
+    /* Release stale packed buffers from a prior pack call on this handle */
+    if (data->packed_memh) {
+        ucp_memh_buffer_release(data->packed_memh, NULL);
+        data->packed_memh     = NULL;
+        data->packed_memh_len = 0;
+    }
+    if (data->rinfo.packed_key) {
+        ucp_rkey_buffer_release(data->rinfo.packed_key);
+        data->rinfo.packed_key     = NULL;
+        data->rinfo.packed_key_len = 0;
     }
     if (ctx->cfg.exported_memory_handle && mode == UCC_MEM_MAP_MODE_EXPORT) {
         pack_params.field_mask = UCP_MEMH_PACK_PARAM_FIELD_FLAGS;
@@ -925,9 +929,13 @@ ucc_status_t ucc_tl_ucp_memh_pack(const ucc_base_context_t *context,
 
 failed_alloc_buffer:
     ucp_rkey_buffer_release(data->rinfo.packed_key);
+    data->rinfo.packed_key     = NULL;
+    data->rinfo.packed_key_len = 0;
 failed_rkey_pack:
     if (data->packed_memh) {
         ucp_memh_buffer_release(data->packed_memh, NULL);
+        data->packed_memh     = NULL;
+        data->packed_memh_len = 0;
     }
     return ucc_status;
 }

--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -242,7 +242,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_context_t,
         ucp_params.features |= UCP_FEATURE_EXPORTED_MEMH;
     }
     ucp_params.tag_sender_mask = UCC_TL_UCP_TAG_SENDER_MASK;
-    ucp_params.name = "UCC_UCP_CONTEXT";
+    ucp_params.name            = "UCC_UCP_CONTEXT";
 
     if (params->estimated_num_ppn > 0) {
         ucp_params.field_mask |= UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
@@ -547,6 +547,8 @@ ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t * ctx,
                                             ucc_mem_map_params_t   map,
                                             ucc_context_oob_coll_t oob)
 {
+    ucc_tl_ucp_lib_t *lib =
+        ucc_derived_of(ctx->super.super.lib, ucc_tl_ucp_lib_t);
     uint32_t             size  = oob.n_oob_eps;
     uint64_t             nsegs = map.n_segments;
     ucp_mem_map_params_t mmap_params;
@@ -566,52 +568,45 @@ ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t * ctx,
     }
 
     if (nsegs > MAX_NR_SEGMENTS) {
-        tl_error(
-            ctx->super.super.lib,
-            "cannot map more than %d segments",
-            MAX_NR_SEGMENTS);
+        tl_error(lib, "cannot map more than %d segments", MAX_NR_SEGMENTS);
         return UCC_ERR_INVALID_PARAM;
     }
-
-    ctx->rkeys = (ucp_rkey_h *)ucc_calloc(
-        sizeof(ucp_rkey_h), nsegs * size, "ucp_ctx_rkeys");
+    ctx->rkeys = (ucp_rkey_h *)ucc_calloc(sizeof(ucp_rkey_h), nsegs * size,
+                                          "ucp_ctx_rkeys");
     if (NULL == ctx->rkeys) {
-        tl_error(
-            ctx->super.super.lib,
-            "failed to allocated %zu bytes",
-            sizeof(ucp_rkey_h) * nsegs * size);
+        tl_error(lib, "failed to allocated %zu bytes",
+                 sizeof(ucp_rkey_h) * nsegs * size);
         return UCC_ERR_NO_MEMORY;
     }
 
     ctx->remote_info = (ucc_tl_ucp_remote_info_t *)ucc_calloc(
         nsegs, sizeof(ucc_tl_ucp_remote_info_t), "ucp_remote_info");
     if (NULL == ctx->remote_info) {
-        tl_error(ctx->super.super.lib, "failed to allocated %zu bytes",
+        tl_error(lib, "failed to allocated %zu bytes",
                  sizeof(ucc_tl_ucp_remote_info_t) * nsegs);
         ucc_status = UCC_ERR_NO_MEMORY;
         goto fail_alloc_remote_segs;
     }
 
     for (i = 0; i < nsegs; i++) {
-        mmap_params.field_mask =
-            UCP_MEM_MAP_PARAM_FIELD_ADDRESS | UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+        mmap_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                                 UCP_MEM_MAP_PARAM_FIELD_LENGTH;
         mmap_params.address = map.segments[i].address;
         mmap_params.length  = map.segments[i].len;
 
         status = ucp_mem_map(ctx->worker.ucp_context, &mmap_params, &mh);
         if (UCS_OK != status) {
-            tl_error(ctx->super.super.lib,
-                     "ucp_mem_map failed with error code: %d", status);
+            tl_error(lib, "ucp_mem_map failed with error code: %d", status);
             ucc_status = ucs_status_to_ucc_status(status);
             goto fail_mem_map;
         }
+
         ctx->remote_info[i].mem_h = (void *)mh;
         status                    = ucp_rkey_pack(ctx->worker.ucp_context, mh,
-                               &ctx->remote_info[i].packed_key,
-                               &ctx->remote_info[i].packed_key_len);
+                                                  &ctx->remote_info[i].packed_key,
+                                                  &ctx->remote_info[i].packed_key_len);
         if (UCS_OK != status) {
-            tl_error(ctx->super.super.lib,
-                     "failed to pack UCP key with error code: %d", status);
+            tl_error(lib, "failed to pack UCP key with error code: %d", status);
             ucc_status = ucs_status_to_ucc_status(status);
             goto fail_mem_map;
         }
@@ -777,7 +772,6 @@ ucc_status_t ucc_tl_ucp_mem_map(const ucc_base_context_t *context, ucc_mem_map_m
     // copy name information for look ups later
     strncpy(tl_h->tl_name, "ucp", UCC_MEM_MAP_TL_NAME_LEN - 1);
 
-    /* nothing to do for UCC_MEM_MAP_MODE_EXPORT_OFFLOAD and UCC_MEM_MAP_MODE_IMPORT */
     if (mode == UCC_MEM_MAP_MODE_EXPORT) {
         ucc_status = ucc_tl_ucp_mem_map_export(ctx, memh->address, memh->len, mode, m_data);
         if (UCC_OK != ucc_status) {
@@ -825,17 +819,25 @@ ucc_status_t ucc_tl_ucp_mem_unmap(const ucc_base_context_t *context, ucc_mem_map
             ucp_rkey_buffer_release(data->rinfo.packed_key);
             data->rinfo.packed_key = NULL;
         }
+        // Free the data structure itself for export mode too
+        ucc_free(data);
+        memh->tl_data = NULL;
     } else if (mode == UCC_MEM_MAP_MODE_IMPORT || mode == UCC_MEM_MAP_MODE_IMPORT_OFFLOAD) {
         // need to free rkeys (data->rkey) , packed memh (data->packed_memh)
         if (data->packed_memh) {
             ucp_memh_buffer_release(data->packed_memh, NULL);
+            data->packed_memh = NULL;
         }
         if (data->rinfo.packed_key) {
             ucp_rkey_buffer_release(data->rinfo.packed_key);
+            data->rinfo.packed_key = NULL;
         }
         if (data->rkey) {
             ucp_rkey_destroy(data->rkey);
         }
+        // Free the data structure itself
+        ucc_free(data);
+        memh->tl_data = NULL;
     } else {
         ucc_error("Unknown mem map mode entered: %d", mode);
         return UCC_ERR_INVALID_PARAM;

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -408,6 +408,7 @@ static inline ucc_status_t ucc_tl_ucp_check_memh(ucp_ep_h *ep, ucc_rank_t me,
     ucs_status_t            ucs_status;
     int                     i;
     size_t                  offset;
+    size_t                  addr_offset;
 
     base = (uint64_t)dst_memh[me]->address;
     end  = base + dst_memh[me]->len;
@@ -415,8 +416,9 @@ static inline ucc_status_t ucc_tl_ucp_check_memh(ucp_ep_h *ep, ucc_rank_t me,
     if (!((uint64_t)va >= base && (uint64_t)va < end)) {
         return UCC_ERR_NOT_FOUND;
     }
-    *rva = (uint64_t)PTR_OFFSET(dst_memh[peer]->address,
-                                ((uint64_t)va - (uint64_t)dst_memh[me]->address));
+    addr_offset = (uint64_t)va - (uint64_t)dst_memh[me]->address;
+    *rva        = (uint64_t)PTR_OFFSET(dst_memh[peer]->address, addr_offset);
+
     dst_tl_data = (ucc_tl_ucp_memh_data_t *)dst_memh[peer]->tl_h[tl_index].tl_data;
     if (NULL == dst_tl_data->rkey) {
         offset = 0;
@@ -480,12 +482,13 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
     void                 *offset;
     ptrdiff_t             base_offset;
     ucc_status_t          status;
+    ucc_rank_t            ctx_peer; /* for onesided reg. through context */
 
     *segment  = -1;
     core_rank = ucc_ep_map_eval(UCC_TL_TEAM_MAP(team), peer);
     ucc_assert(UCC_TL_CORE_TEAM(team) != NULL);
-    peer = ucc_get_ctx_rank(UCC_TL_CORE_TEAM(team), core_rank);
-
+    /* ctx_peer (context rank) is used for segment-based addressing */
+    ctx_peer = ucc_get_ctx_rank(UCC_TL_CORE_TEAM(team), core_rank);
     offset = ucc_get_team_ep_addr(UCC_TL_CORE_CTX(team), UCC_TL_CORE_TEAM(team),
                                   core_rank, ucc_tl_ucp.super.super.id);
     if (ucc_unlikely(NULL == offset)) {
@@ -505,50 +508,33 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
     if (*segment >= 0) {
         *rva = rvas[*segment] +
                ((uint64_t)va - (uint64_t)ctx->remote_info[*segment].va_base);
-        if (ucc_unlikely(NULL == UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment))) {
+        if (ucc_unlikely(NULL == UCC_TL_UCP_REMOTE_RKEY(ctx, ctx_peer, *segment))) {
             ucs_status_t ucs_status = ucp_ep_rkey_unpack(
                 *ep, PTR_OFFSET(keys, key_offset),
-                &UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment));
+                &UCC_TL_UCP_REMOTE_RKEY(ctx, ctx_peer, *segment));
             if (UCS_OK != ucs_status) {
                 return ucs_status_to_ucc_status(ucs_status);
             }
         }
-        *rkey = UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment);
+        *rkey = UCC_TL_UCP_REMOTE_RKEY(ctx, ctx_peer, *segment);
         return UCC_OK;
     }
-    if (ucc_unlikely(0 > *segment)) {
-        if (dst_memh) {
-            /* check if segment is in src/dst memh */
-            status = find_tl_index(dst_memh[grank], &tl_index);
-            if (status == UCC_ERR_NOT_FOUND) {
-               tl_error(UCC_TL_TEAM_LIB(team),
-                 "attempt to perform one-sided operation with malformed mem map handle");
-               return status;
-            }
-
-            status = ucc_tl_ucp_check_memh(ep, grank, peer, va, rva, rkey, tl_index, dst_memh);
-            if (status == UCC_OK) {
-                return UCC_OK;
-            }
+    if (dst_memh) {
+        /* check if segment is in dst memh */
+        status = find_tl_index(dst_memh[grank], &tl_index);
+        if (status == UCC_ERR_NOT_FOUND) {
+           tl_error(UCC_TL_TEAM_LIB(team),
+             "attempt to perform one-sided operation with malformed mem map handle");
+           return status;
         }
-        /* general error if nothing was found */
-        tl_error(UCC_TL_TEAM_LIB(team),
-            "attempt to perform one-sided operation on non-registered memory %p", va);
-        return UCC_ERR_NOT_FOUND;
-    }
-    if (ucc_unlikely(NULL == UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment))) {
-        ucs_status_t ucs_status =
-            ucp_ep_rkey_unpack(*ep, PTR_OFFSET(keys, key_offset),
-                               &UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment));
-        if (UCS_OK != ucs_status) {
-            return ucs_status_to_ucc_status(ucs_status);
+        status = ucc_tl_ucp_check_memh(ep, grank, peer, va, rva, rkey, tl_index, dst_memh);
+        if (status == UCC_OK) {
+            return UCC_OK;
         }
     }
-
-    tl_error(
-        UCC_TL_TEAM_LIB(team),
-        "attempt to perform one-sided operation on non-registered memory %p",
-        va);
+    /* general error if nothing was found */
+    tl_error(UCC_TL_TEAM_LIB(team),
+        "attempt to perform one-sided operation on non-registered memory %p", va);
     return UCC_ERR_NOT_FOUND;
 }
 
@@ -646,6 +632,7 @@ static inline ucc_status_t ucc_tl_ucp_put_nb(void *buffer, void *target,
     }
 
     ucp_status = ucp_put_nbx(ep, buffer, msglen, rva, rkey, &req_param);
+
     task->onesided.put_posted++;
     if (UCS_OK != ucp_status) {
         if (UCS_PTR_IS_ERR(ucp_status)) {
@@ -705,6 +692,7 @@ static inline ucc_status_t ucc_tl_ucp_get_nb(void *buffer, void *target,
     }
 
     ucp_status = ucp_get_nbx(ep, buffer, msglen, rva, rkey, &req_param);
+
     task->onesided.get_posted++;
     if (UCS_OK != ucp_status) {
         if (UCS_PTR_IS_ERR(ucp_status)) {
@@ -722,11 +710,11 @@ static inline ucc_status_t ucc_tl_ucp_atomic_inc(void *     target,
                                                  ucc_mem_map_mem_h *dest_memh,
                                                  ucc_tl_ucp_team_t *team)
 {
-    ucp_request_param_t req_param   = {0};
-    int                 segment     = 0;
-    uint64_t            one         = 1;
-    ucp_rkey_h          rkey        = NULL;
-    uint64_t            rva         = 0;
+    ucp_request_param_t req_param = {0};
+    int                 segment   = 0;
+    uint64_t            one       = 1;
+    ucp_rkey_h          rkey      = NULL;
+    uint64_t            rva       = 0;
     ucs_status_ptr_t    ucp_status;
     ucc_status_t        status;
     ucp_ep_h            ep;

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -444,6 +444,25 @@ static inline ucc_status_t ucc_tl_ucp_check_memh(ucp_ep_h *ep, ucc_rank_t me,
     return UCC_OK;
 }
 
+static inline int resolve_segment(const void *va, size_t *key_sizes,
+                                  ptrdiff_t *key_offset, size_t nr_segments,
+                                  ucc_tl_ucp_remote_info_t *rinfo)
+{
+    int      i;
+    uint64_t base;
+    uint64_t end;
+
+    for (i = 0; i < nr_segments; i++) {
+        base = (uint64_t)rinfo[i].va_base;
+        end  = base + rinfo[i].len;
+        if ((uint64_t)va >= base && (uint64_t)va < end) {
+            return i;
+        }
+        *key_offset += key_sizes[i];
+    }
+    return -1;
+}
+
 static inline ucc_status_t
 ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
                              ucc_rank_t peer, uint64_t *rva, ucp_rkey_h *rkey,
@@ -481,16 +500,21 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
     rvas        = (uint64_t *)base_offset;
     key_sizes   = PTR_OFFSET(base_offset, (section_offset * 2));
     keys        = PTR_OFFSET(base_offset, (section_offset * 3));
-
-    for (int i = 0; i < ctx->n_rinfo_segs; i++) {
-        uint64_t base = (uint64_t)team->va_base[i];
-        uint64_t end = base + team->base_length[i];
-        if ((uint64_t)va >= base &&
-            (uint64_t)va < end) {
-            *segment = i;
-            break;
+    *segment    = resolve_segment(va, key_sizes, &key_offset, ctx->n_rinfo_segs,
+                                  ctx->remote_info);
+    if (*segment >= 0) {
+        *rva = rvas[*segment] +
+               ((uint64_t)va - (uint64_t)ctx->remote_info[*segment].va_base);
+        if (ucc_unlikely(NULL == UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment))) {
+            ucs_status_t ucs_status = ucp_ep_rkey_unpack(
+                *ep, PTR_OFFSET(keys, key_offset),
+                &UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment));
+            if (UCS_OK != ucs_status) {
+                return ucs_status_to_ucc_status(ucs_status);
+            }
         }
-        key_offset += key_sizes[i];
+        *rkey = UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment);
+        return UCC_OK;
     }
     if (ucc_unlikely(0 > *segment)) {
         if (dst_memh) {
@@ -520,9 +544,12 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
             return ucs_status_to_ucc_status(ucs_status);
         }
     }
-    *rkey = UCC_TL_UCP_REMOTE_RKEY(ctx, peer, *segment);
-    *rva  = rvas[*segment] + ((uint64_t)va - (uint64_t)team->va_base[*segment]);
-    return UCC_OK;
+
+    tl_error(
+        UCC_TL_TEAM_LIB(team),
+        "attempt to perform one-sided operation on non-registered memory %p",
+        va);
+    return UCC_ERR_NOT_FOUND;
 }
 
 static inline ucc_status_t ucc_tl_ucp_flush(ucc_tl_ucp_team_t *team)
@@ -619,7 +646,6 @@ static inline ucc_status_t ucc_tl_ucp_put_nb(void *buffer, void *target,
     }
 
     ucp_status = ucp_put_nbx(ep, buffer, msglen, rva, rkey, &req_param);
-
     task->onesided.put_posted++;
     if (UCS_OK != ucp_status) {
         if (UCS_PTR_IS_ERR(ucp_status)) {
@@ -679,7 +705,6 @@ static inline ucc_status_t ucc_tl_ucp_get_nb(void *buffer, void *target,
     }
 
     ucp_status = ucp_get_nbx(ep, buffer, msglen, rva, rkey, &req_param);
-
     task->onesided.get_posted++;
     if (UCS_OK != ucp_status) {
         if (UCS_PTR_IS_ERR(ucp_status)) {
@@ -697,11 +722,11 @@ static inline ucc_status_t ucc_tl_ucp_atomic_inc(void *     target,
                                                  ucc_mem_map_mem_h *dest_memh,
                                                  ucc_tl_ucp_team_t *team)
 {
-    ucp_request_param_t req_param = {0};
-    int                 segment   = 0;
-    uint64_t            one       = 1;
-    ucp_rkey_h          rkey      = NULL;
-    uint64_t            rva       = 0;
+    ucp_request_param_t req_param   = {0};
+    int                 segment     = 0;
+    uint64_t            one         = 1;
+    ucp_rkey_h          rkey        = NULL;
+    uint64_t            rva         = 0;
     ucs_status_ptr_t    ucp_status;
     ucc_status_t        status;
     ucp_ep_h            ep;

--- a/src/components/tl/ucp/tl_ucp_task.h
+++ b/src/components/tl/ucp/tl_ucp_task.h
@@ -34,7 +34,26 @@ typedef struct ucc_tl_ucp_dpu_offload_buf_info
 enum ucc_tl_ucp_task_flags {
     /*indicates whether subset field of tl_ucp_task is set*/
     UCC_TL_UCP_TASK_FLAG_SUBSET = UCC_BIT(0),
+    /* indicates usage of dynamic segments */
+    UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG = UCC_BIT(1),
 };
+
+/* Structure to hold dynamic segment exchange parameters and buffers */
+typedef struct {
+    ucc_tl_ucp_task_t  *task;
+    void               *src_pack_buffer;
+    void               *dst_pack_buffer;
+    size_t              src_pack_size;
+    size_t              dst_pack_size;
+    size_t              max_individual_pack_size;
+    size_t              exchange_size;
+    ucc_mem_map_memh_t *src_memh_pack;
+    ucc_mem_map_memh_t *dst_memh_pack;
+    void               *exchange_buffer;
+    ucc_mem_map_memh_t *src_memh_local;
+    ucc_mem_map_memh_t *dst_memh_local;
+    size_t             *global_sizes;
+} ucc_tl_ucp_dyn_seg_args_t;
 
 typedef struct ucc_tl_ucp_task {
     ucc_coll_task_t super;
@@ -223,6 +242,18 @@ typedef struct ucc_tl_ucp_task {
     };
     uint32_t flush_posted;
     uint32_t flush_completed;
+    struct {
+        ucc_mem_map_memh_t        *src_local;
+        ucc_mem_map_memh_t        *dst_local;
+        ucc_mem_map_memh_t       **src_global;
+        ucc_mem_map_memh_t       **dst_global;
+        ucc_tl_ucp_dyn_seg_args_t *exchange_args;
+        void                      *global_buffer;
+        ucc_service_coll_req_t    *scoll_req_sizes; /* For sizes allgather */
+        ucc_service_coll_req_t    *scoll_req_data; /* For data ex allgather */
+        int                        exchange_step;
+        ucc_status_t               exchange_status;
+    } dynamic_segments;
 } ucc_tl_ucp_task_t;
 
 static inline void ucc_tl_ucp_task_reset(ucc_tl_ucp_task_t *task,

--- a/src/components/tl/ucp/tl_ucp_task.h
+++ b/src/components/tl/ucp/tl_ucp_task.h
@@ -33,7 +33,7 @@ typedef struct ucc_tl_ucp_dpu_offload_buf_info
 
 enum ucc_tl_ucp_task_flags {
     /*indicates whether subset field of tl_ucp_task is set*/
-    UCC_TL_UCP_TASK_FLAG_SUBSET = UCC_BIT(0),
+    UCC_TL_UCP_TASK_FLAG_SUBSET      = UCC_BIT(0),
     /* indicates usage of dynamic segments */
     UCC_TL_UCP_TASK_FLAG_USE_DYN_SEG = UCC_BIT(1),
 };
@@ -47,8 +47,6 @@ typedef struct {
     size_t              dst_pack_size;
     size_t              max_individual_pack_size;
     size_t              exchange_size;
-    ucc_mem_map_memh_t *src_memh_pack;
-    ucc_mem_map_memh_t *dst_memh_pack;
     void               *exchange_buffer;
     ucc_mem_map_memh_t *src_memh_local;
     ucc_mem_map_memh_t *dst_memh_local;
@@ -243,16 +241,16 @@ typedef struct ucc_tl_ucp_task {
     uint32_t flush_posted;
     uint32_t flush_completed;
     struct {
-        ucc_mem_map_memh_t        *src_local;
-        ucc_mem_map_memh_t        *dst_local;
-        ucc_mem_map_memh_t       **src_global;
-        ucc_mem_map_memh_t       **dst_global;
-        ucc_tl_ucp_dyn_seg_args_t *exchange_args;
-        void                      *global_buffer;
-        ucc_service_coll_req_t    *scoll_req_sizes; /* For sizes allgather */
-        ucc_service_coll_req_t    *scoll_req_data; /* For data ex allgather */
-        int                        exchange_step;
-        ucc_status_t               exchange_status;
+        ucc_mem_map_memh_t                *src_local;
+        ucc_mem_map_memh_t                *dst_local;
+        ucc_mem_map_memh_t               **src_global;
+        ucc_mem_map_memh_t               **dst_global;
+        ucc_tl_ucp_dyn_seg_args_t         *exchange_args;
+        void                              *global_buffer;
+        ucc_service_coll_req_t            *scoll_req_sizes; /* For sizes allgather */
+        ucc_service_coll_req_t            *scoll_req_data; /* For data ex allgather */
+        int                                exchange_step;
+        ucc_tl_ucp_onesided_alg_type alg;
     } dynamic_segments;
 } ucc_tl_ucp_task_t;
 

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -239,7 +239,6 @@ ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team)
 {
     ucc_tl_ucp_team_t *   team = ucc_derived_of(tl_team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_context_t *ctx  = UCC_TL_UCP_TEAM_CTX(team);
-    int                   i;
     ucc_status_t          status;
 
     if (USE_SERVICE_WORKER(team)) {
@@ -258,13 +257,6 @@ ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team)
             return UCC_INPROGRESS;
         } else if (UCC_OK != status) {
             goto err_preconnect;
-        }
-    }
-
-    if (ctx->remote_info) {
-        for (i = 0; i < ctx->n_rinfo_segs; i++) {
-            team->va_base[i]     = ctx->remote_info[i].va_base;
-            team->base_length[i] = ctx->remote_info[i].len;
         }
     }
 

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -902,8 +902,8 @@ typedef ucc_oob_coll_t ucc_team_oob_coll_t;
  *  @ingroup UCC_CONTEXT_DT
  */
 typedef struct ucc_mem_map {
-    void *   address; /*!< the address of a buffer to be attached to a UCC context */
-    size_t   len;     /*!< the length of the buffer */
+    void  *address;  /*!< the address of a buffer to be attached to a UCC context */
+    size_t len;      /*!< the length of the buffer */
 } ucc_mem_map_t;
 
 /**
@@ -1710,7 +1710,7 @@ typedef enum {
                                                             Note, the status is not guaranteed
                                                             to be global on all the processes
                                                             participating in the collective.*/
-    UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS   = UCC_BIT(7), /*!< If set, both src
+    UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS   = UCC_BIT(7),  /*!< If set, both src
                                                             and dst buffers
                                                             reside in a memory
                                                             mapped region.
@@ -1720,7 +1720,7 @@ typedef enum {
                                                             the src_memh memory
                                                             handle is an array of
                                                             global handles. */
-    UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL      = UCC_BIT(9), /*!< If set, indicates
+    UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL      = UCC_BIT(9)  /*!< If set, indicates
                                                             the dst_memh memory
                                                             handle is an array of
                                                             global handles. */

--- a/src/ucc/api/ucc.h
+++ b/src/ucc/api/ucc.h
@@ -902,8 +902,8 @@ typedef ucc_oob_coll_t ucc_team_oob_coll_t;
  *  @ingroup UCC_CONTEXT_DT
  */
 typedef struct ucc_mem_map {
-    void  *address;  /*!< the address of a buffer to be attached to a UCC context */
-    size_t len;      /*!< the length of the buffer */
+    void *   address; /*!< the address of a buffer to be attached to a UCC context */
+    size_t   len;     /*!< the length of the buffer */
 } ucc_mem_map_t;
 
 /**
@@ -1710,7 +1710,7 @@ typedef enum {
                                                             Note, the status is not guaranteed
                                                             to be global on all the processes
                                                             participating in the collective.*/
-    UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS   = UCC_BIT(7),  /*!< If set, both src
+    UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS   = UCC_BIT(7), /*!< If set, both src
                                                             and dst buffers
                                                             reside in a memory
                                                             mapped region.
@@ -1720,7 +1720,7 @@ typedef enum {
                                                             the src_memh memory
                                                             handle is an array of
                                                             global handles. */
-    UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL      = UCC_BIT(9)  /*!< If set, indicates
+    UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL      = UCC_BIT(9), /*!< If set, indicates
                                                             the dst_memh memory
                                                             handle is an array of
                                                             global handles. */

--- a/test/gtest/coll/test_alltoall.cc
+++ b/test/gtest/coll/test_alltoall.cc
@@ -12,6 +12,30 @@ using Param_1 = std::tuple<ucc_datatype_t, ucc_memory_type_t, gtest_ucc_inplace_
 class test_alltoall : public UccCollArgs, public ucc::test
 {
 public:
+    uint64_t coll_mask;
+    uint64_t coll_flags;
+
+    test_alltoall() : coll_mask(0), coll_flags(0) {}
+
+    /* Collect ranks from a static team and create an onesided team in job. */
+    UccTeam_h make_dyn_seg_team(UccJob &job, int team_id)
+    {
+        UccTeam_h        ref_team = UccJob::getStaticTeams()[team_id];
+        bool             is_contig = true;
+        std::vector<int> reference_ranks;
+
+        for (auto i = 0; i < ref_team->n_procs; i++) {
+            int rank = ref_team->procs[i].p->job_rank;
+            reference_ranks.push_back(rank);
+            if (is_contig && i > 0 &&
+                (rank - reference_ranks[i - 1] > 1 ||
+                 reference_ranks[i - 1] - rank > 1)) {
+                is_contig = false;
+            }
+        }
+        return job.create_team(reference_ranks, true, is_contig, true);
+    }
+
     void data_init(int nprocs, ucc_datatype_t dtype,
                    size_t single_rank_count, UccCollCtxVec &ctxs,
                    UccTeam_h team, bool persistent)
@@ -30,7 +54,7 @@ public:
                 (gtest_ucc_coll_ctx_t *)calloc(1, sizeof(gtest_ucc_coll_ctx_t));
             ctxs[i]->args = coll;
 
-            coll->mask              = 0;
+            coll->mask              = coll_mask;
             coll->coll_type         = UCC_COLL_TYPE_ALLTOALL;
             coll->src.info.mem_type = mem_type;
             coll->src.info.count    = (ucc_count_t)single_rank_count * nprocs;
@@ -52,9 +76,9 @@ public:
                 sbuf        = team->procs[i].p->onesided_buf[0];
                 rbuf        = team->procs[i].p->onesided_buf[1];
                 work_buf    = (long *)team->procs[i].p->onesided_buf[2];
-                coll->mask  = UCC_COLL_ARGS_FIELD_FLAGS |
+                coll->mask  |= UCC_COLL_ARGS_FIELD_FLAGS |
                              UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER;
-                coll->flags = UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS;
+                coll->flags |= UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS;
                 coll->src.info.buffer    = sbuf;
                 coll->src.info.mem_type  = UCC_MEMORY_TYPE_HOST;
                 coll->dst.info.buffer    = rbuf;
@@ -135,9 +159,8 @@ public:
     void data_fini_onesided(UccCollCtxVec ctxs)
     {
         for (gtest_ucc_coll_ctx_t *ctx : ctxs) {
-            ucc_coll_args_t *coll = ctx->args;
             ucc_free(ctx->init_buf);
-            free(coll);
+            free(ctx->args);
             free(ctx);
         }
         ctxs.clear();
@@ -243,6 +266,107 @@ UCC_TEST_P(test_alltoall_0, single_onesided)
     req.start();
     req.wait();
     EXPECT_EQ(true, data_validate(ctxs));
+    data_fini_onesided(ctxs);
+}
+
+UCC_TEST_P(test_alltoall_0, single_onesided_dynamic_segment)
+{
+    const int            team_id  = std::get<0>(GetParam());
+    const ucc_datatype_t dtype    = std::get<1>(GetParam());
+    ucc_memory_type_t    mem_type = std::get<2>(GetParam());
+    gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
+    const int            count    = std::get<4>(GetParam());
+    int                  size     = UccJob::getStaticTeams()[team_id]->procs.size();
+    ucc_job_env_t        env      = {{"UCC_TL_UCP_TUNE", "alltoall:0-inf:@onesided"}};
+    UccJob               job(size, UccJob::UCC_JOB_CTX_GLOBAL_ONESIDED, env);
+    UccTeam_h            team     = make_dyn_seg_team(job, team_id);
+    UccCollCtxVec        ctxs;
+
+    this->set_inplace(inplace);
+    SET_MEM_TYPE(mem_type);
+    /* for dynamic segments, setup as onesided and override the mask/flags */
+    data_init(size, dtype, count, ctxs, team, false);
+    for (auto i = 0; i < ctxs.size(); i++) {
+        ctxs[i]->args->mask  = UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER |
+                               (ctxs[i]->args->mask & UCC_COLL_ARGS_FIELD_FLAGS);
+        ctxs[i]->args->flags &= UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+    UccReq req(team, ctxs);
+    req.start();
+    req.wait();
+    EXPECT_EQ(true, data_validate(ctxs));
+    data_fini_onesided(ctxs);
+}
+
+UCC_TEST_P(test_alltoall_0, persistent_dynamic_segment_get)
+{
+    const int            team_id  = std::get<0>(GetParam());
+    const ucc_datatype_t dtype    = std::get<1>(GetParam());
+    ucc_memory_type_t    mem_type = std::get<2>(GetParam());
+    gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
+    const int            count    = std::get<4>(GetParam());
+    int                  size     = UccJob::getStaticTeams()[team_id]->procs.size();
+    ucc_job_env_t        env      = {{"UCC_TL_UCP_TUNE", "alltoall:0-inf:@onesided"},
+                                     {"UCC_TL_UCP_ALLTOALL_ONESIDED_ALG", "get"}};
+    UccJob               job(size, UccJob::UCC_JOB_CTX_GLOBAL_ONESIDED, env);
+    UccTeam_h            team     = make_dyn_seg_team(job, team_id);
+    UccCollCtxVec        ctxs;
+
+    this->set_inplace(inplace);
+    SET_MEM_TYPE(mem_type);
+    /* persistent=true so the request may be re-posted across iterations */
+    data_init(size, dtype, count, ctxs, team, true);
+    for (auto i = 0; i < ctxs.size(); i++) {
+        ctxs[i]->args->mask  = UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER |
+                               (ctxs[i]->args->mask & UCC_COLL_ARGS_FIELD_FLAGS);
+        /* keep IN_PLACE and PERSISTENT; drop any buffer/memh flags that would
+         * bypass the dynamic-segment exchange path */
+        ctxs[i]->args->flags &= (UCC_COLL_ARGS_FLAG_IN_PLACE |
+                                 UCC_COLL_ARGS_FLAG_PERSISTENT);
+    }
+    UccReq req(team, ctxs);
+    for (int n = 0; n < 3; n++) {
+        req.start();
+        req.wait();
+        EXPECT_EQ(true, data_validate(ctxs));
+        reset(ctxs);
+    }
+    data_fini_onesided(ctxs);
+}
+
+UCC_TEST_P(test_alltoall_0, persistent_dynamic_segment_put)
+{
+    const int            team_id  = std::get<0>(GetParam());
+    const ucc_datatype_t dtype    = std::get<1>(GetParam());
+    ucc_memory_type_t    mem_type = std::get<2>(GetParam());
+    gtest_ucc_inplace_t  inplace  = std::get<3>(GetParam());
+    const int            count    = std::get<4>(GetParam());
+    int                  size     = UccJob::getStaticTeams()[team_id]->procs.size();
+    ucc_job_env_t        env      = {{"UCC_TL_UCP_TUNE", "alltoall:0-inf:@onesided"},
+                                     {"UCC_TL_UCP_ALLTOALL_ONESIDED_ALG", "put"}};
+    UccJob               job(size, UccJob::UCC_JOB_CTX_GLOBAL_ONESIDED, env);
+    UccTeam_h            team     = make_dyn_seg_team(job, team_id);
+    UccCollCtxVec        ctxs;
+
+    this->set_inplace(inplace);
+    SET_MEM_TYPE(mem_type);
+    /* persistent=true so the request may be re-posted across iterations */
+    data_init(size, dtype, count, ctxs, team, true);
+    for (auto i = 0; i < ctxs.size(); i++) {
+        ctxs[i]->args->mask  = UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER |
+                               (ctxs[i]->args->mask & UCC_COLL_ARGS_FIELD_FLAGS);
+        /* keep IN_PLACE and PERSISTENT; drop any buffer/memh flags that would
+         * bypass the dynamic-segment exchange path */
+        ctxs[i]->args->flags &= (UCC_COLL_ARGS_FLAG_IN_PLACE |
+                                 UCC_COLL_ARGS_FLAG_PERSISTENT);
+    }
+    UccReq req(team, ctxs);
+    for (int n = 0; n < 3; n++) {
+        req.start();
+        req.wait();
+        EXPECT_EQ(true, data_validate(ctxs));
+        reset(ctxs);
+    }
     data_fini_onesided(ctxs);
 }
 

--- a/test/gtest/common/gtest-all.cc
+++ b/test/gtest/common/gtest-all.cc
@@ -7715,6 +7715,7 @@ ScopedTrace::~ScopedTrace()
 #  include <crt_externs.h>
 # endif  // GTEST_OS_MAC
 
+# include <cstdint>
 # include <errno.h>
 # include <fcntl.h>
 # include <limits.h>
@@ -9820,6 +9821,7 @@ Matcher<absl::string_view>::Matcher(absl::string_view s) {
 
 
 
+#include <cstdint>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -430,10 +430,10 @@ exit_err:
 void proc_context_create_mem_params(UccProcess_h proc, int id,
                                     ThreadAllgather *ta)
 {
+    ucc_mem_map_t        map[UCC_TEST_N_MEM_SEGMENTS] = {};
     ucc_status_t         status;
     ucc_context_config_h ctx_config;
     std::stringstream    err_msg;
-    ucc_mem_map_t        map[UCC_TEST_N_MEM_SEGMENTS];
 
     status = ucc_context_config_read(proc->lib_h, NULL, &ctx_config);
     if (status != UCC_OK) {

--- a/test/mpi/test_mpi.cc
+++ b/test/mpi/test_mpi.cc
@@ -41,11 +41,11 @@ static ucc_status_t oob_allgather_free(void *req)
 UccTestMpi::UccTestMpi(int argc, char *argv[], ucc_thread_mode_t _tm,
                        int is_local, bool with_onesided)
 {
+    ucc_mem_map_t        segments[UCC_TEST_N_MEM_SEGMENTS] = {0};
     ucc_lib_config_h     lib_config;
     ucc_context_config_h ctx_config;
     int                  size, rank;
     char                *prev_env;
-    ucc_mem_map_t        segments[UCC_TEST_N_MEM_SEGMENTS];
 
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);


### PR DESCRIPTION
## What
This PR adds support in TL/UCP for implicit memory handle creation for onesided algorithms by the introduction of three internal interfaces: ucc_tl_ucp_dynamic_segment_{init | exchange | finalize}. The interfaces initialize a dynamic or implicit segment by registering the source and destination buffers at initialization time to create memory handles, exchanging memory handles during collective start, and finalizing (unmapping) memory on collective completion. These interfaces can be leveraged or ignored by existing or future algorithms. In the case that the user allocates and maps memory either through (1) context creation or (2) memory handles, then the interfaces do not perform any action. This is an update to PR #909.

## Why ?
Even with the inclusion of PR #1070, the mapping of memory for message passing programming models such as MPI would require modification to current implementations. This is useful in situations where the messages exchanged in the collective are large.
