### PR TITLE
TEST: fix mlx5 test build

### DIFF
--- a/test/gtest/tl/mlx5/test_tl_mlx5_wqe.cc
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_wqe.cc
@@ -343,13 +343,13 @@ UCC_TEST_P(test_tl_mlx5_umr_wqe, umrWqe)
     int      src_size              = (bytes_count + bytes_skip) * repeat_count;
     int      dst_size              = bytes_count * nbr_srcs * repeat_count;
     int      send_mem_access_flags = 0;
-    int      recv_mem_access_flags =
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
+    void    *umr_entries_buf       = nullptr;
+    int      recv_mem_access_flags = IBV_ACCESS_LOCAL_WRITE |
+                                     IBV_ACCESS_REMOTE_WRITE;
     DT                           src[nbr_srcs][src_size], dst[dst_size];
     struct ibv_mr *              src_mr[nbr_srcs], *dst_mr, *umr_entries_mr;
     struct mlx5dv_mkey *         umr_mkey;
     struct mlx5dv_mkey_init_attr umr_mkey_init_attr;
-    void *                       umr_entries_buf;
     size_t                       umr_buf_size;
     struct mlx5dv_mr_interleaved mkey_entries[nbr_srcs];
     struct ibv_wc                wcs[1];


### PR DESCRIPTION
## What
Fixes
```
In file included from /hpc/mtr_scrap/users/dariab/scratch/ucc/20251008_162517_59078_1932_funk01/installs/Jpbn/tests/ucc_repo/ucc_private.git/src/components/tl/mlx5/tl_mlx5.h:15,
                 from tl/mlx5/test_tl_mlx5.h:10,
                 from tl/mlx5/test_tl_mlx5_wqe.h:6,
                 from tl/mlx5/test_tl_mlx5_wqe.cc:6:
In function ‘ibv_mr* __ibv_reg_mr(ibv_pd*, void*, size_t, unsigned int, int)’,
    inlined from ‘virtual void test_tl_mlx5_umr_wqe_umrWqe_Test::TestBody()’ at tl/mlx5/test_tl_mlx5_wqe.cc:378:9:
/usr/include/infiniband/verbs.h:2596:34: error: ‘umr_entries_buf’ may be used uninitialized [-Werror=maybe-uninitialized]
 2596 |                 return ibv_reg_mr(pd, addr, length, (int)access);
      |                        ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~tl/mlx5/test_tl_mlx5_wqe.cc: In member function ‘virtual void test_tl_mlx5_umr_wqe_umrWqe_Test::TestBody()’:
tl/mlx5/test_tl_mlx5_wqe.cc:352:34: note: ‘umr_entries_buf’ was declared here
  352 |     void *                       umr_entries_buf;
      |                                  ^~~~~~~~~~~~~~~cc1plus: all warnings being treated as errors
make[1]: *** [Makefile:1589: tl/mlx5/gtest-test_tl_mlx5_wqe.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/hpc/mtr_scrap/users/dariab/scratch/ucc/20251008_162517_59078_1932_funk01/installs/Jpbn/tests/ucc_repo/ucc_private.git/test/gtest'
make: *** [Makefile:635: install-recursive] Error 1
```
