### PR TITLE
TEST: add gtest and mpi test for ucc_mem_map and ucc_mem_unmap

### DIFF
--- a/src/components/tl/ucp/tl_ucp_context.c
+++ b/src/components/tl/ucp/tl_ucp_context.c
@@ -745,6 +745,8 @@ ucc_status_t ucc_tl_ucp_mem_map(const ucc_base_context_t *context, ucc_mem_map_m
         ucc_status = ucc_tl_ucp_mem_map_export(ctx, memh->address, memh->len, mode, m_data);
         if (UCC_OK != ucc_status) {
             tl_error(ctx->super.super.lib, "failed to export memory handles");
+            ucc_free(m_data);
+            return ucc_status;
         }
     } else if (mode == UCC_MEM_MAP_MODE_IMPORT_OFFLOAD) {
         ucc_status = ucc_tl_ucp_mem_map_offload_import(ctx, memh->address, memh->len,
@@ -777,6 +779,15 @@ ucc_status_t ucc_tl_ucp_mem_unmap(const ucc_base_context_t *context, ucc_mem_map
                      "ucp_mem_unmap failed with error code %d", status);
             return ucs_status_to_ucc_status(status);
         }
+        /* Free the UCP-allocated buffers that are not freed by the core context */
+        if (data->packed_memh) {
+            ucp_memh_buffer_release(data->packed_memh, NULL);
+            data->packed_memh = NULL;
+        }
+        if (data->rinfo.packed_key) {
+            ucp_rkey_buffer_release(data->rinfo.packed_key);
+            data->rinfo.packed_key = NULL;
+        }
     } else if (mode == UCC_MEM_MAP_MODE_IMPORT || mode == UCC_MEM_MAP_MODE_IMPORT_OFFLOAD) {
         // need to free rkeys (data->rkey) , packed memh (data->packed_memh)
         if (data->packed_memh) {
@@ -792,6 +803,13 @@ ucc_status_t ucc_tl_ucp_mem_unmap(const ucc_base_context_t *context, ucc_mem_map
         ucc_error("Unknown mem map mode entered: %d", mode);
         return UCC_ERR_INVALID_PARAM;
     }
+
+    /* Free the TL data structure */
+    if (data) {
+        ucc_free(data);
+        memh->tl_data = NULL;
+    }
+
     return UCC_OK;
 }
 

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -1191,10 +1191,24 @@ ucc_status_t ucc_mem_map_import(ucc_context_h        context,
     }
 
     local_memh = *memh;
+
+    if (ctx->n_tl_ctx == 0) {
+        ucc_debug("No TL contexts available for import");
+        local_memh->mode    = mode;
+        local_memh->context = ctx;
+        *memh_size          = 0;
+        return UCC_OK;
+    }
+
     /* memh should have been used in exchanges or from a remote process,
        addresses, etc. likely garbage. fix it */
     local_memh->tl_h = (ucc_mem_map_tl_t *)ucc_calloc(
         ctx->n_tl_ctx, sizeof(ucc_mem_map_tl_t), "tl memh");
+    if (!local_memh->tl_h) {
+        ucc_error("failed to allocate tl memh for import");
+        return UCC_ERR_NO_MEMORY;
+    }
+
     for (i = 0; i < ctx->n_tl_ctx; i++) {
         offset = 0;
         for (int j = 0; j < local_memh->num_tls; j++) {
@@ -1208,6 +1222,7 @@ ucc_status_t ucc_mem_map_import(ucc_context_h        context,
                     local_memh, &local_memh->tl_h[j]);
                 if (status < UCC_ERR_NOT_IMPLEMENTED) {
                     ucc_error("failed to import mem map memh %d", status);
+                    ucc_free(local_memh->tl_h);
                     return status;
                 }
             }
@@ -1242,6 +1257,16 @@ ucc_status_t ucc_mem_map_export(ucc_context_h         context,
     int                       tls;
     int                       tlh_index;
 
+    if (!params) {
+        ucc_error("params cannot be NULL");
+        return UCC_ERR_INVALID_PARAM;
+    }
+
+    if (ctx->n_tl_ctx == 0) {
+        ucc_debug("No TL contexts available for export");
+        return UCC_OK;
+    }
+
     if (mode == UCC_MEM_MAP_MODE_EXPORT) {
         local_memh = (ucc_mem_map_memh_t *)ucc_calloc(1, sizeof(ucc_mem_map_memh_t),
                                                       "local memh");
@@ -1266,17 +1291,6 @@ ucc_status_t ucc_mem_map_export(ucc_context_h         context,
         }
         local_memh = *memh;
     }
-    packed_buffers =
-        (void **)ucc_calloc(ctx->n_tl_ctx, sizeof(void *), "packed buffers");
-    if (!packed_buffers) {
-        if (mode == UCC_MEM_MAP_MODE_EXPORT) {
-            ucc_free(local_memh->tl_h);
-            ucc_free(local_memh);
-        }
-        ucc_error("failed to allocate space for packed buffers");
-        return UCC_ERR_NO_MEMORY;
-    }
-
     if (mode != UCC_MEM_MAP_MODE_EXPORT_OFFLOAD) {
         /* map all the memory */
         for (i = 0; i < ctx->n_tl_ctx; i++) {
@@ -1297,6 +1311,16 @@ ucc_status_t ucc_mem_map_export(ucc_context_h         context,
                 }
             }
         }
+    }
+    packed_buffers =
+        (void **)ucc_calloc(ctx->n_tl_ctx, sizeof(void *), "packed buffers");
+    if (!packed_buffers) {
+        if (mode == UCC_MEM_MAP_MODE_EXPORT) {
+            ucc_free(local_memh->tl_h);
+            ucc_free(local_memh);
+        }
+        ucc_error("failed to allocate space for packed buffers");
+        return UCC_ERR_NO_MEMORY;
     }
     /* now pack all the memories */
     for (i = 0; i < ctx->n_tl_ctx; i++) {
@@ -1395,9 +1419,6 @@ ucc_status_t ucc_mem_map_export(ucc_context_h         context,
             ucc_free(packed_buffers[i]);
             offset += local_memh->tl_h[i].packed_size;
         }
-        for (; i < ctx->n_tl_ctx; i++) {
-            ucc_free(packed_buffers[i]);
-        }
     }
 
     exported_memh->mode        = mode;
@@ -1426,7 +1447,6 @@ failed_mem_map:
                                          &local_memh->tl_h[j]);
     }
     ucc_free(local_memh);
-    ucc_free(packed_buffers);
     *memh      = NULL;
     *memh_size = 0;
     return status;
@@ -1442,6 +1462,10 @@ ucc_status_t ucc_mem_map(ucc_context_h context, ucc_mem_map_mode_t mode,
     }
     if (mode == UCC_MEM_MAP_MODE_IMPORT || mode == UCC_MEM_MAP_MODE_IMPORT_OFFLOAD) {
         return ucc_mem_map_import(context, mode, params, memh_size, memh);
+    }
+    if (!params) {
+        ucc_error("params cannot be NULL");
+        return UCC_ERR_INVALID_PARAM;
     }
     if (params->n_segments > 1) {
         ucc_error("UCC only supports one mapping per call");
@@ -1465,6 +1489,11 @@ ucc_status_t ucc_mem_unmap(ucc_mem_map_mem_h *memh)
         return UCC_ERR_INVALID_PARAM;
     }
 
+    if (!*memh) {
+        ucc_warn("unable to free NULL memory handle");
+        return UCC_ERR_INVALID_PARAM;
+    }
+
     lmemh = *memh;
     ctx   = (ucc_context_t *)lmemh->context;
     tls   = &ctx->all_tls;
@@ -1483,5 +1512,16 @@ ucc_status_t ucc_mem_unmap(ucc_mem_map_mem_h *memh)
             }
         }
     }
+
+    /* Free the TL handles array if it was allocated separately */
+    if (lmemh->tl_h && (lmemh->mode == UCC_MEM_MAP_MODE_EXPORT ||
+                        lmemh->mode == UCC_MEM_MAP_MODE_IMPORT)) {
+        ucc_free(lmemh->tl_h);
+    }
+
+    /* Free the memory handle structure */
+    ucc_free(lmemh);
+    *memh = NULL;
+
     return UCC_OK;
 }

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -82,6 +82,7 @@ gtest_SOURCES =                           \
 	core/test_service_coll.cc             \
 	core/test_timeout.cc                  \
 	core/test_utils.cc                    \
+	core/test_mem_map.cc                  \
 	coll/test_barrier.cc                  \
 	coll/test_alltoall.cc                 \
 	coll/test_alltoallv.cc                \
@@ -148,6 +149,7 @@ noinst_HEADERS =                         \
 	common/test.h                        \
 	common/test_ucc.h                    \
 	core/test_context.h                  \
+	core/test_mem_map.h                  \
 	core/test_mc_reduce.h                \
 	coll/test_allreduce_sliding_window.h \
 	coll_score/test_score.h

--- a/test/gtest/core/test_mem_map.cc
+++ b/test/gtest/core/test_mem_map.cc
@@ -1,0 +1,427 @@
+/**
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
+#include "test_mem_map.h"
+#include <cstring>
+#include <random>
+
+test_mem_map::test_mem_map() : ctx_h(nullptr), ctx_config(nullptr)
+{
+    memset(&ctx_params, 0, sizeof(ctx_params));
+}
+
+test_mem_map::~test_mem_map()
+{
+}
+
+void test_mem_map::SetUp()
+{
+    test_context_config::SetUp();
+    EXPECT_EQ(UCC_OK, ucc_context_config_read(lib_h, NULL, &ctx_config));
+
+    ctx_params.mask = UCC_CONTEXT_PARAM_FIELD_TYPE;
+    ctx_params.type = UCC_CONTEXT_EXCLUSIVE;
+    EXPECT_EQ(UCC_OK, ucc_context_create(lib_h, &ctx_params, ctx_config,
+                                         &ctx_h));
+}
+
+void test_mem_map::TearDown()
+{
+    if (ctx_h) {
+        EXPECT_EQ(UCC_OK, ucc_context_destroy(ctx_h));
+    }
+    if (ctx_config) {
+        ucc_context_config_release(ctx_config);
+    }
+    test_context_config::TearDown();
+}
+
+test_mem_map_export::test_mem_map_export() : test_buffer(nullptr), buffer_size(0)
+{
+    memset(&map_params, 0, sizeof(map_params));
+    memset(&segment, 0, sizeof(segment));
+}
+
+test_mem_map_export::~test_mem_map_export()
+{
+}
+
+void test_mem_map_export::SetUp()
+{
+    test_mem_map::SetUp();
+
+    /* Allocate test buffer */
+    buffer_size = 1024 * 1024; /* 1MB */
+    test_buffer = malloc(buffer_size);
+    ASSERT_NE(nullptr, test_buffer);
+
+    /* Initialize buffer with test data */
+    memset(test_buffer, 0xAA, buffer_size);
+
+    /* Set up memory map parameters */
+    segment.address = test_buffer;
+    segment.len     = buffer_size;
+
+    map_params.segments   = &segment;
+    map_params.n_segments = 1;
+}
+
+void test_mem_map_export::TearDown()
+{
+    if (test_buffer) {
+        free(test_buffer);
+        test_buffer = nullptr;
+    }
+    test_mem_map::TearDown();
+}
+
+test_mem_map_import::test_mem_map_import()
+    : test_buffer(nullptr), buffer_size(0), memh(nullptr), memh_size(0)
+{
+}
+
+test_mem_map_import::~test_mem_map_import()
+{
+}
+
+void test_mem_map_import::SetUp()
+{
+    test_mem_map::SetUp();
+
+    /* Allocate test buffer */
+    buffer_size = 1024 * 1024; /* 1MB */
+    test_buffer = malloc(buffer_size);
+    ASSERT_NE(nullptr, test_buffer);
+
+    /* Initialize buffer with test data */
+    memset(test_buffer, 0xBB, buffer_size);
+}
+
+void test_mem_map_import::TearDown()
+{
+    if (test_buffer) {
+        free(test_buffer);
+        test_buffer = nullptr;
+    }
+    test_mem_map::TearDown();
+}
+
+/* Test basic memory map export functionality */
+UCC_TEST_F(test_mem_map_export, basic_export)
+{
+    ucc_mem_map_mem_h memh = nullptr;
+    size_t            memh_size = 0;
+
+    EXPECT_EQ(UCC_OK, ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                   &map_params, &memh_size, &memh));
+    EXPECT_NE(nullptr, memh);
+    EXPECT_GT(memh_size, 0);
+
+    /* Test unmap */
+    EXPECT_EQ(UCC_OK, ucc_mem_unmap(&memh));
+    /* Note: ucc_mem_unmap doesn't set memh to nullptr, it only frees the memory */
+}
+
+/* Test memory map export with different buffer sizes */
+UCC_TEST_F(test_mem_map_export, different_sizes)
+{
+    std::vector<size_t> sizes = {1024, 4096, 65536, 1024 * 1024};
+
+    for (auto size : sizes) {
+        /* Reallocate buffer with new size */
+        if (test_buffer) {
+            free(test_buffer);
+        }
+        test_buffer = malloc(size);
+        ASSERT_NE(nullptr, test_buffer);
+        memset(test_buffer, 0xCC, size);
+
+        segment.address = test_buffer;
+        segment.len     = size;
+
+        ucc_mem_map_mem_h memh = nullptr;
+        size_t             memh_size = 0;
+
+        EXPECT_EQ(UCC_OK, ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                       &map_params, &memh_size, &memh));
+        EXPECT_NE(nullptr, memh);
+        EXPECT_GT(memh_size, 0);
+
+        EXPECT_EQ(UCC_OK, ucc_mem_unmap(&memh));
+        /* Note: ucc_mem_unmap doesn't set memh to nullptr, it only frees the memory */
+    }
+}
+
+/* Test memory map export with multiple segments (should fail as UCC only supports one segment) */
+UCC_TEST_F(test_mem_map_export, multiple_segments)
+{
+    ucc_mem_map_mem_h    memh      = nullptr;
+    size_t               memh_size = 0;
+    ucc_mem_map_t        segments[2];
+    ucc_mem_map_params_t multi_params;
+
+    /* Create two segments */
+    segments[0].address     = test_buffer;
+    segments[0].len         = buffer_size / 2;
+    segments[1].address     = (char *)test_buffer + buffer_size / 2;
+    segments[1].len         = buffer_size / 2;
+    multi_params.segments   = segments;
+    multi_params.n_segments = 2;
+
+    /* This should fail as UCC only supports one segment per call */
+    EXPECT_EQ(UCC_ERR_INVALID_PARAM, ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                                   &multi_params, &memh_size,
+                                                   &memh));
+    EXPECT_EQ(nullptr, memh);
+}
+
+/* Test memory map export with invalid parameters */
+UCC_TEST_F(test_mem_map_export, invalid_params)
+{
+    ucc_mem_map_mem_h memh = nullptr;
+    size_t             memh_size = 0;
+
+    /* Test with NULL params */
+    EXPECT_EQ(UCC_ERR_INVALID_PARAM, ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                                   nullptr, &memh_size, &memh));
+
+    /* Test with invalid mode */
+    ucc_mem_map_mode_t invalid_mode = UCC_MEM_MAP_MODE_LAST;
+    EXPECT_EQ(UCC_ERR_INVALID_PARAM, ucc_mem_map(ctx_h, invalid_mode,
+                                                   &map_params, &memh_size,
+                                                   &memh));
+}
+
+/* Test memory map export with zero length buffer */
+UCC_TEST_F(test_mem_map_export, zero_length)
+{
+    ucc_mem_map_mem_h  memh      = nullptr;
+    size_t             memh_size = 0;
+
+    segment.len = 0;
+    /* This might succeed or fail depending on implementation */
+    ucc_status_t status = ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                       &map_params, &memh_size, &memh);
+    if (status == UCC_OK) {
+        EXPECT_NE(nullptr, memh);
+        EXPECT_EQ(UCC_OK, ucc_mem_unmap(&memh));
+    }
+}
+
+/* Test memory map import functionality */
+UCC_TEST_F(test_mem_map_import, basic_import)
+{
+    ucc_mem_map_mem_h    export_memh      = nullptr;
+    size_t               export_memh_size = 0;
+    ucc_mem_map_mem_h    import_memh      = nullptr;
+    size_t               import_memh_size = 0;
+    ucc_mem_map_t        export_segment;
+    ucc_mem_map_params_t export_params;
+
+    export_segment.address   = test_buffer;
+    export_segment.len       = buffer_size;
+    export_params.segments   = &export_segment;
+    export_params.n_segments = 1;
+
+    /* Export the memory handle */
+    ucc_status_t export_status = ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                             &export_params, &export_memh_size,
+                                             &export_memh);
+
+    if (export_status != UCC_OK) {
+        /* If export fails, skip the test */
+        GTEST_SKIP() << "Export failed, skipping import test";
+        return;
+    }
+
+    EXPECT_NE(nullptr, export_memh);
+    EXPECT_GT(export_memh_size, 0);
+
+    /* For import, we need to create a new memory handle with the exported data */
+    /* The import function expects the memh to be pre-allocated with the exported data */
+    import_memh = (ucc_mem_map_mem_h)malloc(export_memh_size);
+    ASSERT_NE(nullptr, import_memh);
+    memcpy(import_memh, export_memh, export_memh_size);
+
+    ucc_status_t import_status = ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_IMPORT,
+                                             &export_params, &import_memh_size,
+                                             &import_memh);
+
+    if (import_status == UCC_OK) {
+        EXPECT_NE(nullptr, import_memh);
+
+        /* Cleanup import */
+        ucc_mem_unmap(&import_memh);
+    } else {
+        /* Import might not be supported, which is acceptable */
+        EXPECT_TRUE(import_status == UCC_ERR_NOT_SUPPORTED ||
+                   import_status == UCC_ERR_NOT_IMPLEMENTED ||
+                   import_status == UCC_ERR_INVALID_PARAM);
+
+        /* Clean up the allocated memory if import failed */
+        free(import_memh);
+    }
+
+    /* Cleanup export */
+    ucc_mem_unmap(&export_memh);
+}
+
+/* Test memory map import with different buffer sizes */
+UCC_TEST_F(test_mem_map_import, import_different_sizes)
+{
+    std::vector<size_t>  sizes            = {1024, 4096, 65536, 1024 * 1024};
+    ucc_mem_map_mem_h    export_memh      = nullptr;
+    size_t               export_memh_size = 0;
+    ucc_mem_map_t        export_segment;
+    ucc_mem_map_params_t export_params;
+    ucc_mem_map_mem_h    import_memh;
+    size_t               import_memh_size;
+    ucc_status_t         import_status;
+
+    for (auto size : sizes) {
+        /* Reallocate buffer with new size */
+        if (test_buffer) {
+            free(test_buffer);
+        }
+        test_buffer = malloc(size);
+        ASSERT_NE(nullptr, test_buffer);
+        memset(test_buffer, 0xDD, size);
+
+        export_segment.address   = test_buffer;
+        export_segment.len       = size;
+        export_params.segments   = &export_segment;
+        export_params.n_segments = 1;
+
+        /* Export the memory handle */
+
+        ucc_status_t export_status = ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                                 &export_params, &export_memh_size,
+                                                 &export_memh);
+
+        if (export_status != UCC_OK) {
+            continue; /* Skip this size if export fails */
+        }
+
+        EXPECT_NE(nullptr, export_memh);
+        EXPECT_GT(export_memh_size, 0);
+
+        /* Test import */
+        import_memh = (ucc_mem_map_mem_h)malloc(export_memh_size);
+        ASSERT_NE(nullptr, import_memh);
+        memcpy(import_memh, export_memh, export_memh_size);
+
+        import_status = ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_IMPORT,
+                                   &export_params, &import_memh_size,
+                                   &import_memh);
+        if (import_status == UCC_OK) {
+            EXPECT_NE(nullptr, import_memh);
+            ucc_mem_unmap(&import_memh);
+        } else {
+            /* Import might not be supported for all sizes */
+            EXPECT_TRUE(import_status == UCC_ERR_NOT_SUPPORTED ||
+                       import_status == UCC_ERR_NOT_IMPLEMENTED ||
+                       import_status == UCC_ERR_INVALID_PARAM);
+
+            /* Clean up the allocated memory if import failed */
+            free(import_memh);
+        }
+        /* Cleanup export */
+        ucc_mem_unmap(&export_memh);
+    }
+}
+
+/* Test memory map import with invalid parameters */
+UCC_TEST_F(test_mem_map_import, import_invalid_params)
+{
+    /* Test import with NULL params */
+    ucc_mem_map_mem_h    memh      = nullptr;
+    size_t               memh_size = 0;
+    ucc_mem_map_params_t params;
+    ucc_mem_map_t        segment;
+
+    EXPECT_EQ(UCC_ERR_INVALID_PARAM, ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_IMPORT,
+                                                 nullptr, &memh_size, &memh));
+
+    /* Test import with NULL memh */
+    segment.address   = test_buffer;
+    segment.len       = buffer_size;
+    params.segments   = &segment;
+    params.n_segments = 1;
+
+    EXPECT_EQ(UCC_ERR_INVALID_PARAM, ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_IMPORT,
+                                                &params, &memh_size, nullptr));
+}
+
+/* Test memory map unmap with NULL handle */
+UCC_TEST_F(test_mem_map_export, unmap_null)
+{
+    ucc_mem_map_mem_h memh = nullptr;
+
+    /* Should handle NULL gracefully */
+    EXPECT_EQ(UCC_ERR_INVALID_PARAM, ucc_mem_unmap(&memh));
+}
+
+/* Test memory map with different modes */
+UCC_TEST_F(test_mem_map_export, different_modes)
+{
+    ucc_mem_map_mem_h memh1 = nullptr;
+    size_t             memh_size = 0;
+
+    /* Test EXPORT mode */
+    EXPECT_EQ(UCC_OK, ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                   &map_params, &memh_size, &memh1));
+    EXPECT_NE(nullptr, memh1);
+    EXPECT_EQ(UCC_OK, ucc_mem_unmap(&memh1));
+}
+
+/* Test memory map with random data patterns */
+UCC_TEST_F(test_mem_map_export, random_data)
+{
+    ucc_mem_map_mem_h  memh      = nullptr;
+    size_t             memh_size = 0;
+    std::random_device rd;
+    std::mt19937       gen(rd());
+    std::uniform_int_distribution<> dis(0, 255);
+    unsigned char *buf;
+    unsigned char *verify_buf;
+
+    /* Fill buffer with random data */
+    buf = (unsigned char *)test_buffer;
+    for (size_t i = 0; i < buffer_size; i++) {
+        buf[i] = dis(gen);
+    }
+    EXPECT_EQ(UCC_OK, ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                 &map_params, &memh_size, &memh));
+    EXPECT_NE(nullptr, memh);
+
+    /* Verify data integrity */
+    verify_buf = (unsigned char *)test_buffer;
+    for (size_t i = 0; i < buffer_size; i++) {
+        EXPECT_EQ(buf[i], verify_buf[i]);
+    }
+    EXPECT_EQ(UCC_OK, ucc_mem_unmap(&memh));
+}
+
+/* Test memory map stress test */
+UCC_TEST_F(test_mem_map_export, stress_test)
+{
+    const int         num_iterations = 100;
+    ucc_mem_map_mem_h memh;
+    size_t            memh_size;
+
+    for (int i = 0; i < num_iterations; i++) {
+        memh      = nullptr;
+        memh_size = 0;
+
+        /* Fill buffer with iteration-specific pattern */
+        memset(test_buffer, i % 256, buffer_size);
+
+        EXPECT_EQ(UCC_OK, ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT,
+                                     &map_params, &memh_size, &memh));
+        EXPECT_NE(nullptr, memh);
+
+        EXPECT_EQ(UCC_OK, ucc_mem_unmap(&memh));
+    }
+}

--- a/test/gtest/core/test_mem_map.h
+++ b/test/gtest/core/test_mem_map.h
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
+#ifndef TEST_MEM_MAP_H
+#define TEST_MEM_MAP_H
+
+#include "../common/test_ucc.h"
+#include "test_context.h"
+#include <vector>
+#include <memory>
+
+class test_mem_map : public test_context_config
+{
+protected:
+    ucc_context_h        ctx_h;
+    ucc_context_params_t ctx_params;
+    ucc_context_config_h ctx_config;
+
+public:
+    test_mem_map();
+    ~test_mem_map();
+
+    void SetUp() override;
+    void TearDown() override;
+};
+
+class test_mem_map_export : public test_mem_map
+{
+protected:
+    void *               test_buffer;
+    size_t               buffer_size;
+    ucc_mem_map_params_t map_params;
+    ucc_mem_map_t        segment;
+
+public:
+    test_mem_map_export();
+    ~test_mem_map_export();
+
+    void SetUp() override;
+    void TearDown() override;
+};
+
+class test_mem_map_import : public test_mem_map
+{
+protected:
+    void *               test_buffer;
+    size_t               buffer_size;
+    ucc_mem_map_mem_h    memh;
+    size_t               memh_size;
+
+public:
+    test_mem_map_import();
+    ~test_mem_map_import();
+
+    void SetUp() override;
+    void TearDown() override;
+};
+
+#endif /* TEST_MEM_MAP_H */ 

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -28,7 +28,8 @@ ucc_test_mpi_SOURCES = \
 	test_gather.cc          \
 	test_gatherv.cc         \
 	test_scatter.cc         \
-	test_scatterv.cc
+	test_scatterv.cc        \
+	test_mem_map.cc
 
 CXX=$(MPICXX)
 LD=$(MPICXX)

--- a/test/mpi/test_mem_map.cc
+++ b/test/mpi/test_mem_map.cc
@@ -1,0 +1,497 @@
+/**
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "test_mpi.h"
+#include "mpi_util.h"
+#include <cstring>
+#include <vector>
+#include "components/mc/ucc_mc.h"
+
+class TestMemMap : public TestCase
+{
+private:
+    void *             test_buffer;
+    size_t             buffer_size;
+    ucc_mem_map_mem_h  memh;
+    size_t             memh_size;
+    ucc_mem_map_mode_t mode;
+    bool               is_export_test;
+
+public:
+    TestMemMap(ucc_test_team_t &_team, TestCaseParams &params,
+               ucc_mem_map_mode_t _mode = UCC_MEM_MAP_MODE_EXPORT)
+        : TestCase(_team, UCC_COLL_TYPE_BARRIER, params), // Using barrier as placeholder
+          test_buffer(nullptr), buffer_size(0), memh(nullptr), memh_size(0),
+          mode(_mode), is_export_test(_mode == UCC_MEM_MAP_MODE_EXPORT)
+    {
+        buffer_size = params.msgsize;
+        int rank;
+        if (buffer_size == 0) {
+            buffer_size = 1024 * 1024; // Default 1MB
+        }
+
+        if (skip_reduce(test_max_size < buffer_size, TEST_SKIP_MEM_LIMIT,
+                        team.comm)) {
+            return;
+        }
+
+        UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, buffer_size, mem_type));
+        test_buffer = rbuf_mc_header->addr;
+        UCC_MALLOC_CHECK(test_buffer);
+
+        // Initialize buffer with rank-specific data
+        MPI_Comm_rank(team.comm, &rank);
+        memset(test_buffer, 0xAA + rank, buffer_size);
+    }
+
+    ~TestMemMap()
+    {
+        if (memh) {
+            ucc_mem_unmap(&memh);
+        }
+    }
+
+    ucc_status_t set_input(int iter_persistent = 0) override
+    {
+        int rank;
+        MPI_Comm_rank(team.comm, &rank);
+
+        // Initialize buffer with rank and iteration specific data
+        memset(test_buffer, 0xAA + rank + iter_persistent, buffer_size);
+        return UCC_OK;
+    }
+
+    ucc_status_t check() override
+    {
+        unsigned char *buf = (unsigned char *)test_buffer;
+        unsigned char  expected;
+        int            rank;
+        size_t         i;
+
+        MPI_Comm_rank(team.comm, &rank);
+
+        expected = 0xAA + rank;
+        for (i = 0; i < buffer_size; i++) {
+            if (buf[i] != expected) {
+                return UCC_ERR_INVALID_PARAM;
+            }
+        }
+        return UCC_OK;
+    }
+
+    void run(bool triggered) override
+    {
+        ucc_mem_map_params_t map_params;
+        ucc_mem_map_t        segment;
+        int                  rank;
+
+        MPI_Comm_rank(team.comm, &rank);
+
+        /* Set up memory map parameters */
+        segment.address       = test_buffer;
+        segment.len           = buffer_size;
+        map_params.segments   = &segment;
+        map_params.n_segments = 1;
+
+        /* Test memory map */
+        ucc_status_t status = ucc_mem_map(team.ctx, mode, &map_params,
+                                          &memh_size, &memh);
+        if (status != UCC_OK) {
+            if (status == UCC_ERR_NOT_SUPPORTED ||
+                status == UCC_ERR_NOT_IMPLEMENTED) {
+                test_skip = TEST_SKIP_NOT_SUPPORTED;
+                return;
+            }
+            UCC_CHECK(status);
+        }
+
+        if (!memh) {
+            std::cerr << "Rank " << rank << ": Memory handle is NULL"
+                      << std::endl;
+            return;
+        }
+        if (memh_size == 0) {
+            std::cerr << "Rank " << rank << ": Memory handle size is 0"
+                      << std::endl;
+            return;
+        }
+
+        /* Verify data integrity after mapping */
+        UCC_CHECK(check());
+
+        /* Test unmap */
+        UCC_CHECK(ucc_mem_unmap(&memh));
+        if (memh != nullptr) {
+            std::cerr << "Rank " << rank
+                      << ": Memory handle not NULL after unmap" << std::endl;
+            return;
+        }
+
+        /* Verify data integrity after unmapping */
+        UCC_CHECK(check());
+    }
+
+    std::string str() override
+    {
+        return std::string("mem_map mode=") + std::to_string(mode) +
+               " team=" + team_str(team.type) +
+               " buffer_size=" + std::to_string(buffer_size) +
+               " mem_type=" + std::to_string(mem_type);
+    }
+};
+
+class TestMemMapExport : public TestMemMap
+{
+public:
+    TestMemMapExport(ucc_test_team_t &_team, TestCaseParams &params)
+        : TestMemMap(_team, params, UCC_MEM_MAP_MODE_EXPORT)
+    {
+    }
+    static std::shared_ptr<TestCase> init_single(ucc_test_team_t &_team,
+                                                 ucc_coll_type_t _type,
+                                                 TestCaseParams params);
+};
+
+class TestMemMapImport : public TestMemMap
+{
+public:
+    TestMemMapImport(ucc_test_team_t &_team, TestCaseParams &params)
+        : TestMemMap(_team, params, UCC_MEM_MAP_MODE_IMPORT)
+    {
+    }
+    static std::shared_ptr<TestCase> init_single(ucc_test_team_t &_team,
+                                                 ucc_coll_type_t _type,
+                                                 TestCaseParams params);
+};
+
+class TestMemMapStress : public TestCase
+{
+private:
+    void                          *test_buffer;
+    size_t                         buffer_size;
+    std::vector<ucc_mem_map_mem_h> memhs;
+    int                            num_iterations = 10;
+
+public:
+    TestMemMapStress(ucc_test_team_t &_team, TestCaseParams &params)
+        : TestCase(_team, UCC_COLL_TYPE_BARRIER, params),
+          test_buffer(nullptr), buffer_size(0), num_iterations(10)
+    {
+        buffer_size = params.msgsize;
+        if (buffer_size == 0) {
+            buffer_size = 1024 * 1024; /* Default 1MB */
+        }
+
+        if (skip_reduce(test_max_size < buffer_size, TEST_SKIP_MEM_LIMIT,
+                        team.comm)) {
+            return;
+        }
+
+        UCC_CHECK(ucc_mc_alloc(&rbuf_mc_header, buffer_size, mem_type));
+        test_buffer = rbuf_mc_header->addr;
+        UCC_MALLOC_CHECK(test_buffer);
+
+        memhs.reserve(num_iterations);
+    }
+
+    ~TestMemMapStress()
+    {
+        for (auto memh : memhs) {
+            if (memh) {
+                ucc_mem_unmap(&memh);
+            }
+        }
+        if (test_buffer) {
+            ucc_free(test_buffer);
+        }
+    }
+
+    ucc_status_t set_input(int iter_persistent = 0) override
+    {
+        int rank;
+        MPI_Comm_rank(team.comm, &rank);
+
+        // Initialize buffer with iteration-specific data
+        memset(test_buffer, 0xBB + rank + iter_persistent, buffer_size);
+        return UCC_OK;
+    }
+
+    ucc_status_t check() override
+    {
+        unsigned char *buf      = (unsigned char *)test_buffer;
+        unsigned char  expected;
+        size_t         i;
+        int            rank;
+
+        MPI_Comm_rank(team.comm, &rank);
+
+        /* Verify buffer integrity */
+        expected = 0xBB + rank;
+        for (i = 0; i < buffer_size; i++) {
+            if (buf[i] != expected) {
+                return UCC_ERR_INVALID_PARAM;
+            }
+        }
+        return UCC_OK;
+    }
+
+    void run(bool triggered) override
+    {
+        ucc_mem_map_params_t map_params;
+        ucc_mem_map_t        segment;
+        int                  rank;
+        int                  i;
+
+        MPI_Comm_rank(team.comm, &rank);
+
+        /* Set up memory map parameters */
+        segment.address = test_buffer;
+        segment.len     = buffer_size;
+        map_params.segments = &segment;
+        map_params.n_segments = 1;
+
+        /* Stress test: multiple map/unmap operations */
+        for (i = 0; i < num_iterations; i++) {
+            ucc_mem_map_mem_h memh;
+            size_t             memh_size;
+
+            /* Fill buffer with iteration-specific pattern */
+            memset(test_buffer, 0xCC + rank + i, buffer_size);
+
+            ucc_status_t status = ucc_mem_map(team.ctx, UCC_MEM_MAP_MODE_EXPORT,
+                                              &map_params, &memh_size, &memh);
+            if (status != UCC_OK) {
+                if (status == UCC_ERR_NOT_SUPPORTED ||
+                    status == UCC_ERR_NOT_IMPLEMENTED) {
+                    test_skip = TEST_SKIP_NOT_SUPPORTED;
+                    return;
+                }
+                UCC_CHECK(status);
+            }
+
+            if (!memh) {
+                std::cerr << "Rank " << rank
+                          << ": Memory handle is NULL in stress test"
+                          << std::endl;
+                return;
+            }
+            if (memh_size == 0) {
+                std::cerr << "Rank " << rank
+                          << ": Memory handle size is 0 in stress test"
+                          << std::endl;
+                return;
+            }
+
+            /* Store memh for cleanup */
+            memhs.push_back(memh);
+
+            /* Verify data integrity */
+            UCC_CHECK(check());
+        }
+
+        /* Cleanup all memory handles */
+        for (auto &memh : memhs) {
+            UCC_CHECK(ucc_mem_unmap(&memh));
+        }
+        memhs.clear();
+
+        /* Final verification */
+        UCC_CHECK(check());
+    }
+
+    std::string str() override
+    {
+        return std::string("mem_map_stress") +
+               " team=" + team_str(team.type) +
+               " buffer_size=" + std::to_string(buffer_size) +
+               " iterations=" + std::to_string(num_iterations) +
+               " mem_type=" + std::to_string(mem_type);
+    }
+    static std::shared_ptr<TestCase> init_single(ucc_test_team_t &_team,
+                                                 ucc_coll_type_t _type,
+                                                 TestCaseParams params);
+};
+
+class TestMemMapMultiSize : public TestCase
+{
+private:
+    std::vector<size_t>                      buffer_sizes;
+    std::vector<void *>                      test_buffers;
+    std::vector<ucc_mem_map_mem_h>           memhs;
+
+public:
+    TestMemMapMultiSize(ucc_test_team_t &_team, TestCaseParams &params)
+        : TestCase(_team, UCC_COLL_TYPE_BARRIER, params)
+    {
+        size_t i;
+        /* Test different buffer sizes */
+        buffer_sizes = {1024, 4096, 65536, 1024 * 1024};
+
+        if (skip_reduce(test_max_size < buffer_sizes.back(), TEST_SKIP_MEM_LIMIT,
+                        team.comm)) {
+            return;
+        }
+
+        test_buffers.resize(buffer_sizes.size());
+        memhs.resize(buffer_sizes.size());
+
+        /* Allocate buffers */
+        for (i = 0; i < buffer_sizes.size(); i++) {
+            test_buffers[i] = ucc_malloc(buffer_sizes[i], "test buffer");
+            UCC_MALLOC_CHECK(test_buffers[i]);
+
+            /* Initialize with size-specific pattern */
+            memset(test_buffers[i], 0xDD + i, buffer_sizes[i]);
+        }
+    }
+
+    ~TestMemMapMultiSize()
+    {
+        for (auto memh : memhs) {
+            if (memh) {
+                ucc_mem_unmap(&memh);
+            }
+        }
+        for (auto buf : test_buffers) {
+            if (buf) {
+                ucc_free(buf);
+            }
+        }
+    }
+
+    ucc_status_t set_input(int iter_persistent = 0) override
+    {
+        size_t i;
+        int    rank;
+
+        MPI_Comm_rank(team.comm, &rank);
+        /* Initialize all buffers with rank and iteration specific data */
+        for (i = 0; i < test_buffers.size(); i++) {
+            memset(test_buffers[i], 0xDD + rank + iter_persistent,
+                   buffer_sizes[i]);
+        }
+        return UCC_OK;
+    }
+
+    ucc_status_t check() override
+    {
+        size_t i;
+        size_t j;
+        int    rank;
+
+        MPI_Comm_rank(team.comm, &rank);
+        for (i = 0; i < test_buffers.size(); i++) {
+            unsigned char *buf      = (unsigned char *)test_buffers[i];
+            unsigned char  expected = 0xDD + rank;
+
+            for (j = 0; j < buffer_sizes[i]; j++) {
+                if (buf[j] != expected) {
+                    return UCC_ERR_INVALID_PARAM;
+                }
+            }
+        }
+        return UCC_OK;
+    }
+
+    void run(bool triggered) override
+    {
+        ucc_mem_map_params_t map_params;
+        ucc_mem_map_t        segment;
+        int                  rank;
+        size_t               i;
+        ucc_mem_map_mem_h    memh;
+        size_t               memh_size;
+
+        MPI_Comm_rank(team.comm, &rank);
+
+        /* Test memory mapping with different buffer sizes */
+        for (i = 0; i < buffer_sizes.size(); i++) {
+            segment.address       = test_buffers[i];
+            segment.len           = buffer_sizes[i];
+            map_params.segments   = &segment;
+            map_params.n_segments = 1;
+            memh                  = nullptr;
+            memh_size             = 0;
+            ucc_status_t status = ucc_mem_map(team.ctx, UCC_MEM_MAP_MODE_EXPORT,
+                                              &map_params, &memh_size, &memh);
+            if (status != UCC_OK) {
+                if (status == UCC_ERR_NOT_SUPPORTED ||
+                    status == UCC_ERR_NOT_IMPLEMENTED) {
+                    test_skip = TEST_SKIP_NOT_SUPPORTED;
+                    return;
+                }
+                UCC_CHECK(status);
+            }
+
+            if (!memh) {
+                std::cerr << "Rank " << rank
+                          << ": Memory handle is NULL in multi-size test"
+                          << std::endl;
+                return;
+            }
+            if (memh_size == 0) {
+                std::cerr << "Rank " << rank
+                          << ": Memory handle size is 0 in multi-size test"
+                          << std::endl;
+                return;
+            }
+
+            /* Store memh for cleanup */
+            memhs[i] = memh;
+
+            /* Verify data integrity */
+            UCC_CHECK(check());
+        }
+
+        /* Cleanup all memory handles */
+        for (auto &memh : memhs) {
+            UCC_CHECK(ucc_mem_unmap(&memh));
+        }
+
+        /* Final verification */
+        UCC_CHECK(check());
+    }
+
+    std::string str() override
+    {
+        return std::string("mem_map_multi_size") +
+               " team=" + team_str(team.type) +
+               " num_sizes=" + std::to_string(buffer_sizes.size()) +
+               " mem_type=" + std::to_string(mem_type);
+    }
+    static std::shared_ptr<TestCase> init_single(ucc_test_team_t &_team,
+                                                 ucc_coll_type_t _type,
+                                                 TestCaseParams params);
+};
+
+// Factory functions for creating test instances
+std::shared_ptr<TestCase> TestMemMapExport::init_single(ucc_test_team_t &_team,
+                                                        ucc_coll_type_t _type,
+                                                        TestCaseParams params)
+{
+    return std::make_shared<TestMemMapExport>(_team, params);
+}
+
+std::shared_ptr<TestCase> TestMemMapImport::init_single(ucc_test_team_t &_team,
+                                                        ucc_coll_type_t _type,
+                                                        TestCaseParams params)
+{
+    return std::make_shared<TestMemMapImport>(_team, params);
+}
+
+std::shared_ptr<TestCase> TestMemMapStress::init_single(ucc_test_team_t &_team,
+                                                        ucc_coll_type_t _type,
+                                                        TestCaseParams params)
+{
+    return std::make_shared<TestMemMapStress>(_team, params);
+}
+
+std::shared_ptr<TestCase> TestMemMapMultiSize::init_single(ucc_test_team_t &_team,
+                                                           ucc_coll_type_t _type,
+                                                           TestCaseParams params)
+{
+    return std::make_shared<TestMemMapMultiSize>(_team, params);
+} 


### PR DESCRIPTION
## What
Add gtest and mpi tests for ucc_mem_map and ucc_mem_unmap. Also fixes memory leaks present in the current ucc_mem_map code path.

