### PR TITLE
TL/CUDA: link libstdc++ for aarch64

### DIFF
--- a/src/components/tl/cuda/Makefile.am
+++ b/src/components/tl/cuda/Makefile.am
@@ -84,7 +84,7 @@ module_LTLIBRARIES = libucc_tl_cuda.la
 libucc_tl_cuda_la_SOURCES  = $(sources)
 libucc_tl_cuda_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
 libucc_tl_cuda_la_CFLAGS   = $(BASE_CFLAGS)
-libucc_tl_cuda_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLAGS)
+libucc_tl_cuda_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(CUDA_LDFLAGS) -lstdc++
 libucc_tl_cuda_la_LIBADD   = $(CUDA_LIBS) $(NVML_LIBS) $(UCC_TOP_BUILDDIR)/src/libucc.la kernels/libucc_tl_cuda_kernels.la
 
 include $(top_srcdir)/config/module.am


### PR DESCRIPTION
## What
The NVLS CUDA kernels use cuda::atomic_ref from libcudacxx, which generates references to C++ runtime symbols such as __cxa_guard_acquire. 
Without an explicit libstdc++ dependency, libucc_tl_cuda.so fails to load on **aarch64** with 
`undefined symbol: __cxa_guard_acquire`, crashing all UCC CUDA collective operations.

## Why ?
Fixes: [RM 4975054](https://redmine.mellanox.com/issues/4975054)

## How ?
Add -lstdc++ to the TL CUDA LDFLAGS, matching the pattern already used by the EC CUDA component (libucc_ec_cuda).

