### PR TITLE
BUILD: update clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,9 @@
 ---
 Language:        Cpp
-# BasedOnStyle:  LLVM
 AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: AcrossEmptyLinesAndComments
+AlignConsecutiveDeclarations: AcrossEmptyLinesAndComments
 AlignConsecutiveMacros: true
 AlignEscapedNewlines: Right
 AlignOperands:   true
@@ -20,13 +19,13 @@ AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
+BreakAfterReturnType: ExceptShortType
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
-BinPackArguments: true
+BinPackArguments: false
 BinPackParameters: true
 BreakBeforeBraces: Custom
-BraceWrapping:   
+BraceWrapping:
   AfterCaseLabel:  true
   AfterClass:      false
   AfterControlStatement: false
@@ -59,12 +58,17 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros:   
+ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+  - ucc_list_for_each
+  - ucc_list_for_each_safe
+  - ucc_for_each_bit
+  - ucs_list_for_each
+  - ucs_list_for_each_safe
 IncludeBlocks:   Preserve
-IncludeCategories: 
+IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
@@ -73,30 +77,25 @@ IncludeCategories:
     Priority:        1
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: false
+IndentGotoLabels: true
 IndentPPDirectives: None
 IndentWidth:     4
 IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-ObjCBinPackProtocolList: Auto
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 150
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 250
+PenaltyBreakAssignment: 100000
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 300
+PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyReturnTypeOnItsOwnLine: 2000000
 PointerAlignment: Right
-ReflowComments:  false
+ReflowComments:  IndentOnly
 SortIncludes:    false
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
@@ -116,9 +115,17 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Cpp11
-StatementMacros: 
+StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
+  - UCC_PROFILE_FUNC
+  - UCC_CORE_PROFILE_FUNC
+  - UCC_CL_HIER_PROFILE_FUNC
+  - UCC_TL_UCP_PROFILE_FUNC
+  - UCC_CL_HIER_PROFILE_REQUEST_EVENT
+  - UCC_TL_UCP_PROFILE_REQUEST_EVENT
+  - UCC_CHECK_GOTO
+  - UCPCHECK_GOTO
 TabWidth:        4
 UseTab:          Never
 ...


### PR DESCRIPTION
## What
Update clang format

## Why ?
Make formatting stable

## How ?
Change function wrap:
When function declaration cannot be placed on a single line then  place all arguments on a second line
```c
/* before */
static inline void
ucc_knomial_pattern_init(ucc_rank_t size, ucc_rank_t rank, ucc_kn_radix_t radix,
                         ucc_knomial_pattern_t *p)
{
    ucc_knomial_pattern_init_impl(size, rank, radix, p, 0, 1);
}
/* after */
static inline void ucc_knomial_pattern_init(
    ucc_rank_t size, ucc_rank_t rank, ucc_kn_radix_t radix,
    ucc_knomial_pattern_t *p)
{
    ucc_knomial_pattern_init_impl(size, rank, radix, p, 0, 1);
}
```
When function call cannot be placed on a single line then place one arg per line
```c
/* before */
            status =
                ucc_mc_memcpy(rbuf, scratch_header->addr, tsize * data_size,
                              rmem, UCC_MEMORY_TYPE_HOST);
            if (ucc_unlikely(status != UCC_OK)) {
                tl_error(UCC_TASK_LIB(task),
                         "failed to copy from scratch buffer to dst");
                task->super.status = status;
                return;
            }
/* after */
            status = ucc_mc_memcpy(
                rbuf,
                scratch_header->addr,
                tsize * data_size,
                rmem,
                UCC_MEMORY_TYPE_HOST);
            if (ucc_unlikely(status != UCC_OK)) {
                tl_error(
                    UCC_TASK_LIB(task),
                    "failed to copy from scratch buffer to dst");
                task->super.status = status;
                return;
            }
```
reflow comments
```c
/* before */
/**
 * Computes actual radix at current iteration
    * @param [in] p ucc_knomial_pattern
      * @return radix
 */
static inline
ucc_rank_t ucc_kn_compute_step_radix(ucc_knomial_pattern_t *p);
/* after */
/**
 * Computes actual radix at current iteration
 * @param [in] p ucc_knomial_pattern
 * @return radix
 */
static inline ucc_rank_t ucc_kn_compute_step_radix(ucc_knomial_pattern_t *p)
```

Please avoid using inline comments as they break alignment. E.g.
```c
/*with inline comments*/
typedef struct ucc_knomial_pattern {

    ucc_kn_radix_t radix;     /* knomial tree radix */
    uint8_t        type;      /* pattern type */
    uint8_t        iteration; /* current iteration */
    uint8_t        n_iters;   /* number of iterations in knomial algorithm */
    uint8_t
        pow_radix_sup; /* smallest integer N such that (radix ** N) >= size */
    uint8_t node_type; /* type of current rank: BASE, PROXY or EXTRA */
    uint8_t backward;  /* boolean, iteration direction */
    ucc_rank_t
        radix_pow; /* power of radix for current algorithm iteration
                    * forward: initial value is 1
                    * backward: initial valus is full_pow_size if have >1 full subtrees, OR
                    *           (full_pow_size / radix) otherwise
                    */
    ucc_rank_t
               full_pow_size; /* largest power of radix <= size. It is equal to
                               * (radix ** pow_radix_sup) if (radix ** pow_radix_sup) == size, OR
                               * (radix ** (_pow_radix_sup - 1)) otherwise
                               */
    ucc_rank_t size;          /* total number of ranks */
    ucc_rank_t rank;          /* process rank */
    ucc_rank_t n_extra; /* number of "extra" ranks to be served by "proxies" */
    size_t     block_size_counts;
    size_t     count; /* collective buffer size */
    ucc_count_t *counts;
    ucc_rank_t   block_size;
    ptrdiff_t    block_offset;
    int          is64;
} ucc_knomial_pattern_t;
/* no inline comments */
typedef struct ucc_knomial_pattern {
    /* knomial tree radix */
    ucc_kn_radix_t radix;
    /* pattern type */
    uint8_t        type;
    /* current iteration */
    uint8_t        iteration;
    /* number of iterations in knomial algorithm */
    uint8_t        n_iters;
    /* smallest integer N such that (radix ** N) >= size */
    uint8_t        pow_radix_sup;
    /* type of current rank: BASE, PROXY or EXTRA */
    uint8_t        node_type;
    /* boolean, iteration direction */
    uint8_t        backward;
    /* power of radix for current algorithm iteration
     * forward: initial value is 1
     * backward: initial valus is full_pow_size if have >1 full subtrees, OR
     *           (full_pow_size / radix) otherwise
     */
    ucc_rank_t     radix_pow;
    /* largest power of radix <= size. It is equal to
     * (radix ** pow_radix_sup) if (radix ** pow_radix_sup) == size, OR
     * (radix ** (_pow_radix_sup - 1)) otherwise
     */
    ucc_rank_t     full_pow_size;
    /* total number of ranks */
    ucc_rank_t     size;
    /* process rank */
    ucc_rank_t     rank;
    /* number of "extra" ranks to be served by "proxies" */
    ucc_rank_t     n_extra;
    size_t         block_size_counts;
    /* collective buffer size */
    size_t         count;
    ucc_count_t   *counts;
    ucc_rank_t     block_size;
    ptrdiff_t      block_offset;
    int            is64;
} ucc_knomial_pattern_t;
```