### PR TITLE
TOOLS: perftest add matrix generator

### DIFF
--- a/tools/perf/Makefile.am
+++ b/tools/perf/Makefile.am
@@ -9,34 +9,35 @@
 
 bin_PROGRAMS = ucc_perftest
 
-ucc_perftest_SOURCES =             \
-	ucc_perftest.cc                \
-	ucc_pt_config.cc               \
-	ucc_pt_comm.cc                 \
-	ucc_pt_cuda.cc                 \
-	ucc_pt_rocm.cc                 \
-	ucc_pt_benchmark.cc            \
-	ucc_pt_bootstrap_mpi.cc        \
-	ucc_pt_coll.cc                 \
-	ucc_pt_coll_allgather.cc       \
-	ucc_pt_coll_allgatherv.cc      \
-	ucc_pt_coll_allreduce.cc       \
-	ucc_pt_coll_alltoall.cc        \
-	ucc_pt_coll_alltoallv.cc       \
-	ucc_pt_coll_barrier.cc         \
-	ucc_pt_coll_bcast.cc           \
-	ucc_pt_coll_gather.cc          \
-	ucc_pt_coll_gatherv.cc         \
-	ucc_pt_coll_reduce.cc          \
-	ucc_pt_coll_reduce_scatter.cc  \
-	ucc_pt_coll_reduce_scatterv.cc \
-	ucc_pt_coll_scatter.cc         \
-	ucc_pt_coll_scatterv.cc        \
-	ucc_pt_op_memcpy.cc            \
-	ucc_pt_op_reduce.cc            \
-	ucc_pt_op_reduce_strided.cc    \
-	generator/ucc_pt_generator_exp.cc        \
-	generator/ucc_pt_generator_file.cc
+ucc_perftest_SOURCES =             		\
+	ucc_perftest.cc                		\
+	ucc_pt_config.cc               		\
+	ucc_pt_comm.cc                 		\
+	ucc_pt_cuda.cc                 		\
+	ucc_pt_rocm.cc                 		\
+	ucc_pt_benchmark.cc            		\
+	ucc_pt_bootstrap_mpi.cc        		\
+	ucc_pt_coll.cc                 		\
+	ucc_pt_coll_allgather.cc       		\
+	ucc_pt_coll_allgatherv.cc      		\
+	ucc_pt_coll_allreduce.cc       		\
+	ucc_pt_coll_alltoall.cc        		\
+	ucc_pt_coll_alltoallv.cc       		\
+	ucc_pt_coll_barrier.cc         		\
+	ucc_pt_coll_bcast.cc           		\
+	ucc_pt_coll_gather.cc          		\
+	ucc_pt_coll_gatherv.cc         		\
+	ucc_pt_coll_reduce.cc          		\
+	ucc_pt_coll_reduce_scatter.cc  		\
+	ucc_pt_coll_reduce_scatterv.cc 		\
+	ucc_pt_coll_scatter.cc         		\
+	ucc_pt_coll_scatterv.cc        		\
+	ucc_pt_op_memcpy.cc            		\
+	ucc_pt_op_reduce.cc            		\
+	ucc_pt_op_reduce_strided.cc    		\
+	generator/ucc_pt_generator_exp.cc   \
+	generator/ucc_pt_generator_file.cc	\
+	generator/ucc_pt_generator_traffic_matrix.cc
 
 CXX=$(MPICXX)
 LD=$(MPICXX)

--- a/tools/perf/generator/ucc_pt_generator.h
+++ b/tools/perf/generator/ucc_pt_generator.h
@@ -7,11 +7,12 @@
 #ifndef UCC_PT_GENERATOR_H
 #define UCC_PT_GENERATOR_H
 
-#include <cstddef>
-#include <vector>
-#include <cstdint>
-#include <string>
 #include "ucc_pt_config.h"
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
 
 class ucc_pt_generator_base
 {
@@ -93,6 +94,53 @@ public:
     size_t get_src_count_max() override;
     size_t get_dst_count_max() override;
     size_t get_count_max() override;
+};
+
+class ucc_pt_generator_traffic_matrix : public ucc_pt_generator_base {
+  private:
+    uint32_t        comm_size;
+    uint32_t        rank_id;
+    int             kind;
+    int             token_size_KB_mean;
+    int             tgt_group_size_mean;
+    int             num_tokens;
+    int             tgt_group_size_std;
+    int             token_size_KB_std;
+    int             num_hl_ranks;
+    double          bias_factor;
+    size_t          nrep;
+    size_t          current_pattern;
+    size_t          current_rep;
+    size_t          dt_size;
+    std::mt19937_64 rng_;
+    std::vector<std::vector<uint32_t>>
+        pattern_counts; // Store counts for each pattern. vector of vectors of counts (#vectors = #matrices)
+    std::vector<uint32_t>         src_counts;
+    std::vector<uint32_t>         src_displs;
+    std::vector<uint32_t>         dst_counts;
+    std::vector<uint32_t>         dst_displs;
+    std::vector<std::vector<int>> traffic_matrix;
+    void                         *counts_state_ptr = nullptr;
+    void                          setup_counts_displs();
+    ucc_pt_op_type_t              op_type;
+
+  public:
+    ucc_pt_generator_traffic_matrix(
+        int kind, uint32_t gsize, uint32_t rank, ucc_datatype_t dtype,
+        ucc_pt_op_type_t type, size_t nrep, int token_size_KB_mean,
+        int num_tokens, int tgt_group_size_mean, uint64_t seed);
+    bool         has_next() override;
+    void         next() override;
+    void         reset() override;
+    size_t       get_src_count() override;
+    size_t       get_dst_count() override;
+    ucc_count_t *get_src_counts() override;
+    ucc_aint_t  *get_src_displs() override;
+    ucc_count_t *get_dst_counts() override;
+    ucc_aint_t  *get_dst_displs() override;
+    size_t       get_src_count_max() override;
+    size_t       get_dst_count_max() override;
+    size_t       get_count_max() override;
 };
 
 #endif

--- a/tools/perf/generator/ucc_pt_generator_file.cc
+++ b/tools/perf/generator/ucc_pt_generator_file.cc
@@ -276,7 +276,7 @@ size_t ucc_pt_generator_file::get_dst_count_max()
 
 size_t ucc_pt_generator_file::get_count_max()
 {
-    auto matrix = pattern_counts[current_pattern];
+    const auto &matrix    = pattern_counts[current_pattern];
     size_t max_count = 0;
     size_t cur_row_col;
 

--- a/tools/perf/generator/ucc_pt_generator_traffic_matrix.cc
+++ b/tools/perf/generator/ucc_pt_generator_traffic_matrix.cc
@@ -1,0 +1,481 @@
+#include "ucc_pt_generator.h"
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <ucc/api/ucc.h>
+#include <utils/ucc_math.h>
+#include <vector>
+
+template <typename T>
+void random_choice(
+    const std::vector<T> &data, size_t size, std::vector<T> &result_vec,
+    std::mt19937_64 &rng, const std::vector<double> &weights = {})
+{
+    if (data.empty()) {
+        throw std::runtime_error("Cannot pick from an empty vector.");
+    }
+
+    result_vec.clear();
+    result_vec.reserve(size);
+
+    std::vector<double> final_weights;
+    size_t              N = data.size();
+
+    if (!weights.empty()) {
+        if (weights.size() != N) {
+            throw std::runtime_error(
+                "Weights vector size must match data vector size.");
+        }
+        final_weights = weights;
+    } else {
+        final_weights.assign(N, 1.0);
+    }
+
+    std::discrete_distribution<int> distribution(
+        final_weights.begin(), final_weights.end());
+
+    for (size_t i = 0; i < size; ++i) {
+        int index = distribution(rng);
+        result_vec.push_back(data.at(index));
+    }
+
+    return;
+}
+
+std::vector<std::vector<int>> create_a2aV_traffic_matrix(
+    int num_ranks, int token_size_KB_mean, int tgt_group_size_mean,
+    int num_tokens, size_t dt_size, std::mt19937_64 &rng, bool add_bias = false,
+    double bias_factor = 2, int num_hl_ranks = 2)
+{
+    // Create a random a2aV traffic matrix where each rank sends token_size_KB_mean messages
+    // to a random group of tgt_group_size_mean other ranks.
+    // If add_bias is true, the bias_factor is used to increase the probability of sending messages to the higher level
+    // ranks. If num_hl_ranks is greater than 0, the num_hl_ranks highest level ranks will be used to send messages to
+    // the lower level ranks. The traffic matrix is returned as a matrix of size num_ranks x num_ranks.
+    std::vector<int>              bias_indices(num_hl_ranks);
+    std::vector<int>              possible_targets(num_ranks);
+    std::vector<std::vector<int>> traffic_matrix(
+        num_ranks,
+        std::vector<int>(num_ranks, 0)); // matrix of size num_ranks x num_ranks
+    for (int i = 0; i < num_hl_ranks; i++) {
+        bias_indices[i] = std::uniform_int_distribution<int>(
+            0, num_ranks - 1)(rng);
+    }
+    for (int src_rank = 0; src_rank < num_ranks; src_rank++) {
+        // Choose random target ranks, excluding self
+        possible_targets.clear();
+        for (int i = 0; i < num_ranks; i++) {
+            if (i != src_rank) {
+                possible_targets.push_back(i);
+            }
+        }
+        for (int token = 0; token < num_tokens; token++) {
+            std::vector<int> target_ranks(tgt_group_size_mean);
+            if (add_bias) {
+                // Create biased probabilities for target selection
+                std::vector<double> probabilities(
+                    possible_targets.size(), 1.0 / possible_targets.size());
+                for (int i = 0; i < num_hl_ranks; i++) {
+                    int  bias_rank = bias_indices[i];
+                    auto it        = std::find(
+                        possible_targets.begin(),
+                        possible_targets.end(),
+                        bias_rank);
+                    if (it != possible_targets.end()) {
+                        int bias_index = std::distance(
+                            possible_targets.begin(), it);
+                        probabilities[bias_index] *= bias_factor;
+                    }
+                }
+                double sum = std::accumulate(
+                    probabilities.begin(), probabilities.end(), 0.0);
+                for (int i = 0; i < probabilities.size(); i++) {
+                    probabilities[i] = probabilities[i] / sum;
+                }
+
+                random_choice(
+                    possible_targets,
+                    tgt_group_size_mean,
+                    target_ranks,
+                    rng,
+                    probabilities);
+            } else {
+                random_choice(
+                    possible_targets, tgt_group_size_mean, target_ranks, rng);
+            }
+            for (int i = 0; i < target_ranks.size(); i++) {
+                int target_rank = target_ranks[i];
+                traffic_matrix
+                    [src_rank]
+                    [target_rank] += (token_size_KB_mean * (1000 / dt_size));
+            }
+        }
+    }
+    return traffic_matrix;
+}
+
+std::vector<std::vector<int>> create_random_tgt_group_a2aV_traffic_matrix(
+    int num_ranks, int token_size_KB_mean, int tgt_group_size_mean,
+    int tgt_group_size_std, int num_tokens, size_t dt_size,
+    std::mt19937_64 &rng)
+{
+    // Create a random a2aV traffic matrix where each rank sends token_size_KB_mean messages
+    // to a random group of ranks with random size.
+    // The traffic matrix is returned as a matrix of size num_ranks x num_ranks.
+
+    std::vector<std::vector<int>> traffic_matrix(
+        num_ranks, std::vector<int>(num_ranks, 0));
+    for (int src_rank = 0; src_rank < num_ranks; src_rank++) {
+        std::vector<int> possible_targets;
+        possible_targets.reserve(num_ranks - 1);
+        for (int i = 0; i < num_ranks; i++) {
+            if (i != src_rank) {
+                possible_targets.push_back(i);
+            }
+        }
+        for (int token = 0; token < num_tokens; token++) {
+            std::normal_distribution<double> distribution(
+                tgt_group_size_mean, tgt_group_size_std);
+            double normal_sample = distribution(rng);
+            int    tgt_group_size;
+            tgt_group_size = std::max(1, static_cast<int>(normal_sample));
+            tgt_group_size = std::min(
+                tgt_group_size, num_ranks - 1); // Cap at available targets
+
+            std::vector<int> target_ranks(tgt_group_size);
+            random_choice(possible_targets, tgt_group_size, target_ranks, rng);
+            for (int i = 0; i < target_ranks.size(); i++) {
+                traffic_matrix
+                    [src_rank]
+                    [target_ranks
+                         [i]] += (token_size_KB_mean * (1000 / dt_size));
+            }
+        }
+    }
+    return traffic_matrix;
+}
+
+std::vector<std::vector<int>>
+create_random_tgt_group_random_msg_size_a2aV_traffic_matrix(
+    int num_ranks, int token_size_KB_mean, int token_size_KB_std,
+    int tgt_group_size_mean, int tgt_group_size_std, int num_tokens,
+    size_t dt_size, std::mt19937_64 &rng)
+{
+    // Create a random a2aV traffic matrix where each rank sends a random message size
+    // to a random group of tgt_group_size_mean other ranks.
+    // The traffic matrix is returned as a matrix of size num_ranks x num_ranks.
+
+    std::vector<std::vector<int>> traffic_matrix(
+        num_ranks, std::vector<int>(num_ranks, 0));
+    std::normal_distribution<double> distribution_tgt_group_size(
+        tgt_group_size_mean, tgt_group_size_std);
+    std::normal_distribution<double> distribution_token_size(
+        token_size_KB_mean, token_size_KB_std);
+
+    for (int src_rank = 0; src_rank < num_ranks; src_rank++) {
+        std::vector<int> possible_targets(num_ranks - 1);
+        possible_targets.clear();
+        for (int i = 0; i < num_ranks; i++) {
+            if (i != src_rank) {
+                possible_targets.push_back(i);
+            }
+        }
+        for (int token = 0; token < num_tokens; token++) {
+            int normal_sample_tgt_group_size = static_cast<int>(
+                distribution_tgt_group_size(rng));
+            int tgt_group_size;
+            tgt_group_size = std::max(1, normal_sample_tgt_group_size);
+            tgt_group_size = std::min(
+                tgt_group_size, num_ranks - 1); // Cap at available targets
+
+            std::vector<int> target_ranks(tgt_group_size);
+            random_choice(possible_targets, tgt_group_size, target_ranks, rng);
+            for (int i = 0; i < target_ranks.size(); i++) {
+                int normal_sample_token_size = static_cast<int>(
+                    distribution_token_size(rng));
+                traffic_matrix
+                    [src_rank]
+                    [target_ranks[i]] += std::max(0, normal_sample_token_size) *
+                                         (1000 / dt_size);
+            }
+        }
+    }
+    return traffic_matrix;
+}
+
+void print_result(
+    std::vector<std::vector<int>> traffic_matrix, bool print_full_result)
+{
+    // Print the traffic matrix
+    // The first dimension is the source rank.
+    // The second dimension is the target rank.
+    for (int src_rank = 0; src_rank < traffic_matrix.size(); src_rank++) {
+        for (int tgt_rank = 0; tgt_rank < traffic_matrix[0].size();
+             tgt_rank++) {
+            std::cout << traffic_matrix[src_rank][tgt_rank] << " ";
+        }
+        std::cout << std::endl;
+    }
+}
+
+ucc_pt_generator_traffic_matrix::ucc_pt_generator_traffic_matrix(
+    int kind, uint32_t gsize, uint32_t rank, ucc_datatype_t dtype,
+    ucc_pt_op_type_t type, size_t nrepeats, int token_size_KB_mean_,
+    int num_tokens_, int tgt_group_size_mean_, uint64_t seed)
+{
+
+    comm_size           = gsize;
+    rank_id             = rank;
+    op_type             = type;
+    current_pattern     = 0;
+    current_rep         = 0;
+    nrep                = nrepeats;
+    rng_                = std::mt19937_64(seed);
+
+    token_size_KB_mean  = token_size_KB_mean_;
+    tgt_group_size_mean = tgt_group_size_mean_;
+    num_tokens          = num_tokens_;
+    bias_factor         = 2;
+    num_hl_ranks        = 2;
+    tgt_group_size_std  = 1;
+    token_size_KB_std   = 1;
+    dt_size             = ucc_dt_size(dtype);
+
+    if (kind == 0) {
+        traffic_matrix = create_a2aV_traffic_matrix(
+            comm_size,
+            token_size_KB_mean,
+            tgt_group_size_mean,
+            num_tokens,
+            dt_size,
+            rng_,
+            false,
+            bias_factor,
+            num_hl_ranks);
+    } else if (kind == 1) {
+        traffic_matrix = create_a2aV_traffic_matrix(
+            comm_size,
+            token_size_KB_mean,
+            tgt_group_size_mean,
+            num_tokens,
+            dt_size,
+            rng_,
+            true,
+            bias_factor,
+            num_hl_ranks);
+    } else if (kind == 2) {
+        traffic_matrix = create_random_tgt_group_a2aV_traffic_matrix(
+            comm_size,
+            token_size_KB_mean,
+            tgt_group_size_mean,
+            tgt_group_size_std,
+            num_tokens,
+            dt_size,
+            rng_);
+    } else if (kind == 3) {
+        traffic_matrix =
+            create_random_tgt_group_random_msg_size_a2aV_traffic_matrix(
+                comm_size,
+                token_size_KB_mean,
+                token_size_KB_std,
+                tgt_group_size_mean,
+                tgt_group_size_std,
+                num_tokens,
+                dt_size,
+                rng_);
+    }
+
+    // print_result(traffic_matrix, false);
+    pattern_counts.reserve(traffic_matrix.size());
+
+    std::vector<uint32_t> pattern;
+    if (!traffic_matrix.empty()) {
+        pattern.reserve(comm_size * comm_size);
+    }
+    if (traffic_matrix[0].size() != comm_size ||
+        traffic_matrix.size() != comm_size) {
+        throw std::runtime_error(
+            "Matrix size (" + std::to_string(traffic_matrix[0].size()) + "x" +
+            std::to_string(traffic_matrix.size()) +
+            ") is not equal to comm_size*comm_size (" +
+            std::to_string(comm_size * comm_size) +
+            "). "
+            "Please check the traffic_matrix.");
+    }
+
+    for (const auto &row : traffic_matrix) {
+        pattern.insert(pattern.end(), row.begin(), row.end());
+    }
+    pattern_counts.push_back(pattern);
+
+    if (pattern_counts.empty()) {
+        throw std::runtime_error(
+            "No collective patterns provided in traffic_matrix.");
+    }
+
+    // Initialize arrays for counts and displacements
+    src_counts.resize(comm_size);
+    src_displs.resize(comm_size);
+    dst_counts.resize(comm_size);
+    dst_displs.resize(comm_size);
+}
+
+bool ucc_pt_generator_traffic_matrix::has_next()
+{
+    return current_rep < nrep;
+}
+
+void ucc_pt_generator_traffic_matrix::next()
+{
+    current_pattern++;
+    if (current_pattern >= pattern_counts.size()) {
+        current_pattern = 0;
+        current_rep++;
+    }
+    if (has_next()) {
+        setup_counts_displs();
+    }
+}
+
+void ucc_pt_generator_traffic_matrix::reset()
+{
+    current_pattern = 0;
+    current_rep     = 0;
+    setup_counts_displs();
+}
+
+size_t ucc_pt_generator_traffic_matrix::get_src_count()
+{
+    size_t total = 0;
+    for (int i = 0; i < comm_size; i++) {
+        total += src_counts[i];
+    }
+    return total;
+}
+
+size_t ucc_pt_generator_traffic_matrix::get_dst_count()
+{
+    size_t total = 0;
+    for (int i = 0; i < comm_size; i++) {
+        total += dst_counts[i];
+    }
+    return total;
+}
+
+ucc_count_t *ucc_pt_generator_traffic_matrix::get_src_counts()
+{
+    return (ucc_count_t *)src_counts.data();
+}
+
+ucc_aint_t *ucc_pt_generator_traffic_matrix::get_src_displs()
+{
+    return (ucc_aint_t *)src_displs.data();
+}
+
+ucc_count_t *ucc_pt_generator_traffic_matrix::get_dst_counts()
+{
+    return (ucc_count_t *)dst_counts.data();
+}
+
+ucc_aint_t *ucc_pt_generator_traffic_matrix::get_dst_displs()
+{
+    return (ucc_aint_t *)dst_displs.data();
+}
+
+void ucc_pt_generator_traffic_matrix::setup_counts_displs()
+{
+    const auto &counts = pattern_counts[current_pattern];
+
+    if (counts.size() < comm_size * comm_size) {
+        throw std::runtime_error(
+            "Pattern size (" + std::to_string(counts.size()) +
+            ") is less than comm_size*comm_size (" +
+            std::to_string(comm_size * comm_size) + ")");
+    }
+
+    for (int i = 0; i < comm_size; i++) {
+        src_counts[i] = counts[rank_id * comm_size + i];
+    }
+
+    size_t displ = 0;
+    for (int i = 0; i < comm_size; i++) {
+        src_displs[i] = displ;
+        displ += src_counts[i];
+    }
+
+    for (int i = 0; i < comm_size; i++) {
+        dst_counts[i] = counts[i * comm_size + rank_id];
+    }
+
+    displ = 0;
+    for (int i = 0; i < comm_size; i++) {
+        dst_displs[i] = displ;
+        displ += dst_counts[i];
+    }
+}
+
+size_t ucc_pt_generator_traffic_matrix::get_src_count_max()
+{
+    size_t max_src_count = 0;
+
+    for (size_t i = 0; i < pattern_counts.size(); i++) {
+        const auto &counts    = pattern_counts[i];
+        size_t      total_src = 0;
+        for (int j = 0; j < comm_size; j++) {
+            total_src += counts[rank_id * comm_size + j];
+        }
+        if (total_src > max_src_count) {
+            max_src_count = total_src;
+        }
+    }
+    return max_src_count;
+}
+
+size_t ucc_pt_generator_traffic_matrix::get_dst_count_max()
+{
+    size_t max_dst_count = 0;
+
+    for (size_t i = 0; i < pattern_counts.size(); i++) {
+        const auto &counts    = pattern_counts[i];
+        size_t      total_dst = 0;
+        for (int j = 0; j < comm_size; j++) {
+            total_dst += counts[j * comm_size + rank_id];
+        }
+        if (total_dst > max_dst_count) {
+            max_dst_count = total_dst;
+        }
+    }
+    return max_dst_count;
+}
+
+size_t ucc_pt_generator_traffic_matrix::get_count_max()
+{
+    const auto &matrix    = pattern_counts[current_pattern];
+    size_t      max_count = 0;
+    size_t      cur_row_col;
+
+    for (int i = 0; i < comm_size; i++) {
+        cur_row_col = 0;
+        for (int j = 0; j < comm_size; j++) {
+            cur_row_col += matrix[i * comm_size + j];
+        }
+        if (cur_row_col > max_count) {
+            max_count = cur_row_col;
+        }
+    }
+
+    for (int i = 0; i < comm_size; i++) {
+        cur_row_col = 0;
+        for (int j = 0; j < comm_size; j++) {
+            cur_row_col += matrix[j * comm_size + i];
+        }
+        if (cur_row_col > max_count) {
+            max_count = cur_row_col;
+        }
+    }
+    return max_count;
+}

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -7,13 +7,14 @@
 #ifndef UCC_PT_CONFIG_H
 #define UCC_PT_CONFIG_H
 
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <map>
-#include <getopt.h>
-#include <ucc/api/ucc.h>
 #include "utils/ucc_log.h"
+#include <getopt.h>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <stdint.h>
+#include <string>
+#include <ucc/api/ucc.h>
 
 #define UCC_PT_DEFAULT_N_BUFS 0
 
@@ -62,7 +63,8 @@ typedef enum {
 
 typedef enum {
     UCC_PT_GEN_TYPE_EXP,
-    UCC_PT_GEN_TYPE_FILE
+    UCC_PT_GEN_TYPE_FILE,
+    UCC_PT_GEN_TYPE_TRAFFIC_MATRIX
 } ucc_pt_gen_type_t;
 
 static inline const char* ucc_pt_op_type_str(ucc_pt_op_type_t op)
@@ -82,13 +84,27 @@ static inline const char* ucc_pt_op_type_str(ucc_pt_op_type_t op)
     }
     return NULL;
 }
-
+struct ucc_pt_gen_traffic_matrix_config {
+    int    kind;
+    int    token_size_KB_mean;
+    int    token_size_KB_std;
+    int    tgt_group_size_mean;
+    int    tgt_group_size_std;
+    int    num_tokens;
+    int    num_hl_ranks;
+    double bias_factor;
+};
 struct ucc_pt_gen_config {
     ucc_pt_gen_type_t type;
-    size_t exp_min;
-    size_t exp_max;
+    size_t      nrep; // Number of repetitions for file/matrix-based generation
     std::string file_name;
-    size_t nrep;  // Number of repetitions for file-based generation
+    union {
+        struct {
+            size_t min;
+            size_t max;
+        } exp;
+        ucc_pt_gen_traffic_matrix_config matrix;
+    };
 };
 
 struct ucc_pt_benchmark_config {
@@ -112,6 +128,7 @@ struct ucc_pt_benchmark_config {
     int                root;
     int                root_shift;
     int                mult_factor;
+    uint64_t           seed;
     ucc_pt_gen_config  gen;
 };
 


### PR DESCRIPTION
Add Matrix generator option to pt generator for A2AV matrices.
This PR adds matrix creation based on [this](https://gitlab-master.nvidia.com/e2e-arch-network/a2aV_analysis_misc_tools) repo

In addition, added a --seed option for all ucc perftests using random number generator (like this one)

**4 kinds of matrices -** 
0. Basic A2AV (uniform traffic)
1. Biased A2AV (higher intensity for selected ranks)
2. Random target group sizes (topK)
3. Random token sizes

### Command Line Arguments

| Argument | Default | Description |
|----------|---------|-------------|
| `kind` | 0 | Kind of matrix as described above |
| `nrep` | 1 | Number of iterations (repetitions of pattern matrix) |
| `token_size_K_mean` | 16 | Average message size in KiB |
| `tgt_group_size_mean` | 8 | Average number of targets per rank |
| `num_tokens` | 2048 | Number of communication tokens per rank (usually 32 for inference, 512 for training) |


### Example cmd and output on GAIA cluster:
_cmd:_
```mpirun -np $NP -npernode $NPERNODE --host $NODES --bind-to socket --mca coll_ucc_enable 0 --oversubscribe -x LD_LIBRARY_PATH -x UCC_TLS=ucp -x UCC_TL_UCP_ALLTOALLV_PAIRWISE_NUM_POSTS=0 -x UCC_TL_UCP_TUNE=alltoallv:@pairwise -x UCX_RNDV_THRESH=0 -x UCX_RNDV_SCHEME=put_zcopy -x UCX_IB_GID_INDEX="auto" -x UCX_TLS=rc,cuda_copy $BIND $PREFIX/bin/ucc_perftest -c alltoallv -m cuda -F --gen matrix:kind=1@token_size_KB_mean=16@num_tokens=16@tgt_group_size_mean=16@nrep=10 --seed 1234```

_Output_
```Rank    10      : dgx-gaia-47 - NVIDIA H100 80GB HBM3 0000:52:00.0
Rank    5       : dgx-gaia-46 - NVIDIA H100 80GB HBM3 0000:C3:00.0
...


Collective:             Alltoallv
Memory type:            cuda
Datatype:               float32
Reduction:              N/A
Inplace:                0
Warmup:
  small                 100
  large                 20
Iterations:
  small                 1000
  large                 200

       Count        Size                Time, us                       Bus Bandwidth, GB/s
                                 avg         min         max         avg         max         min
      512000     2048000      104.60       86.73      116.77       36.42       43.93       32.63
      512000     2048000      105.53       88.55      119.63       36.10       43.03       31.85
      512000     2048000      105.01       91.36      121.83       36.28       41.71       31.27
      512000     2048000      104.62       91.00      121.12       36.42       41.87       31.46
      512000     2048000      104.50       91.39      123.06       36.46       41.69       30.96
      512000     2048000      103.61       88.39      120.89       36.77       43.11       31.51
      512000     2048000      103.63       88.75      121.86       36.77       42.93       31.26
      512000     2048000      103.39       88.84      121.75       36.85       42.89       31.29
      512000     2048000      102.93       87.55      120.83       37.02       43.52       31.53
      512000     2048000      104.26       89.16      123.49       36.54       42.73       30.85
Total time: 1.21123 ms```
