### PR TITLE
CI: Fix issue docker build

### DIFF
--- a/.ci/Dockerfile.ngc_pytorch
+++ b/.ci/Dockerfile.ngc_pytorch
@@ -14,7 +14,7 @@ RUN ${SRC_DIR}/ucc/.ci/scripts/build_ucc.sh
 RUN chown -R 6213:11429 /opt/nvidia
 #==============================================================================
 RUN groupadd -g 11429 swx-jenkins
-RUN adduser --no-create-home --uid 6213 --gid 11429 --home /labhome/swx-jenkins swx-jenkins
+RUN useradd --no-create-home --uid 6213 --gid 11429 --home /labhome/swx-jenkins swx-jenkins
 #==============================================================================
 USER swx-jenkins
 


### PR DESCRIPTION
Changed using adduser to useradd ( useradd doesn't check HOME is present)

Due to the changing NFS servers policy root can't reach the swx-jenkins home.

