### PR TITLE
CI: add local git hooks for commit validation

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,94 @@
+# Git Hooks
+
+This directory contains shared Git hooks to enforce code quality and standards.
+
+## Installation
+
+After cloning the repository, run:
+
+```bash
+./.githooks/setup.sh
+```
+
+This will configure Git to use these hooks automatically.
+
+## Architecture
+
+The commit message validation uses a **shared script** located at `.github/scripts/check-commit-msg.sh`. This same script is used by:
+
+1. **Local git hooks** (`.githooks/commit-msg`) - validates commits before they are created
+2. **GitHub Actions CI** (`.github/workflows/codestyle.yaml`) - validates all commits in pull requests
+
+This ensures that commit message standards are consistently enforced both locally and in CI.
+
+## Hooks
+
+### commit-msg
+
+Enforces commit message standards:
+
+- **Commit title length**: Maximum 50 characters (merge commits are exempt)
+- **Commit title prefix**: Must start with an approved prefix (see list below)
+- **No trailing period**: Title must NOT end with a period
+
+#### Approved Prefixes
+
+**Category 1:**
+`CODESTYLE`, `REVIEW`, `CORE`, `UTIL`, `TEST`, `API`, `DOCS`, `TOOLS`, `BUILD`, `MC`, `EC`, `SCHEDULE`, `TOPO`
+
+**Category 2:**
+`CI`, `CL/`, `TL/`, `MC/`, `EC/`, `UCP`, `SHM`, `NCCL`, `SHARP`, `BASIC`, `HIER`, `DOCA_UROM`, `CUDA`, `CPU`, `EE`, `RCCL`, `ROCM`, `SELF`, `MLX5`
+
+**Format:** `PREFIX: description`
+
+If a commit message violates these rules, the commit will be rejected with an error message.
+
+## Examples
+
+**❌ Bad commits (will be rejected):**
+```
+CI: fix command for clang-format in codestyle workflow
+```
+(54 characters - too long)
+
+```
+Fix typo in README
+```
+(Missing approved prefix)
+
+```
+TEST: add new unit tests.
+```
+(Ends with a period)
+
+**✅ Good commits (will be accepted):**
+```
+CI: fix clang-format command in codestyle
+```
+(42 characters, valid prefix, no period)
+
+```
+TL/CUDA: add support for multinode NVLS
+```
+(Valid prefix with slash notation)
+
+```
+BUILD: update clang format
+```
+(Short and follows all rules)
+
+## Bypassing Hooks (Not Recommended)
+
+In rare cases where you need to bypass the hooks, you can use:
+```bash
+git commit --no-verify
+```
+
+**Warning**: Only use this in exceptional circumstances and ensure your commit messages still follow the project standards.
+
+## Uninstalling
+
+To disable the hooks:
+```bash
+git config --unset core.hooksPath
+```

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Git commit-msg hook to enforce commit message standards
+# This hook uses a shared validation script used by both local hooks and CI
+#
+# The validation checks:
+# - The commit title (first line) is not longer than 50 characters (except merge commits)
+# - The commit title starts with an approved prefix
+# - The commit title does NOT end with a period
+
+commit_msg_file=$1
+
+# Find the repository root
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VALIDATION_SCRIPT="$REPO_ROOT/.github/scripts/check-commit-msg.sh"
+
+# Check if the validation script exists
+if [ ! -f "$VALIDATION_SCRIPT" ]; then
+    echo "Error: Validation script not found at $VALIDATION_SCRIPT"
+    echo "Please ensure the repository is properly set up."
+    exit 1
+fi
+
+# Run the shared validation script
+if ! "$VALIDATION_SCRIPT" --file "$commit_msg_file"; then
+    echo ""
+    echo "Commit message requirements:"
+    echo "  • Title must be ≤ 50 characters"
+    echo "  • Title must start with approved prefix (e.g., CI:, TEST:, BUILD:, TL/CUDA:)"
+    echo "  • Title must NOT end with a period"
+    echo ""
+    echo "See .githooks/README.md for more details and examples."
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/.githooks/setup.sh
+++ b/.githooks/setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Setup script to install git hooks
+# Run this script after cloning the repository to enable commit message checks
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Setting up git hooks..."
+
+# Configure git to use .githooks directory
+git config --local core.hooksPath "$SCRIPT_DIR"
+
+if [ $? -eq 0 ]; then
+    echo "✓ Git hooks installed successfully!"
+    echo ""
+    echo "The following checks are now enabled:"
+    echo "  - Commit title length must be ≤ 50 characters"
+    echo ""
+else
+    echo "✗ Failed to install git hooks"
+    exit 1
+fi

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,59 @@
+# GitHub Scripts
+
+This directory contains shared scripts used by both local development tools and CI workflows.
+
+## check-commit-msg.sh
+
+Validates commit message format and standards.
+
+### Usage
+
+**Direct invocation:**
+```bash
+.github/scripts/check-commit-msg.sh "COMMIT_MESSAGE_HERE"
+```
+
+**From file:**
+```bash
+.github/scripts/check-commit-msg.sh --file path/to/commit-msg-file
+```
+
+### Validation Rules
+
+1. **Title Length**: Maximum 50 characters (merge commits exempt)
+2. **Title Prefix**: Must start with approved prefix
+3. **No Period**: Title must NOT end with a period
+
+### Approved Prefixes
+
+**Category 1:** `CODESTYLE`, `REVIEW`, `CORE`, `UTIL`, `TEST`, `API`, `DOCS`, `TOOLS`, `BUILD`, `MC`, `EC`, `SCHEDULE`, `TOPO`
+
+**Category 2:** `CI`, `CL/`, `TL/`, `MC/`, `EC/`, `UCP`, `SHM`, `NCCL`, `SHARP`, `BASIC`, `HIER`, `DOCA_UROM`, `CUDA`, `CPU`, `EE`, `RCCL`, `ROCM`, `SELF`, `MLX5`
+
+### Used By
+
+- **Local Git Hooks**: `.githooks/commit-msg`
+- **GitHub Actions**: `.github/workflows/codestyle.yaml`
+
+### Exit Codes
+
+- `0`: Commit message is valid
+- `1`: Commit message validation failed
+
+### Examples
+
+**Valid:**
+```bash
+$ .github/scripts/check-commit-msg.sh "CI: fix typo in workflow"
+Good commit title: 'CI: fix typo in workflow'
+```
+
+**Invalid:**
+```bash
+$ .github/scripts/check-commit-msg.sh "fix typo"
+Commit title is too long: 8
+
+Bad commit title: 'fix typo'
+
+  ✗ Wrong header - must start with one of: ...
+```

--- a/.github/scripts/check-commit-msg.sh
+++ b/.github/scripts/check-commit-msg.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Shared script to validate commit messages
+# Used by both git hooks and GitHub Actions CI
+#
+# Usage:
+#   check-commit-msg.sh <commit-message>
+#   check-commit-msg.sh --file <commit-msg-file>
+
+set -e
+
+# Parse arguments
+if [ "$1" = "--file" ]; then
+    commit_title=$(head -n1 "$2")
+else
+    commit_title="$1"
+fi
+
+if [ -z "$commit_title" ]; then
+    echo "Error: No commit message provided"
+    echo "Usage: $0 <commit-message>"
+    echo "   or: $0 --file <commit-msg-file>"
+    exit 1
+fi
+
+title_length=${#commit_title}
+max_length=50
+errors=()
+
+# Check title length (except for merge commits)
+if [ $title_length -gt $max_length ]; then
+    if ! echo "$commit_title" | grep -qP '^Merge'; then
+        errors+=("Commit title is too long: $title_length characters (max: $max_length)")
+    fi
+fi
+
+# Check title prefix
+H1="CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC|EC|SCHEDULE|TOPO"
+H2="CI|CL/|TL/|MC/|EC/|UCP|SHM|NCCL|SHARP|BASIC|HIER|DOCA_UROM|CUDA|CPU|EE|RCCL|ROCM|SELF|MLX5"
+if ! echo "$commit_title" | grep -qP '^Merge |^'"(($H1)|($H2))"'+: \w'; then
+    errors+=("Wrong header - must start with one of: $H1, $H2")
+fi
+
+# Check for period at the end
+if [ "${commit_title: -1}" = "." ]; then
+    errors+=("Commit title must NOT end with a period")
+fi
+
+# If there are errors, display them and exit
+if [ ${#errors[@]} -gt 0 ]; then
+    echo "Commit title is too long: ${#commit_title}"
+    echo ""
+    echo "Bad commit title: '$commit_title'"
+    echo ""
+    for error in "${errors[@]}"; do
+        echo "  ✗ $error"
+    done
+    echo ""
+    exit 1
+fi
+
+echo "Good commit title: '$commit_title'"
+exit 0


### PR DESCRIPTION
## What
Local Git Hooks - Developers can install hooks that validate commit messages before they're created
Shared Validation Script - Single source of truth for commit message rules 
Easy Setup - Simple installation with .githooks/setup.sh
Complete Documentation - README files explaining usage and examples
**Validation Rules Enforced**
- Title must be ≤ 50 characters (merge commits exempt)
- Title must start with approved prefix (CI, TEST, BUILD, TL/CUDA, etc.)
- Title must NOT end with a period

## Why ?

1. **Catch Issues Before Push**
Developers get immediate feedback on commit message format locally, before pushing to remote. This prevents frustration of failed CI checks and having to rewrite commit history after the fact.
2. **Reduce CI Build Failures**
By validating commit messages locally, this prevents PRs from failing the codestyle workflow due to improperly formatted commit titles. This saves CI resources and reduces noise in PR checks.
3. **Single Source of Truth**
The shared validation script (`.github/scripts/check-commit-msg.sh`) is used by both local git hooks and GitHub Actions CI, ensuring 100% consistency between local validation and CI checks. No more "Commit title is too long: 54" scenarios.
4. **Improved Developer Experience**
The hook provides clear, actionable error messages with examples of valid commit formats. Developers learn the project's commit message standards through immediate feedback rather than reading documentation or learning from CI failures.
5. **Easy Maintenance**
When commit message standards need to be updated, changes only need to be made in one place (the shared script). Both local hooks and CI automatically use the updated validation logic, eliminating the risk of drift between environments.
Bonus: The setup is completely optional and non-intrusive. Developers can choose to install the hooks with a single command (`./.githooks/setup.sh`), and the repository continues to work normally for those who don't install them, with CI still enforcing the standards.
