### PR TITLE
initialize perftest default generator

### DIFF
--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -34,6 +34,7 @@ ucc_pt_config::ucc_pt_config() {
     bench.root_shift     = 0;
     bench.mult_factor    = 2;
     bench.seed           = 0;
+    bench.gen.type       = UCC_PT_GEN_TYPE_EXP;
     comm.mt              = bench.mt;
 }
 


### PR DESCRIPTION
## What

Initialize `bench.gen.type` to `UCC_PT_GEN_TYPE_EXP` in `ucc_pt_config`.

## Why

Without `--gen`, `ucc_perftest` leaves the scalar generator type indeterminate and later branches on it during benchmark construction. If it happens to equal the file-generator value, the tool attempts to open the default empty pattern path and fails before benchmarking.

## Impact

Restores deterministic legacy/default exponential size generation for normal `ucc_perftest` invocations. Explicit `--gen` modes are unchanged. This affects the benchmark tool only, not UCC runtime collective execution.

## Validation

- `git diff --check`
- The existing GitHub Actions `ucc_perftest` coverage exercises normal invocations without `--gen`.
- Full build/test was not run locally because this environment lacks a C++/MPI toolchain.
