### PR TITLE
TL/CUDA: multinode cleanup fixes

### DIFF
--- a/.ci/scripts/run_tests_ucc_mpi.sh
+++ b/.ci/scripts/run_tests_ucc_mpi.sh
@@ -193,6 +193,13 @@ for MT in "" "-T"; do
     clhier_colls="allreduce"
     mpirun $(mpi_params $PPN) $ucx_tls_no_cuda_ipc $clhier_args $EXE $MT $TG --mtypes host,cuda -c $clhier_colls
     echo "INFO: UCC MPI unit tests (CL/HIER+split_rail+pipeline) ... DONE"
+
+
+    echo "INFO: UCC MPI unit tests (CL/HIER+2step bcast) ..."
+    # shellcheck disable=SC2086
+    clhier_args=" -x UCC_CLS=all -x UCC_TLS=^sharp -x UCC_CL_HIER_TUNE=bcast:0-inf:@2step "
+    mpirun $(mpi_params $PPN) $ucx_tls_no_cuda_ipc $clhier_args $EXE $MT $TG --mtypes host,cuda -c bcast
+    echo "INFO: UCC MPI unit tests (CL/HIER+2step bcast) ... DONE"
 done
 
 end=`date +%s`

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -13,6 +13,7 @@
 #endif
 #include "core/ucc_team.h"
 #include "coll_score/ucc_coll_score.h"
+#include "utils/ucc_math.h"
 #include "utils/arch/cpu.h"
 #include "utils/arch/cuda_def.h"
 #include "utils/ucc_sys.h"
@@ -274,7 +275,8 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_team_t)
                     st, cudaGetErrorName(st));
         }
     }
-    for (i = 0; i < UCC_TL_TEAM_SIZE(self); i++) {
+    for (i = 0; i < ucc_min(UCC_TL_TEAM_SIZE(self), UCC_TL_CUDA_MAX_PEERS);
+         i++) {
         if (self->scratch.rem[i] && self->scratch.rem_info[i].ptr) {
             ucc_tl_cuda_unmap_memhandle((uintptr_t)self->scratch.rem_info[i].ptr,
                                         self->scratch.rem[i],
@@ -543,7 +545,8 @@ exit_err:
     }
 
     // Clean up mapped scratch memory
-    for (i = 0; i < UCC_TL_TEAM_SIZE(team); i++) {
+    for (i = 0; i < ucc_min(UCC_TL_TEAM_SIZE(team), UCC_TL_CUDA_MAX_PEERS);
+         i++) {
         if (team->scratch.rem[i] && team->scratch.rem_info[i].ptr) {
             ucc_tl_cuda_unmap_memhandle(
                 (uintptr_t)team->scratch.rem_info[i].ptr,


### PR DESCRIPTION
## What

- Fix segfault in TL/CUDA team cleanup when destroying multi-node teams with size > UCC_TL_CUDA_MAX_PEERS (8). 
- Add CI coverage for CL/HIER 2step bcast.

Closes: [RM 4975757](https://redmine.mellanox.com/issues/4975757)

## Why ?
scratch.rem[] is statically sized to UCC_TL_CUDA_MAX_PEERS (8), but the cleanup loop iterated up to UCC_TL_TEAM_SIZE (e.g. 192 for a multi-node team). For multi-node NVLS teams, INIT returns early before the team-size check, so the cleanup runs on a team with size >> 8, causing an out-of-bounds read and crash. Reproduces 100% with multi-node bcast using UCC_CLS=all and `UCC_CL_HIER_TUNE=bcast:0-inf:@2step`.

## How ?
Clamp the scratch.rem[] cleanup loops to ucc_min(UCC_TL_TEAM_SIZE, UCC_TL_CUDA_MAX_PEERS) in both CLEANUP_FUNC and exit_err paths.