### PR TITLE
stop perftest after argument parse errors

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -177,7 +177,7 @@ jobs:
         fi
         echo "${output}"
         case "${output}" in
-          *"Invalid format for --gen exp:min=N[[]@max=M]"*) ;;
+          *"Invalid format for --gen exp:min=N[@max=M]"*) ;;
           *)
             echo "ucc_perftest did not report the parse error"
             exit 1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -171,6 +171,24 @@ jobs:
           -x UCC_CONFIG_FILE=
         )
         PERFTEST_ARGS=(-m host -d float32 -b 1024 -e 1024 -n 10 -w 2)
+        if output=$(/tmp/ucc/install/bin/ucc_perftest --gen exp: 2>&1); then
+          echo "ucc_perftest accepted malformed --gen argument"
+          exit 1
+        fi
+        echo "${output}"
+        case "${output}" in
+          *"Invalid format for --gen exp:min=N[[]@max=M]"*) ;;
+          *)
+            echo "ucc_perftest did not report the parse error"
+            exit 1
+            ;;
+        esac
+        case "${output}" in
+          *"Collective:"*)
+            echo "ucc_perftest initialized the benchmark after a parse error"
+            exit 1
+            ;;
+        esac
         COLLS=(
           allgather allgatherv allreduce alltoall alltoallv
           barrier bcast gather gatherv

--- a/tools/perf/ucc_perftest.cc
+++ b/tools/perf/ucc_perftest.cc
@@ -13,7 +13,10 @@ int main(int argc, char *argv[])
     ucc_pt_benchmark *bench;
     ucc_status_t st;
 
-    pt_config.process_args(argc, argv);
+    st = pt_config.process_args(argc, argv);
+    if (st != UCC_OK) {
+        return 1;
+    }
     ucc_pt_cuda_init();
     ucc_pt_rocm_init();
     try {


### PR DESCRIPTION
## What
Stop `ucc_perftest` immediately when `ucc_pt_config::process_args()` returns an error.

Add a regression check that invokes `ucc_perftest --gen exp:` and verifies a nonzero exit, the parser diagnostic, and no benchmark header.

## Why
Malformed arguments were diagnosed by the parser, but `main()` discarded the returned status and continued into CUDA/ROCm probing, communicator initialization, and potentially benchmark execution.

## Validation
- Build & Test passed: https://github.com/jeffnvidia/ucc/actions/runs/28795294451
- The `UCC perftest` job passed, including the new malformed-argument regression check.