### PR TITLE
TL/CUDA: NVLS barrier

### DIFF
--- a/src/components/tl/cuda/allreduce/allreduce_nvls.c
+++ b/src/components/tl/cuda/allreduce/allreduce_nvls.c
@@ -79,9 +79,8 @@ void ucc_tl_cuda_allreduce_nvls_progress(ucc_coll_task_t *coll_task)
 
         status = post_allreduce_kernel(stream, sm_count, threads, mc_va,
                                        task->allreduce_nvls.buf_size_bytes,
-                                       (CUdeviceptr)TASK_NVLS_CONTROL_MC(task),
-                                       (CUdeviceptr)TASK_NVLS_CONTROL_UC(task),
-                                       sm_count * UCC_TL_TEAM_SIZE(team),
+                                       TASK_NVLS_CONTROL_MC(task),
+                                       TASK_NVLS_CONTROL_UC(task),
                                        task->allreduce_nvls.coll_id,
                                        trank,
                                        UCC_TL_TEAM_SIZE(team), dt);

--- a/src/components/tl/cuda/kernels/Makefile.am
+++ b/src/components/tl/cuda/kernels/Makefile.am
@@ -24,9 +24,13 @@ comp_noinst = libucc_tl_cuda_kernels.la
 if TL_CUDA_NVLS_ENABLED
 libucc_tl_cuda_kernels_la_SOURCES  = reduce_scatter_kernel.cu allreduce_kernel.cu
 else
-libucc_tl_cuda_kernels_la_SOURCES  = 
+libucc_tl_cuda_kernels_la_SOURCES  =
 endif
 
 libucc_tl_cuda_kernels_la_CPPFLAGS =
 
 noinst_LTLIBRARIES = $(comp_noinst)
+
+# Ensure kernels rebuild when helper header changes
+reduce_scatter_kernel.lo: nvls.cuh
+allreduce_kernel.lo: nvls.cuh

--- a/src/components/tl/cuda/kernels/allreduce_kernel.cu
+++ b/src/components/tl/cuda/kernels/allreduce_kernel.cu
@@ -17,12 +17,21 @@ extern "C" {
 
 #include "nvls.cuh"
 
+
 // vectorized allreduce kernel for 32-bit lanes
 template <typename NvlsOps>
 __global__ void __launch_bounds__(UCC_TL_CUDA_MAX_NVLS_THREADS)
-allreduce_kernel_vec32(uint32_t *base_u32, size_t count_u32, uint32_t rank,
-                       uint32_t tsize)
+    allreduce_kernel_vec32(ucc_tl_cuda_nvls_control_t *mc_bar,
+                           ucc_tl_cuda_nvls_control_t *uc_bar,
+                           const uint32_t total_blocks, // block count per gpu * num gpus in Multicast group
+                           uint64_t launch_counter,
+                           uint32_t *base_u32, size_t count_u32, uint32_t rank,
+                           uint32_t tsize)
 {
+    // pre barrier
+    nvls_bar(&(mc_bar->arrival_counter), &(uc_bar->arrival_counter), total_blocks * (launch_counter * 2 + 1));
+
+    // Kernel execution
     size_t chunk_start = ((int64_t)count_u32 * (int64_t)rank) / (int64_t)tsize;
     size_t chunk_end   = ((int64_t)count_u32 * (int64_t)(rank + 1)) / (int64_t)tsize;
 
@@ -34,6 +43,9 @@ allreduce_kernel_vec32(uint32_t *base_u32, size_t count_u32, uint32_t rank,
         NvlsOps::ld(val, base_u32 + idx);
         NvlsOps::st(val, base_u32 + idx);
     }
+
+    // post barrier
+    nvls_bar(&(mc_bar->arrival_counter), &(uc_bar->arrival_counter), total_blocks * (launch_counter * 2 + 2));
 }
 
 #ifdef __cplusplus
@@ -41,25 +53,32 @@ extern "C" {
 #endif
 
 ucc_status_t post_allreduce_kernel(cudaStream_t stream, uint32_t sm_count,
-                                   uint32_t threads, CUdeviceptr src_addr,
-                                   size_t src_size_bytes, uint32_t rank,
+                                   uint32_t threads, CUdeviceptr mc_base_addr,
+                                   size_t src_size_bytes,
+                                   CUdeviceptr mc_control_addr,
+                                   CUdeviceptr uc_control_addr,
+                                   uint32_t expected_blocks,
+                                   uint64_t launch_counter,
+                                   uint32_t rank,
                                    uint32_t tsize, ucc_datatype_t datatype)
 {
     assert(sm_count > 0 && sm_count <= UCC_TL_CUDA_MAX_NVLS_SM_COUNT);
     assert(threads > 0 && threads <= UCC_TL_CUDA_MAX_NVLS_THREADS);
-    uint32_t *base_u32   = reinterpret_cast<uint32_t *>(src_addr);
+    uint32_t *base_u32   = reinterpret_cast<uint32_t *>(mc_base_addr);
     size_t    count_u32  = src_size_bytes / sizeof(uint32_t);
+    ucc_tl_cuda_nvls_control_t *mc_bar = reinterpret_cast<ucc_tl_cuda_nvls_control_t *>(mc_control_addr);
+    ucc_tl_cuda_nvls_control_t *uc_bar = reinterpret_cast<ucc_tl_cuda_nvls_control_t *>(uc_control_addr);
 
     switch (datatype) {
     case UCC_DT_FLOAT32:
-        assert(((uintptr_t)(src_addr) % 8) == 0);
+        assert(((uintptr_t)(mc_base_addr) % 8) == 0);
         allreduce_kernel_vec32<NvlsFp32Ops><<<sm_count, threads, 0, stream>>>(
-            base_u32, count_u32, rank, tsize);
+            mc_bar, uc_bar, expected_blocks, launch_counter, base_u32, count_u32, rank, tsize);
         break;
     case UCC_DT_BFLOAT16:
-        assert(((uintptr_t)(src_addr) % 8) == 0);
+        assert(((uintptr_t)(mc_base_addr) % 8) == 0);
         allreduce_kernel_vec32<NvlsBf16Ops><<<sm_count, threads, 0, stream>>>(
-            base_u32, count_u32, rank, tsize);
+            mc_bar, uc_bar, expected_blocks, launch_counter, base_u32, count_u32, rank, tsize);
         break;
     default:
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/tl/cuda/kernels/allreduce_kernel.cu
+++ b/src/components/tl/cuda/kernels/allreduce_kernel.cu
@@ -57,7 +57,6 @@ ucc_status_t post_allreduce_kernel(cudaStream_t stream, uint32_t sm_count,
                                    size_t src_size_bytes,
                                    CUdeviceptr mc_control_addr,
                                    CUdeviceptr uc_control_addr,
-                                   uint32_t expected_blocks,
                                    uint64_t launch_counter,
                                    uint32_t rank,
                                    uint32_t tsize, ucc_datatype_t datatype)
@@ -68,6 +67,7 @@ ucc_status_t post_allreduce_kernel(cudaStream_t stream, uint32_t sm_count,
     size_t    count_u32  = src_size_bytes / sizeof(uint32_t);
     ucc_tl_cuda_nvls_control_t *mc_bar = reinterpret_cast<ucc_tl_cuda_nvls_control_t *>(mc_control_addr);
     ucc_tl_cuda_nvls_control_t *uc_bar = reinterpret_cast<ucc_tl_cuda_nvls_control_t *>(uc_control_addr);
+    uint32_t expected_blocks = sm_count * tsize; // total num of blocks in the multicast group, num gpus * num blocks per gpu, used for barrier synchronization
 
     switch (datatype) {
     case UCC_DT_FLOAT32:

--- a/src/components/tl/cuda/kernels/allreduce_kernel.h
+++ b/src/components/tl/cuda/kernels/allreduce_kernel.h
@@ -16,8 +16,13 @@ extern "C" {
 
 // Kernel function declaration
 ucc_status_t post_allreduce_kernel(cudaStream_t stream, uint32_t sm_count,
-                                   uint32_t threads, CUdeviceptr src_addr,
-                                   size_t src_size_bytes, uint32_t rank,
+                                   uint32_t threads, CUdeviceptr mc_base_addr,
+                                   size_t src_size_bytes,
+                                   CUdeviceptr mc_control_addr,
+                                   CUdeviceptr uc_control_addr,
+                                   uint32_t expected_blocks, // total num of blocks in the multicast group, num gpus * num blocks per gpu, used for barrier synchronization
+                                   uint64_t launch_counter, // launch counter for specific NVLS task in flight slot, used for barrier synchronization
+                                   uint32_t rank,
                                    uint32_t tsize, ucc_datatype_t datatype);
 
 #ifdef __cplusplus

--- a/src/components/tl/cuda/kernels/allreduce_kernel.h
+++ b/src/components/tl/cuda/kernels/allreduce_kernel.h
@@ -20,7 +20,6 @@ ucc_status_t post_allreduce_kernel(cudaStream_t stream, uint32_t sm_count,
                                    size_t src_size_bytes,
                                    CUdeviceptr mc_control_addr,
                                    CUdeviceptr uc_control_addr,
-                                   uint32_t expected_blocks, // total num of blocks in the multicast group, num gpus * num blocks per gpu, used for barrier synchronization
                                    uint64_t launch_counter, // launch counter for specific NVLS task in flight slot, used for barrier synchronization
                                    uint32_t rank,
                                    uint32_t tsize, ucc_datatype_t datatype);

--- a/src/components/tl/cuda/kernels/nvls.cuh
+++ b/src/components/tl/cuda/kernels/nvls.cuh
@@ -9,6 +9,7 @@
 
 #include <cuda.h>
 #include <stdint.h>
+#include <cuda/atomic>
 
 #define MULTIMEM_ST(val, ptr)                                                  \
     asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};" ::"l"(ptr),  \
@@ -33,6 +34,30 @@
         : "memory");
 
 #ifdef __cplusplus
+// NVLS global barrier helper used by kernels to synchronize via multicast/unicast counters
+__device__ __forceinline__ void nvls_bar(uint64_t *mc_arrival_counter,
+                                         uint64_t *uc_arrival_counter,
+                                         uint64_t  expected_count)
+{
+    if (threadIdx.x == 0) {
+        // first thread in block increments the multicast arrival counter
+        asm volatile("multimem.red.release.sys.global.add.u64 [%0], %1;" ::"l"(
+                         mc_arrival_counter),
+                     "n"(1)
+                     : "memory");
+        asm volatile("fence.proxy.alias;" ::: "memory");
+
+        // waits others blocks to reach the same phase
+        cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ac(
+            *uc_arrival_counter);
+        // sync per block: block 0 on gpu 0 with block 0 on gpu 1, block 1 on gpu 0 with block 1 on gpu 1, etc.
+        while (expected_count > ac.load(cuda::memory_order_acquire)) {
+        }
+    }
+    // all other threads in block wait for the first thread to finish
+    __syncthreads();
+}
+
 // Traits wrapping NVLS LD/ST variants on 32-bit lanes
 struct NvlsFp32Ops {
     __device__ static inline void ld(uint4 &v, const uint32_t *ptr) {

--- a/src/components/tl/cuda/kernels/reduce_scatter_kernel.cu
+++ b/src/components/tl/cuda/kernels/reduce_scatter_kernel.cu
@@ -4,18 +4,10 @@
  * See file LICENSE for terms.
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "utils/arch/cuda_def.h"
 #include "../tl_cuda.h"
 
 #include "nvls.cuh"
-
-#ifdef __cplusplus
-}
-#endif
 
 __global__ void __launch_bounds__(UCC_TL_CUDA_MAX_NVLS_THREADS)
     reduce_scatter_kernel(float *src_addr, float *dst_addr, size_t src_count,

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -318,9 +318,10 @@ struct ucc_tl_cuda_task {
             void          *sbuf;
             void          *rbuf;
             size_t         buf_size_bytes;
-            CUdeviceptr   mc_va; // Memory handle for MC symmetric memory
-            CUdeviceptr   uc_va; // Memory handle for UC symmetric memory
+            CUdeviceptr    mc_va; // Memory handle for MC symmetric memory
+            CUdeviceptr    uc_va; // Memory handle for UC symmetric memory
             void          *evtCompletion;
+            size_t         coll_id; // Coll id for the NVLS task in flight slot
         } allreduce_nvls;
 #endif
     };

--- a/src/components/tl/cuda/tl_cuda_cache.c
+++ b/src/components/tl/cuda/tl_cuda_cache.c
@@ -229,7 +229,7 @@ ucc_tl_cuda_map_memhandle(const void *d_ptr, size_t size,
             cudaGetLastError();
         } else {
             ucc_error("%s: failed to open ipc mem handle. addr:%p len:%lu "
-                      "err:%d", cache->name, d_ptr, size, cuerr);
+                      "err: %d %s", cache->name, d_ptr, size, cuerr, cudaGetErrorName(cuerr));
             status = UCC_ERR_NO_MESSAGE;
             goto err;
         }

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -66,7 +66,7 @@ extern const char
         ucc_tl_cuda_team_t *_team = TASK_TEAM(_task);                              \
         size_t _symm_payload_size = UCC_TL_CUDA_TEAM_LIB(_team)->cfg.nvls_symmetric_size;  \
         size_t _symm_size = _symm_payload_size + NVLS_CONTROL_SIZE;  \
-        (PTR_OFFSET(_team->nvls.mc_va, (_task)->coll_id * _symm_size + _symm_payload_size));            \
+        ((CUdeviceptr) PTR_OFFSET(_team->nvls.mc_va, (_task)->coll_id * _symm_size + _symm_payload_size));            \
     })
 
 #define TASK_NVLS_CONTROL_UC(_task)                                                 \
@@ -74,7 +74,7 @@ extern const char
         ucc_tl_cuda_team_t *_team = TASK_TEAM(_task);                              \
         size_t _symm_payload_size = UCC_TL_CUDA_TEAM_LIB(_team)->cfg.nvls_symmetric_size;  \
         size_t _symm_size = _symm_payload_size + NVLS_CONTROL_SIZE;  \
-        (PTR_OFFSET(_team->nvls.uc_va, (_task)->coll_id * _symm_size + _symm_payload_size));            \
+        ((CUdeviceptr) PTR_OFFSET(_team->nvls.uc_va, (_task)->coll_id * _symm_size + _symm_payload_size));            \
     })
 
 static inline void ucc_tl_cuda_task_reset(ucc_tl_cuda_task_t *task)

--- a/src/components/tl/cuda/tl_cuda_coll.h
+++ b/src/components/tl/cuda/tl_cuda_coll.h
@@ -45,18 +45,36 @@ extern const char
         (PTR_OFFSET(_scratch, (_task)->coll_id * _scratch_size));              \
     })
 
+#define NVLS_CONTROL_SIZE 1024
+
 #define TASK_SYMMETRIC_MC(_task)                                                   \
     ({                                                                             \
         ucc_tl_cuda_team_t *_team = TASK_TEAM(_task);                              \
-        size_t _symm_size = UCC_TL_CUDA_TEAM_LIB(_team)->cfg.nvls_symmetric_size;  \
+        size_t _symm_size = UCC_TL_CUDA_TEAM_LIB(_team)->cfg.nvls_symmetric_size + NVLS_CONTROL_SIZE;  \
         (PTR_OFFSET(_team->nvls.mc_va, (_task)->coll_id * _symm_size));            \
     })
 
 #define TASK_SYMMETRIC_UC(_task)                                                   \
     ({                                                                             \
         ucc_tl_cuda_team_t *_team = TASK_TEAM(_task);                              \
-        size_t _symm_size = UCC_TL_CUDA_TEAM_LIB(_team)->cfg.nvls_symmetric_size;  \
+        size_t _symm_size = UCC_TL_CUDA_TEAM_LIB(_team)->cfg.nvls_symmetric_size + NVLS_CONTROL_SIZE;  \
         (PTR_OFFSET(_team->nvls.uc_va, (_task)->coll_id * _symm_size));            \
+    })
+
+#define TASK_NVLS_CONTROL_MC(_task)                                                 \
+    ({                                                                             \
+        ucc_tl_cuda_team_t *_team = TASK_TEAM(_task);                              \
+        size_t _symm_payload_size = UCC_TL_CUDA_TEAM_LIB(_team)->cfg.nvls_symmetric_size;  \
+        size_t _symm_size = _symm_payload_size + NVLS_CONTROL_SIZE;  \
+        (PTR_OFFSET(_team->nvls.mc_va, (_task)->coll_id * _symm_size + _symm_payload_size));            \
+    })
+
+#define TASK_NVLS_CONTROL_UC(_task)                                                 \
+    ({                                                                             \
+        ucc_tl_cuda_team_t *_team = TASK_TEAM(_task);                              \
+        size_t _symm_payload_size = UCC_TL_CUDA_TEAM_LIB(_team)->cfg.nvls_symmetric_size;  \
+        size_t _symm_size = _symm_payload_size + NVLS_CONTROL_SIZE;  \
+        (PTR_OFFSET(_team->nvls.uc_va, (_task)->coll_id * _symm_size + _symm_payload_size));            \
     })
 
 static inline void ucc_tl_cuda_task_reset(ucc_tl_cuda_task_t *task)

--- a/src/components/tl/cuda/tl_cuda_nvls.c
+++ b/src/components/tl/cuda/tl_cuda_nvls.c
@@ -391,9 +391,8 @@ ucc_status_t ucc_tl_cuda_nvls_init(struct ucc_tl_cuda_team *self,
         status = UCC_ERR_NO_MEMORY;
         goto cleanup;
     }
-    for (i = 0; i < lib->cfg.max_concurrent; ++i) {
-        nvls->coll_ids[i] = 0;
-    }
+    // Initialize the coll_ids to 0
+    memset(nvls->coll_ids, 0, lib->cfg.max_concurrent * sizeof(size_t));
 
     if (UCC_TL_TEAM_RANK(self) == 0) {
         // root rank initializes the arrival counter for each task

--- a/src/components/tl/cuda/tl_cuda_nvls.h
+++ b/src/components/tl/cuda/tl_cuda_nvls.h
@@ -22,8 +22,12 @@ typedef struct ucc_tl_cuda_nvls {
     CUdeviceptr                  uc_va;        // Device pointer for unicast memory
     size_t                       mc_size;      // Size of multicast memory
     size_t                       mc_offset;    // Offset of the multicast memory
+    size_t                      *coll_ids;     // Coll id for the each task in flight slot, needed for barrier
 } ucc_tl_cuda_nvls_t;
 
+typedef struct ucc_tl_cuda_nvls_control {
+    uint64_t arrival_counter;
+} ucc_tl_cuda_nvls_control_t;
 
 ucc_status_t ucc_tl_cuda_nvls_init(struct ucc_tl_cuda_team *self, ucc_base_context_t *tl_context);
 

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -339,6 +339,9 @@ barrier:
     tl_debug(tl_team->context->lib, "initialized tl team: %p", team);
 
 #ifdef HAVE_NVLS
+    // zero out the nvls struct
+    memset(&team->nvls, 0, sizeof(team->nvls));
+    // initialize the nvls struct
     status = ucc_tl_cuda_nvls_init(team, tl_team->context);
     if (status != UCC_OK) {
         ucc_error("failed to init nvls multicast");


### PR DESCRIPTION
## What
Introduce a cross-GPU barrier implementation using NVLS symmetric memory, eliminating the need for host-side synchronization.

## Why ?
The existing barrier relies on a host-managed shared memory synchronization mechanism. While functional, this approach is:
- **Expensive in performance** - frequent host-device roundtrips add latency.
- **Not scalable across nodes** - shared memory is not available in multinode deployments, making the current design unsuitable for larger topologies.
This PR addresses both issues by moving barrier management fully into device-side execution.

## How ?
- **Control space**: Reserve 1024 bytes in the NVLS symmetric buffer for barrier control segments.
- **Mechanism**:
  - The barrier is represented by a single monotonically incremented **uint64_t** counter.
  - Each participating GPU in the NVLS group increments the counter upon reaching the barrier.
  - Progress is determined by comparing the counter against the expected value, which scales with the NVLS group size.
- **Kernel integration**:
  - NVLS kernels launch with 1–32 blocks.
  - Each block designates a leader thread (`threadIdx.x == 0`).
  - The leader thread performs the atomic increment and spins until the counter matches the expected group-wide value.

This design ensures all GPUs in the NVLS group complete a given phase of the algorithm before any proceed, without requiring host intervention.

## Performance results:
<img width="1200" height="500" alt="bandwidth_comparison" src="https://github.com/user-attachments/assets/694bf5e6-5129-489c-a350-7b75e6924fc0" />
<img width="1200" height="500" alt="latency_comparison" src="https://github.com/user-attachments/assets/637967c2-99bf-4ed3-97de-52cbecf958f1" />
