### PR TITLE
TL/UCP: add exact mixed-radix allgather schedules

### DIFF
--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -7,7 +7,11 @@
 #ifndef RECURSIVE_KNOMIAL_H_
 #define RECURSIVE_KNOMIAL_H_
 
+#include <limits.h>
+
 #define UCC_KN_PEER_NULL ((ucc_rank_t)-1)
+/* An exact schedule of radix >= 2 cannot have more phases than this. */
+#define UCC_KN_MAX_RADIX_PHASES (sizeof(ucc_rank_t) * CHAR_BIT - 1)
 typedef uint16_t ucc_kn_radix_t;
 
 enum {
@@ -29,7 +33,7 @@ enum {
 
 typedef struct ucc_knomial_pattern {
 
-    ucc_kn_radix_t radix;         /* knomial tree radix */
+    ucc_kn_radix_t radix;         /* radix for current iteration */
     uint8_t        type;          /* pattern type */
     uint8_t        iteration;     /* current iteration */
     uint8_t        n_iters;       /* number of iterations in knomial algorithm */
@@ -54,6 +58,8 @@ typedef struct ucc_knomial_pattern {
     ucc_rank_t     block_size;
     ptrdiff_t      block_offset;
     int            is64;
+    uint8_t        is_mixed;
+    ucc_kn_radix_t radices[UCC_KN_MAX_RADIX_PHASES];
 } ucc_knomial_pattern_t;
 
 /**
@@ -101,6 +107,7 @@ ucc_knomial_pattern_init_impl(ucc_rank_t size, ucc_rank_t rank,
     p->rank          = rank;
     p->backward      = backward;
     p->iteration     = 0;
+    p->is_mixed      = 0;
     n_full_subtrees  = ucc_kn_pattern_n_full(p);
     p->n_extra       = has_extra ? size - n_full_subtrees * p->full_pow_size : 0;
     p->n_iters       = (p->n_extra && n_full_subtrees == 1) ?
@@ -229,6 +236,9 @@ ucc_knomial_pattern_next_iteration(ucc_knomial_pattern_t *p)
 {
     p->iteration++;
     p->radix_pow *= p->radix;
+    if (p->is_mixed && !ucc_knomial_pattern_loop_done(p)) {
+        p->radix = p->radices[p->iteration];
+    }
 }
 
 static inline void ucc_knomial_pattern_prev_iteration(ucc_knomial_pattern_t *p)

--- a/src/coll_patterns/sra_knomial.h
+++ b/src/coll_patterns/sra_knomial.h
@@ -17,6 +17,9 @@
 static inline
 ucc_rank_t ucc_kn_compute_step_radix(ucc_knomial_pattern_t *p)
 {
+    if (p->is_mixed) {
+        return p->radix;
+    }
     int n_full = ucc_kn_pattern_n_full(p);
 
     return p->radix_pow * p->radix >= p->size ? (n_full > 1 ? n_full : p->radix)
@@ -270,6 +273,38 @@ ucc_kn_ag_pattern_init(ucc_rank_t size, ucc_rank_t rank, ucc_kn_radix_t radix,
     p->block_size   = p->radix_pow * radix;
     p->block_offset = ucc_knomial_pattern_loop_rank(p, rank) / p->block_size *
                       p->block_size;
+}
+
+static inline void ucc_kn_ag_pattern_reset(ucc_knomial_pattern_t *p)
+{
+    p->iteration    = 0;
+    p->radix        = p->radices[0];
+    p->radix_pow    = 1;
+    p->block_size   = p->radix;
+    p->block_offset = ucc_knomial_pattern_loop_rank(p, p->rank) /
+                      p->block_size * p->block_size;
+}
+
+static inline void ucc_kn_ag_pattern_init_mixed(
+    ucc_rank_t size, ucc_rank_t rank, size_t count,
+    const ucc_kn_radix_t *radices, uint8_t nradices, ucc_knomial_pattern_t *p)
+{
+    uint8_t i;
+
+    ucc_assert(nradices > 0 && nradices <= UCC_KN_MAX_RADIX_PHASES);
+    p->type      = KN_PATTERN_ALLGATHER;
+    p->n_iters   = nradices;
+    p->node_type = KN_NODE_BASE;
+    p->backward  = 0;
+    p->size      = size;
+    p->rank      = rank;
+    p->n_extra   = 0;
+    p->count     = count;
+    p->is_mixed  = 1;
+    for (i = 0; i < nradices; i++) {
+        p->radices[i] = radices[i];
+    }
+    ucc_kn_ag_pattern_reset(p);
 }
 
 static inline void

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -11,6 +11,7 @@ endif
 
 allgather =                        \
 	allgather/allgather.h          \
+	allgather/allgather_knomial_schedule.c \
 	allgather/allgather.c          \
 	allgather/allgather_ring.c     \
 	allgather/allgather_neighbor.c \

--- a/src/components/tl/ucp/allgather/allgather.h
+++ b/src/components/tl/ucp/allgather/allgather.h
@@ -100,4 +100,8 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_init(ucc_base_coll_args_t *coll_args,
 ucc_status_t ucc_tl_ucp_allgather_knomial_init_r(
     ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
     ucc_coll_task_t **task_h, ucc_kn_radix_t radix);
+
+ucc_status_t ucc_tl_ucp_allgather_knomial_parse_radices(
+    const char *value, ucc_rank_t team_size, ucc_kn_radix_t *radices,
+    uint8_t *nradices);
 #endif

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -10,6 +10,7 @@
 #include "tl_ucp_sendrecv.h"
 #include "tl_ucp_copy.h"
 #include "core/ucc_progress_queue.h"
+#include "allgather.h"
 #include "coll_patterns/sra_knomial.h"
 #include "tl_ucp_task.h"
 #include "ucc/api/ucc.h"
@@ -198,6 +199,7 @@ UCC_KN_PHASE_EXTRA:
             return;
         }
         ucc_kn_ag_pattern_next_iter(p);
+        radix = p->radix;
     }
 
     if (KN_NODE_PROXY == node_type) {
@@ -243,8 +245,11 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
     task->allgather_kn.copy_task = NULL;
     task->allgather_kn.phase     = UCC_KN_PHASE_INIT;
     if (ct == UCC_COLL_TYPE_ALLGATHER) {
-        ucc_kn_ag_pattern_init(size, rank, radix, args->dst.info.count,
-                               &task->allgather_kn.p);
+        if (p->is_mixed) {
+            ucc_kn_ag_pattern_reset(p);
+        } else {
+            ucc_kn_ag_pattern_init(size, rank, radix, args->dst.info.count, p);
+        }
         offset = ucc_buffer_block_offset(args->dst.info.count, size, rank) *
                  ucc_dt_size(args->dst.info.datatype);
         rbuf   = args->dst.info.buffer;
@@ -306,9 +311,10 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 }
 
-ucc_status_t ucc_tl_ucp_allgather_knomial_init_r(
+static ucc_status_t ucc_tl_ucp_allgather_knomial_init_common(
     ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
-    ucc_coll_task_t **task_h, ucc_kn_radix_t radix)
+    ucc_coll_task_t **task_h, ucc_kn_radix_t radix,
+    const ucc_kn_radix_t *radices, uint8_t nradices)
 {
     ucc_tl_ucp_team_t    *tl_team = ucc_derived_of(team, ucc_tl_ucp_team_t);
     ucc_tl_ucp_context_t *ctx     = UCC_TL_UCP_TEAM_CTX(tl_team);
@@ -323,7 +329,20 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_init_r(
         task->subset.myrank = sbgp->group_rank;
         task->subset.map    = sbgp->map;
     }
-    task->allgather_kn.p.radix = radix;
+    if (nradices > 0) {
+        ucc_rank_t tsize = UCC_TL_TEAM_SIZE(tl_team);
+
+        ucc_kn_ag_pattern_init_mixed(
+            tsize,
+            task->subset.myrank,
+            GET_TOTAL_COUNT(&coll_args->args, tsize),
+            radices,
+            nradices,
+            &task->allgather_kn.p);
+    } else {
+        task->allgather_kn.p.radix    = radix;
+        task->allgather_kn.p.is_mixed = 0;
+    }
     if (!UCC_IS_INPLACE(coll_args->args)) {
         if (ctx->cfg.local_copy_type == UCC_TL_UCP_LOCAL_COPY_TYPE_EC) {
             task->super.flags         |= UCC_COLL_TASK_FLAG_EXECUTOR;
@@ -357,6 +376,14 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_init_r(
     return UCC_OK;
 }
 
+ucc_status_t ucc_tl_ucp_allgather_knomial_init_r(
+    ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+    ucc_coll_task_t **task_h, ucc_kn_radix_t radix)
+{
+    return ucc_tl_ucp_allgather_knomial_init_common(
+        coll_args, team, task_h, radix, NULL, 0);
+}
+
 ucc_status_t ucc_tl_ucp_allgather_knomial_init(ucc_base_coll_args_t *coll_args,
                                                ucc_base_team_t      *team,
                                                ucc_coll_task_t     **task_h)
@@ -368,8 +395,30 @@ ucc_status_t ucc_tl_ucp_allgather_knomial_init(ucc_base_coll_args_t *coll_args,
     size_t             count   = GET_TOTAL_COUNT(&coll_args->args, tsize);
     ucc_datatype_t     dtype   = GET_DT(&coll_args->args);
     ucc_kn_radix_t     radix;
+    ucc_kn_radix_t     radices[UCC_KN_MAX_RADIX_PHASES];
+    uint8_t            nradices = 0;
+    ucc_status_t       status;
 
     radix = ucc_tl_ucp_get_knomial_radix(tl_team, count, dtype, mtype, p, 0);
+    if (coll_args->args.coll_type != UCC_COLL_TYPE_ALLGATHER) {
+        return ucc_tl_ucp_allgather_knomial_init_r(
+            coll_args, team, task_h, radix);
+    }
 
-    return ucc_tl_ucp_allgather_knomial_init_r(coll_args, team, task_h, radix);
+    if (tl_team->cfg.allgather_kn_mixed_radices != NULL &&
+        tl_team->cfg.allgather_kn_mixed_radices[0] != '\0') {
+        status = ucc_tl_ucp_allgather_knomial_parse_radices(
+            tl_team->cfg.allgather_kn_mixed_radices, tsize, radices, &nradices);
+        if (status != UCC_OK) {
+            tl_error(
+                UCC_TL_TEAM_LIB(tl_team),
+                "invalid ALLGATHER_KN_MIXED_RADICES '%s' for team size %u",
+                tl_team->cfg.allgather_kn_mixed_radices,
+                tsize);
+            return status;
+        }
+    }
+
+    return ucc_tl_ucp_allgather_knomial_init_common(
+        coll_args, team, task_h, radix, radices, nradices);
 }

--- a/src/components/tl/ucp/allgather/allgather_knomial_schedule.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial_schedule.c
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
+#include "allgather.h"
+
+#include <stdlib.h>
+
+ucc_status_t ucc_tl_ucp_allgather_knomial_parse_radices(
+    const char *value, ucc_rank_t team_size, ucc_kn_radix_t *radices,
+    uint8_t *nradices)
+{
+    const char   *p = value;
+    char         *end;
+    unsigned long parsed;
+    ucc_rank_t    product = 1;
+    uint8_t       n       = 0;
+
+    *nradices             = 0;
+    if (value == NULL || value[0] == '\0') {
+        return UCC_ERR_NOT_FOUND;
+    }
+
+    while (*p != '\0') {
+        if (n == UCC_KN_MAX_RADIX_PHASES) {
+            return UCC_ERR_INVALID_PARAM;
+        }
+        parsed = strtoul(p, &end, 10);
+        if (end == p || parsed < 2 || parsed > UINT16_MAX ||
+            product > UCC_RANK_MAX / parsed) {
+            return UCC_ERR_INVALID_PARAM;
+        }
+        radices[n++] = (ucc_kn_radix_t)parsed;
+        product *= (ucc_rank_t)parsed;
+        if (*end == '\0') {
+            break;
+        }
+        if (*end != ',' || end[1] == '\0') {
+            return UCC_ERR_INVALID_PARAM;
+        }
+        p = end + 1;
+    }
+
+    if (product != team_size) {
+        return UCC_ERR_INVALID_PARAM;
+    }
+    *nradices = n;
+    return UCC_OK;
+}

--- a/src/components/tl/ucp/tl_ucp.c
+++ b/src/components/tl/ucp/tl_ucp.c
@@ -172,6 +172,13 @@ ucc_config_field_t ucc_tl_ucp_lib_config_table[] = {
      ucc_offsetof(ucc_tl_ucp_lib_config_t, allgather_kn_radix),
      UCC_CONFIG_TYPE_UINT_RANGED},
 
+    {"ALLGATHER_KN_MIXED_RADICES", "",
+     "Optional exact mixed-radix schedule for knomial allgather, for example "
+     "4,4,6. Every radix must be at least 2 and their product must equal the "
+     "team size. Invalid schedules are rejected",
+     ucc_offsetof(ucc_tl_ucp_lib_config_t, allgather_kn_mixed_radices),
+     UCC_CONFIG_TYPE_STRING},
+
     {"BCAST_KN_RADIX", "4", "Radix of the recursive-knomial bcast algorithm",
      ucc_offsetof(ucc_tl_ucp_lib_config_t, bcast_kn_radix),
      UCC_CONFIG_TYPE_UINT},

--- a/src/components/tl/ucp/tl_ucp.h
+++ b/src/components/tl/ucp/tl_ucp.h
@@ -63,6 +63,7 @@ typedef struct ucc_tl_ucp_lib_config {
     ucc_mrange_uint_t                  allreduce_sra_kn_radix;
     uint32_t                           reduce_scatter_kn_radix;
     ucc_mrange_uint_t                  allgather_kn_radix;
+    char                              *allgather_kn_mixed_radices;
     uint32_t                           bcast_kn_radix;
     ucc_mrange_uint_t                  bcast_sag_kn_radix;
     uint32_t                           reduce_kn_radix;

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -144,6 +144,12 @@ gtest_LDFLAGS  += $(UCX_LDFLAGS)
 gtest_LDADD    += $(UCX_LIBS) $(UCX_LIBADD)
 endif
 
+if TL_UCP_ENABLED
+gtest_SOURCES +=                                                    \
+	coll/test_knomial_schedule.cc                                   \
+	$(top_srcdir)/src/components/tl/ucp/allgather/allgather_knomial_schedule.c
+endif
+
 noinst_HEADERS =                         \
 	common/gtest.h                       \
 	common/test.h                        \

--- a/test/gtest/coll/test_knomial_schedule.cc
+++ b/test/gtest/coll/test_knomial_schedule.cc
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include "utils/ucc_coll_utils.h"
+#include "coll_patterns/sra_knomial.h"
+
+ucc_status_t ucc_tl_ucp_allgather_knomial_parse_radices(
+    const char *value, ucc_rank_t team_size, ucc_kn_radix_t *radices,
+    uint8_t *nradices);
+}
+
+#include <common/test.h>
+#include <sstream>
+#include <vector>
+
+class test_knomial_schedule : public ucc::test {
+  protected:
+    static void expect_parse_status(
+        const char *value, ucc_rank_t size, ucc_status_t expected)
+    {
+        ucc_kn_radix_t radices[UCC_KN_MAX_RADIX_PHASES];
+        uint8_t        nradices;
+
+        EXPECT_EQ(
+            expected,
+            ucc_tl_ucp_allgather_knomial_parse_radices(
+                value, size, radices, &nradices));
+    }
+
+    static void expect_valid(
+        const char *value, ucc_rank_t size,
+        const std::vector<ucc_kn_radix_t> &expected)
+    {
+        ucc_kn_radix_t radices[UCC_KN_MAX_RADIX_PHASES];
+        uint8_t        nradices;
+
+        ASSERT_EQ(
+            UCC_OK,
+            ucc_tl_ucp_allgather_knomial_parse_radices(
+                value, size, radices, &nradices));
+        ASSERT_EQ(expected.size(), nradices);
+        for (size_t i = 0; i < expected.size(); i++) {
+            EXPECT_EQ(expected[i], radices[i]);
+        }
+    }
+
+    static void expect_mixed_pattern(
+        ucc_rank_t size, const std::vector<ucc_kn_radix_t> &radices)
+    {
+        for (ucc_rank_t rank = 0; rank < size; rank++) {
+            ucc_knomial_pattern_t p;
+            ucc_rank_t            phase_size = 1;
+
+            ucc_kn_ag_pattern_init_mixed(
+                size, rank, size, radices.data(), radices.size(), &p);
+            ASSERT_TRUE(p.is_mixed);
+            ASSERT_EQ(radices.size(), p.n_iters);
+            ASSERT_EQ(0, p.n_extra);
+            for (size_t phase = 0; phase < radices.size(); phase++) {
+                ucc_kn_radix_t radix      = radices[phase];
+                ucc_rank_t     group_size = phase_size * radix;
+                size_t         count;
+                ptrdiff_t      offset;
+
+                EXPECT_EQ(radix, p.radix);
+                EXPECT_EQ(radix, ucc_kn_compute_step_radix(&p));
+                ucc_kn_ag_pattern_peer_seg(rank, &p, &count, &offset);
+                EXPECT_EQ(phase_size, count);
+                EXPECT_EQ((rank / phase_size) * phase_size, offset);
+
+                for (ucc_kn_radix_t step = 1; step < radix; step++) {
+                    ucc_rank_t peer = ucc_knomial_pattern_get_loop_peer(
+                        &p, rank, step);
+                    ASSERT_NE(UCC_KN_PEER_NULL, peer);
+                    EXPECT_EQ(rank / group_size, peer / group_size);
+                    EXPECT_EQ(rank % phase_size, peer % phase_size);
+                    ucc_kn_ag_pattern_peer_seg(peer, &p, &count, &offset);
+                    EXPECT_EQ(phase_size, count);
+                    EXPECT_EQ((peer / phase_size) * phase_size, offset);
+                }
+                ucc_kn_ag_pattern_next_iter(&p);
+                phase_size = group_size;
+            }
+            EXPECT_TRUE(ucc_knomial_pattern_loop_done(&p));
+            EXPECT_EQ(size, phase_size);
+        }
+    }
+};
+
+UCC_TEST_F(test_knomial_schedule, parse_valid_exact_schedules)
+{
+    expect_valid("8,6", 48, {8, 6});
+    expect_valid("3,3,2,2,2", 72, {3, 3, 2, 2, 2});
+    expect_valid("4,4,6", 96, {4, 4, 6});
+}
+
+UCC_TEST_F(test_knomial_schedule, parse_invalid_tokens_and_radices)
+{
+    expect_parse_status("", 96, UCC_ERR_NOT_FOUND);
+    expect_parse_status("4,x,6", 96, UCC_ERR_INVALID_PARAM);
+    expect_parse_status("4,0,6", 96, UCC_ERR_INVALID_PARAM);
+    expect_parse_status("4,1,6", 96, UCC_ERR_INVALID_PARAM);
+    expect_parse_status("4,4,4", 96, UCC_ERR_INVALID_PARAM);
+    expect_parse_status("4,4,6,", 96, UCC_ERR_INVALID_PARAM);
+    expect_parse_status("65536", 65536, UCC_ERR_INVALID_PARAM);
+    expect_parse_status("65535,65535,2", 2, UCC_ERR_INVALID_PARAM);
+}
+
+UCC_TEST_F(test_knomial_schedule, parse_overlong_schedule)
+{
+    std::ostringstream value;
+
+    for (unsigned i = 0; i <= UCC_KN_MAX_RADIX_PHASES; i++) {
+        value << (i ? ",2" : "2");
+    }
+    expect_parse_status(
+        value.str().c_str(), UCC_RANK_MAX, UCC_ERR_INVALID_PARAM);
+}
+
+UCC_TEST_F(test_knomial_schedule, fixed_pattern_preserves_legacy_layout)
+{
+    const ucc_rank_t     sizes[]   = {16, 48, 72, 96};
+    const ucc_kn_radix_t radices[] = {2, 3, 4, 6, 8};
+
+    for (auto size : sizes) {
+        for (auto radix : radices) {
+            for (ucc_rank_t rank = 0; rank < size; rank++) {
+                ucc_knomial_pattern_t p;
+                ucc_rank_t            legacy_radix_pow = 1;
+
+                ucc_kn_ag_pattern_init(size, rank, radix, size, &p);
+                ASSERT_FALSE(p.is_mixed);
+                for (uint8_t phase = 0; phase < p.n_iters; phase++) {
+                    ucc_rank_t n_full               = size / p.full_pow_size;
+                    ucc_rank_t legacy_segment_radix = radix;
+
+                    if (legacy_radix_pow * radix >= size && n_full > 1) {
+                        legacy_segment_radix = n_full;
+                    }
+                    EXPECT_EQ(radix, p.radix);
+                    EXPECT_EQ(
+                        legacy_segment_radix, ucc_kn_compute_step_radix(&p));
+                    if (p.node_type != KN_NODE_EXTRA) {
+                        for (ucc_kn_radix_t step = 1; step < radix; step++) {
+                            ucc_rank_t
+                                loop_rank = ucc_knomial_pattern_loop_rank(
+                                    &p, rank);
+                            ucc_rank_t step_size = legacy_radix_pow * radix;
+                            ucc_rank_t peer      = (loop_rank +
+                                               step * legacy_radix_pow) %
+                                                  step_size +
+                                              ucc_align_down(
+                                                  loop_rank, step_size);
+                            ucc_rank_t expected =
+                                peer >= size - p.n_extra
+                                    ? UCC_KN_PEER_NULL
+                                    : ucc_knomial_pattern_loop_rank_inv(
+                                          &p, peer);
+                            EXPECT_EQ(
+                                expected,
+                                ucc_knomial_pattern_get_loop_peer(
+                                    &p, rank, step));
+                        }
+                    }
+                    ucc_kn_ag_pattern_next_iter(&p);
+                    legacy_radix_pow *= radix;
+                }
+            }
+        }
+    }
+}
+
+UCC_TEST_F(test_knomial_schedule, mixed_peer_and_segment_layout)
+{
+    expect_mixed_pattern(48, {8, 6});
+    expect_mixed_pattern(72, {3, 3, 2, 2, 2});
+    expect_mixed_pattern(96, {4, 4, 6});
+}


### PR DESCRIPTION
## What

Add exact per-phase radix schedules to TL/UCP K-nomial AllGather. A schedule
such as `8x6` uses radix 8 in the first phase and radix 6 in the second; its
product must equal the team size.

Set an explicit schedule with, for example:

```
UCC_TL_UCP_ALLGATHER_KN_RADIX=8x6
```

The same option accepts a fixed radix or `auto`. The existing fixed-radix path
and AllGatherV behavior remain unchanged. Invalid schedules are rejected, and
existing algorithm tuning still decides whether K-nomial AllGather is selected.

## Why

For non-power team sizes, a fixed radix can produce a truncated final phase or
proxy/extra ranks. An exact mixed schedule covers the complete team with an
explicit radix for every phase.

Across three tested environments at 96 ranks, a representative exact schedule
improved the large-message endpoint by **1.81x--1.99x** over the best measured
fixed radix by avoiding the fixed-radix remainder path.

## Performance evidence

Results are intentionally anonymized and normalized to the best measured
fixed-radix execution for each environment. Each row uses one exact schedule
at the endpoint; it is not a pointwise best-schedule envelope.

| Environment | Team | Exact schedule | Fixed baseline | Normalized speedup |
|---|---:|---|---|---:|
| System A | 96 ranks | `4x4x6` | R4 | 1.98x |
| System B | 96 ranks | `2x2x2x2x2x3` | R4 | 1.99x |
| System C | 96 ranks | `8x3x4` | R3 | 1.81x |

These relative results demonstrate the remainder-path mechanism; they are not
intended as absolute system-performance comparisons.

## Validation

- Capability debug build and focused schedule tests passed.
- 16-rank CUDA AllGather covered fixed R2/R4/R8 and explicit `8x2`, `2x8`,
  and `4x4`; all cases passed with zero failures.
- Tests cover parsing and bounded formatting, legacy fixed-radix behavior, and
  exact mixed peer sets, segment sizes, and offsets for every rank.

Automatic schedule selection is proposed separately in #1328.
