### PR TITLE
BUILD: Resolve absolute prefix in cmake config.

### DIFF
--- a/cmake/ucc-targets.cmake.in
+++ b/cmake/ucc-targets.cmake.in
@@ -3,6 +3,7 @@
 #
 
 set(prefix ${CMAKE_CURRENT_LIST_DIR}/../../..)
+get_filename_component(prefix "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
 set(exec_prefix "@exec_prefix@")
 
 # Check if target already exists to avoid duplicate target errors


### PR DESCRIPTION
## What
Resolve the install prefix to an absolute path in the imported CMake config.

## Why ?
Current imported CMake targets contain deeply nested relative paths, i.e. `/path/to/install/lib/cmake/ucc/../../../lib/libucx.so`. Resolving to an absolute path in the imported config gives a much cleaner path for the build system, i.e. `/path/to/install/lib/libucc.so` while still keeping the config portable by leaving the prefix derivation from `${CMAKE_CURENT_LIST_DIR}` unchanged.

This is also consistent with ucx-targets.cmake
