### PR TITLE
TOOLS: add CUDA managed mem type to ucc_perftest

### DIFF
--- a/tools/perf/ucc_pt_comm.cc
+++ b/tools/perf/ucc_pt_comm.cc
@@ -87,16 +87,18 @@ ucc_ee_h ucc_pt_comm::get_ee()
     return ee;
 }
 
-ucc_ee_executor_t* ucc_pt_comm::get_executor()
+ucc_ee_executor_t *ucc_pt_comm::get_executor()
 {
     ucc_ee_executor_params_t executor_params;
     ucc_status_t             status;
 
     if (!executor) {
         executor_params.mask = UCC_EE_EXECUTOR_PARAM_FIELD_TYPE;
-        if (cfg.mt ==  UCC_MEMORY_TYPE_HOST) {
+        if (cfg.mt == UCC_MEMORY_TYPE_HOST) {
             executor_params.ee_type = UCC_EE_CPU_THREAD;
-        } else if (cfg.mt == UCC_MEMORY_TYPE_CUDA) {
+        } else if (
+            cfg.mt == UCC_MEMORY_TYPE_CUDA ||
+            cfg.mt == UCC_MEMORY_TYPE_CUDA_MANAGED) {
             executor_params.ee_type = UCC_EE_CUDA_STREAM;
         } else if (cfg.mt == UCC_MEMORY_TYPE_ROCM) {
             executor_params.ee_type = UCC_EE_ROCM_STREAM;


### PR DESCRIPTION
## What
Add CUDA managed mem type to ucc_perftest 

## Why ?
CUDA manager is supported in executor but missing in ucc_perftest.
fixed crash since ucc_perftest throws `std::runtime_error("not supported");`
## How ?
```
# mpirun --mca coll ^hcoll --mca coll_ucc_enable 0 -x LD_LIBRARY_PATH=/work/ikryukov/ucc_build/install/lib:$LD_LIBRARY_PATH -x UCC_TLS=ucp -x UCX_NET_DEVICES=mlx5_0:1 -x UCC_LOG_LEVEL=warn -np 2 /work/ikryukov/ucc_build/install/bin/ucc_perftest -c reducedt -m cuda-mng
Rank    1       : dgx-gaia-22 - NVIDIA H100 80GB HBM3 0000:43:00.0
Rank    0       : dgx-gaia-22 - NVIDIA H100 80GB HBM3 0000:1B:00.0
Collective:             Reduce DT
Memory type:            cuda-managed
Datatype:               float32
Reduction:              sum
Inplace:                N/A
Warmup:
  small                 100
  large                 20
Iterations:
  small                 1000
  large                 200

       Count        Size                Time, us
                                 avg         min         max
         128         512        8.30        7.83        8.76
Total time: 0.008764 ms
```
