### PR TITLE
CI: Add Blossom init GHA workflow

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     branches:
-      - 'release/*'
       - master
   workflow_dispatch:
       inputs:


### PR DESCRIPTION
## What
Add a GitHub Action workflow to start Blossom pipeline.

## Why ?
(Internal doc)
https://confluence.nvidia.com/pages/viewpage.action?spaceKey=BLOS&title=Github+Support+User+Documentation#GithubSupportUserDocumentation-Addworkflowfile


