### PR TITLE
EC/CUDA: Link with stdc++ (#1168)

### DIFF
--- a/src/components/ec/cuda/Makefile.am
+++ b/src/components/ec/cuda/Makefile.am
@@ -20,7 +20,7 @@ module_LTLIBRARIES         = libucc_ec_cuda.la
 libucc_ec_cuda_la_SOURCES  = $(sources)
 libucc_ec_cuda_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
 libucc_ec_cuda_la_CFLAGS   = $(BASE_CFLAGS)
-libucc_ec_cuda_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLAGS)
+libucc_ec_cuda_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLAGS) -lstdc++
 libucc_ec_cuda_la_LIBADD   = $(CUDA_LIBS)                      \
                              $(UCC_TOP_BUILDDIR)/src/libucc.la \
                              kernel/libucc_ec_cuda_kernels.la

--- a/src/components/ec/cuda/kernel/Makefile.am
+++ b/src/components/ec/cuda/kernel/Makefile.am
@@ -11,7 +11,7 @@ NVCCFLAGS =                                      \
     -I${UCC_TOP_BUILDDIR}/src                    \
     --compiler-options -fno-rtti,-fno-exceptions
 
-LINK = $(LIBTOOL) --mode=link $(CC) -o $@
+LINK = $(LIBTOOL) --tag=CXX --mode=link $(NVCC) -o $@
 
 .cu.o:
 	$(NVCC) -c $< -o $@  $(NVCCFLAGS) $(NVCC_ARCH)


### PR DESCRIPTION
UCC's ec_cuda component (libucc_ec_cuda.so) is c++, so the compiler should link with libstdc++.so to add the c++ runtime symbols.

With cuda 13 (specifically on x86, ARM does not have this issue--the reason is the ARM libcudart.so depends on libstdc++.so, so it gets loaded, masking the issue), there is an unresolved symbol __cxa_guard_acquire that is left unresolved because libstdc++.so is not marked as a dependency.

Interestingly, with cuda 12, that symbol is not required by libucc_ec_cuda.so. I have not figured out why cuda 12 doesn't add it.

Regardless, I think not having -lstdc++ may have been an issue in UCC for a long time that was only exposed with the new cuda 13.

:x: Cuda 13 before the fix:
```
[nsarkauskas@rock17 ucc_private]$ nm -D /hpc/mtr_scrap/users/nsarkauskas/ucc_private/install/lib/ucc/libucc_ec_cuda.so | grep __cxa_guard_acquire
                 U __cxa_guard_acquire
[nsarkauskas@rock17 ucc_private]$ ldd /hpc/mtr_scrap/users/nsarkauskas/ucc_private/install/lib/ucc/libucc_ec_cuda.so
    linux-vdso.so.1 (0x00007ffd0912b000)
    libcuda.so.1 => /lib64/libcuda.so.1 (0x00007fe4b8544000)
    libcudart.so.13 => /hpc/local/oss/cuda13.0.0/redhat8/lib64/libcudart.so.13 (0x00007fe4b8296000)
    libucc.so.1 => /hpc/mtr_scrap/users/nsarkauskas/ucc_private/install/lib/libucc.so.1 (0x00007fe4b805b000)
    libucs.so.0 => /hpc/mtr_scrap/users/nsarkauskas/ucx/install/lib/libucs.so.0 (0x00007fe4b7c9c000)
    libm.so.6 => /lib64/libm.so.6 (0x00007fe4b791a000)
    libucm.so.0 => /hpc/mtr_scrap/users/nsarkauskas/ucx/install/lib/libucm.so.0 (0x00007fe4b76fb000)
    libz.so.1 => /lib64/libz.so.1 (0x00007fe4b74e3000)
    libdl.so.2 => /lib64/libdl.so.2 (0x00007fe4b72df000)
    libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fe4b70bf000)
    librt.so.1 => /lib64/librt.so.1 (0x00007fe4b6eb7000)
    libc.so.6 => /lib64/libc.so.6 (0x00007fe4b6af2000)
    /lib64/ld-linux-x86-64.so.2 (0x00007fe4beaeb000)
[nsarkauskas@rock17 ucc_private]$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2025 NVIDIA Corporation
Built on Wed_Jul__2_10:42:27_AM_PDT_2025
Cuda compilation tools, release 13.0, V13.0.39
Build cuda_13.0.r13.0/compiler.36195134_0
```

:white_check_mark: Cuda 13 after the fix:

```
[nsarkauskas@rock17 ucc_private]$ nm -D /hpc/mtr_scrap/users/nsarkauskas/ucc_private/install/lib/ucc/libucc_ec_cuda.so | grep __cxa_guard_acquire
                 U __cxa_guard_acquire
[nsarkauskas@rock17 ucc_private]$ ldd /hpc/mtr_scrap/users/nsarkauskas/ucc_private/install/lib/ucc/libucc_ec_cuda.so | grep c++
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007fb177515000)
```

(cherry picked from commit 7cff72599e4badcd58e8ab825bedf866506cd8e6)

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
