### PR TITLE
CI: fix build result not set to FAILURE on exception

### DIFF
--- a/.ci/Jenkinsfile.shlib
+++ b/.ci/Jenkinsfile.shlib
@@ -26,6 +26,7 @@ if (params.githubData) {
 try {
     matrix.main()
 } catch (Exception ex) {
+    currentBuild.result = 'FAILURE'
     println ex
     throw ex
 } finally {


### PR DESCRIPTION
## What
Update Jenkinsfile behavior on corner case failures 

## Why ?
In some very specific case the job may fail to run but will report as succeeded to GH checks

## How ?
force update build result on any failure
