### PR TITLE
TL/UCP: add implementation for team-based segments

### DIFF
--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -113,6 +113,8 @@ sources =                 \
 	tl_ucp_lib.c          \
 	tl_ucp_context.c      \
 	tl_ucp_team.c         \
+	tl_ucp_team_mem.h     \
+	tl_ucp_team_mem.c     \
 	tl_ucp_ep.h           \
 	tl_ucp_ep.c           \
 	tl_ucp_coll.c         \

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -350,17 +350,10 @@ ucc_status_t ucc_tl_ucp_service_allreduce(ucc_base_team_t *team, void *sbuf,
                                           ucc_subset_t      subset,
                                           ucc_coll_task_t **task);
 
-ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
-                                          void *rbuf, size_t msgsize,
-                                          ucc_subset_t      subset,
-                                          ucc_coll_task_t **task_p);
-
 ucc_status_t ucc_tl_ucp_service_bcast(ucc_base_team_t *team, void *buf,
                                       size_t msgsize, ucc_rank_t root,
                                       ucc_subset_t      subset,
                                       ucc_coll_task_t **task_p);
-
-ucc_status_t ucc_tl_ucp_service_test(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_service_cleanup(ucc_coll_task_t *task);
 

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -179,6 +179,16 @@ typedef struct ucc_tl_ucp_team {
     ucc_rank_t                 opt_radix; /* generic opt radix */
     ucc_rank_t                 opt_radix_host; /* host specific opt radix */
     ucc_ring_pattern_t         *cuda_ring;
+    /* Team-scoped memory segment registration */
+    ucc_tl_ucp_remote_info_t  *mem_segs;              /* local seg metadata, n_mem_segs entries */
+    uint64_t                   n_mem_segs;             /* total registered segs (user + scratch) */
+    uint64_t                  *team_remote_va;         /* [rank * n_mem_segs + seg]               */
+    size_t                    *team_remote_len;        /* [rank * n_mem_segs + seg]               */
+    ucp_rkey_h                *team_rkeys;             /* [rank * n_mem_segs + seg], eager unpack */
+    ucc_coll_task_t           *mem_map_task;           /* in-flight service allgather task        */
+    void                      *mem_map_allgather_rbuf; /* receive buffer for allgather            */
+    uint8_t                    mem_map_phase;          /* 0=idle, 1=size_exch in flight, 2=data_exch */
+    uint64_t                   mem_map_max_key_len;    /* max packed_key_len from phase 1         */
 } ucc_tl_ucp_team_t;
 UCC_CLASS_DECLARE(ucc_tl_ucp_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
@@ -280,6 +290,15 @@ extern ucc_config_field_t ucc_tl_ucp_lib_config_table[];
 #define UCC_TL_UCP_REMOTE_RKEY(_ctx, _rank, _seg)                              \
     ((_ctx)->rkeys[_rank * _ctx->n_rinfo_segs + _seg])
 
+#define UCC_TL_UCP_TEAM_RKEY(_team, _rank, _seg) \
+    ((_team)->team_rkeys[(_rank) * (_team)->n_mem_segs + (_seg)])
+
+#define UCC_TL_UCP_TEAM_REMOTE_VA(_team, _rank, _seg) \
+    ((_team)->team_remote_va[(_rank) * (_team)->n_mem_segs + (_seg)])
+
+#define UCC_TL_UCP_TEAM_REMOTE_LEN(_team, _rank, _seg) \
+    ((_team)->team_remote_len[(_rank) * (_team)->n_mem_segs + (_seg)])
+
 /*
  * For context, the data order of the MEMH Headers / Packed Headers
  *
@@ -315,4 +334,9 @@ void ucc_tl_ucp_pre_register_mem(ucc_tl_ucp_team_t *team, void *addr,
 ucc_status_t ucc_tl_ucp_ctx_remote_populate(ucc_tl_ucp_context_t *ctx,
                                             ucc_mem_map_params_t  map,
                                             ucc_team_oob_coll_t   oob);
+
+ucc_status_t ucc_tl_ucp_service_allgather(ucc_base_team_t *team, void *sbuf,
+                                          void *rbuf, size_t msgsize,
+                                          ucc_subset_t      subset,
+                                          ucc_coll_task_t **task_p);
 #endif

--- a/src/components/tl/ucp/tl_ucp_sendrecv.h
+++ b/src/components/tl/ucp/tl_ucp_sendrecv.h
@@ -454,6 +454,7 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
     ptrdiff_t             key_offset     = 0;
     const size_t          section_offset = sizeof(uint64_t) * ctx->n_rinfo_segs;
     int                   tl_index       = 0;
+    ucc_rank_t            team_peer      = peer; /* team rank, before ctx remap */
     ucc_rank_t            core_rank;
     uint64_t             *rvas;
     uint64_t             *key_sizes;
@@ -486,6 +487,19 @@ ucc_tl_ucp_resolve_p2p_by_va(ucc_tl_ucp_team_t *team, void *va, ucp_ep_h *ep,
         key_offset += key_sizes[i];
     }
     if (ucc_unlikely(0 > *segment)) {
+        /* Step 2: search team-level segments (eager-unpacked, no lazy check) */
+        for (int i = 0; i < (int)team->n_mem_segs; i++) {
+            uint64_t tbase = (uint64_t)team->mem_segs[i].va_base;
+            uint64_t tend  = tbase + team->mem_segs[i].len;
+            if ((uint64_t)va >= tbase && (uint64_t)va < tend) {
+                *rkey    = UCC_TL_UCP_TEAM_RKEY(team, team_peer, i);
+                *rva     = UCC_TL_UCP_TEAM_REMOTE_VA(team, team_peer, i) +
+                           ((uint64_t)va - tbase);
+                *segment = (int)(ctx->n_rinfo_segs + i);
+                return UCC_OK;
+            }
+        }
+        /* Step 3: per-collective dst_memh path (unchanged) */
         if (dst_memh) {
             /* check if segment is in src/dst memh */
             status = find_tl_index(dst_memh[grank], &tl_index);

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -8,6 +8,7 @@
 #include "tl_ucp_ep.h"
 #include "tl_ucp_coll.h"
 #include "tl_ucp_sendrecv.h"
+#include "tl_ucp_team_mem.h"
 #include "utils/ucc_parser.h"
 #include "coll_score/ucc_coll_score.h"
 #include "coll_patterns/ring.h"
@@ -56,14 +57,23 @@ UCC_CLASS_INIT_FUNC(ucc_tl_ucp_team_t, ucc_base_context_t *tl_context,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
     /* TODO: init based on ctx settings and on params: need to check
              if all the necessary ranks mappings are provided */
-    self->preconnect_task = NULL;
-    self->seq_num         = 0;
-    self->status          = UCC_INPROGRESS;
-    self->tuning_str      = "";
-    self->topo            = NULL;
-    self->opt_radix       = UCC_UUNITS_AUTO_RADIX;
-    self->opt_radix_host  = UCC_UUNITS_AUTO_RADIX;
-    self->cuda_ring       = NULL;
+    self->preconnect_task        = NULL;
+    self->seq_num                = 0;
+    self->status                 = UCC_INPROGRESS;
+    self->tuning_str             = "";
+    self->topo                   = NULL;
+    self->opt_radix              = UCC_UUNITS_AUTO_RADIX;
+    self->opt_radix_host         = UCC_UUNITS_AUTO_RADIX;
+    self->cuda_ring              = NULL;
+    self->mem_segs               = NULL;
+    self->n_mem_segs             = 0;
+    self->team_remote_va         = NULL;
+    self->team_remote_len        = NULL;
+    self->team_rkeys             = NULL;
+    self->mem_map_task           = NULL;
+    self->mem_map_allgather_rbuf = NULL;
+    self->mem_map_phase          = 0;
+    self->mem_map_max_key_len    = 0;
 
     status = ucc_config_clone_table(&UCC_TL_UCP_TEAM_LIB(self)->cfg, &self->cfg,
                                     ucc_tl_ucp_lib_config_table);
@@ -157,6 +167,8 @@ ucc_status_t ucc_tl_ucp_team_destroy(ucc_base_team_t *tl_team)
 {
     ucc_tl_ucp_team_t *team = ucc_derived_of(tl_team, ucc_tl_ucp_team_t);
 
+    ucc_tl_ucp_team_mem_map_destroy(team);
+
     if (team->cuda_ring) {
         ucc_ring_pattern_destroy(team->cuda_ring);
         ucc_free(team->cuda_ring);
@@ -242,6 +254,55 @@ ucc_status_t ucc_tl_ucp_team_create_test(ucc_base_team_t *tl_team)
         for (i = 0; i < ctx->n_rinfo_segs; i++) {
             team->va_base[i]     = ctx->remote_info[i].va_base;
             team->base_length[i] = ctx->remote_info[i].len;
+        }
+    }
+
+    if ((team->super.super.params.params.mask & UCC_TEAM_PARAM_FIELD_MEM_PARAMS) &&
+        team->super.super.params.params.mem_params.n_segments > 0 &&
+        !UCC_TL_IS_SERVICE_TEAM(team)) {
+        if (team->mem_map_phase == 0) {
+            status = ucc_tl_ucp_team_mem_map_size_exch(team);
+            if (status != UCC_INPROGRESS) {
+                goto err_preconnect;
+            }
+            return UCC_INPROGRESS;
+        }
+        /* The allgather ring task is driven by the context progress queue;
+         * never call task->progress directly here -- doing so risks completing
+         * the task while it is still in the queue, which corrupts the queue
+         * when the task is subsequently freed. */
+        if (team->mem_map_phase == 1) {
+            status = team->mem_map_task->status;
+            if (status == UCC_INPROGRESS) {
+                return UCC_INPROGRESS;
+            }
+            if (status != UCC_OK) {
+                tl_error(UCC_TL_TEAM_LIB(team),
+                         "team mem_map size exchange allgather failed: %s",
+                         ucc_status_string(status));
+                goto err_preconnect;
+            }
+            status = ucc_tl_ucp_team_mem_map_data_exch(team);
+            if (status != UCC_INPROGRESS) {
+                goto err_preconnect;
+            }
+            return UCC_INPROGRESS;
+        }
+        if (team->mem_map_phase == 2) {
+            status = team->mem_map_task->status;
+            if (status == UCC_INPROGRESS) {
+                return UCC_INPROGRESS;
+            }
+            if (status != UCC_OK) {
+                tl_error(UCC_TL_TEAM_LIB(team),
+                         "team mem_map data exchange allgather failed: %s",
+                         ucc_status_string(status));
+                goto err_preconnect;
+            }
+            status = ucc_tl_ucp_team_mem_map_finalize(team);
+            if (status != UCC_OK) {
+                goto err_preconnect;
+            }
         }
     }
 

--- a/src/components/tl/ucp/tl_ucp_team_mem.c
+++ b/src/components/tl/ucp/tl_ucp_team_mem.c
@@ -323,7 +323,10 @@ void ucc_tl_ucp_team_mem_map_destroy(ucc_tl_ucp_team_t *team)
     /* Clean up any in-flight allgather task on error path.
      * If the task is still queued (UCC_INPROGRESS), remove it from the
      * progress queue's linked list before freeing to prevent the next
-     * ucc_context_progress() from walking freed memory. */
+     * ucc_context_progress() from walking freed memory.
+     * Pre-condition: caller serialises ucc_context_progress and
+     * ucc_team_create_test (UCC_THREAD_SINGLE contract); manipulating
+     * list_elem without the MT progress-queue lock is safe here. */
     if (team->mem_map_task != NULL) {
         if (team->mem_map_task->status == UCC_INPROGRESS) {
             ucc_list_del(&team->mem_map_task->list_elem);

--- a/src/components/tl/ucp/tl_ucp_team_mem.c
+++ b/src/components/tl/ucp/tl_ucp_team_mem.c
@@ -1,0 +1,376 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_ucp_team_mem.h"
+#include "tl_ucp_ep.h"
+#include "tl_ucp_coll.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_assert.h"
+#include <string.h>
+
+ucc_status_t ucc_tl_ucp_team_mem_map_size_exch(ucc_tl_ucp_team_t *team)
+{
+    ucc_tl_ucp_context_t         *ctx        = UCC_TL_UCP_TEAM_CTX(team);
+    const ucc_base_team_params_t *bparams    = &team->super.super.params;
+    ucc_rank_t                    local_rank = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t                    size       = UCC_TL_TEAM_SIZE(team);
+    uint64_t                     *sbuf       = NULL;
+    uint64_t                     *rbuf       = NULL;
+    ucc_mem_map_params_t         *mp;
+    uint64_t                      n_segs;
+    ucc_subset_t                  subset;
+    ucc_status_t                  status;
+    ucp_mem_map_params_t          mmap_params;
+    ucp_mem_h                     mh;
+    void                         *packed_key;
+    size_t                        packed_key_len;
+    ucs_status_t                  ucs_status;
+    uint64_t                      i;
+
+    mp     = (ucc_mem_map_params_t *)&bparams->params.mem_params;
+    n_segs = mp->n_segments;
+
+    team->mem_segs = ucc_calloc(n_segs, sizeof(ucc_tl_ucp_remote_info_t),
+                                "team_mem_segs");
+    if (!team->mem_segs) {
+        goto err_no_memory;
+    }
+
+    team->team_remote_va = ucc_calloc((size_t)size * n_segs, sizeof(uint64_t),
+                                      "team_remote_va");
+    if (!team->team_remote_va) {
+        goto err_no_memory;
+    }
+
+    team->team_remote_len = ucc_calloc((size_t)size * n_segs, sizeof(size_t),
+                                       "team_remote_len");
+    if (!team->team_remote_len) {
+        goto err_no_memory;
+    }
+
+    team->team_rkeys = ucc_calloc((size_t)size * n_segs, sizeof(ucp_rkey_h),
+                                  "team_rkeys");
+    if (!team->team_rkeys) {
+        goto err_no_memory;
+    }
+
+    /* Size exchange: allgather packed_key_len per segment */
+    sbuf = ucc_calloc(n_segs, sizeof(uint64_t), "mem_map_sbuf_p1");
+    if (!sbuf) {
+        goto err_no_memory;
+    }
+
+    rbuf = ucc_malloc((size_t)size * n_segs * sizeof(uint64_t),
+                      "mem_map_rbuf_p1");
+    if (!rbuf) {
+        goto err_no_memory;
+    }
+
+    /* Register user segments, dup packed keys, fill phase 1 sbuf */
+    for (i = 0; i < n_segs; i++) {
+        mmap_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                                 UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+        mmap_params.address    = mp->segments[i].address;
+        mmap_params.length     = mp->segments[i].len;
+
+        ucs_status = ucp_mem_map(ctx->worker.ucp_context, &mmap_params, &mh);
+        if (UCS_OK != ucs_status) {
+            tl_error(UCC_TL_TEAM_LIB(team),
+                     "ucp_mem_map failed for user segment %lu: %s",
+                     i, ucs_status_string(ucs_status));
+            status = ucs_status_to_ucc_status(ucs_status);
+            goto err;
+        }
+
+        ucs_status = ucp_rkey_pack(ctx->worker.ucp_context, mh,
+                                   &packed_key, &packed_key_len);
+        if (UCS_OK != ucs_status) {
+            tl_error(UCC_TL_TEAM_LIB(team),
+                     "ucp_rkey_pack failed for user segment %lu: %s",
+                     i, ucs_status_string(ucs_status));
+            ucp_mem_unmap(ctx->worker.ucp_context, mh);
+            status = ucs_status_to_ucc_status(ucs_status);
+            goto err;
+        }
+
+        team->mem_segs[i].va_base        = mp->segments[i].address;
+        team->mem_segs[i].len            = mp->segments[i].len;
+        team->mem_segs[i].mem_h          = (void *)mh;
+        team->mem_segs[i].packed_key_len = packed_key_len;
+        team->mem_segs[i].packed_key     = ucc_malloc(packed_key_len,
+                                                      "packed_key_dup");
+        if (!team->mem_segs[i].packed_key) {
+            ucp_rkey_buffer_release(packed_key);
+            ucp_mem_unmap(ctx->worker.ucp_context, mh);
+            team->mem_segs[i].mem_h = NULL;
+            goto err_no_memory;
+        }
+        memcpy(team->mem_segs[i].packed_key, packed_key, packed_key_len);
+        ucp_rkey_buffer_release(packed_key);
+
+        sbuf[i] = (uint64_t)packed_key_len;
+    }
+
+    team->n_mem_segs             = n_segs;
+    team->mem_map_allgather_rbuf = rbuf;
+
+    subset.map.type   = UCC_EP_MAP_FULL;
+    subset.map.ep_num = (uint64_t)size;
+    subset.myrank     = local_rank;
+
+    status = ucc_tl_ucp_service_allgather(
+        (ucc_base_team_t *)team, sbuf, rbuf,
+        n_segs * sizeof(uint64_t), subset, &team->mem_map_task);
+    if (status != UCC_OK && status != UCC_INPROGRESS) {
+        tl_error(UCC_TL_TEAM_LIB(team),
+                 "phase 1 service allgather failed: %s",
+                 ucc_status_string(status));
+        team->mem_map_allgather_rbuf = NULL;
+        goto err;
+    }
+
+    /* sbuf is consumed synchronously by allgather_ring_start */
+    ucc_free(sbuf);
+    team->mem_map_phase = 1;
+    return UCC_INPROGRESS;
+
+err_no_memory:
+    status = UCC_ERR_NO_MEMORY;
+err:
+    ucc_free(sbuf);
+    ucc_free(rbuf);
+    team->mem_map_allgather_rbuf = NULL;
+    if (team->mem_segs) {
+        for (i = 0; i < n_segs; i++) {
+            if (team->mem_segs[i].mem_h) {
+                ucp_mem_unmap(ctx->worker.ucp_context,
+                              (ucp_mem_h)team->mem_segs[i].mem_h);
+            }
+            ucc_free(team->mem_segs[i].packed_key);
+        }
+        ucc_free(team->mem_segs);
+        team->mem_segs = NULL;
+    }
+    ucc_free(team->team_remote_va);
+    team->team_remote_va = NULL;
+    ucc_free(team->team_remote_len);
+    team->team_remote_len = NULL;
+    ucc_free(team->team_rkeys);
+    team->team_rkeys = NULL;
+    team->n_mem_segs = 0;
+    return status;
+}
+
+ucc_status_t ucc_tl_ucp_team_mem_map_data_exch(ucc_tl_ucp_team_t *team)
+{
+    uint64_t    *rbuf_p1     = (uint64_t *)team->mem_map_allgather_rbuf;
+    ucc_rank_t   size        = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t   local_rank  = UCC_TL_TEAM_RANK(team);
+    uint64_t     n_segs      = team->n_mem_segs;
+    uint64_t     max_key_len = 0;
+    uint8_t     *sbuf        = NULL;
+    uint8_t     *rbuf        = NULL;
+    uint8_t     *elem;
+    uint64_t     klen;
+    size_t       stride;
+    ucc_subset_t subset;
+    ucc_status_t status;
+    ucc_rank_t   r;
+    uint64_t     i;
+
+    /* Caller (tl_ucp_team.c) only enters the mem-map path when both are > 0. */
+    ucc_assert_always(n_segs > 0);
+    ucc_assert_always(size > 0);
+
+    /* Determine the max packed_key_len across all ranks and segments */
+    for (r = 0; r < size; r++) {
+        for (i = 0; i < n_segs; i++) {
+            klen = rbuf_p1[(uint64_t)r * n_segs + i];
+            if (klen > max_key_len) {
+                max_key_len = klen;
+            }
+        }
+    }
+
+    ucc_tl_ucp_coll_finalize(team->mem_map_task);
+    team->mem_map_task = NULL;
+    ucc_free(rbuf_p1);
+    team->mem_map_allgather_rbuf = NULL;
+
+    team->mem_map_max_key_len = max_key_len;
+
+    /*
+     * Data exchange element layout (per segment per rank):
+     *   [va: u64][len: u64][packed_key_len: u64][packed_key: max_key_len bytes]
+     *
+     * Pad stride to a multiple of 8 so uint64_t fields in subsequent elements
+     * remain naturally aligned.
+     */
+    stride = (3 * sizeof(uint64_t) + (size_t)max_key_len + 7) & ~(size_t)7;
+
+    sbuf = ucc_calloc(n_segs, stride, "mem_map_sbuf_p2");
+    if (!sbuf) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    rbuf = ucc_malloc((size_t)size * n_segs * stride, "mem_map_rbuf_p2");
+    if (!rbuf) {
+        ucc_free(sbuf);
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    for (i = 0; i < n_segs; i++) {
+        elem = sbuf + i * stride;
+        *(uint64_t *)(elem + 0)  = (uint64_t)team->mem_segs[i].va_base;
+        *(uint64_t *)(elem + 8)  = (uint64_t)team->mem_segs[i].len;
+        *(uint64_t *)(elem + 16) = (uint64_t)team->mem_segs[i].packed_key_len;
+        memcpy(elem + 24, team->mem_segs[i].packed_key,
+               team->mem_segs[i].packed_key_len);
+    }
+
+    team->mem_map_allgather_rbuf = rbuf;
+
+    subset.map.type   = UCC_EP_MAP_FULL;
+    subset.map.ep_num = (uint64_t)size;
+    subset.myrank     = local_rank;
+
+    status = ucc_tl_ucp_service_allgather(
+        (ucc_base_team_t *)team, sbuf, rbuf,
+        n_segs * stride, subset, &team->mem_map_task);
+    if (status != UCC_OK && status != UCC_INPROGRESS) {
+        tl_error(UCC_TL_TEAM_LIB(team),
+                 "phase 2 service allgather failed: %s",
+                 ucc_status_string(status));
+        ucc_free(sbuf);
+        ucc_free(rbuf);
+        team->mem_map_allgather_rbuf = NULL;
+        return status;
+    }
+
+    ucc_free(sbuf);
+    team->mem_map_phase = 2;
+    return UCC_INPROGRESS;
+}
+
+ucc_status_t ucc_tl_ucp_team_mem_map_finalize(ucc_tl_ucp_team_t *team)
+{
+    uint8_t     *rbuf   = (uint8_t *)team->mem_map_allgather_rbuf;
+    ucc_rank_t   size   = UCC_TL_TEAM_SIZE(team);
+    uint64_t     n_segs = team->n_mem_segs;
+    uint8_t     *elem;
+    size_t       stride;
+    ucs_status_t ucs_status;
+    ucc_status_t status;
+    ucp_ep_h     ep;
+    ucc_rank_t   r;
+    uint64_t     s;
+
+    stride = (3 * sizeof(uint64_t) +
+              (size_t)team->mem_map_max_key_len + 7) & ~(size_t)7;
+
+    for (r = 0; r < size; r++) {
+        status = ucc_tl_ucp_get_ep(team, r, &ep);
+        if (ucc_unlikely(UCC_OK != status)) {
+            tl_error(UCC_TL_TEAM_LIB(team),
+                     "failed to get ep for rank %u: %s",
+                     r, ucc_status_string(status));
+            goto err;
+        }
+
+        for (s = 0; s < n_segs; s++) {
+            elem = rbuf + ((uint64_t)r * n_segs + s) * stride;
+
+            UCC_TL_UCP_TEAM_REMOTE_VA(team, r, s)  = *(uint64_t *)(elem + 0);
+            UCC_TL_UCP_TEAM_REMOTE_LEN(team, r, s) =
+                (size_t)(*(uint64_t *)(elem + 8));
+
+            ucs_status = ucp_ep_rkey_unpack(
+                ep, elem + 24, &UCC_TL_UCP_TEAM_RKEY(team, r, s));
+            if (UCS_OK != ucs_status) {
+                tl_error(UCC_TL_TEAM_LIB(team),
+                         "ucp_ep_rkey_unpack failed for rank %u seg %lu: %s",
+                         r, s, ucs_status_string(ucs_status));
+                status = ucs_status_to_ucc_status(ucs_status);
+                goto err;
+            }
+        }
+    }
+
+    status = UCC_OK;
+err:
+    /* Free scratch and finalize the allgather task on both success and error.
+     * Already-unpacked rkeys remain in team_rkeys[] and are released by
+     * ucc_tl_ucp_team_mem_map_destroy during team teardown. */
+    ucc_free(rbuf);
+    team->mem_map_allgather_rbuf = NULL;
+    ucc_tl_ucp_coll_finalize(team->mem_map_task);
+    team->mem_map_task  = NULL;
+    team->mem_map_phase = 0;
+    return status;
+}
+
+void ucc_tl_ucp_team_mem_map_destroy(ucc_tl_ucp_team_t *team)
+{
+    ucc_tl_ucp_context_t *ctx    = UCC_TL_UCP_TEAM_CTX(team);
+    ucc_rank_t            size   = UCC_TL_TEAM_SIZE(team);
+    uint64_t              n_segs = team->n_mem_segs;
+    ucc_rank_t            r;
+    uint64_t              s;
+
+    /* Clean up any in-flight allgather task on error path.
+     * If the task is still queued (UCC_INPROGRESS), remove it from the
+     * progress queue's linked list before freeing to prevent the next
+     * ucc_context_progress() from walking freed memory. */
+    if (team->mem_map_task != NULL) {
+        if (team->mem_map_task->status == UCC_INPROGRESS) {
+            ucc_list_del(&team->mem_map_task->list_elem);
+        }
+        ucc_tl_ucp_coll_finalize(team->mem_map_task);
+        team->mem_map_task = NULL;
+    }
+    if (team->mem_map_allgather_rbuf != NULL) {
+        ucc_free(team->mem_map_allgather_rbuf);
+        team->mem_map_allgather_rbuf = NULL;
+    }
+
+    /* Destroy unpacked rkeys */
+    if (team->team_rkeys != NULL) {
+        for (r = 0; r < size; r++) {
+            for (s = 0; s < n_segs; s++) {
+                if (UCC_TL_UCP_TEAM_RKEY(team, r, s) != NULL) {
+                    ucp_rkey_destroy(UCC_TL_UCP_TEAM_RKEY(team, r, s));
+                }
+            }
+        }
+        ucc_free(team->team_rkeys);
+        team->team_rkeys = NULL;
+    }
+
+    /* Unmap memory handles and free packed key copies */
+    if (team->mem_segs != NULL) {
+        for (s = 0; s < n_segs; s++) {
+            if (team->mem_segs[s].mem_h) {
+                ucp_mem_unmap(ctx->worker.ucp_context,
+                              (ucp_mem_h)team->mem_segs[s].mem_h);
+            }
+            ucc_free(team->mem_segs[s].packed_key);
+        }
+        ucc_free(team->mem_segs);
+        team->mem_segs = NULL;
+    }
+
+    if (team->team_remote_va != NULL) {
+        ucc_free(team->team_remote_va);
+        team->team_remote_va = NULL;
+    }
+
+    if (team->team_remote_len != NULL) {
+        ucc_free(team->team_remote_len);
+        team->team_remote_len = NULL;
+    }
+
+    team->n_mem_segs = 0;
+}

--- a/src/components/tl/ucp/tl_ucp_team_mem.h
+++ b/src/components/tl/ucp/tl_ucp_team_mem.h
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_UCP_TEAM_MEM_H_
+#define UCC_TL_UCP_TEAM_MEM_H_
+
+#include "tl_ucp.h"
+
+/* Exchange packed_key_len values to find max key size across all ranks.
+ * Registers local segments and posts size-only allgather. Sets mem_map_phase=1. */
+ucc_status_t ucc_tl_ucp_team_mem_map_size_exch(ucc_tl_ucp_team_t *team);
+
+/* Exchange actual memory keys and metadata after determining max key size.
+ * Reads phase-1 allgather results, posts full data allgather. Sets mem_map_phase=2. */
+ucc_status_t ucc_tl_ucp_team_mem_map_data_exch(ucc_tl_ucp_team_t *team);
+
+/* Called once data exchange task completes. Unpacks all remote rkeys, populates
+ * team_remote_va/len, frees allgather scratch, finalizes task. */
+ucc_status_t ucc_tl_ucp_team_mem_map_finalize(ucc_tl_ucp_team_t *team);
+
+/*
+ * Called from ucc_tl_ucp_team_destroy to release all team-segment resources:
+ * unpacked rkeys, UCP memory handles, packed key buffers, and remote VA/len arrays.
+ * Safe to call when n_mem_segs == 0.
+ */
+void ucc_tl_ucp_team_mem_map_destroy(ucc_tl_ucp_team_t *team);
+
+#endif

--- a/test/gtest/coll/test_alltoall.cc
+++ b/test/gtest/coll/test_alltoall.cc
@@ -49,9 +49,9 @@ public:
                                    rank_size);
             }
             if (is_onesided) {
-                sbuf        = team->procs[i].p->onesided_buf[0];
-                rbuf        = team->procs[i].p->onesided_buf[1];
-                work_buf    = (long *)team->procs[i].p->onesided_buf[2];
+                sbuf        = team->onesided_buf(i, 0);
+                rbuf        = team->onesided_buf(i, 1);
+                work_buf    = (long *)team->onesided_buf(i, 2);
                 coll->mask  = UCC_COLL_ARGS_FIELD_FLAGS |
                              UCC_COLL_ARGS_FIELD_GLOBAL_WORK_BUFFER;
                 coll->flags = UCC_COLL_ARGS_FLAG_MEM_MAPPED_BUFFERS;
@@ -236,6 +236,42 @@ UCC_TEST_P(test_alltoall_0, single_onesided)
         }
     }
     team = job.create_team(reference_ranks, true, is_contig, true);
+    this->set_inplace(inplace);
+    SET_MEM_TYPE(mem_type);
+    data_init(size, dtype, count, ctxs, team, false);
+    UccReq req(team, ctxs);
+    req.start();
+    req.wait();
+    EXPECT_EQ(true, data_validate(ctxs));
+    data_fini_onesided(ctxs);
+}
+
+UCC_TEST_P(test_alltoall_0, single_team_onesided)
+{
+    const int            team_id        = std::get<0>(GetParam());
+    const ucc_datatype_t dtype          = std::get<1>(GetParam());
+    ucc_memory_type_t    mem_type       = std::get<2>(GetParam());
+    gtest_ucc_inplace_t  inplace        = std::get<3>(GetParam());
+    const int            count          = std::get<4>(GetParam());
+    UccTeam_h            reference_team = UccJob::getStaticTeams()[team_id];
+    int                  size           = reference_team->procs.size();
+    ucc_job_env_t        env       = {{"UCC_TL_UCP_TUNE", "alltoall:0-inf:@1"}};
+    bool                 is_contig = true;
+    UccJob               job(size, UccJob::UCC_JOB_CTX_GLOBAL, env);
+    UccTeam_h            team;
+    std::vector<int>     reference_ranks;
+    UccCollCtxVec        ctxs;
+
+    for (auto i = 0; i < reference_team->n_procs; i++) {
+        int rank = reference_team->procs[i].p->job_rank;
+        reference_ranks.push_back(rank);
+        if (is_contig && i > 0 &&
+            (rank - reference_ranks[i - 1] > 1 ||
+             reference_ranks[i - 1] - rank > 1)) {
+            is_contig = false;
+        }
+    }
+    team = job.create_team(reference_ranks, true, is_contig, false, true);
     this->set_inplace(inplace);
     SET_MEM_TYPE(mem_type);
     data_init(size, dtype, count, ctxs, team, false);

--- a/test/gtest/common/test_ucc.cc
+++ b/test/gtest/common/test_ucc.cc
@@ -3,6 +3,7 @@
  * See file LICENSE for terms.
  */
 #include "test_ucc.h"
+#include <array>
 extern "C" {
 #include "core/ucc_team.h"
 #include "components/tl/ucc_tl.h"
@@ -164,11 +165,25 @@ uint64_t rank_map_cb(uint64_t ep, void *cb_ctx) {
 }
 
 void UccTeam::init_team(bool use_team_ep_map, bool use_ep_range,
-                        bool is_onesided)
+                        bool is_onesided, bool is_team_onesided)
 {
     ucc_team_params_t                    team_params;
     std::vector<allgather_coll_info_t *> cis;
     ucc_status_t                         status;
+    std::vector<std::array<ucc_mem_map_t, UCC_TEST_N_MEM_SEGMENTS>> seg_maps(
+        n_procs);
+    if (is_team_onesided) {
+        for (int i = 0; i < n_procs; i++) {
+            for (int s = 0; s < UCC_TEST_N_MEM_SEGMENTS; s++) {
+                procs[i].onesided_buf[s] =
+                    ucc_calloc(UCC_TEST_MEM_SEGMENT_SIZE, 1,
+                               "team_onesided_buffer");
+                EXPECT_NE(procs[i].onesided_buf[s], nullptr);
+                seg_maps[i][s].address = procs[i].onesided_buf[s];
+                seg_maps[i][s].len     = UCC_TEST_MEM_SEGMENT_SIZE;
+            }
+        }
+    }
     for (int i = 0; i < n_procs; i++) {
         cis.push_back(new allgather_coll_info);
         cis.back()->self     = this;
@@ -199,6 +214,13 @@ void UccTeam::init_team(bool use_team_ep_map, bool use_ep_range,
         if (is_onesided) {
             team_params.mask |= UCC_TEAM_PARAM_FIELD_FLAGS;
             team_params.flags = UCC_TEAM_FLAG_COLL_WORK_BUFFER;
+        }
+        if (is_team_onesided) {
+            team_params.mask |= UCC_TEAM_PARAM_FIELD_FLAGS |
+                                UCC_TEAM_PARAM_FIELD_MEM_PARAMS;
+            team_params.flags = UCC_TEAM_FLAG_COLL_WORK_BUFFER;
+            team_params.mem_params.segments   = seg_maps[i].data();
+            team_params.mem_params.n_segments = UCC_TEST_N_MEM_SEGMENTS;
         }
         EXPECT_EQ(UCC_OK,
                   ucc_team_create_post(&(procs[i].p.get()->ctx_h), 1, &team_params,
@@ -251,9 +273,10 @@ void UccTeam::progress()
 }
 
 UccTeam::UccTeam(std::vector<UccProcess_h> &_procs, bool use_team_ep_map,
-                 bool use_ep_range, bool is_onesided)
+                 bool use_ep_range, bool is_onesided, bool _is_team_onesided)
 {
-    n_procs = _procs.size();
+    n_procs           = _procs.size();
+    is_team_onesided  = _is_team_onesided;
     ag.resize(n_procs);
     for (auto &p : _procs) {
         procs.push_back(proc(p));
@@ -262,13 +285,31 @@ UccTeam::UccTeam(std::vector<UccProcess_h> &_procs, bool use_team_ep_map,
         a.phase = AG_INIT;
     }
     copy_complete_count = 0;
-    init_team(use_team_ep_map, use_ep_range, is_onesided);
+    init_team(use_team_ep_map, use_ep_range, is_onesided, is_team_onesided);
     // test_allgather(128);
 }
 
 UccTeam::~UccTeam()
 {
     destroy_team();
+    if (is_team_onesided) {
+        for (int i = 0; i < n_procs; i++) {
+            for (int s = 0; s < UCC_TEST_N_MEM_SEGMENTS; s++) {
+                if (procs[i].onesided_buf[s]) {
+                    ucc_free(procs[i].onesided_buf[s]);
+                    procs[i].onesided_buf[s] = NULL;
+                }
+            }
+        }
+    }
+}
+
+void *UccTeam::onesided_buf(int rank, int seg)
+{
+    if (is_team_onesided) {
+        return procs[rank].onesided_buf[seg];
+    }
+    return procs[rank].p->onesided_buf[seg];
 }
 
 UccJob::UccJob(int _n_procs, ucc_job_ctx_mode_t _ctx_mode, ucc_job_env_t vars) :
@@ -554,7 +595,8 @@ void UccJob::cleanup()
 }
 
 UccTeam_h UccJob::create_team(int _n_procs, bool use_team_ep_map,
-                              bool use_ep_range, bool is_onesided)
+                              bool use_ep_range, bool is_onesided,
+                              bool is_team_onesided)
 {
     EXPECT_GE(n_procs, _n_procs);
     std::vector<UccProcess_h> team_procs;
@@ -562,11 +604,12 @@ UccTeam_h UccJob::create_team(int _n_procs, bool use_team_ep_map,
         team_procs.push_back(procs[i]);
     }
     return std::make_shared<UccTeam>(team_procs, use_team_ep_map, use_ep_range,
-                                     is_onesided);
+                                     is_onesided, is_team_onesided);
 }
 
 UccTeam_h UccJob::create_team(std::vector<int> &ranks, bool use_team_ep_map,
-                              bool use_ep_range, bool is_onesided)
+                              bool use_ep_range, bool is_onesided,
+                              bool is_team_onesided)
 {
     EXPECT_GE(n_procs, ranks.size());
     std::vector<UccProcess_h> team_procs;
@@ -574,7 +617,7 @@ UccTeam_h UccJob::create_team(std::vector<int> &ranks, bool use_team_ep_map,
         team_procs.push_back(procs[ranks[i]]);
     }
     return std::make_shared<UccTeam>(team_procs, use_team_ep_map, use_ep_range,
-                                     is_onesided);
+                                     is_onesided, is_team_onesided);
 }
 
 UccReq::UccReq(UccTeam_h _team, ucc_coll_args_t *args) :

--- a/test/gtest/common/test_ucc.h
+++ b/test/gtest/common/test_ucc.h
@@ -150,12 +150,21 @@ typedef std::shared_ptr<UccProcess> UccProcess_h;
 /* Ucc team that consists of several processes. The team
    is created from UccJob environment */
 class UccTeam {
+public:
     struct proc {
         UccProcess_h p;
-        ucc_team_h     team;
-        proc(){};
-        proc(UccProcess_h _p) : p(_p) {};
+        ucc_team_h   team;
+        void *       onesided_buf[3];
+        proc()
+        {
+            onesided_buf[0] = onesided_buf[1] = onesided_buf[2] = NULL;
+        };
+        proc(UccProcess_h _p) : p(_p)
+        {
+            onesided_buf[0] = onesided_buf[1] = onesided_buf[2] = NULL;
+        };
     };
+private:
     typedef enum {
         AG_INIT,
         AG_READY,
@@ -173,7 +182,8 @@ class UccTeam {
         UccTeam *self;
     } allgather_coll_info_t;
     std::vector<struct allgather_data> ag;
-    void init_team(bool use_team_ep_map, bool use_ep_range, bool is_onesided);
+    void init_team(bool use_team_ep_map, bool use_ep_range, bool is_onesided,
+                   bool is_team_onesided);
     void destroy_team();
     void test_allgather(size_t msglen);
     static ucc_status_t allgather(void *src_buf, void *recv_buf, size_t size,
@@ -185,9 +195,12 @@ public:
     int n_procs;
     void progress();
     std::vector<proc> procs;
+    bool is_team_onesided;
     UccTeam(std::vector<UccProcess_h> &_procs, bool use_team_ep_map = false,
-            bool use_ep_range = true, bool is_onesided = false);
+            bool use_ep_range = true, bool is_onesided = false,
+            bool is_team_onesided = false);
     ~UccTeam();
+    void *onesided_buf(int rank, int seg);
 };
 typedef std::shared_ptr<UccTeam> UccTeam_h;
 typedef std::pair<std::string, std::string> ucc_env_var_t;
@@ -216,9 +229,11 @@ public:
     ~UccJob();
     std::vector<UccProcess_h> procs;
     UccTeam_h create_team(int n_procs, bool use_team_ep_map = false,
-                          bool use_ep_range = true, bool is_onesided = false);
+                          bool use_ep_range = true, bool is_onesided = false,
+                          bool is_team_onesided = false);
     UccTeam_h create_team(std::vector<int> &ranks, bool use_team_ep_map = false,
-                          bool use_ep_range = true, bool is_onesided = false);
+                          bool use_ep_range = true, bool is_onesided = false,
+                          bool is_team_onesided = false);
     void create_context();
     ucc_job_ctx_mode_t ctx_mode;
 };


### PR DESCRIPTION
## What
Implements a team-based memory map param support for TL/UCP.

## Why ?
This adds an expensive path over team creation for TL/UCP if the user sets the memory map parameters during team creation. It enables segments that are restricted to a team rather than a context and would be useful for (1) OpenSHMEM Team's support and (2) using global-work buffer for features such as PR #1248 and PR #1149 to enable onesided scratch buffers.
