### PR TITLE
CORE: Fix deadlock in asymmetric collectives check

### DIFF
--- a/contrib/ucc.conf
+++ b/contrib/ucc.conf
@@ -21,6 +21,14 @@ UCC_CL_HIER_NET_SBGP_TLS=^sharp,nccl,cuda
 # with ucp sbgp on top
 UCC_CL_HIER_FULL_SBGP_TLS=ucp
 
+# Disable scatterv/gatherv in TL/UCP and scatter/scatterv/gatherv in TL/NCCL
+# by default to avoid hangs with unsupported (non-predefined) datatypes.
+# These collectives lack collective fallback coordination: when some ranks
+# have unsupported types the TL rejects locally while other ranks proceed,
+# causing a deadlock.
+UCC_TL_UCP_TUNE=scatterv:0#gatherv:0
+UCC_TL_NCCL_TUNE=scatter:0#scatterv:0#gatherv:0
+
 # Tuning sections, currently only supports TL/UCP
 #Intel Broadwell:
 [vendor=intel model=broadwell team_size=28 ppn=28 nnodes=1]


### PR DESCRIPTION
Scatterv/gatherv in TL/UCP and scatter/scatterv/gatherv in TL/NCCL can hang when ranks use non-predefined (derived) datatypes. The TL rejects unsupported types locally without collective coordination, so some ranks fall back to the MPI layer while others proceed into UCC, causing a deadlock. Disable these collectives by default via score=0 tuning until collective fallback is properly supported.