### PR TITLE
TOPO: exchange cpu vendor and model

### DIFF
--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -219,6 +219,20 @@ ucc_status_t ucc_topo_init(
     topo->device_map.n_ranks    = 0;
     topo->n_nodes               = 0;
 
+    topo->cpu_vendor = (ucc_cpu_vendor_t)ctx_topo->procs[
+                           ucc_ep_map_eval(set.map, 0)].cpu_vendor;
+    topo->cpu_model  = (ucc_cpu_model_t)ctx_topo->procs[
+                           ucc_ep_map_eval(set.map, 0)].cpu_model;
+    for (i = 1; i < size; i++) {
+        ctx_rank = ucc_ep_map_eval(set.map, i);
+        if (ctx_topo->procs[ctx_rank].cpu_vendor != topo->cpu_vendor ||
+            ctx_topo->procs[ctx_rank].cpu_model  != topo->cpu_model) {
+            topo->cpu_vendor = UCC_CPU_VENDOR_UNKNOWN;
+            topo->cpu_model  = UCC_CPU_MODEL_UNKNOWN;
+            break;
+        }
+    }
+
     for (i = 0; i < size; i++) {
 
         ctx_rank = ucc_ep_map_eval(set.map, i);

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -7,6 +7,7 @@
 #include "ucc_sbgp.h"
 #include "utils/ucc_proc_info.h"
 #include "utils/ucc_coll_utils.h"
+#include "utils/arch/cpu.h"
 
 /* Topo data structure initialized per UCC context.
    key elements of this struct are the arrays of ucc_proc_info_t and
@@ -83,6 +84,12 @@ typedef struct ucc_topo {
     ucc_rank_t   max_numa_size; /*< max number of processes on a numa,
                                     across all nodes of a team */
     ucc_device_map_t device_map; /*< map of team ranks to device indices */
+    ucc_cpu_vendor_t cpu_vendor;  /*< CPU vendor shared by all team members,
+                                      or UCC_CPU_VENDOR_UNKNOWN if the team is
+                                      CPU-heterogeneous. Used to keep config-file
+                                      tuning selection symmetric across ranks. */
+    ucc_cpu_model_t  cpu_model;   /*< CPU model shared by all team members,
+                                      or UCC_CPU_MODEL_UNKNOWN if heterogeneous */
 } ucc_topo_t;
 
 /* Initializes ctx level topo structure using addr_storage.

--- a/src/utils/ucc_parser.c
+++ b/src/utils/ucc_parser.c
@@ -618,12 +618,15 @@ ucc_status_t ucc_add_team_sections(void                *team_cfg,
                                    const char          *component_prefix)
 {
     khash_t(ucc_sections) *sections  = &ucc_global_config.file_cfg->sections;
-    ucc_cpu_vendor_t       vendor    = ucc_arch_get_cpu_vendor();
-    ucc_cpu_model_t        model     = ucc_arch_get_cpu_model();
+    ucc_cpu_vendor_t       vendor    = team_topo->cpu_vendor;
+    ucc_cpu_model_t        model     = team_topo->cpu_model;
     ucc_rank_t             ppn_min   = ucc_topo_min_ppn(team_topo);
     ucc_rank_t             ppn_max   = ucc_topo_max_ppn(team_topo);
-    ucc_rank_t             sock_min  = ucc_topo_min_socket_size(team_topo);
-    ucc_rank_t             sock_max  = ucc_topo_max_socket_size(team_topo);
+    ucc_rank_t             sock_min  = team_topo->topo->sock_bound ?
+                                       ucc_topo_min_socket_size(team_topo) : 0;
+    ucc_rank_t             sock_max  = team_topo->topo->sock_bound ?
+                                       ucc_topo_max_socket_size(team_topo) :
+                                       UCC_RANK_MAX;
     ucc_rank_t             nnodes    = ucc_topo_nnodes(team_topo);
     ucc_rank_t             team_size = team_topo->set.map.ep_num;
     int                    found     = 0;

--- a/src/utils/ucc_proc_info.c
+++ b/src/utils/ucc_proc_info.c
@@ -17,6 +17,7 @@
 #include "utils/ucc_malloc.h"
 #include "utils/ucc_math.h"
 #include "utils/ucc_sys.h"
+#include "utils/arch/cpu.h"
 #ifdef HAVE_UCS_GET_SYSTEM_ID
 #include <ucs/sys/uid.h>
 #endif
@@ -380,10 +381,12 @@ error:
 
 ucc_status_t ucc_local_proc_info_init()
 {
-    ucc_local_proc.host_hash = ucc_get_system_id();
-    ucc_local_proc.pid       = getpid();
-    ucc_local_proc.socket_id = UCC_SOCKET_ID_INVALID;
-    ucc_local_proc.numa_id   = UCC_NUMA_ID_INVALID;
+    ucc_local_proc.host_hash  = ucc_get_system_id();
+    ucc_local_proc.pid        = getpid();
+    ucc_local_proc.socket_id  = UCC_SOCKET_ID_INVALID;
+    ucc_local_proc.numa_id    = UCC_NUMA_ID_INVALID;
+    ucc_local_proc.cpu_vendor = (uint8_t)ucc_arch_get_cpu_vendor();
+    ucc_local_proc.cpu_model  = (uint8_t)ucc_arch_get_cpu_model();
 
     if (UCC_OK != ucc_get_bound_socket_id(&ucc_local_proc.socket_id)) {
         ucc_debug("failed to get bound socket id");

--- a/src/utils/ucc_proc_info.h
+++ b/src/utils/ucc_proc_info.h
@@ -37,6 +37,8 @@ typedef struct ucc_proc_info {
     ucc_numa_id_t   numa_id;
     ucc_host_id_t   host_id;
     pid_t           pid;
+    uint8_t         cpu_vendor;
+    uint8_t         cpu_model;
 } ucc_proc_info_t;
 
 typedef struct ucc_pci_info {


### PR DESCRIPTION
## What
Fix two crashes/hangs when UCC selects config-file tuning sections for a team that is not socket-bound or CPU-heterogeneous:
Guard socket-size queries in ucc_add_team_sections so they aren't called when processes aren't socket-bound.
Make CPU vendor/model tuning selection team-wide consistent: exchange each rank's CPU vendor/model and fall back to UNKNOWN when the team spans different CPUs, so all ranks pick the same tuning — and therefore the same collective algorithm.
