### PR TITLE
TEST: bus bw

### DIFF
--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -361,7 +361,7 @@ void ucc_pt_benchmark::print_header()
                   << std::setw(12) << "Size"
                   << std::setw(24) << "Time, us";
         if (config.full_print) {
-            std::cout << std::setw(42) << "Bandwidth, GB/s";
+            std::cout << std::setw(42) << "Bus Bandwidth, GB/s";
         }
         std::cout << std::endl;
         std::cout << std::setw(36) << "avg"


### PR DESCRIPTION
## What
Specifying perf test print to be bus BW instead of just BW 

## Why ?
each collective perf test has its own get_bw function which calculates the bus bw depending more then just on S/t.
As seen also in NCCL-tests explanation- 
https://github.com/NVIDIA/nccl-tests/blob/9a5c15461abcef145b907c54d04aea4e8d1cb21f/doc/PERFORMANCE.md?plain=1#L22
Bus BW depends also on number of ranks and other collective specifics.
