### PR TITLE
CI: Add Blossom CI starter Jenkins job

### DIFF
--- a/.ci/proj_jjb.yaml
+++ b/.ci/proj_jjb.yaml
@@ -199,7 +199,6 @@
     jjb_owner: 'artemry'
     jjb_jenkinsfile: '.ci/Jenkinsfile.shlib'
     jjb_gh_auth_id: 'svcnbu-swx-hpcx_ssh_with_key'
-    jjb_ghprb_auth_id: 'ghprb-auth-svcnbu-swx-hpcx'
     jobs:
       - "{jjb_proj}"
       - "{jjb_proj}-build-hpcsdk"


### PR DESCRIPTION
## What
Add Jenkins Dispatcher job (`ucc-ci-dispatcher`) to trigger existing UCC CI pipelines (`ucc`, `ucc-build-hpcsdk`) via Blossom integration.

## Why
To enable automated builds triggered by GitHub comments (`/build`) on the Blossom infrastructure, utilizing existing validated build jobs.

## How?
- Add `.ci/jenkins/pipeline/proj-jjb.yaml`: Defines `ucc-ci-dispatcher` job which triggers the legacy jobs in parallel.
- Add `.github/workflows/blossom-ci.yml`: GitHub Action to forward `/build` events to the Jenkins dispatcher.