### PR TITLE
CORE: add ucc_modules config

### DIFF
--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -29,7 +29,8 @@ ucc_global_config_t ucc_global_config = {
     .log_buffer_size  = 1024,
     .log_data_size    = 0,
     .log_print_enable = 0,
-    .log_level_trigger = UCC_LOG_LEVEL_FATAL};
+    .log_level_trigger = UCC_LOG_LEVEL_FATAL,
+    .modules           = {{NULL, 0}, 0}};
 
 ucc_config_field_t ucc_global_config_table[] = {
     {"LOG_LEVEL", "warn",
@@ -116,6 +117,18 @@ ucc_config_field_t ucc_global_config_table[] = {
      "datatypes for proper fallback behavior.",
      ucc_offsetof(ucc_global_config_t, check_asymmetric_dt),
      UCC_CONFIG_TYPE_BOOL},
+
+    {"MODULES", "all",
+     "Comma-separated list of component modules to load.\n"
+     "Use <name> to match a component in any framework, or\n"
+     "<framework>_<name> for a specific framework (e.g. tl_cuda).\n"
+     "Prefix with '^' to negate.\n"
+     " - all              - load all available modules (default).\n"
+     " - ^cuda            - load all modules except cuda (any framework).\n"
+     " - ^tl_cuda,ec_cuda - load all modules except tl_cuda and ec_cuda.\n"
+     " - ucp,nccl         - load only ucp and nccl.",
+     ucc_offsetof(ucc_global_config_t, modules),
+     UCC_CONFIG_TYPE_ALLOW_LIST},
 
     {NULL}
 };

--- a/src/core/ucc_global_opts.c
+++ b/src/core/ucc_global_opts.c
@@ -30,7 +30,7 @@ ucc_global_config_t ucc_global_config = {
     .log_data_size    = 0,
     .log_print_enable = 0,
     .log_level_trigger = UCC_LOG_LEVEL_FATAL,
-    .modules           = {{NULL, 0}, 0}};
+    .modules           = {{NULL, 0}, UCC_CONFIG_ALLOW_LIST_ALLOW_ALL}};
 
 ucc_config_field_t ucc_global_config_table[] = {
     {"LOG_LEVEL", "warn",
@@ -120,13 +120,16 @@ ucc_config_field_t ucc_global_config_table[] = {
 
     {"MODULES", "all",
      "Comma-separated list of component modules to load.\n"
-     "Use <name> to match a component in any framework, or\n"
-     "<framework>_<name> for a specific framework (e.g. tl_cuda).\n"
-     "Prefix with '^' to negate.\n"
-     " - all              - load all available modules (default).\n"
-     " - ^cuda            - load all modules except cuda (any framework).\n"
-     " - ^tl_cuda,ec_cuda - load all modules except tl_cuda and ec_cuda.\n"
-     " - ucp,nccl         - load only ucp and nccl.",
+     "Use <framework>_<name> to target a specific component (e.g. tl_cuda),\n"
+     "or a bare <name> to match that component in any framework.\n"
+     "Prefix with '^' to negate (exclude matching components).\n"
+     "In ALLOW mode (no '^'), only frameworks that have at least one\n"
+     "qualified entry (e.g. tl_*) are filtered; other frameworks load all\n"
+     "their components, so required frameworks (cl, mc) are never excluded.\n"
+     " - all                  - load all available modules (default).\n"
+     " - ^cuda                - load all modules except cuda (any framework).\n"
+     " - ^tl_cuda,ec_cuda     - load all modules except tl_cuda and ec_cuda.\n"
+     " - tl_ucp,tl_nccl       - load only ucp and nccl from the tl framework.",
      ucc_offsetof(ucc_global_config_t, modules),
      UCC_CONFIG_TYPE_ALLOW_LIST},
 

--- a/src/core/ucc_global_opts.h
+++ b/src/core/ucc_global_opts.h
@@ -27,6 +27,8 @@ typedef struct ucc_global_config {
     /* Coll component libraries path */
     char *component_path;
     char *install_path;
+    /* Modules filter (allow/negate list) */
+    ucc_config_allow_list_t modules;
     int   initialized;
     /* Profiling mode */
     uint64_t                   profile_mode;

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -22,6 +22,47 @@
 #define IFACE_NAME_LEN_MAX                                                     \
     (UCC_MAX_FRAMEWORK_NAME_LEN + UCC_MAX_COMPONENT_NAME_LEN + 32)
 
+/* Check if a module name from the allow list matches the given component.
+   Entries with a framework prefix are matched as <framework>_<component>
+   (e.g. "tl_cuda"), entries without a known framework prefix are matched
+   against the component name only (e.g. "cuda" matches cuda in any
+   framework). */
+static int ucc_modules_list_search(const ucc_config_names_array_t *names,
+                                   const char *framework_name,
+                                   const char *component_name)
+{
+    char     qualified[UCC_MAX_FRAMEWORK_NAME_LEN +
+                       UCC_MAX_COMPONENT_NAME_LEN + 2];
+    unsigned i;
+
+    ucc_snprintf_safe(qualified, sizeof(qualified), "%s_%s",
+                      framework_name, component_name);
+
+    for (i = 0; i < names->count; i++) {
+        if ((strcmp(names->names[i], qualified) == 0) ||
+            (strcmp(names->names[i], component_name) == 0)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static int ucc_component_is_enabled(const char *framework_name,
+                                    const char *component_name)
+{
+    ucc_config_allow_list_t *modules = &ucc_global_config.modules;
+    int                      found;
+
+    if (modules->mode == UCC_CONFIG_ALLOW_LIST_ALLOW_ALL) {
+        return 1;
+    }
+
+    found = ucc_modules_list_search(&modules->array, framework_name,
+                                    component_name) >= 0;
+    return ((modules->mode == UCC_CONFIG_ALLOW_LIST_ALLOW) && found) ||
+           ((modules->mode == UCC_CONFIG_ALLOW_LIST_NEGATE) && !found);
+}
+
 static ucc_status_t ucc_component_load_one(const char *so_path,
                                            const char *framework_name,
                                            ucc_component_iface_t **c_iface)
@@ -49,6 +90,14 @@ static ucc_status_t ucc_component_load_one(const char *so_path,
     iface_struct_name_len = strlen(so_path) - basename_start - 3;
     ucc_strncpy_safe(iface_struct, so_path + basename_start,
                      iface_struct_name_len + 1);
+
+    if (!ucc_component_is_enabled(framework_name,
+                                  iface_struct + strlen(framework_pattern))) {
+        ucc_debug("component '%s_%s' is disabled by UCC_MODULES configuration",
+                  framework_name, iface_struct + strlen(framework_pattern));
+        *c_iface = NULL;
+        return UCC_ERR_NO_MESSAGE;
+    }
 
     handle = dlopen(so_path, RTLD_LAZY);
     if (!handle) {

--- a/src/utils/ucc_component.c
+++ b/src/utils/ucc_component.c
@@ -47,6 +47,26 @@ static int ucc_modules_list_search(const ucc_config_names_array_t *names,
     return -1;
 }
 
+/* Returns 1 if the allow list has at least one qualified entry targeting
+   this framework (e.g. "tl_ucp" targets "tl"). Bare names like "ucp" do
+   not target any specific framework, so ALLOW mode ignores frameworks
+   that have no qualified entries — preventing required frameworks (cl, mc)
+   from being accidentally excluded when the user writes e.g. "tl_ucp". */
+static int ucc_framework_is_targeted(const ucc_config_names_array_t *names,
+                                     const char *framework_name)
+{
+    char     prefix[UCC_MAX_FRAMEWORK_NAME_LEN + 2];
+    unsigned i;
+
+    ucc_snprintf_safe(prefix, sizeof(prefix), "%s_", framework_name);
+    for (i = 0; i < names->count; i++) {
+        if (strncmp(names->names[i], prefix, strlen(prefix)) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static int ucc_component_is_enabled(const char *framework_name,
                                     const char *component_name)
 {
@@ -59,8 +79,13 @@ static int ucc_component_is_enabled(const char *framework_name,
 
     found = ucc_modules_list_search(&modules->array, framework_name,
                                     component_name) >= 0;
-    return ((modules->mode == UCC_CONFIG_ALLOW_LIST_ALLOW) && found) ||
-           ((modules->mode == UCC_CONFIG_ALLOW_LIST_NEGATE) && !found);
+    if (modules->mode == UCC_CONFIG_ALLOW_LIST_ALLOW) {
+        if (!ucc_framework_is_targeted(&modules->array, framework_name)) {
+            return 1;
+        }
+        return found;
+    }
+    return !found; /* NEGATE mode */
 }
 
 static ucc_status_t ucc_component_load_one(const char *so_path,
@@ -96,7 +121,7 @@ static ucc_status_t ucc_component_load_one(const char *so_path,
         ucc_debug("component '%s_%s' is disabled by UCC_MODULES configuration",
                   framework_name, iface_struct + strlen(framework_pattern));
         *c_iface = NULL;
-        return UCC_ERR_NO_MESSAGE;
+        return UCC_OK;
     }
 
     handle = dlopen(so_path, RTLD_LAZY);
@@ -205,7 +230,7 @@ ucc_status_t ucc_components_load(const char *framework_name,
     for (i = 0; i < globbuf.gl_pathc; i++) {
         status = ucc_component_load_one(globbuf.gl_pathv[i], framework_name,
                                         &ifaces[n_loaded]);
-        if (status != UCC_OK) {
+        if (status != UCC_OK || ifaces[n_loaded] == NULL) {
             continue;
         }
         n_loaded++;
@@ -249,6 +274,27 @@ ucc_status_t ucc_components_load(const char *framework_name,
     for (i = 0; i < n_loaded; i++) {
         framework->names.names[i] = strdup(framework->components[i]->name);
     }
+
+    /* Warn about qualified allow-list entries that matched no component in
+       this framework — most likely a typo in UCC_MODULES. */
+    if (ucc_global_config.modules.mode != UCC_CONFIG_ALLOW_LIST_ALLOW_ALL) {
+        const ucc_config_names_array_t *mnames = &ucc_global_config.modules.array;
+        char prefix[UCC_MAX_FRAMEWORK_NAME_LEN + 2];
+
+        ucc_snprintf_safe(prefix, sizeof(prefix), "%s_", framework_name);
+        for (i = 0; i < (int)mnames->count; i++) {
+            if (strncmp(mnames->names[i], prefix, strlen(prefix)) != 0) {
+                continue;
+            }
+            /* This entry targets our framework; check if it matched anything. */
+            if (ucc_modules_list_search(&framework->names, framework_name,
+                                        mnames->names[i] + strlen(prefix)) < 0) {
+                ucc_warn("UCC_MODULES entry '%s' did not match any component "
+                         "in framework '%s'", mnames->names[i], framework_name);
+            }
+        }
+    }
+
     return UCC_OK;
 err:
     ucc_free(framework->components);


### PR DESCRIPTION
## What
Add configuration variable UCC_MODULES to disable/enable loading of specific components before they initialized.
Examples:
UCC_MODULES=^cuda disables all cuda components including mc_cuda, ec_cuda, tl_cuda, sysinfo_cuda
UCC_MODULES=^tl_cuda,ec_cuda disables tl_cuda and ec_cuda, but keeps mc_cuda and sysinfo_cuda
