### PR TITLE
TL/NCCL: add user buffer registration via memmap

### DIFF
--- a/src/components/tl/nccl/tl_nccl.c
+++ b/src/components/tl/nccl/tl_nccl.c
@@ -45,8 +45,7 @@ static ucs_config_field_t ucc_tl_nccl_context_config_table[] = {
     {"SYNC", "auto",
      "Determines how UCC tests completion of NCCL collective",
      ucs_offsetof(ucc_tl_nccl_context_config_t, sync_type),
-     UCS_CONFIG_TYPE_ENUM(ucc_tl_nccl_completion_sync_names)
-    },
+     UCS_CONFIG_TYPE_ENUM(ucc_tl_nccl_completion_sync_names)},
 
     {"BLOCKING", "yes",
      "If set to no will use non-blocking mode communicator behavior, "
@@ -58,6 +57,12 @@ static ucs_config_field_t ucc_tl_nccl_context_config_table[] = {
      "Initialize NCCL communicator on first collective",
      ucc_offsetof(ucc_tl_nccl_context_config_t, nccl_lazy_init),
      UCC_CONFIG_TYPE_BOOL},
+
+    {"ENABLE_UBR", "try",
+     "Enable NCCL User Buffer Registration for zero-copy operations. "
+     "Requires NCCL v2.19+.",
+     ucc_offsetof(ucc_tl_nccl_context_config_t, enable_ubr),
+     UCC_CONFIG_TYPE_TERNARY},
 
     {NULL}};
 

--- a/src/components/tl/nccl/tl_nccl.h
+++ b/src/components/tl/nccl/tl_nccl.h
@@ -12,6 +12,8 @@
 #include "components/tl/ucc_tl.h"
 #include "components/tl/ucc_tl_log.h"
 #include "utils/ucc_mpool.h"
+#include "utils/ucc_list.h"
+#include "utils/ucc_spinlock.h"
 
 #include <cuda_runtime.h>
 #if CUDART_VERSION >= 11000
@@ -44,6 +46,8 @@
 #define UCC_TL_NCCL_PROFILE_REQUEST_FREE UCC_PROFILE_REQUEST_FREE
 #define NCCL_VERSION_COMM_INIT_NB NCCL_VERSION(2,14,3)
 #define NCCL_USE_NON_BLOCKING NCCL_VERSION_CODE >= NCCL_VERSION_COMM_INIT_NB
+#define NCCL_VERSION_UBR NCCL_VERSION(2,19,0)
+#define NCCL_HAS_UBR (NCCL_VERSION_CODE >= NCCL_VERSION_UBR)
 
 enum {
     TL_NCCL_COMM_STATE_ERROR,
@@ -76,6 +80,7 @@ typedef struct ucc_tl_nccl_context_config {
     ucc_tl_nccl_completion_sync_type_t sync_type;
     int                                nccl_cfg_blocking;
     int                                nccl_lazy_init;
+    int                                enable_ubr;
 } ucc_tl_nccl_context_config_t;
 
 typedef struct ucc_tl_nccl_lib {
@@ -84,11 +89,33 @@ typedef struct ucc_tl_nccl_lib {
 UCC_CLASS_DECLARE(ucc_tl_nccl_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);
 
+/* Data structure for NCCL memory handle with lazy registration support */
+typedef struct ucc_tl_nccl_memh_data {
+    void             *address;
+    size_t            length;
+    /* Array of NCCL comms this buffer is registered with (NULL = invalidated) */
+    ncclComm_t       *registered_comms;
+    /* Array of NCCL handles from ncclCommRegister */
+    void            **nccl_handles;
+    /* Number of comms in the array */
+    int               num_comms;
+    /* Allocated size of the array */
+    int               max_comms;
+    /* Protects registered_comms/nccl_handles/num_comms/max_comms */
+    ucc_spinlock_t    lock;
+    /* Linked into ucc_tl_nccl_context_t::memh_list */
+    ucc_list_link_t   list_elem;
+} ucc_tl_nccl_memh_data_t;
+
 typedef struct ucc_tl_nccl_context {
     ucc_tl_context_t             super;
     ucc_tl_nccl_context_config_t cfg;
     ucc_mpool_t                  req_mp;
     void                        *scratch_buf;
+    int                          ubr_available;
+    /* List of all live ucc_tl_nccl_memh_data_t objects; protected by memh_lock */
+    ucc_list_link_t              memh_list;
+    ucc_spinlock_t               memh_lock;
 } ucc_tl_nccl_context_t;
 UCC_CLASS_DECLARE(ucc_tl_nccl_context_t, const ucc_base_context_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -9,6 +9,7 @@
 #include "components/mc/ucc_mc.h"
 #include "components/ec/ucc_ec.h"
 #include "core/ucc_ee.h"
+#include "core/ucc_context.h"
 #include "utils/ucc_compiler_def.h"
 #include "utils/ucc_math.h"
 #include "utils/ucc_coll_utils.h"
@@ -127,6 +128,164 @@ static inline ucc_status_t ucc_tl_nccl_check_and_convert_buffer_reduction(
     return UCC_OK;
 }
 
+#if NCCL_HAS_UBR
+/* Helper function to lazily register a memory region with NCCL communicator */
+static inline ucc_status_t ucc_tl_nccl_lazy_register_memh(
+    void *buffer, size_t length, ucc_tl_nccl_team_t *team,
+    ucc_mem_map_mem_h memh)
+{
+    ucc_tl_nccl_context_t   *ctx = UCC_TL_NCCL_TEAM_CTX(team);
+    ucc_tl_nccl_memh_data_t *m_data;
+    ucc_mem_map_memh_t      *mem_handle;
+    ncclResult_t             nccl_status;
+    ncclComm_t              *new_comms;
+    void                   **new_handles;
+    void                    *nccl_handle;
+    int                      i, new_max;
+    uintptr_t                buf_start, buf_end, region_start, region_end;
+
+    /* Skip if UBR is not available or memh not provided */
+    if (!ctx->ubr_available || !memh) {
+        return UCC_OK;
+    }
+
+    mem_handle = (ucc_mem_map_memh_t *)memh;
+    m_data     = NULL;
+    for (i = 0; i < mem_handle->num_tls; i++) {
+        if (strcmp(mem_handle->tl_h[i].tl_name, "nccl") == 0) {
+            m_data = (ucc_tl_nccl_memh_data_t *)mem_handle->tl_h[i].tl_data;
+            break;
+        }
+    }
+
+    if (!m_data) {
+        /* No NCCL memh data - buffer not registered with TL/NCCL */
+        return UCC_OK;
+    }
+
+    if (length > (UINTPTR_MAX - (uintptr_t)buffer)) {
+        tl_error(UCC_TL_TEAM_LIB(team), "NCCL UBR: buffer size causes overflow");
+        return UCC_ERR_INVALID_PARAM;
+    }
+
+    /* Verify that the entire buffer is within the registered memory region */
+    buf_start    = (uintptr_t)buffer;
+    buf_end      = buf_start + length;
+    region_start = (uintptr_t)m_data->address;
+    region_end   = region_start + m_data->length;
+
+    if (buf_start < region_start || buf_end > region_end) {
+        tl_error(
+            UCC_TL_TEAM_LIB(team),
+            "NCCL UBR: buffer [%p, %p) is outside registered region [%p, %p)",
+            buffer,
+            (void *)buf_end,
+            m_data->address,
+            (void *)region_end);
+        return UCC_ERR_INVALID_PARAM;
+    }
+
+    /* Verify team communicator is initialized */
+    if (!team->nccl_comm) {
+        tl_debug(UCC_TL_TEAM_LIB(team),
+                 "NCCL UBR: communicator not initialized, skipping registration");
+        return UCC_OK;
+    }
+
+    ucc_spin_lock(&m_data->lock);
+
+    /* Check if already registered with this communicator */
+    for (i = 0; i < m_data->num_comms; i++) {
+        if (m_data->registered_comms[i] == team->nccl_comm) {
+            /* Already registered */
+            ucc_spin_unlock(&m_data->lock);
+            return UCC_OK;
+        }
+    }
+
+    /* Need to register the memory region with this communicator.
+     * Release the lock while calling into NCCL (potentially slow), then
+     * re-acquire to update the bookkeeping arrays. */
+    ucc_spin_unlock(&m_data->lock);
+
+    nccl_status = ncclCommRegister(
+        team->nccl_comm, m_data->address, m_data->length, &nccl_handle);
+    if (nccl_status != ncclSuccess) {
+        tl_warn(
+            UCC_TL_TEAM_LIB(team),
+            "NCCL UBR: failed to register region %p, size %zu: %s",
+            m_data->address,
+            m_data->length,
+            ncclGetErrorString(nccl_status));
+        /* Don't fail - UBR is an optimization */
+        return UCC_OK;
+    }
+
+    ucc_spin_lock(&m_data->lock);
+
+    /* Re-check after re-acquiring the lock: another thread may have registered
+     * while we were in ncclCommRegister. */
+    for (i = 0; i < m_data->num_comms; i++) {
+        if (m_data->registered_comms[i] == team->nccl_comm) {
+            ucc_spin_unlock(&m_data->lock);
+            /* Undo the redundant registration */
+            ncclCommDeregister(team->nccl_comm, nccl_handle);
+            return UCC_OK;
+        }
+    }
+
+    /* Add this comm and handle to the registered lists */
+    if (m_data->num_comms >= m_data->max_comms) {
+        /* Need to grow the arrays.  Allocate both new buffers before touching
+         * m_data so that a failure on either leaves the struct untouched. */
+        new_max     = (m_data->max_comms == 0) ? 4 : (m_data->max_comms * 2);
+        new_comms   = (ncclComm_t *)ucc_malloc(new_max * sizeof(ncclComm_t),
+                                               "nccl_registered_comms");
+        new_handles = (void **)ucc_malloc(new_max * sizeof(void *),
+                                          "nccl_handles");
+        if (!new_comms || !new_handles) {
+            ucc_free(new_comms);
+            ucc_free(new_handles);
+            ucc_spin_unlock(&m_data->lock);
+            tl_error(UCC_TL_TEAM_LIB(team),
+                     "failed to grow NCCL UBR bookkeeping arrays");
+            ncclCommDeregister(team->nccl_comm, nccl_handle);
+            return UCC_ERR_NO_MEMORY;
+        }
+        /* Copy existing entries into the new buffers, then swap. */
+        if (m_data->num_comms > 0) {
+            memcpy(new_comms, m_data->registered_comms,
+                   m_data->num_comms * sizeof(ncclComm_t));
+            memcpy(new_handles, m_data->nccl_handles,
+                   m_data->num_comms * sizeof(void *));
+        }
+        ucc_free(m_data->registered_comms);
+        ucc_free(m_data->nccl_handles);
+        m_data->registered_comms = new_comms;
+        m_data->nccl_handles     = new_handles;
+        m_data->max_comms        = new_max;
+    }
+
+    m_data->registered_comms[m_data->num_comms] = team->nccl_comm;
+    m_data->nccl_handles[m_data->num_comms]     = nccl_handle;
+    m_data->num_comms++;
+
+    ucc_spin_unlock(&m_data->lock);
+
+    tl_debug(
+        UCC_TL_TEAM_LIB(team),
+        "NCCL UBR: lazily registered region %p, size %zu with comm %p "
+        "(for buffer [%p, %p))",
+        m_data->address,
+        m_data->length,
+        team->nccl_comm,
+        buffer,
+        (void *)buf_end);
+
+    return UCC_OK;
+}
+#endif
+
 ucc_status_t ucc_tl_nccl_init_task(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t *team,
                                    ucc_tl_nccl_task_t **coll_task)
@@ -175,6 +334,102 @@ ucc_status_t ucc_tl_nccl_init_task(ucc_base_coll_args_t *coll_args,
             return status;
         }
     }
+
+#if NCCL_HAS_UBR
+    /* Lazily register memory regions if they were pre-mapped and UBR is enabled */
+    if (nccl_ctx->ubr_available) {
+        ucc_mem_map_mem_h src_memh = NULL;
+        ucc_mem_map_mem_h dst_memh = NULL;
+        ucc_rank_t        grank    = UCC_TL_TEAM_RANK(nccl_team);
+        ucc_count_t       total_count;
+        ucc_datatype_t    dt;
+        int               is_src_v_type;
+        int               is_dst_v_type;
+
+        /* SCATTERV: src is info_v (root distributes variable chunks),
+         *           dst is info   (each rank receives one contiguous chunk).
+         * GATHERV:  src is info   (each rank contributes one contiguous chunk),
+         *           dst is info_v (root collects variable chunks).
+         * ALLGATHERV: src is info, dst is info_v.
+         * ALLTOALLV:  src is info_v, dst is info_v. */
+        is_src_v_type = (coll_args->args.coll_type == UCC_COLL_TYPE_ALLTOALLV ||
+                         coll_args->args.coll_type == UCC_COLL_TYPE_SCATTERV);
+        is_dst_v_type = (coll_args->args.coll_type == UCC_COLL_TYPE_ALLTOALLV ||
+                         coll_args->args.coll_type == UCC_COLL_TYPE_ALLGATHERV ||
+                         coll_args->args.coll_type == UCC_COLL_TYPE_GATHERV);
+
+        /* Register source buffer's memory region if memh provided */
+        if (coll_args->args.mask & UCC_COLL_ARGS_FIELD_MEM_MAP_SRC_MEMH) {
+            /* Check if global or local memh */
+            if ((coll_args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
+                (coll_args->args.flags & UCC_COLL_ARGS_FLAG_SRC_MEMH_GLOBAL)) {
+                src_memh = coll_args->args.src_memh.global_memh[grank];
+            } else {
+                src_memh = coll_args->args.src_memh.local_memh;
+            }
+
+            if (is_src_v_type) {
+                total_count = ucc_coll_args_get_v_buffer_size(
+                    &coll_args->args,
+                    coll_args->args.src.info_v.counts,
+                    coll_args->args.src.info_v.displacements,
+                    UCC_TL_TEAM_SIZE(nccl_team));
+                dt = coll_args->args.src.info_v.datatype;
+            } else {
+                total_count = coll_args->args.src.info.count;
+                dt          = coll_args->args.src.info.datatype;
+            }
+            status = ucc_tl_nccl_lazy_register_memh(
+                is_src_v_type ? coll_args->args.src.info_v.buffer
+                              : coll_args->args.src.info.buffer,
+                total_count * ucc_dt_size(dt),
+                nccl_team,
+                src_memh);
+            if (ucc_unlikely(status != UCC_OK)) {
+                tl_error(
+                    team->context->lib,
+                    "NCCL UBR: lazy_register failed with status %d",
+                    status);
+                ucc_tl_nccl_free_task(task);
+                return status;
+            }
+        }
+
+        /* Register destination buffer's memory region if memh provided */
+        if (coll_args->args.mask & UCC_COLL_ARGS_FIELD_MEM_MAP_DST_MEMH) {
+            /* Check if global or local memh */
+            if ((coll_args->args.mask & UCC_COLL_ARGS_FIELD_FLAGS) &&
+                (coll_args->args.flags & UCC_COLL_ARGS_FLAG_DST_MEMH_GLOBAL)) {
+                dst_memh = coll_args->args.dst_memh.global_memh[grank];
+            } else {
+                dst_memh = coll_args->args.dst_memh.local_memh;
+            }
+
+            if (is_dst_v_type) {
+                total_count = ucc_coll_args_get_v_buffer_size(
+                    &coll_args->args,
+                    coll_args->args.dst.info_v.counts,
+                    coll_args->args.dst.info_v.displacements,
+                    UCC_TL_TEAM_SIZE(nccl_team));
+                dt = coll_args->args.dst.info_v.datatype;
+            } else {
+                total_count = coll_args->args.dst.info.count;
+                dt          = coll_args->args.dst.info.datatype;
+            }
+
+            status = ucc_tl_nccl_lazy_register_memh(
+                is_dst_v_type ? coll_args->args.dst.info_v.buffer
+                              : coll_args->args.dst.info.buffer,
+                total_count * ucc_dt_size(dt),
+                nccl_team,
+                dst_memh);
+            if (ucc_unlikely(status != UCC_OK)) {
+                ucc_tl_nccl_free_task(task);
+                return status;
+            }
+        }
+    }
+#endif
 
     *coll_task = task;
     return UCC_OK;

--- a/src/components/tl/nccl/tl_nccl_context.c
+++ b/src/components/tl/nccl/tl_nccl_context.c
@@ -202,6 +202,50 @@ UCC_CLASS_INIT_FUNC(ucc_tl_nccl_context_t,
     if (cuda_st != cudaSuccess) {
         return UCC_ERR_NO_MEMORY;
     }
+
+    /* Initialize UBR support */
+    self->ubr_available = 0;
+
+#if NCCL_HAS_UBR
+    /* Check if UBR should be enabled based on config and NCCL version */
+    if (self->cfg.enable_ubr != UCC_NO) {
+        self->ubr_available = 1;
+        tl_debug(
+            self->super.super.lib,
+            "NCCL User Buffer Registration available (NCCL %d.%d.%d), using "
+            "lazy registration",
+            NCCL_MAJOR,
+            NCCL_MINOR,
+            NCCL_PATCH);
+    } else {
+        tl_debug(
+            self->super.super.lib,
+            "NCCL User Buffer Registration disabled by config");
+    }
+#else
+    if (self->cfg.enable_ubr == UCC_YES) {
+        tl_error(
+            self->super.super.lib,
+            "NCCL User Buffer Registration requested but NCCL version %d.%d.%d "
+            "< 2.19.0",
+            NCCL_MAJOR,
+            NCCL_MINOR,
+            NCCL_PATCH);
+        cudaFree(self->scratch_buf);
+        ucc_mpool_cleanup(&self->req_mp, 1);
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+    tl_debug(
+        self->super.super.lib,
+        "NCCL User Buffer Registration not available (NCCL %d.%d.%d < 2.19.0)",
+        NCCL_MAJOR,
+        NCCL_MINOR,
+        NCCL_PATCH);
+#endif
+
+    ucc_list_head_init(&self->memh_list);
+    ucc_spinlock_init(&self->memh_lock, 0);
+
     tl_debug(self->super.super.lib, "initialized tl context: %p", self);
     return UCC_OK;
 }
@@ -212,6 +256,7 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_context_t)
     ucc_mpool_cleanup(&self->req_mp, 1);
     cudaFree(self->scratch_buf);
     self->scratch_buf = NULL;
+    ucc_spinlock_destroy(&self->memh_lock);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_nccl_context_t, ucc_tl_context_t);
@@ -224,20 +269,257 @@ ucc_tl_nccl_get_context_attr(const ucc_base_context_t *context, /* NOLINT */
     return UCC_OK;
 }
 
-ucc_status_t ucc_tl_nccl_mem_map(const ucc_base_context_t *context, int type, /* NOLINT */
-                                 void *memh, void *tl_h) /* NOLINT */
+/* Map memory for NCCL User Buffer Registration (UBR).
+ * 
+ * This function creates a memory handle for UBR but does not immediately register
+ * the buffer with NCCL communicators. The actual registration happens lazily when
+ * the buffer is first used in a collective operation.
+ * 
+ * Requirements:
+ * - NCCL >= 2.19.0 compiled with UBR support
+ * - UCC_TL_NCCL_ENABLE_UBR must be enabled (default: try)
+ * - Buffer must be CUDA device memory (cudaMalloc, cudaMallocManaged, etc.)
+ * - Buffer must have non-zero length
+ * 
+ * Lifecycle:
+ * - mem_map() creates handle (no NCCL registration)
+ * - team_create() initializes NCCL communicators (no registration)
+ * - collective_init() triggers lazy registration via ncclCommRegister()
+ * - mem_unmap() deregisters via ncclCommDeregister()
+ * 
+ * Best Practice: Call mem_unmap() BEFORE team_destroy() for clean deregistration.
+ * However, if team_destroy() is called first, NCCL automatically cleans up all
+ * registrations, so no resource leak occurs (just a debug message in mem_unmap)
+ */
+ucc_status_t ucc_tl_nccl_mem_map(
+    const ucc_base_context_t *context, ucc_mem_map_mode_t mode,
+    ucc_mem_map_memh_t *memh, ucc_mem_map_tl_t *tl_h)
 {
-    return UCC_ERR_NOT_SUPPORTED;
+    ucc_tl_nccl_context_t *ctx = ucc_derived_of(context, ucc_tl_nccl_context_t);
+    ucc_tl_nccl_memh_data_t *m_data;
+
+    /* Check if UBR is available and enabled */
+    if (!ctx->ubr_available) {
+        tl_debug(
+            ctx->super.super.lib, "NCCL UBR not available, skipping mem_map");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    /* Support both EXPORT and IMPORT modes for global memh */
+    if (mode != UCC_MEM_MAP_MODE_EXPORT && mode != UCC_MEM_MAP_MODE_IMPORT) {
+        tl_debug(ctx->super.super.lib,
+                 "NCCL UBR: unsupported mode %d", mode);
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    /* Reject zero-length buffers */
+    if (memh->len == 0) {
+        tl_debug(ctx->super.super.lib,
+                 "NCCL UBR: zero-length buffer, skipping mem_map");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    /* Allocate TL-specific memory handle data */
+    m_data = (ucc_tl_nccl_memh_data_t *)ucc_calloc(
+        1, sizeof(ucc_tl_nccl_memh_data_t), "tl_nccl_memh_data");
+    if (!m_data) {
+        tl_error(
+            ctx->super.super.lib, "failed to allocate TL memory handle data");
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    m_data->registered_comms = NULL;
+    m_data->nccl_handles     = NULL;
+    m_data->num_comms        = 0;
+    m_data->max_comms        = 0;
+    ucc_spinlock_init(&m_data->lock, 0);
+
+    if (mode == UCC_MEM_MAP_MODE_IMPORT) {
+        /* On import the top-level memh fields (address/len) contain the
+         * exporting rank's virtual addresses and are not valid locally.
+         * Unpack the address and length from the blob that was packed by
+         * the exporting rank, which carries the same remote values.
+         * NOTE: the core must have already patched local_memh->address/len
+         * from the user params before calling us (see ucc_mem_map_import). */
+        void  *packed_addr;
+        size_t packed_len;
+        size_t offset = 0;
+        int    j;
+
+        m_data->address = NULL;
+        m_data->length  = 0;
+        for (j = 0; j < memh->num_tls; j++) {
+            char   *name = PTR_OFFSET(memh->pack_buffer, offset);
+            size_t *psz  = PTR_OFFSET(memh->pack_buffer,
+                                      offset + UCC_MEM_MAP_TL_NAME_LEN);
+            if (strcmp(name, "nccl") == 0 &&
+                *psz == sizeof(void *) + sizeof(size_t)) {
+                void *blob = PTR_OFFSET(memh->pack_buffer,
+                                        offset + UCC_MEM_MAP_TL_NAME_LEN +
+                                            sizeof(size_t));
+                memcpy(&packed_addr, blob, sizeof(void *));
+                memcpy(&packed_len,
+                       (char *)blob + sizeof(void *), sizeof(size_t));
+                /* Use the importer's local address from the dedicated import
+                 * fields set by the core (memh->local_address/local_len).
+                 * These fields preserve the remote address in memh->address
+                 * unchanged so that other TLs (e.g. UCP) can still use it
+                 * for remote-VA translation.  Fall back to the packed (remote)
+                 * values only when the import params were absent. */
+                m_data->address = memh->local_address ? memh->local_address
+                                                      : packed_addr;
+                m_data->length  = memh->local_len     ? memh->local_len
+                                                      : packed_len;
+                break;
+            }
+            offset += UCC_MEM_MAP_TL_NAME_LEN + sizeof(size_t) + *psz;
+        }
+        if (!m_data->address || m_data->length == 0) {
+            tl_error(ctx->super.super.lib,
+                     "NCCL UBR: failed to unpack address/length from import blob");
+            ucc_spinlock_destroy(&m_data->lock);
+            ucc_free(m_data);
+            return UCC_ERR_INVALID_PARAM;
+        }
+    } else {
+        m_data->address = memh->address;
+        m_data->length  = memh->len;
+    }
+
+    /* Set TL handle data */
+    tl_h->tl_data = m_data;
+    strncpy(tl_h->tl_name, "nccl", UCC_MEM_MAP_TL_NAME_LEN - 1);
+    tl_h->tl_name[UCC_MEM_MAP_TL_NAME_LEN - 1] = '\0';
+
+    /* Register in the context's live-handle list so team_destroy can find it */
+    ucc_spin_lock(&ctx->memh_lock);
+    ucc_list_add_tail(&ctx->memh_list, &m_data->list_elem);
+    ucc_spin_unlock(&ctx->memh_lock);
+
+    tl_debug(ctx->super.super.lib,
+             "NCCL UBR: %s memh for buffer %p, size %zu (lazy registration)",
+             mode == UCC_MEM_MAP_MODE_EXPORT ? "created" : "imported",
+             m_data->address, m_data->length);
+
+    return UCC_OK;
 }
 
-ucc_status_t ucc_tl_nccl_mem_unmap(const ucc_base_context_t *context, int type, /* NOLINT */
-                                   void *memh) /* NOLINT */
+ucc_status_t ucc_tl_nccl_mem_unmap(
+    const ucc_base_context_t *context, ucc_mem_map_mode_t mode,
+    ucc_mem_map_tl_t *tl_h)
 {
-    return UCC_ERR_NOT_SUPPORTED;
+    ucc_tl_nccl_context_t *ctx = ucc_derived_of(context, ucc_tl_nccl_context_t);
+    ucc_tl_nccl_memh_data_t *m_data;
+#if NCCL_HAS_UBR
+    ncclResult_t  nccl_status;
+    ncclComm_t   *reg_comms;
+    void        **reg_handles;
+    int           i, n_comms;
+#endif
+
+    if (!tl_h || !tl_h->tl_data) {
+        return UCC_OK;
+    }
+
+    m_data = (ucc_tl_nccl_memh_data_t *)tl_h->tl_data;
+
+    /* Remove from the context's live-handle list before touching the arrays.
+     * After this point team_destroy will no longer find this m_data. */
+    ucc_spin_lock(&ctx->memh_lock);
+    ucc_list_del(&m_data->list_elem);
+    ucc_spin_unlock(&ctx->memh_lock);
+
+#if NCCL_HAS_UBR
+    /* Transfer ownership of the registered-comm arrays under the lock so
+     * that ncclCommDeregister (a potentially slow NCCL/CUDA call) can be
+     * invoked after the spinlock is released. */
+    ucc_spin_lock(&m_data->lock);
+    reg_comms              = m_data->registered_comms;
+    reg_handles            = m_data->nccl_handles;
+    n_comms                = m_data->num_comms;
+    m_data->registered_comms = NULL;
+    m_data->nccl_handles    = NULL;
+    m_data->num_comms       = 0;
+    m_data->max_comms       = 0;
+    ucc_spin_unlock(&m_data->lock);
+
+    /* Both locks are now released; safe to call into NCCL. */
+    for (i = 0; i < n_comms; i++) {
+        if (!reg_comms[i]) {
+            /* Already deregistered by team_destroy */
+            continue;
+        }
+        nccl_status = ncclCommDeregister(reg_comms[i], reg_handles[i]);
+        if (nccl_status == ncclSuccess) {
+            tl_debug(
+                ctx->super.super.lib,
+                "NCCL UBR: deregistered buffer %p from comm %p",
+                m_data->address,
+                reg_comms[i]);
+        } else {
+            tl_warn(
+                ctx->super.super.lib,
+                "NCCL UBR: failed to deregister buffer %p from comm %p: %s",
+                m_data->address,
+                reg_comms[i],
+                ncclGetErrorString(nccl_status));
+        }
+    }
+
+    ucc_free(reg_comms);
+    ucc_free(reg_handles);
+#endif
+
+    /* Free the TL data */
+    ucc_spinlock_destroy(&m_data->lock);
+    ucc_free(m_data);
+    tl_h->tl_data = NULL;
+
+    tl_debug(ctx->super.super.lib, "NCCL UBR: unmapped buffer");
+    return UCC_OK;
 }
 
-ucc_status_t ucc_tl_nccl_memh_pack(const ucc_base_context_t *context, /* NOLINT */
-                                   int type, void *memh, void **pack_buffer) /* NOLINT */
+ucc_status_t ucc_tl_nccl_memh_pack(
+    const ucc_base_context_t *context, ucc_mem_map_mode_t mode,
+    ucc_mem_map_tl_t *tl_h, void **pack_buffer)
 {
-    return UCC_ERR_NOT_SUPPORTED;
+    ucc_tl_nccl_context_t   *ctx = ucc_derived_of(context, ucc_tl_nccl_context_t);
+    ucc_tl_nccl_memh_data_t *m_data;
+    void                    *packed;
+
+    /* If tl_h is NULL, return early */
+    if (!tl_h) {
+        *pack_buffer = NULL;
+        return UCC_OK;
+    }
+
+    /* If UBR is not available/disabled or no TL data, return empty pack */
+    if (!ctx->ubr_available || !tl_h->tl_data) {
+        tl_h->packed_size = 0;
+        *pack_buffer      = NULL;
+        return UCC_OK;
+    }
+
+    m_data = (ucc_tl_nccl_memh_data_t *)tl_h->tl_data;
+
+    /* Pack minimal data (address + length) so this TL is included in the memh.
+     * The core filters out TLs with packed_size == 0, so we must pack something.
+     * Actual NCCL registration happens lazily when buffer is first used. */
+    tl_h->packed_size = sizeof(void *) + sizeof(size_t);
+    packed = ucc_malloc(tl_h->packed_size, "nccl_memh_pack");
+    if (!packed) {
+        tl_error(ctx->super.super.lib,
+                 "failed to allocate pack buffer");
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    memcpy(packed, &m_data->address, sizeof(void *));
+    memcpy((char *)packed + sizeof(void *), &m_data->length, sizeof(size_t));
+    *pack_buffer = packed;
+
+    tl_debug(ctx->super.super.lib,
+             "NCCL UBR: packed memh for buffer %p, size %zu (lazy registration)",
+             m_data->address, m_data->length);
+
+    return UCC_OK;
 }

--- a/src/components/tl/nccl/tl_nccl_team.c
+++ b/src/components/tl/nccl/tl_nccl_team.c
@@ -68,6 +68,83 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_nccl_team_t)
 UCC_CLASS_DEFINE_DELETE_FUNC(ucc_tl_nccl_team_t, ucc_base_team_t);
 UCC_CLASS_DEFINE(ucc_tl_nccl_team_t, ucc_tl_team_t);
 
+/* Before destroying a communicator, remove it from every open memory handle
+ * that was registered against it.  This prevents use-after-free in mem_unmap
+ * and avoids calling ncclCommDeregister on a freed ncclComm_t.
+ *
+ * ncclCommDeregister is a potentially slow NCCL/CUDA call that must NOT be
+ * made while holding a spinlock.  We therefore collect all (comm, handle)
+ * pairs under the locks, null the slots, release both locks, and only then
+ * call ncclCommDeregister. */
+static void ucc_tl_nccl_team_deregister_memhs(ucc_tl_nccl_team_t *team)
+{
+#if NCCL_HAS_UBR
+    ucc_tl_nccl_context_t   *ctx = UCC_TL_NCCL_TEAM_CTX(team);
+    ucc_tl_nccl_memh_data_t *m_data;
+    int                      i, n = 0, capacity = 8;
+    int                      oom = 0;
+    struct {
+        ncclComm_t  comm;
+        void       *handle;
+    }                       *pending, *tmp;
+
+    pending = ucc_malloc(capacity * sizeof(*pending), "nccl_deregister_list");
+    if (!pending) {
+        tl_error(ctx->super.super.lib,
+                 "NCCL UBR: OOM allocating deregistration list; slots will be "
+                 "nulled and ncclCommDestroy will release handles");
+        oom      = 1;
+        capacity = 0;
+    }
+
+    /* Always walk every m_data and null every matching slot regardless of OOM.
+     * Nulling prevents mem_unmap from calling ncclCommDeregister on a comm
+     * that is about to be destroyed.  Pairs we cannot store in the pending
+     * buffer are handled implicitly by the subsequent ncclCommDestroy call. */
+    ucc_spin_lock(&ctx->memh_lock);
+    ucc_list_for_each(m_data, &ctx->memh_list, list_elem) {
+        ucc_spin_lock(&m_data->lock);
+        for (i = 0; i < m_data->num_comms; i++) {
+            if (m_data->registered_comms[i] == team->nccl_comm) {
+                if (!oom && n == capacity) {
+                    capacity *= 2;
+                    tmp = ucc_realloc(pending, capacity * sizeof(*pending),
+                                      "nccl_deregister_list");
+                    if (!tmp) {
+                        tl_error(ctx->super.super.lib,
+                                 "NCCL UBR: OOM growing deregistration list; "
+                                 "remaining handles released by ncclCommDestroy");
+                        oom = 1;
+                    } else {
+                        pending = tmp;
+                    }
+                }
+                if (!oom) {
+                    pending[n].comm   = m_data->registered_comms[i];
+                    pending[n].handle = m_data->nccl_handles[i];
+                    n++;
+                }
+                /* Null unconditionally so mem_unmap skips this slot. */
+                m_data->registered_comms[i] = NULL;
+                m_data->nccl_handles[i]     = NULL;
+                break;
+            }
+        }
+        ucc_spin_unlock(&m_data->lock);
+    }
+    ucc_spin_unlock(&ctx->memh_lock);
+
+    /* Explicitly deregister the pairs we collected; any not collected due to
+     * OOM are cleaned up by the subsequent ncclCommDestroy. */
+    for (i = 0; i < n; i++) {
+        ncclCommDeregister(pending[i].comm, pending[i].handle);
+    }
+    ucc_free(pending); /* free(NULL) is safe when initial malloc failed */
+#else
+    (void)team;
+#endif
+}
+
 ucc_status_t ucc_tl_nccl_team_destroy(ucc_base_team_t *tl_team)
 {
     ucc_tl_nccl_team_t *team = ucc_derived_of(tl_team, ucc_tl_nccl_team_t);
@@ -85,6 +162,8 @@ ucc_status_t ucc_tl_nccl_team_destroy(ucc_base_team_t *tl_team)
         team->stream = NULL;
     }
     if (team->nccl_comm) {
+        /* Deregister from all open memory handles before the comm is freed */
+        ucc_tl_nccl_team_deregister_memhs(team);
         if (team->comm_state == TL_NCCL_COMM_STATE_ERROR) {
             ncclCommAbort(team->nccl_comm);
         } else {

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -1250,6 +1250,14 @@ ucc_status_t ucc_mem_map_import(ucc_context_h        context,
         return UCC_ERR_NO_MEMORY;
     }
 
+    /* Record the local process's address/len in dedicated import fields so TL
+     * mem_map implementations can access the local VA without overwriting the
+     * remote address/len that other TLs (e.g. UCP) rely on for RVA translation. */
+    local_memh->local_address = (params->n_segments > 0)
+                                    ? params->segments[0].address : NULL;
+    local_memh->local_len     = (params->n_segments > 0)
+                                    ? params->segments[0].len : 0;
+
     for (i = 0; i < ctx->n_tl_ctx; i++) {
         offset = 0;
         for (int j = 0; j < local_memh->num_tls; j++) {

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -108,8 +108,10 @@ typedef struct ucc_mem_map_tl_t {
 typedef struct ucc_mem_map_memh_t {
     ucc_mem_map_mode_t mode;
     ucc_context_h      context;
-    void              *address;
+    void              *address;        /* exporter's (remote) VA */
     size_t             len;
+    void              *local_address;  /* importer's local VA; set on import, NULL on export */
+    size_t             local_len;      /* importer's local length; set on import, 0 on export */
     ucc_mem_map_tl_t  *tl_h;
     int                num_tls;
     char               pack_buffer[0];

--- a/test/gtest/core/test_mem_map.cc
+++ b/test/gtest/core/test_mem_map.cc
@@ -6,6 +6,9 @@
 #include "test_mem_map.h"
 #include <cstring>
 #include <random>
+extern "C" {
+#include "core/ucc_context.h"
+}
 
 test_mem_map::test_mem_map() : ctx_h(nullptr), ctx_config(nullptr)
 {
@@ -394,5 +397,136 @@ UCC_TEST_F(test_mem_map_export, stress_test)
         EXPECT_NE(nullptr, memh);
 
         EXPECT_EQ(UCC_OK, ucc_mem_unmap(&memh));
+    }
+}
+
+/* Test that unmap-export before unmap-import is safe (reverse lifecycle order).
+ * basic_import only exercises unmap-import first; this covers the other path
+ * through ucc_tl_nccl_team_deregister_memhs and ucc_tl_nccl_mem_unmap. */
+UCC_TEST_F(test_mem_map_import, unmap_export_before_import)
+{
+    ucc_mem_map_t        seg      = {test_buffer, buffer_size};
+    ucc_mem_map_params_t params   = {&seg, 1};
+    ucc_mem_map_mem_h    exp      = nullptr;
+    ucc_mem_map_mem_h    imp      = nullptr;
+    size_t               exp_size = 0;
+    size_t               imp_size = 0;
+
+    if (ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT, &params,
+                    &exp_size, &exp) != UCC_OK) {
+        GTEST_SKIP() << "export not supported";
+    }
+    imp = malloc(exp_size);
+    ASSERT_NE(nullptr, imp);
+    memcpy(imp, exp, exp_size);
+
+    ucc_status_t st = ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_IMPORT,
+                                  &params, &imp_size, &imp);
+    if (st != UCC_OK) {
+        free(imp);
+        ucc_mem_unmap(&exp);
+        GTEST_SKIP() << "import not supported";
+    }
+
+    /* Destroy export first, then the import handle. */
+    EXPECT_EQ(UCC_OK, ucc_mem_unmap(&exp));
+    EXPECT_EQ(UCC_OK, ucc_mem_unmap(&imp));
+}
+
+/* Test that import does not overwrite memh->address/len with the local VA.
+ * basic_import passes the same params to both export and import so it cannot
+ * distinguish a bug where the remote address is silently replaced.  This test
+ * uses a separate local buffer so the two addresses are distinct. */
+UCC_TEST_F(test_mem_map_import, import_preserves_remote_address)
+{
+    ucc_mem_map_t        seg      = {test_buffer, buffer_size};
+    ucc_mem_map_params_t params   = {&seg, 1};
+    ucc_mem_map_mem_h    exp      = nullptr;
+    ucc_mem_map_mem_h    imp      = nullptr;
+    size_t               exp_size = 0;
+    size_t               imp_size = 0;
+    void                *local_buf;
+
+    if (ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT, &params,
+                    &exp_size, &exp) != UCC_OK) {
+        GTEST_SKIP() << "export not supported";
+    }
+    imp = malloc(exp_size);
+    ASSERT_NE(nullptr, imp);
+    memcpy(imp, exp, exp_size);
+
+    /* Use a distinct local buffer so remote VA != local VA. */
+    local_buf = malloc(buffer_size);
+    ASSERT_NE(nullptr, local_buf);
+    ucc_mem_map_t        local_seg    = {local_buf, buffer_size};
+    ucc_mem_map_params_t local_params = {&local_seg, 1};
+
+    ucc_status_t st = ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_IMPORT,
+                                  &local_params, &imp_size, &imp);
+    if (st == UCC_OK) {
+        ucc_mem_map_memh_t *ih = (ucc_mem_map_memh_t *)imp;
+
+        /* address/len must still carry the remote (export) values. */
+        EXPECT_EQ(test_buffer, ih->address)
+            << "import must not overwrite memh->address with local VA";
+        EXPECT_EQ(buffer_size, ih->len)
+            << "import must not overwrite memh->len";
+
+        /* Local values are in the dedicated import fields. */
+        EXPECT_EQ(local_buf,   ih->local_address);
+        EXPECT_EQ(buffer_size, ih->local_len);
+
+        EXPECT_EQ(UCC_OK, ucc_mem_unmap(&imp));
+    } else {
+        free(imp);
+    }
+    free(local_buf);
+    EXPECT_EQ(UCC_OK, ucc_mem_unmap(&exp));
+}
+
+/* Test repeated export+import+unmap cycles to catch cumulative leaks or
+ * corruption in the bookkeeping arrays.  Alternates unmap order each cycle. */
+UCC_TEST_F(test_mem_map_import, repeated_export_import_cycles)
+{
+    const int            num_cycles = 20;
+    ucc_mem_map_t        seg        = {test_buffer, buffer_size};
+    ucc_mem_map_params_t params     = {&seg, 1};
+    bool                 skipped    = false;
+
+    for (int c = 0; c < num_cycles; c++) {
+        ucc_mem_map_mem_h exp      = nullptr;
+        ucc_mem_map_mem_h imp      = nullptr;
+        size_t            exp_size = 0;
+        size_t            imp_size = 0;
+
+        if (ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_EXPORT, &params,
+                        &exp_size, &exp) != UCC_OK) {
+            skipped = true;
+            break;
+        }
+        imp = malloc(exp_size);
+        ASSERT_NE(nullptr, imp);
+        memcpy(imp, exp, exp_size);
+
+        ucc_status_t st = ucc_mem_map(ctx_h, UCC_MEM_MAP_MODE_IMPORT,
+                                      &params, &imp_size, &imp);
+        if (st != UCC_OK) {
+            free(imp);
+            ucc_mem_unmap(&exp);
+            skipped = true;
+            break;
+        }
+
+        if (c % 2 == 0) {
+            EXPECT_EQ(UCC_OK, ucc_mem_unmap(&imp));
+            EXPECT_EQ(UCC_OK, ucc_mem_unmap(&exp));
+        } else {
+            EXPECT_EQ(UCC_OK, ucc_mem_unmap(&exp));
+            EXPECT_EQ(UCC_OK, ucc_mem_unmap(&imp));
+        }
+    }
+
+    if (skipped) {
+        GTEST_SKIP() << "export/import not supported";
     }
 }


### PR DESCRIPTION
## What
This PR implements NCCL User Buffer Registration (UBR) in TL/NCCL. It replaces the three stub functions (mem_map, mem_unmap, memh_pack) that previously returned UCC_ERR_NOT_SUPPORTED with an implementation that registers GPU memory buffers with NCCL communicators.

## Why
NCCL UBR (available since NCCL 2.19.0) lets applications pre-register GPU buffers so NCCL can bypass its internal memory registration on each collective call. Without this, NCCL must re-pin and register the buffer every time it's used in a collective, which adds latency. This is particularly impactful for AI/ML workloads where the same buffers (e.g., model gradients) are used in AllReduce repeatedly across training steps. This PR wires UCC's existing mem_map API into NCCL's ncclCommRegister/ncclCommDeregister, enabling that optimization.

## How
 - Lazy registration: mem_map only allocates a ucc_tl_nccl_memh_data_t tracking struct — no NCCL call
  yet. The actual ncclCommRegister call is deferred to the first collective operation that uses the
  buffer (ucc_tl_nccl_lazy_register_memh in tl_nccl_coll.c). This avoids registering with comms that
  never use the buffer.
  - Per-comm tracking: Each memh_data maintains dynamic arrays of (ncclComm_t, handle) pairs — one entry
   per NCCL communicator that has registered the buffer — growing as needed.
  - Thread safety: Spinlocks guard both the per-handle arrays and the context-level handle list. The
  NCCL calls (ncclCommRegister/ncclCommDeregister) are made outside spinlocks to avoid holding them
  during potentially slow CUDA operations.
  - Clean teardown: team_destroy calls ucc_tl_nccl_team_deregister_memhs to null out all slots for the
  dying comm before calling ncclCommDestroy, preventing use-after-free in a later mem_unmap. The reverse
   order (mem_unmap before team_destroy) is also handled cleanly.
  - Export/import support: memh_pack packs the buffer address and length for cross-process sharing.
  mem_map in import mode unpacks the local address from the blob.
  - Config toggle: A new UCC_TL_NCCL_ENABLE_UBR config option (try/yes/no) controls the feature, with
  version gating against NCCL 2.19.0 at compile time.
