### PR TITLE
TL/CUDA: NVLS allreduce small buffers (#1304)

### DIFF
--- a/src/components/tl/cuda/allreduce/allreduce_nvls.c
+++ b/src/components/tl/cuda/allreduce/allreduce_nvls.c
@@ -30,6 +30,12 @@ ucc_status_t ucc_tl_cuda_allreduce_nvls_start(ucc_coll_task_t *coll_task)
 
     task->allreduce_nvls.buf_size_bytes = args->dst.info.count *
                                           ucc_dt_size(task->allreduce_nvls.dt);
+    /* Pad up to one uint4 (16 B); the NVLS kernels' 16 B vector quantum is
+     * the only alignment we need. Padding bytes are uninitialized — the
+     * MC LD-SUM over them produces a fault-free arbitrary value that we
+     * never copy back to the user buffer. */
+    task->allreduce_nvls.kernel_size_bytes = ucc_align_up(
+        task->allreduce_nvls.buf_size_bytes, 16);
     task->allreduce_nvls.rbuf = args->dst.info.buffer;
     task->allreduce_nvls.sbuf = UCC_IS_INPLACE(*args) ? args->dst.info.buffer
                                                       : args->src.info.buffer;
@@ -72,7 +78,7 @@ void ucc_tl_cuda_allreduce_nvls_progress(ucc_coll_task_t *coll_task)
 
     switch (task->allreduce_nvls.stage) {
     case STAGE_KERNEL:
-        // copy src buffer to symmetric memory first
+        /* Copy the user source into the symmetric buffer. */
         status = CUDA_FUNC(cudaMemcpyAsync(
             (void *)uc_va,
             task->allreduce_nvls.sbuf,
@@ -89,7 +95,7 @@ void ucc_tl_cuda_allreduce_nvls_progress(ucc_coll_task_t *coll_task)
             sm_count,
             threads,
             mc_va,
-            task->allreduce_nvls.buf_size_bytes,
+            task->allreduce_nvls.kernel_size_bytes,
             TASK_NVLS_CONTROL_MC(task),
             TASK_NVLS_CONTROL_UC(task),
             task->allreduce_nvls.coll_id,
@@ -101,6 +107,8 @@ void ucc_tl_cuda_allreduce_nvls_progress(ucc_coll_task_t *coll_task)
             task->super.status = status;
             return;
         }
+        /* Copy back only the user data range; padding stays in the
+         * symmetric buffer and is overwritten on the next collective. */
         status = CUDA_FUNC(cudaMemcpyAsync(
             (void *)task->allreduce_nvls.rbuf,
             (void *)uc_va,
@@ -182,26 +190,31 @@ ucc_status_t ucc_tl_cuda_allreduce_nvls_init(
     ucc_tl_cuda_team_t *team     = ucc_derived_of(tl_team, ucc_tl_cuda_team_t);
     size_t              buf_size = coll_args->args.dst.info.count *
                       ucc_dt_size(coll_args->args.dst.info.datatype);
+    size_t              kernel_size = ucc_align_up(buf_size, 16);
     ucc_tl_cuda_task_t *task;
     ucc_status_t        status;
 
-    if (buf_size < 1024 || coll_args->args.op != UCC_OP_SUM ||
+    /* The kernels operate on 16-byte vector units (uint4 / 4xu32 / 2xu64),
+     * so the only size constraint is 16 B alignment. The tail is left
+     * uninitialized and only buf_size bytes are copied back after the
+     * kernel. */
+    if (buf_size == 0 || coll_args->args.op != UCC_OP_SUM ||
         !ucc_tl_cuda_allreduce_nvls_dt_supported(
             coll_args->args.dst.info.datatype)) {
         tl_debug(
             UCC_TL_TEAM_LIB(team),
             "NVLS allreduce is supported only with SUM operation "
             "and float32, bfloat16, int32, uint32, int64, or uint64 "
-            "datatype, with message size >= 1024 bytes");
+            "datatype, with non-zero message size");
         return UCC_ERR_NOT_SUPPORTED;
     }
-    if (ucc_unlikely(
-            buf_size > UCC_TL_CUDA_TEAM_LIB(team)->cfg.nvls_symmetric_size)) {
+    if (ucc_unlikely(kernel_size >
+                     UCC_TL_CUDA_TEAM_LIB(team)->cfg.nvls_symmetric_size)) {
         tl_debug(
             UCC_TL_TEAM_LIB(team),
-            "NVLS allreduce buffer size %zu bytes exceeds symmetric buffer "
-            "size %zu bytes",
-            buf_size,
+            "NVLS allreduce padded buffer size %zu bytes exceeds "
+            "symmetric buffer size %zu bytes",
+            kernel_size,
             UCC_TL_CUDA_TEAM_LIB(team)->cfg.nvls_symmetric_size);
         return UCC_ERR_NOT_SUPPORTED;
     }

--- a/src/components/tl/cuda/kernels/allreduce_kernel.cu
+++ b/src/components/tl/cuda/kernels/allreduce_kernel.cu
@@ -17,35 +17,43 @@ extern "C" {
 
 #include "nvls.cuh"
 
-
 // vectorized allreduce kernel for 32-bit lanes
 template <typename NvlsOps>
 __global__ void __launch_bounds__(UCC_TL_CUDA_MAX_NVLS_THREADS)
-    allreduce_kernel_vec32(ucc_tl_cuda_nvls_control_t *mc_bar,
-                           ucc_tl_cuda_nvls_control_t *uc_bar,
-                           const uint32_t total_blocks, // block count per gpu * num gpus in Multicast group
-                           uint64_t launch_counter,
-                           uint32_t *base_u32, size_t count_u32, uint32_t rank,
-                           uint32_t tsize)
+    allreduce_kernel_vec32(
+        ucc_tl_cuda_nvls_control_t *mc_bar, ucc_tl_cuda_nvls_control_t *uc_bar,
+        const uint32_t total_blocks, uint64_t launch_counter,
+        uint32_t *base_u32, size_t count_u32, uint32_t rank, uint32_t tsize)
 {
-    // pre barrier
-    nvls_bar(&(mc_bar->arrival_counter), &(uc_bar->arrival_counter), total_blocks * (launch_counter * 2 + 1));
-
-    // Kernel execution
-    size_t chunk_start = ((int64_t)count_u32 * (int64_t)rank) / (int64_t)tsize;
-    size_t chunk_end   = ((int64_t)count_u32 * (int64_t)(rank + 1)) / (int64_t)tsize;
-
     size_t thread_offset = (threadIdx.x + blockIdx.x * blockDim.x) * 4;
     size_t stride        = blockDim.x * gridDim.x * 4;
+    size_t chunk_start;
+    size_t chunk_end;
+    uint4  val;
 
-    for (size_t idx = chunk_start + thread_offset; idx < chunk_end; idx += stride) {
-        uint4 val;
+    nvls_bar(
+        &(mc_bar->arrival_counter),
+        &(uc_bar->arrival_counter),
+        total_blocks * (launch_counter * 2 + 1));
+
+    if (count_u32 >= 4 * tsize) {
+        chunk_start = ((int64_t)count_u32 * (int64_t)rank) / (int64_t)tsize;
+        chunk_end = ((int64_t)count_u32 * (int64_t)(rank + 1)) / (int64_t)tsize;
+    } else {
+        chunk_start = 0;
+        chunk_end   = (rank == 0) ? count_u32 : 0;
+    }
+
+    for (size_t idx = chunk_start + thread_offset; idx < chunk_end;
+         idx += stride) {
         NvlsOps::ld(val, base_u32 + idx);
         NvlsOps::st(val, base_u32 + idx);
     }
 
-    // post barrier
-    nvls_bar(&(mc_bar->arrival_counter), &(uc_bar->arrival_counter), total_blocks * (launch_counter * 2 + 2));
+    nvls_bar(
+        &(mc_bar->arrival_counter),
+        &(uc_bar->arrival_counter),
+        total_blocks * (launch_counter * 2 + 2));
 }
 
 template <typename NvlsOps>
@@ -55,23 +63,27 @@ __global__ void __launch_bounds__(UCC_TL_CUDA_MAX_NVLS_THREADS)
         const uint32_t total_blocks, uint64_t launch_counter,
         uint32_t *base_u32, size_t count_u32, uint32_t rank, uint32_t tsize)
 {
-    // pre barrier
+    size_t thread_offset = (threadIdx.x + blockIdx.x * blockDim.x) * 4;
+    size_t stride        = blockDim.x * gridDim.x * 4;
+    size_t chunk_start;
+    size_t chunk_end;
+    typename NvlsOps::value_type v0, v1, v2, v3;
+
     nvls_bar(
         &(mc_bar->arrival_counter),
         &(uc_bar->arrival_counter),
         total_blocks * (launch_counter * 2 + 1));
 
-    // Kernel execution
-    size_t chunk_start = ((int64_t)count_u32 * (int64_t)rank) / (int64_t)tsize;
-    size_t chunk_end   = ((int64_t)count_u32 * (int64_t)(rank + 1)) /
-                       (int64_t)tsize;
-
-    size_t thread_offset = (threadIdx.x + blockIdx.x * blockDim.x) * 4;
-    size_t stride        = blockDim.x * gridDim.x * 4;
+    if (count_u32 >= 4 * tsize) {
+        chunk_start = ((int64_t)count_u32 * (int64_t)rank) / (int64_t)tsize;
+        chunk_end = ((int64_t)count_u32 * (int64_t)(rank + 1)) / (int64_t)tsize;
+    } else {
+        chunk_start = 0;
+        chunk_end   = (rank == 0) ? count_u32 : 0;
+    }
 
     for (size_t idx = chunk_start + thread_offset; idx < chunk_end;
          idx += stride) {
-        typename NvlsOps::value_type v0, v1, v2, v3;
         NvlsOps::ld(v0, base_u32 + idx + 0);
         NvlsOps::ld(v1, base_u32 + idx + 1);
         NvlsOps::ld(v2, base_u32 + idx + 2);
@@ -82,7 +94,6 @@ __global__ void __launch_bounds__(UCC_TL_CUDA_MAX_NVLS_THREADS)
         NvlsOps::st(v3, base_u32 + idx + 3);
     }
 
-    // post barrier
     nvls_bar(
         &(mc_bar->arrival_counter),
         &(uc_bar->arrival_counter),
@@ -96,30 +107,33 @@ __global__ void __launch_bounds__(UCC_TL_CUDA_MAX_NVLS_THREADS)
         const uint32_t total_blocks, uint64_t launch_counter,
         uint64_t *base_u64, size_t count_u64, uint32_t rank, uint32_t tsize)
 {
-    // pre barrier
+    size_t thread_offset = (threadIdx.x + blockIdx.x * blockDim.x) * 2;
+    size_t stride        = blockDim.x * gridDim.x * 2;
+    size_t chunk_start;
+    size_t chunk_end;
+    typename NvlsOps::value_type v0, v1;
+
     nvls_bar(
         &(mc_bar->arrival_counter),
         &(uc_bar->arrival_counter),
         total_blocks * (launch_counter * 2 + 1));
 
-    // Kernel execution
-    size_t chunk_start = ((int64_t)count_u64 * (int64_t)rank) / (int64_t)tsize;
-    size_t chunk_end   = ((int64_t)count_u64 * (int64_t)(rank + 1)) /
-                       (int64_t)tsize;
-
-    size_t thread_offset = (threadIdx.x + blockIdx.x * blockDim.x) * 2;
-    size_t stride        = blockDim.x * gridDim.x * 2;
+    if (count_u64 >= 2 * tsize) {
+        chunk_start = ((int64_t)count_u64 * (int64_t)rank) / (int64_t)tsize;
+        chunk_end = ((int64_t)count_u64 * (int64_t)(rank + 1)) / (int64_t)tsize;
+    } else {
+        chunk_start = 0;
+        chunk_end   = (rank == 0) ? count_u64 : 0;
+    }
 
     for (size_t idx = chunk_start + thread_offset; idx < chunk_end;
          idx += stride) {
-        typename NvlsOps::value_type v0, v1;
         NvlsOps::ld(v0, base_u64 + idx + 0);
         NvlsOps::ld(v1, base_u64 + idx + 1);
         NvlsOps::st(v0, base_u64 + idx + 0);
         NvlsOps::st(v1, base_u64 + idx + 1);
     }
 
-    // post barrier
     nvls_bar(
         &(mc_bar->arrival_counter),
         &(uc_bar->arrival_counter),

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -320,6 +320,11 @@ struct ucc_tl_cuda_task {
             void          *sbuf;
             void          *rbuf;
             size_t         buf_size_bytes;
+            /* Padded size launched on the NVLS kernel; >= buf_size_bytes,
+             * rounded up so each rank gets a full vec/scalar unit. The
+             * tail is zero-filled before the kernel; SUM with zeros is
+             * a no-op so user data is unaffected. */
+            size_t         kernel_size_bytes;
             /* Memory handle for MC symmetric memory */
             CUdeviceptr    mc_va;
             /* Memory handle for UC symmetric memory */


### PR DESCRIPTION
The NVLS allreduce path rejected any buf_size below 1024 bytes, forcing small CUDA allreduces through TL_UCP.
The 1024 limit is artificial: it's not a CUDA driver / multicast constraint, only a kernel-launch overhead heuristic. 
