### PR TITLE
CI: fix command for clang-format in codestyle workflow

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -86,7 +86,7 @@ jobs:
       run: |
         set -eEuo pipefail
         echo "Commit ${{ github.event.pull_request.base.sha }}"
-        diff=`git-clang-format --binary=clang-format-${LLVM_VERSION} --style=file --diff ${{ github.event.pull_request.base.sha }}`
+        diff=`git-clang-format --binary=clang-format-${LLVM_VERSION} --style=file --diff ${{ github.event.pull_request.base.sha }}` || true
         if [ "$diff" = "no modified files to format" ] || [ "$diff" = "clang-format did not modify any files" ]
         then
           echo "Format check PASS"


### PR DESCRIPTION
- Updated the command in the GitHub Actions workflow to use `git-clang-format-21` instead of `git clang-format` for consistency and correctness in formatting checks.
- Fixed clang installation for ubuntu 22.04
- Modernised GHA workflow

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
