### PR TITLE
TOOLS: add selectable iteration cadence

### DIFF
--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -231,6 +231,11 @@ ucc_status_t ucc_pt_benchmark::run_single_coll_test(ucc_coll_args_t args,
 
     args.root = config.root % comm->get_size();
     for (int i = 0; i < nwarmup + niter; i++) {
+        /* Start the measured streaming batch with ranks aligned. */
+        if (i == nwarmup && nwarmup > 0 &&
+            config.iteration_mode == UCC_PT_ITER_MODE_STREAMING) {
+            UCCCHECK_GOTO(comm->barrier(), exit_err, st);
+        }
         double s = get_time_us();
 
         if (!persistent) {
@@ -265,7 +270,9 @@ ucc_status_t ucc_pt_benchmark::run_single_coll_test(ucc_coll_args_t args,
             time += f - s;
         }
         args.root = (args.root + config.root_shift) % comm->get_size();
-        UCCCHECK_GOTO(comm->barrier(), exit_err, st);
+        if (config.iteration_mode == UCC_PT_ITER_MODE_ISOLATED) {
+            UCCCHECK_GOTO(comm->barrier(), exit_err, st);
+        }
     }
 
     if (persistent) {
@@ -376,6 +383,9 @@ void ucc_pt_benchmark::print_header()
                   << "  small" << config.n_iter_small << std::endl
                   << std::left << std::setw(24)
                   << "  large" << config.n_iter_large << std::endl;
+        std::cout << std::left << std::setw(24)
+                  << "Iteration mode:"
+                  << ucc_pt_iter_mode_str(config.iteration_mode) << std::endl;
         std::cout.copyfmt(iostate);
         std::cout << std::endl;
         std::cout << std::setw(12) << "Count"

--- a/tools/perf/ucc_pt_benchmark.cc
+++ b/tools/perf/ucc_pt_benchmark.cc
@@ -202,6 +202,8 @@ ucc_status_t ucc_pt_benchmark::run_single_coll_test(ucc_coll_args_t args,
 {
     const bool    triggered  = config.triggered;
     const bool    persistent = config.persistent;
+    const bool    streaming  =
+        config.iteration_mode == UCC_PT_ITER_MODE_STREAMING;
     ucc_team_h    team       = comm->get_team();
     ucc_context_h ctx        = comm->get_context();
     ucc_status_t  st         = UCC_OK;
@@ -231,11 +233,6 @@ ucc_status_t ucc_pt_benchmark::run_single_coll_test(ucc_coll_args_t args,
 
     args.root = config.root % comm->get_size();
     for (int i = 0; i < nwarmup + niter; i++) {
-        /* Start the measured streaming batch with ranks aligned. */
-        if (i == nwarmup && nwarmup > 0 &&
-            config.iteration_mode == UCC_PT_ITER_MODE_STREAMING) {
-            UCCCHECK_GOTO(comm->barrier(), exit_err, st);
-        }
         double s = get_time_us();
 
         if (!persistent) {
@@ -270,7 +267,7 @@ ucc_status_t ucc_pt_benchmark::run_single_coll_test(ucc_coll_args_t args,
             time += f - s;
         }
         args.root = (args.root + config.root_shift) % comm->get_size();
-        if (config.iteration_mode == UCC_PT_ITER_MODE_ISOLATED) {
+        if (!streaming || (niter > 0 && i == nwarmup - 1)) {
             UCCCHECK_GOTO(comm->barrier(), exit_err, st);
         }
     }

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -34,6 +34,7 @@ ucc_pt_config::ucc_pt_config() {
     bench.root_shift     = 0;
     bench.mult_factor    = 2;
     bench.seed           = 0;
+    bench.iteration_mode = UCC_PT_ITER_MODE_ISOLATED;
     bench.gen.type       = UCC_PT_GEN_TYPE_EXP;
     comm.mt              = bench.mt;
 }
@@ -105,6 +106,7 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
     static struct option long_options[] = {
         {"gen", required_argument, 0, 0},
         {"seed", required_argument, 0, 0},
+        {"iteration-mode", required_argument, 0, 0},
         {0, 0, 0, 0}};
 
     // Reset getopt state
@@ -340,6 +342,18 @@ ucc_status_t ucc_pt_config::process_args(int argc, char *argv[])
                     std::cerr << "Invalid seed value in --seed" << std::endl;
                     return UCC_ERR_INVALID_PARAM;
                 }
+            } else if (strcmp(long_options[option_index].name,
+                              "iteration-mode") == 0) {
+                if (strcmp(optarg, "isolated") == 0) {
+                    bench.iteration_mode = UCC_PT_ITER_MODE_ISOLATED;
+                } else if (strcmp(optarg, "streaming") == 0) {
+                    bench.iteration_mode = UCC_PT_ITER_MODE_STREAMING;
+                } else {
+                    std::cerr << "Invalid --iteration-mode value: " << optarg
+                              << ". Expected isolated or streaming."
+                              << std::endl;
+                    return UCC_ERR_INVALID_PARAM;
+                }
             } else {
                 std::cerr << "Unknown long option" << std::endl;
                 return UCC_ERR_INVALID_PARAM;
@@ -468,6 +482,9 @@ void ucc_pt_config::print_help()
                  "[@tgt_group_size=G][@shuffle=0|1]>: Pattern generator (exponential or file-based or matrix-based)"
               << std::endl;
     std::cout << " --seed <number>: seed for the random distributions" << std::endl;
+    std::cout << "  --iteration-mode <isolated|streaming>: synchronize ranks "
+                 "between iterations (isolated, default) or run back-to-back "
+                 "without an iteration barrier (streaming)" << std::endl;
     std::cout << "  -h: show this help message"<<std::endl;
     std::cout << std::endl;
 }

--- a/tools/perf/ucc_pt_config.cc
+++ b/tools/perf/ucc_pt_config.cc
@@ -485,6 +485,9 @@ void ucc_pt_config::print_help()
     std::cout << "  --iteration-mode <isolated|streaming>: synchronize ranks "
                  "between iterations (isolated, default) or run back-to-back "
                  "without an iteration barrier (streaming)" << std::endl;
+    std::cout << "    Note: streaming mode may hang with the TL/UCP one-sided "
+                 "Alltoallv algorithm; use isolated mode for that configuration"
+              << std::endl;
     std::cout << "  -h: show this help message"<<std::endl;
     std::cout << std::endl;
 }

--- a/tools/perf/ucc_pt_config.h
+++ b/tools/perf/ucc_pt_config.h
@@ -67,6 +67,16 @@ typedef enum {
     UCC_PT_GEN_TYPE_TRAFFIC_MATRIX
 } ucc_pt_gen_type_t;
 
+typedef enum {
+    UCC_PT_ITER_MODE_ISOLATED,
+    UCC_PT_ITER_MODE_STREAMING
+} ucc_pt_iter_mode_t;
+
+static inline const char *ucc_pt_iter_mode_str(ucc_pt_iter_mode_t mode)
+{
+    return mode == UCC_PT_ITER_MODE_STREAMING ? "streaming" : "isolated";
+}
+
 static inline const char* ucc_pt_op_type_str(ucc_pt_op_type_t op)
 {
     if ((uint64_t)op < (uint64_t)UCC_COLL_TYPE_LAST) {
@@ -130,6 +140,7 @@ struct ucc_pt_benchmark_config {
     int                root_shift;
     int                mult_factor;
     uint64_t           seed;
+    ucc_pt_iter_mode_t iteration_mode;
     ucc_pt_gen_config  gen;
 };
 


### PR DESCRIPTION
## Summary

Add `--iteration-mode isolated|streaming` to `ucc_perftest`.

- `isolated` preserves the existing per-iteration barrier behavior and remains the default.
- `streaming` runs measured collectives back-to-back, with ranks aligned once before the measured batch.

The streaming mode matches the default measurement cadence in `nccl-tests`, enabling like-for-like comparisons without changing existing `ucc_perftest` results by default. This distinction can be significant: in one representative 32-rank, 2 GiB Alltoall run, isolated and streaming UCC measurements reached 94.33 and 54.16 GB/s bus bandwidth respectively; the `nccl-tests` default cadence measured 53.67 GB/s through the UCC NCCL net plugin.

## Validation

- Built with warnings treated as errors.
- Runtime-tested both modes on multi-node Alltoall.
- Verified the default remains equivalent to `--iteration-mode isolated`.
