### PR TITLE
CI: Add timeout to torch ucc tests

### DIFF
--- a/.ci/job_matrix.yaml
+++ b/.ci/job_matrix.yaml
@@ -85,7 +85,7 @@ steps:
     run: |
       echo "INFO: Run UCC tests"
       hostname
-      docker exec $(cat /tmp/ucc_docker-"${BUILD_TAG}".id) bash -c "\${SRC_DIR}/ucc/.ci/scripts/run_tests_ucc.sh"
+      timeout -k 20 90m docker exec $(cat /tmp/ucc_docker-"${BUILD_TAG}".id) bash -c "\${SRC_DIR}/ucc/.ci/scripts/run_tests_ucc.sh"
     always: |
       docker rm --force $(cat /tmp/ucc_docker-"${BUILD_TAG}".id)
   #============================================================================


### PR DESCRIPTION
## What
Add timeout to ucc torch tests in CI

## Why ?
In some cases the tests can hang and job is stuck for 5 hours until job global timeout is reached.

## How ?
This commit add 90 minutes timeout to the torch ucc test command to have quick termination in case this test is hung.

