### PR TITLE
TOPO: resolve NVML fabric symbols lazily

### DIFF
--- a/src/components/topo/cuda/ucc_sysinfo_cuda.c
+++ b/src/components/topo/cuda/ucc_sysinfo_cuda.c
@@ -62,7 +62,13 @@ static void *ucc_sysinfo_cuda_nvml_get_handle(void)
     }
 #endif
 
-    return handle ? handle : RTLD_DEFAULT;
+    if (!handle) {
+        ucc_debug("could not obtain dedicated NVML handle; "
+                  "falling back to RTLD_DEFAULT");
+        return RTLD_DEFAULT;
+    }
+
+    return handle;
 }
 
 static void *ucc_sysinfo_cuda_nvml_get_symbol(const char *symbol)

--- a/src/components/topo/cuda/ucc_sysinfo_cuda.c
+++ b/src/components/topo/cuda/ucc_sysinfo_cuda.c
@@ -34,50 +34,18 @@ static pthread_mutex_t ucc_sysinfo_cuda_nvml_lock = PTHREAD_MUTEX_INITIALIZER;
  * headers while users run against an older libnvidia-ml.so.1, so resolve these
  * symbols lazily and leave fabric metadata unset when they are unavailable.
  */
-static void *ucc_sysinfo_cuda_nvml_get_handle(void)
-{
-    static int    resolved;
-    static void  *handle;
-    Dl_info       dl_info;
-
-    if (resolved) {
-        return handle ? handle : RTLD_DEFAULT;
-    }
-
-    resolved = 1;
-    if (dladdr((void *)nvmlInit_v2, &dl_info) && dl_info.dli_fname) {
-#ifdef RTLD_NOLOAD
-        handle = dlopen(dl_info.dli_fname,
-                        RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
-#endif
-        if (!handle) {
-            handle = dlopen(dl_info.dli_fname, RTLD_LAZY | RTLD_LOCAL);
-        }
-    }
-
-#ifdef RTLD_NOLOAD
-    if (!handle) {
-        handle = dlopen("libnvidia-ml.so.1",
-                        RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
-    }
-#endif
-
-    if (!handle) {
-        ucc_debug("could not obtain dedicated NVML handle; "
-                  "falling back to RTLD_DEFAULT");
-        return RTLD_DEFAULT;
-    }
-
-    return handle;
-}
-
 static void *ucc_sysinfo_cuda_nvml_get_symbol(const char *symbol)
 {
     void *sym;
     char *error;
 
+    /*
+     * libnvidia-ml.so.1 is already mapped (the component links it and calls
+     * nvmlInit_v2), so RTLD_DEFAULT resolves whatever fabric symbols the
+     * running driver exports without an explicit dlopen.
+     */
     dlerror();
-    sym = dlsym(ucc_sysinfo_cuda_nvml_get_handle(), symbol);
+    sym = dlsym(RTLD_DEFAULT, symbol);
     error = dlerror();
     if (error) {
         ucc_debug("NVML symbol %s is unavailable: %s", symbol, error);
@@ -87,44 +55,33 @@ static void *ucc_sysinfo_cuda_nvml_get_symbol(const char *symbol)
     return sym;
 }
 
+#define UCC_NVML_SYMBOL_LOADER(_fn, _type, _sym)                               \
+    static _type _fn(void)                                                     \
+    {                                                                          \
+        static int   resolved;                                                 \
+        static _type fn;                                                       \
+                                                                               \
+        if (!resolved) {                                                       \
+            fn       = (_type)ucc_sysinfo_cuda_nvml_get_symbol(_sym);          \
+            resolved = 1;                                                      \
+        }                                                                      \
+        return fn;                                                             \
+    }
+
 #ifdef HAVE_NVML_GPU_FABRIC_INFO_V
 typedef nvmlReturn_t (*ucc_nvmlDeviceGetGpuFabricInfoV_t)(
     nvmlDevice_t device, nvmlGpuFabricInfoV_t *gpuFabricInfo);
-
-static ucc_nvmlDeviceGetGpuFabricInfoV_t
-ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_v_fn(void)
-{
-    static int                               resolved;
-    static ucc_nvmlDeviceGetGpuFabricInfoV_t fn;
-
-    if (!resolved) {
-        fn = (ucc_nvmlDeviceGetGpuFabricInfoV_t)
-            ucc_sysinfo_cuda_nvml_get_symbol("nvmlDeviceGetGpuFabricInfoV");
-        resolved = 1;
-    }
-
-    return fn;
-}
+UCC_NVML_SYMBOL_LOADER(ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_v_fn,
+                       ucc_nvmlDeviceGetGpuFabricInfoV_t,
+                       "nvmlDeviceGetGpuFabricInfoV")
 #endif
 
 #ifdef HAVE_NVML_GPU_FABRIC_INFO
 typedef nvmlReturn_t (*ucc_nvmlDeviceGetGpuFabricInfo_t)(
     nvmlDevice_t device, nvmlGpuFabricInfo_t *gpuFabricInfo);
-
-static ucc_nvmlDeviceGetGpuFabricInfo_t
-ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_fn(void)
-{
-    static int                              resolved;
-    static ucc_nvmlDeviceGetGpuFabricInfo_t fn;
-
-    if (!resolved) {
-        fn = (ucc_nvmlDeviceGetGpuFabricInfo_t)
-            ucc_sysinfo_cuda_nvml_get_symbol("nvmlDeviceGetGpuFabricInfo");
-        resolved = 1;
-    }
-
-    return fn;
-}
+UCC_NVML_SYMBOL_LOADER(ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_fn,
+                       ucc_nvmlDeviceGetGpuFabricInfo_t,
+                       "nvmlDeviceGetGpuFabricInfo")
 #endif
 
 static void ucc_sysinfo_cuda_update_fabric_info(nvmlDevice_t nvml_dev,
@@ -159,10 +116,13 @@ static void ucc_sysinfo_cuda_update_fabric_info(nvmlDevice_t nvml_dev,
                 memcpy(gpu->fabric_cluster_uuid, fabric_info_v.clusterUuid,
                        UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
             }
-            return;
+        } else {
+            ucc_debug("nvmlDeviceGetGpuFabricInfoV failed: %s",
+                      nvmlErrorString(nvml_st));
         }
-        ucc_debug("nvmlDeviceGetGpuFabricInfoV failed: %s",
-                  nvmlErrorString(nvml_st));
+        /* The versioned API is present and authoritative; the legacy API is
+         * only a fallback for drivers that lack the versioned symbol. */
+        return;
     }
 #endif
 

--- a/src/components/topo/cuda/ucc_sysinfo_cuda.c
+++ b/src/components/topo/cuda/ucc_sysinfo_cuda.c
@@ -12,6 +12,10 @@
 #include <nvml.h>
 #include <pthread.h>
 #include <string.h>
+#if defined(HAVE_NVML_GPU_FABRIC_INFO_V) || \
+    defined(HAVE_NVML_GPU_FABRIC_INFO)
+#include <dlfcn.h>
+#endif
 #endif
 
 static ucc_config_field_t ucc_sysinfo_cuda_config_table[] = {
@@ -20,6 +24,171 @@ static ucc_config_field_t ucc_sysinfo_cuda_config_table[] = {
 
 #ifdef HAVE_NVML_H
 static pthread_mutex_t ucc_sysinfo_cuda_nvml_lock = PTHREAD_MUTEX_INITIALIZER;
+#endif
+
+#if defined(HAVE_NVML_H) && \
+    (defined(HAVE_NVML_GPU_FABRIC_INFO_V) || \
+     defined(HAVE_NVML_GPU_FABRIC_INFO))
+/*
+ * NVML fabric-info APIs are optional at runtime. Builds may use newer NVML
+ * headers while users run against an older libnvidia-ml.so.1, so resolve these
+ * symbols lazily and leave fabric metadata unset when they are unavailable.
+ */
+static void *ucc_sysinfo_cuda_nvml_get_handle(void)
+{
+    static int    resolved;
+    static void  *handle;
+    Dl_info       dl_info;
+
+    if (resolved) {
+        return handle ? handle : RTLD_DEFAULT;
+    }
+
+    resolved = 1;
+    if (dladdr((void *)nvmlInit_v2, &dl_info) && dl_info.dli_fname) {
+#ifdef RTLD_NOLOAD
+        handle = dlopen(dl_info.dli_fname,
+                        RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
+#endif
+        if (!handle) {
+            handle = dlopen(dl_info.dli_fname, RTLD_LAZY | RTLD_LOCAL);
+        }
+    }
+
+#ifdef RTLD_NOLOAD
+    if (!handle) {
+        handle = dlopen("libnvidia-ml.so.1",
+                        RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
+    }
+#endif
+
+    return handle ? handle : RTLD_DEFAULT;
+}
+
+static void *ucc_sysinfo_cuda_nvml_get_symbol(const char *symbol)
+{
+    void *sym;
+    char *error;
+
+    dlerror();
+    sym = dlsym(ucc_sysinfo_cuda_nvml_get_handle(), symbol);
+    error = dlerror();
+    if (error) {
+        ucc_debug("NVML symbol %s is unavailable: %s", symbol, error);
+        return NULL;
+    }
+
+    return sym;
+}
+
+#ifdef HAVE_NVML_GPU_FABRIC_INFO_V
+typedef nvmlReturn_t (*ucc_nvmlDeviceGetGpuFabricInfoV_t)(
+    nvmlDevice_t device, nvmlGpuFabricInfoV_t *gpuFabricInfo);
+
+static ucc_nvmlDeviceGetGpuFabricInfoV_t
+ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_v_fn(void)
+{
+    static int                                resolved;
+    static ucc_nvmlDeviceGetGpuFabricInfoV_t fn;
+
+    if (!resolved) {
+        fn = (ucc_nvmlDeviceGetGpuFabricInfoV_t)
+            ucc_sysinfo_cuda_nvml_get_symbol("nvmlDeviceGetGpuFabricInfoV");
+        resolved = 1;
+    }
+
+    return fn;
+}
+#endif
+
+#ifdef HAVE_NVML_GPU_FABRIC_INFO
+typedef nvmlReturn_t (*ucc_nvmlDeviceGetGpuFabricInfo_t)(
+    nvmlDevice_t device, nvmlGpuFabricInfo_t *gpuFabricInfo);
+
+static ucc_nvmlDeviceGetGpuFabricInfo_t
+ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_fn(void)
+{
+    static int                               resolved;
+    static ucc_nvmlDeviceGetGpuFabricInfo_t fn;
+
+    if (!resolved) {
+        fn = (ucc_nvmlDeviceGetGpuFabricInfo_t)
+            ucc_sysinfo_cuda_nvml_get_symbol("nvmlDeviceGetGpuFabricInfo");
+        resolved = 1;
+    }
+
+    return fn;
+}
+#endif
+
+static void ucc_sysinfo_cuda_update_fabric_info(nvmlDevice_t nvml_dev,
+                                                ucc_gpu_info_t *gpu)
+{
+    nvmlReturn_t nvml_st;
+
+#ifdef HAVE_NVML_GPU_FABRIC_INFO_V
+    ucc_nvmlDeviceGetGpuFabricInfoV_t get_fabric_info_v;
+
+    get_fabric_info_v = ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_v_fn();
+    if (get_fabric_info_v) {
+        nvmlGpuFabricInfoV_t fabric_info;
+
+        memset(&fabric_info, 0, sizeof(fabric_info));
+        fabric_info.version = nvmlGpuFabricInfo_v2;
+        nvml_st = get_fabric_info_v(nvml_dev, &fabric_info);
+        UCC_STATIC_ASSERT(
+            sizeof(fabric_info.clusterUuid) ==
+            UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
+        if (nvml_st == NVML_SUCCESS) {
+            if (fabric_info.state == NVML_GPU_FABRIC_STATE_COMPLETED) {
+                gpu->caps |= UCC_GPU_CAP_FABRIC;
+                gpu->fabric_clique_id = fabric_info.cliqueId;
+#ifdef HAVE_NVML_FABRIC_PARTITION_ID
+                gpu->fabric_partition_id = fabric_info.partitionId;
+#endif
+                /* Globally-unique fabric id; needed for cross-node match. */
+                memcpy(
+                    gpu->fabric_cluster_uuid,
+                    fabric_info.clusterUuid,
+                    UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
+            }
+            return;
+        }
+        ucc_debug("nvmlDeviceGetGpuFabricInfoV failed: %s",
+                  nvmlErrorString(nvml_st));
+    }
+#endif
+
+#ifdef HAVE_NVML_GPU_FABRIC_INFO
+    {
+        ucc_nvmlDeviceGetGpuFabricInfo_t get_fabric_info;
+
+        get_fabric_info = ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_fn();
+        if (get_fabric_info) {
+            nvmlGpuFabricInfo_t fabric_info;
+
+            memset(&fabric_info, 0, sizeof(fabric_info));
+            nvml_st = get_fabric_info(nvml_dev, &fabric_info);
+            UCC_STATIC_ASSERT(
+                sizeof(fabric_info.clusterUuid) ==
+                UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
+            if (nvml_st == NVML_SUCCESS &&
+                fabric_info.state == NVML_GPU_FABRIC_STATE_COMPLETED) {
+                gpu->caps |= UCC_GPU_CAP_FABRIC;
+                gpu->fabric_clique_id = fabric_info.cliqueId;
+                /* Globally-unique fabric id; needed for cross-node match. */
+                memcpy(
+                    gpu->fabric_cluster_uuid,
+                    fabric_info.clusterUuid,
+                    UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
+            } else if (nvml_st != NVML_SUCCESS) {
+                ucc_debug("nvmlDeviceGetGpuFabricInfo failed: %s",
+                          nvmlErrorString(nvml_st));
+            }
+        }
+    }
+#endif
+}
 #endif
 
 static ucc_status_t ucc_sysinfo_cuda_init(const ucc_sysinfo_params_t *params)
@@ -510,35 +679,9 @@ static ucc_status_t ucc_sysinfo_cuda_get_info(void **info, int *n_info)
             }
         }
 
-#if defined(HAVE_NVML_GPU_FABRIC_INFO_V) || defined(HAVE_NVML_GPU_FABRIC_INFO)
-        {
-#ifdef HAVE_NVML_GPU_FABRIC_INFO_V
-            nvmlGpuFabricInfoV_t fabric_info;
-
-            fabric_info.version = nvmlGpuFabricInfo_v2;
-            nvml_st = nvmlDeviceGetGpuFabricInfoV(nvml_dev, &fabric_info);
-#else
-            nvmlGpuFabricInfo_t fabric_info;
-
-            nvml_st = nvmlDeviceGetGpuFabricInfo(nvml_dev, &fabric_info);
-#endif
-            UCC_STATIC_ASSERT(
-                sizeof(fabric_info.clusterUuid) ==
-                UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
-            if (nvml_st == NVML_SUCCESS &&
-                fabric_info.state == NVML_GPU_FABRIC_STATE_COMPLETED) {
-                gpu_info->gpus[i].caps |= UCC_GPU_CAP_FABRIC;
-                gpu_info->gpus[i].fabric_clique_id = fabric_info.cliqueId;
-#if defined(HAVE_NVML_GPU_FABRIC_INFO_V) && defined(HAVE_NVML_FABRIC_PARTITION_ID)
-                gpu_info->gpus[i].fabric_partition_id = fabric_info.partitionId;
-#endif
-                /* Globally-unique fabric id; needed for cross-node match. */
-                memcpy(
-                    gpu_info->gpus[i].fabric_cluster_uuid,
-                    fabric_info.clusterUuid,
-                    UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
-            }
-        }
+#if defined(HAVE_NVML_GPU_FABRIC_INFO_V) || \
+    defined(HAVE_NVML_GPU_FABRIC_INFO)
+        ucc_sysinfo_cuda_update_fabric_info(nvml_dev, &gpu_info->gpus[i]);
 #endif
         u = gpu_info->gpus[i].fabric_cluster_uuid;
         ucc_debug(

--- a/src/components/topo/cuda/ucc_sysinfo_cuda.c
+++ b/src/components/topo/cuda/ucc_sysinfo_cuda.c
@@ -94,7 +94,7 @@ typedef nvmlReturn_t (*ucc_nvmlDeviceGetGpuFabricInfoV_t)(
 static ucc_nvmlDeviceGetGpuFabricInfoV_t
 ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_v_fn(void)
 {
-    static int                                resolved;
+    static int                               resolved;
     static ucc_nvmlDeviceGetGpuFabricInfoV_t fn;
 
     if (!resolved) {
@@ -114,7 +114,7 @@ typedef nvmlReturn_t (*ucc_nvmlDeviceGetGpuFabricInfo_t)(
 static ucc_nvmlDeviceGetGpuFabricInfo_t
 ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_fn(void)
 {
-    static int                               resolved;
+    static int                              resolved;
     static ucc_nvmlDeviceGetGpuFabricInfo_t fn;
 
     if (!resolved) {
@@ -131,32 +131,33 @@ static void ucc_sysinfo_cuda_update_fabric_info(nvmlDevice_t nvml_dev,
                                                 ucc_gpu_info_t *gpu)
 {
     nvmlReturn_t nvml_st;
-
 #ifdef HAVE_NVML_GPU_FABRIC_INFO_V
     ucc_nvmlDeviceGetGpuFabricInfoV_t get_fabric_info_v;
+    nvmlGpuFabricInfoV_t              fabric_info_v;
+#endif
+#ifdef HAVE_NVML_GPU_FABRIC_INFO
+    ucc_nvmlDeviceGetGpuFabricInfo_t get_fabric_info;
+    nvmlGpuFabricInfo_t              fabric_info;
+#endif
 
+#ifdef HAVE_NVML_GPU_FABRIC_INFO_V
     get_fabric_info_v = ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_v_fn();
     if (get_fabric_info_v) {
-        nvmlGpuFabricInfoV_t fabric_info;
-
-        memset(&fabric_info, 0, sizeof(fabric_info));
-        fabric_info.version = nvmlGpuFabricInfo_v2;
-        nvml_st = get_fabric_info_v(nvml_dev, &fabric_info);
-        UCC_STATIC_ASSERT(
-            sizeof(fabric_info.clusterUuid) ==
-            UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
+        memset(&fabric_info_v, 0, sizeof(fabric_info_v));
+        fabric_info_v.version = nvmlGpuFabricInfo_v2;
+        nvml_st = get_fabric_info_v(nvml_dev, &fabric_info_v);
+        UCC_STATIC_ASSERT(sizeof(fabric_info_v.clusterUuid) ==
+                          UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
         if (nvml_st == NVML_SUCCESS) {
-            if (fabric_info.state == NVML_GPU_FABRIC_STATE_COMPLETED) {
+            if (fabric_info_v.state == NVML_GPU_FABRIC_STATE_COMPLETED) {
                 gpu->caps |= UCC_GPU_CAP_FABRIC;
-                gpu->fabric_clique_id = fabric_info.cliqueId;
+                gpu->fabric_clique_id = fabric_info_v.cliqueId;
 #ifdef HAVE_NVML_FABRIC_PARTITION_ID
-                gpu->fabric_partition_id = fabric_info.partitionId;
+                gpu->fabric_partition_id = fabric_info_v.partitionId;
 #endif
                 /* Globally-unique fabric id; needed for cross-node match. */
-                memcpy(
-                    gpu->fabric_cluster_uuid,
-                    fabric_info.clusterUuid,
-                    UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
+                memcpy(gpu->fabric_cluster_uuid, fabric_info_v.clusterUuid,
+                       UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
             }
             return;
         }
@@ -166,31 +167,22 @@ static void ucc_sysinfo_cuda_update_fabric_info(nvmlDevice_t nvml_dev,
 #endif
 
 #ifdef HAVE_NVML_GPU_FABRIC_INFO
-    {
-        ucc_nvmlDeviceGetGpuFabricInfo_t get_fabric_info;
-
-        get_fabric_info = ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_fn();
-        if (get_fabric_info) {
-            nvmlGpuFabricInfo_t fabric_info;
-
-            memset(&fabric_info, 0, sizeof(fabric_info));
-            nvml_st = get_fabric_info(nvml_dev, &fabric_info);
-            UCC_STATIC_ASSERT(
-                sizeof(fabric_info.clusterUuid) ==
-                UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
-            if (nvml_st == NVML_SUCCESS &&
-                fabric_info.state == NVML_GPU_FABRIC_STATE_COMPLETED) {
-                gpu->caps |= UCC_GPU_CAP_FABRIC;
-                gpu->fabric_clique_id = fabric_info.cliqueId;
-                /* Globally-unique fabric id; needed for cross-node match. */
-                memcpy(
-                    gpu->fabric_cluster_uuid,
-                    fabric_info.clusterUuid,
-                    UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
-            } else if (nvml_st != NVML_SUCCESS) {
-                ucc_debug("nvmlDeviceGetGpuFabricInfo failed: %s",
-                          nvmlErrorString(nvml_st));
-            }
+    get_fabric_info = ucc_sysinfo_cuda_nvml_get_gpu_fabric_info_fn();
+    if (get_fabric_info) {
+        memset(&fabric_info, 0, sizeof(fabric_info));
+        nvml_st = get_fabric_info(nvml_dev, &fabric_info);
+        UCC_STATIC_ASSERT(sizeof(fabric_info.clusterUuid) ==
+                          UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
+        if (nvml_st == NVML_SUCCESS &&
+            fabric_info.state == NVML_GPU_FABRIC_STATE_COMPLETED) {
+            gpu->caps |= UCC_GPU_CAP_FABRIC;
+            gpu->fabric_clique_id = fabric_info.cliqueId;
+            /* Globally-unique fabric id; needed for cross-node match. */
+            memcpy(gpu->fabric_cluster_uuid, fabric_info.clusterUuid,
+                   UCC_GPU_FABRIC_CLUSTER_UUID_LEN);
+        } else if (nvml_st != NVML_SUCCESS) {
+            ucc_debug("nvmlDeviceGetGpuFabricInfo failed: %s",
+                      nvmlErrorString(nvml_st));
         }
     }
 #endif


### PR DESCRIPTION
## What
This PR avoids a hard runtime dependency on newer NVML fabric-info symbols in the CUDA sysinfo component.

Specifically, `nvmlDeviceGetGpuFabricInfoV` and the legacy `nvmlDeviceGetGpuFabricInfo` path are now resolved lazily with `dlsym()` before use.

## Why ?
HPC SDK users can build UCC/HPC-X with newer CUDA/NVML headers but run on systems with older NVIDIA drivers. In that case, `libucc_sysinfo_cuda.so` could fail to load with:

`undefined symbol: nvmlDeviceGetGpuFabricInfoV`

That symbol is only available in newer `libnvidia-ml.so.1` versions, so directly referencing it raises the effective runtime driver requirement even when fabric metadata is optional.

## How ?
The CUDA sysinfo fabric query now uses a small runtime resolver for optional NVML fabric APIs. If the versioned fabric-info symbol is available, UCC uses it and preserves partition ID support. If it is unavailable, UCC falls back to the legacy fabric-info API when present. If neither symbol exists, fabric metadata remains unset and UCC continues without failing library load.

## Testing
Tested before/after with CUDA 12.9.1 and NVML 555 at build time, then switched runtime NVML to R525.60.13.

Before this PR:
- `config.h` defined `HAVE_NVML_GPU_FABRIC_INFO_V`.
- `readelf -Ws libucc_sysinfo_cuda.so | grep nvmlDeviceGetGpuFabricInfo` showed an undefined relocation for `nvmlDeviceGetGpuFabricInfoV`.
- With R525 NVML loaded, `ldd -r libucc_sysinfo_cuda.so` failed with:
  `undefined symbol: nvmlDeviceGetGpuFabricInfoV`

After this PR:
- `readelf` and `nm -D` show no dynamic dependency on `nvmlDeviceGetGpuFabricInfo*`.
- With R525 NVML loaded, `ldd -r libucc_sysinfo_cuda.so` reports no undefined fabric-info symbols.