### PR TITLE
v1.5.x: EC/CUDA: Binary search max kernel threads

### DIFF
--- a/src/components/ec/cuda/ec_cuda_executor.h
+++ b/src/components/ec/cuda/ec_cuda_executor.h
@@ -32,6 +32,8 @@ ucc_status_t ucc_cuda_executor_task_finalize(ucc_ee_executor_task_t *task);
 /* implemented in ec_cuda_executor.cu */
 ucc_status_t ucc_ec_cuda_persistent_kernel_start(ucc_ec_cuda_executor_t *eee);
 
+ucc_status_t ucc_ec_cuda_executor_kernel_calc_max_threads(int *max);
+
 ucc_status_t ucc_ec_cuda_reduce(ucc_ee_executor_task_args_t *task,
                                 cudaStream_t                 stream);
 #endif


### PR DESCRIPTION
In UCC we use a kernel to handle copies and reductions for cuda buffers. The kernel is failing to launch because it requires Registers Per Thread: 156 according to an nsys profile. By default we launch with 512 threads, so 512 * 156 = 79872, greater than the 64k limit.

So, the this PR will binary search to find the maximum threads per block that will fit the kernel.

(cherry picked from commit dfcc2332c52c74be79f4bb63993cce83585c03ae)

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
