### PR TITLE
TOOLS/UCC_PERFTEST:  Adding missing progress calls

### DIFF
--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -169,6 +169,9 @@ ucc_status_t ucc_pt_comm::init()
                   free_ctx, st);
     do {
         st = ucc_team_create_test(team);
+        if (st == UCC_INPROGRESS) {
+            ucc_context_progress(context);
+        }
     } while(st == UCC_INPROGRESS);
     UCCCHECK_GOTO(st, free_ctx, st);
     ucc_context_config_release(ctx_config);
@@ -215,6 +218,9 @@ ucc_status_t ucc_pt_comm::finalize()
 
     do {
         status = ucc_team_destroy(team);
+        if (status == UCC_INPROGRESS) {
+            ucc_context_progress(context);
+        }
     } while (status == UCC_INPROGRESS);
     if (status != UCC_OK) {
         std::cerr << "ucc team destroy error: " << ucc_status_string(status);


### PR DESCRIPTION
Add ucc_context_progress() calls to team creation and destruction loops to prevent hangs when collective operations need progress to complete.

This fixes a hang  in team creatation observed during the mcast-enabled ucc_perftest.