### PR TITLE
CORE: add team (communicator) caching

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -195,6 +195,100 @@ which of those TLs with the highest score is selected.
 
 Tuning UCC heuristics is also possible with the UCC configuration file (`ucc.conf`). This file provides a unified way of tailoring the behavior of UCC components - CLs, TLs, and ECs. It can contain any UCC variables of the format `VAR = VALUE`, e.g. `UCC_TL_NCCL_TUNE=allreduce:cuda:inf#alltoall:0` to force NCCL allreduce for "cuda" buffers and disable NCCL for alltoall. See [`contrib/ucc.conf`](../contrib/ucc.conf) for an example and the [FAQ](https://github.com/openucx/ucc/wiki/FAQ#13-ucc-configuration-file-and-priority) for further details.
 
+## Team (communicator) caching
+
+Building a UCC team (collective communicator structure) is an expensive operation involving out-of-band communication, unique ID allocation, and per-component initialization. UCC can transparently cache and reuse teams built for identical-membership communicator groups, avoiding repeated reconstruction for the same process sets.
+
+### When caching helps
+
+Caching accelerates **create → use → free → recreate-identical** workloads via two
+complementary mechanisms:
+
+1. **Dormant reuse** — a freed team is retained and re-adopted when an
+   identical-membership communicator is recreated:
+   - An MPI program repeatedly creates and destroys communicators with the same rank membership (e.g., iterative solvers splitting a rank subset each iteration).
+   - Repeated `MPI_Comm_split` or `MPI_Comm_create` with stable rank sets or colors (common in ScaLAPACK-style process-grid splitting and domain decomposition).
+
+2. **Derived teams (simultaneous coexistence)** — when a second identical-membership
+   communicator is created while the first is *still live* (e.g., `MPI_Comm_dup` of a
+   live communicator), UCC builds a lightweight **derived team** that shares the
+   parent's immutable membership and topology while getting its **own** team id (its
+   own tag/sequence domain, so the two live teams never alias). This skips the
+   address exchange and topology build — the bulk of team-creation cost.
+
+Both mechanisms are transparent and work for externally-provided team ids (e.g. an
+MPI communicator's context id): dormant reuse re-adopts only when membership **and**
+id match, while derived-create keys coexistence on membership alone (a dup legitimately
+carries a different id than its live parent).
+
+**Order-dependence note:** teams are keyed by their materialized membership — the rank-to-endpoint mapping. If the same process set is reordered (a different `MPI_Comm_create` with a different `ranks` argument order), it is treated as a *different* team, so no reuse occurs. Only identical membership in identical rank order is eligible for reuse.
+
+### Configuration reference
+
+UCC team caching is controlled via environment variables (`UCC_*`) or the `ucc.conf` configuration file. It is **experimental and disabled by default** (`UCC_TEAM_CACHE_ENABLE=n`). Use `ucc_info -c` to list the current settings:
+
+```text
+$ ucc_info -c | grep -i team_cache
+UCC_TEAM_CACHE_ENABLE: n
+UCC_TEAM_CACHE_AGREEMENT: y
+UCC_TEAM_CACHE_MAX_SIZE: 128
+UCC_TEAM_CACHE_EVICTION: fifo
+UCC_TEAM_CACHE_DISABLE_LINEAR_CHECK: n
+UCC_TEAM_CACHE_DUMP_STATS: n
+UCC_TEAM_CACHE_DERIVED: y
+UCC_TEAM_CACHE_RESEAT: n
+```
+
+| Knob | Type | Default | Description |
+|------|------|---------|-------------|
+| `UCC_TEAM_CACHE_ENABLE` | Boolean | `n` | Enable team caching. When disabled, each communicator creation rebuilds its team from scratch. Experimental. |
+| `UCC_TEAM_CACHE_AGREEMENT` | Boolean | `y` | Run a cross-rank agreement on every cacheable create so all members reach an identical reuse-vs-fresh decision, making reuse safe for overlapping subcommunicators (adds one small member-scoped allreduce per create). Set to `n` only when communicator scopes never overlap. |
+| `UCC_TEAM_CACHE_MAX_SIZE` | Unsigned integer | `128` | Maximum number of teams (live plus dormant) tracked by the cache. Each holds a unique team ID, so the effective limit is also clamped by `UCC_TEAM_IDS_POOL_SIZE` (see [Team-ID pool and cache sizing](#team-id-pool-and-cache-sizing)). |
+| `UCC_TEAM_CACHE_EVICTION` | Enum: `fifo`, `lfu`, `lru`, `none` | `fifo` | Eviction policy at capacity (only dormant teams are evictable): `none` never evicts; `fifo` evicts the oldest dormant team; `lfu` evicts the least-used (fewest collectives, by `seq_num`); `lru` is an alias for `lfu` (UCC has no wall-clock recency). |
+| `UCC_TEAM_CACHE_DISABLE_LINEAR_CHECK` | Boolean | `n` | Trust the 64-bit membership hash alone and skip the exact rank-array compare after a hash match. Faster, but a hash collision would reuse the wrong team. Enable only if collisions cannot occur. |
+| `UCC_TEAM_CACHE_DUMP_STATS` | Boolean | `n` | Log cache statistics (lookups, hits and hit rate, misses, inserts, evictions) at context destruction. |
+| `UCC_TEAM_CACHE_DERIVED` | Boolean | `y` | Cache and reuse derived teams: when a create duplicates the membership of a still-live team (e.g. `MPI_Comm_dup`), build it with its own team ID but borrow the parent's shared membership/topology artifacts. No effect unless `UCC_TEAM_CACHE_ENABLE=y`. |
+| `UCC_TEAM_CACHE_RESEAT` | Boolean | `n` | Experimental: recover reuse under context-id drift by re-adopting a cached dormant derived team of identical membership but a different external id, re-seating its id/tag domain instead of rebuilding. Requires `UCC_TEAM_CACHE_DERIVED=y`. |
+| `UCC_TEAM_IDS_POOL_SIZE` | Unsigned integer | `32` | Size of the team-ID pool in 64-ID blocks; total unique IDs per context is `pool_size × 64` (32 → 2048). See [Team-ID pool and cache sizing](#team-id-pool-and-cache-sizing). |
+
+### Team-ID pool and cache sizing
+
+Dormant cached teams retain their unique team IDs, so the team-ID pool (`UCC_TEAM_IDS_POOL_SIZE`, default 32 blocks × 64 = 2048 IDs) must accommodate both live and cached dormant teams. If the cache grows too large it risks pool exhaustion, failing team creation with `UCC_ERR_NO_RESOURCE`. To guard against this, `UCC_TEAM_CACHE_MAX_SIZE` is automatically clamped at runtime to stay safely below the pool size, reserving headroom for live and in-flight teams.
+
+If your workload needs a large cache, raise `UCC_TEAM_IDS_POOL_SIZE` to match. The clamp reserves a small ID headroom for live/in-flight teams, so a pool of `N × 64` IDs caches somewhat fewer than `N × 64` dormant teams — size the pool with margin (e.g. `UCC_TEAM_IDS_POOL_SIZE=5` comfortably caches 256 teams) rather than exactly. Monitor with `UCC_TEAM_CACHE_DUMP_STATS`: high eviction counts mean the cache is thrashing and the pool is undersized. Verify both values with `ucc_info -c`.
+
+### Reading cache statistics
+
+Set `UCC_TEAM_CACHE_DUMP_STATS=y` to log per-context cache statistics at context destruction. Each context (typically one per MPI process) logs a line like:
+
+```text
+team_cache stats: lookups=1000 hits=950 (95.0%) misses=50 inserts=50 evictions=0
+```
+
+`hits` counts reuses of a cached dormant team (derived-team creates are new teams sharing a parent's artifacts, not hits). If the hit rate is low and evictions are high, raise `UCC_TEAM_CACHE_MAX_SIZE` (and `UCC_TEAM_IDS_POOL_SIZE` if the cache is pool-clamped — see [Team-ID pool and cache sizing](#team-id-pool-and-cache-sizing)).
+
+### Configuration example
+
+To enable aggressive caching with increased pool size and detailed statistics:
+
+```bash
+export UCC_TEAM_CACHE_ENABLE=y
+export UCC_TEAM_CACHE_MAX_SIZE=256
+export UCC_TEAM_CACHE_EVICTION=lfu
+export UCC_TEAM_IDS_POOL_SIZE=5
+export UCC_TEAM_CACHE_DUMP_STATS=y
+```
+
+Or in `ucc.conf`:
+
+```ini
+UCC_TEAM_CACHE_ENABLE=y
+UCC_TEAM_CACHE_MAX_SIZE=256
+UCC_TEAM_CACHE_EVICTION=lfu
+UCC_TEAM_IDS_POOL_SIZE=5
+UCC_TEAM_CACHE_DUMP_STATS=y
+```
+
 ## Logging
 
 To detect if Open MPI leverages UCC for a given collective one can set `OMPI_MCA_coll_ucc_verbose=3` checking for output like

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -51,6 +51,7 @@ noinst_HEADERS =                       \
 	core/ucc_lib.h                     \
 	core/ucc_context.h                 \
 	core/ucc_team.h                    \
+	core/ucc_team_cache.h              \
 	core/ucc_ee.h                      \
 	core/ucc_progress_queue.h          \
 	core/ucc_service_coll.h            \
@@ -115,6 +116,7 @@ libucc_la_SOURCES =                   \
 	core/ucc_version.c                \
 	core/ucc_context.c                \
 	core/ucc_team.c                   \
+	core/ucc_team_cache.c             \
 	core/ucc_ee.c                     \
 	core/ucc_coll.c                   \
 	core/ucc_progress_queue.c         \

--- a/src/components/base/ucc_base_iface.h
+++ b/src/components/base/ucc_base_iface.h
@@ -180,6 +180,9 @@ typedef struct ucc_base_team_iface {
     ucc_status_t (*create_test)(ucc_base_team_t *team);
     ucc_status_t (*destroy)(ucc_base_team_t *team);
     ucc_get_coll_scores_fn_t get_scores;
+    /* Re-seat the team's external id / tag domain in place (CL/BASIC, CL/HIER);
+       left NULL by UCC_BASE_IFACE_DECLARE and NULL-guarded by the core caller. */
+    void (*update_id)(ucc_base_team_t *team, uint16_t id);
 } ucc_base_team_iface_t;
 
 enum {

--- a/src/components/cl/basic/cl_basic.c
+++ b/src/components/cl/basic/cl_basic.c
@@ -59,3 +59,10 @@ ucc_status_t ucc_cl_basic_coll_init(ucc_base_coll_args_t *coll_args,
 ucc_status_t ucc_cl_basic_team_get_scores(ucc_base_team_t   *cl_team,
                                           ucc_coll_score_t **score);
 UCC_CL_IFACE_DECLARE(basic, BASIC);
+
+__attribute__((constructor)) static void cl_basic_iface_init(void)
+{
+    /* Wire update_id (left NULL by UCC_BASE_IFACE_DECLARE): CL/BASIC holds UCP
+       TL teams whose tag domain must be re-seated on id change. */
+    ucc_cl_basic.super.team.update_id = ucc_cl_basic_team_update_id;
+}

--- a/src/components/cl/basic/cl_basic.h
+++ b/src/components/cl/basic/cl_basic.h
@@ -52,6 +52,8 @@ typedef struct ucc_cl_basic_team {
 UCC_CLASS_DECLARE(ucc_cl_basic_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);
 
+void ucc_cl_basic_team_update_id(ucc_base_team_t *cl_team, uint16_t id);
+
 #define UCC_CL_BASIC_TEAM_CTX(_team)                                           \
     (ucc_derived_of((_team)->super.super.context, ucc_cl_basic_context_t))
 

--- a/src/components/cl/basic/cl_basic_team.c
+++ b/src/components/cl/basic/cl_basic_team.c
@@ -61,6 +61,22 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_basic_team_t)
     cl_debug(self->super.super.context->lib, "finalizing cl team: %p", self);
 }
 
+void ucc_cl_basic_team_update_id(ucc_base_team_t *cl_team, uint16_t id)
+{
+    ucc_cl_basic_team_t *team = ucc_derived_of(cl_team, ucc_cl_basic_team_t);
+    ucc_tl_team_t       *tl;
+    unsigned             i;
+
+    /* Re-seat every child TL team's tag domain to the new core team id.
+       Only UCP TLs expose scoll.update_id; others are skipped. */
+    for (i = 0; i < team->n_tl_teams; i++) {
+        tl = team->tl_teams[i];
+        if (tl && UCC_TL_TEAM_IFACE(tl)->scoll.update_id) {
+            UCC_TL_TEAM_IFACE(tl)->scoll.update_id(&tl->super, id);
+        }
+    }
+}
+
 UCC_CLASS_DEFINE_DELETE_FUNC(ucc_cl_basic_team_t, ucc_base_team_t);
 UCC_CLASS_DEFINE(ucc_cl_basic_team_t, ucc_cl_team_t);
 

--- a/src/components/cl/hier/allgatherv/allgatherv.c
+++ b/src/components/cl/hier/allgatherv/allgatherv.c
@@ -54,7 +54,7 @@ static inline ucc_status_t find_leader_rank(ucc_base_team_t *team,
     ucc_assert(team_rank < UCC_CL_TEAM_SIZE(cl_team));
     ucc_assert(SBGP_EXISTS(cl_team, NODE_LEADERS));
 
-    status = ucc_topo_get_node_leaders(core_team->topo, &node_leaders);
+    status = ucc_topo_get_node_leaders(UCC_TEAM_TOPO(core_team), &node_leaders);
     if (UCC_OK != status) {
         cl_error(team->context->lib, "Could not get node leaders");
         return status;
@@ -69,7 +69,7 @@ static inline ucc_status_t find_leader_rank(ucc_base_team_t *team,
    dst buffer is contiguous */
 static inline ucc_status_t is_block_ordered(ucc_cl_hier_team_t *cl_team, int *ordered)
 {
-    ucc_topo_t  *topo             = cl_team->super.super.params.team->topo;
+    ucc_topo_t  *topo = UCC_TEAM_TOPO(cl_team->super.super.params.team);
     ucc_sbgp_t  *all_nodes        = NULL;
     int          is_block_ordered = 1;
     int          n_nodes;
@@ -129,7 +129,7 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allgatherv_init,
     ucc_rank_t              node_sbgp_size   = SBGP_SIZE(cl_team, NODE);
     ucc_rank_t              leader_sbgp_size = SBGP_SIZE(cl_team, NODE_LEADERS);
     ucc_rank_t              team_size        = UCC_CL_TEAM_SIZE(cl_team);
-    ucc_topo_t             *topo             = team->params.team->topo;
+    ucc_topo_t             *topo             = UCC_TEAM_TOPO(team->params.team);
     ucc_aint_t             *node_disps       = NULL;
     ucc_count_t            *node_counts      = NULL;
     ucc_aint_t             *leader_disps     = NULL;

--- a/src/components/cl/hier/allgatherv/unpack.c
+++ b/src/components/cl/hier/allgatherv/unpack.c
@@ -72,7 +72,7 @@ ucc_status_t ucc_cl_hier_allgatherv_unpack_start(ucc_coll_task_t *task)
     ucc_rank_t                 *node_leaders      = NULL;
     ucc_sbgp_t                 *all_nodes         = NULL;
     ucc_sbgp_t                 *node_leaders_sbgp = NULL;
-    ucc_topo_t                 *topo              = task->team->params.team->topo;
+    ucc_topo_t                 *topo = UCC_TEAM_TOPO(task->team->params.team);
     ucc_ee_executor_t          *exec;
     ucc_status_t                status;
     ucc_rank_t                  i;

--- a/src/components/cl/hier/allreduce/allreduce_split_rail.c
+++ b/src/components/cl/hier/allreduce/allreduce_split_rail.c
@@ -296,7 +296,7 @@ UCC_CL_HIER_PROFILE_FUNC(ucc_status_t, ucc_cl_hier_allreduce_split_rail_init,
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    if (!ucc_topo_isoppn(team->params.team->topo)) {
+    if (!ucc_topo_isoppn(UCC_TEAM_TOPO(team->params.team))) {
         cl_debug(team->context->lib, "split_rail algorithm does not support "
                                      "teams with non-uniform ppn across nodes");
         return UCC_ERR_NOT_SUPPORTED;

--- a/src/components/cl/hier/alltoallv/alltoallv.c
+++ b/src/components/cl/hier/alltoallv/alltoallv.c
@@ -42,33 +42,42 @@ static ucc_status_t ucc_cl_hier_alltoallv_finalize(ucc_coll_task_t *task)
     return status;
 }
 
-#define SET_FULL_COUNTS(_type, _sbgp, _coll_args, _team, _node_thresh,         \
-                        _sdt_size, _rdt_size, _sc_full, _sd_full, _rc_full,    \
-                        _rd_full)                                              \
+#define SET_FULL_COUNTS(                                                       \
+    _type,                                                                     \
+    _sbgp,                                                                     \
+    _coll_args,                                                                \
+    _team,                                                                     \
+    _node_thresh,                                                              \
+    _sdt_size,                                                                 \
+    _rdt_size,                                                                 \
+    _sc_full,                                                                  \
+    _sd_full,                                                                  \
+    _rc_full,                                                                  \
+    _rd_full)                                                                  \
     do {                                                                       \
         int   _i, _is_local;                                                   \
         _type _scount, _rcount;                                                \
                                                                                \
         for (_i = 0; _i < (_sbgp)->group_size; _i++) {                         \
-            _scount = ((_type *)(_coll_args)->args.src.info_v.counts)[_i];     \
-            _rcount = ((_type *)(_coll_args)->args.dst.info_v.counts)[_i];     \
-            _is_local =                                                        \
-                ucc_rank_on_local_node(_i, (_team)->params.team->topo);        \
+            _scount   = ((_type *)(_coll_args)->args.src.info_v.counts)[_i];   \
+            _rcount   = ((_type *)(_coll_args)->args.dst.info_v.counts)[_i];   \
+            _is_local = ucc_rank_on_local_node(                                \
+                _i, UCC_TEAM_TOPO((_team)->params.team));                      \
             if ((_scount * _sdt_size > (_node_thresh)) && _is_local) {         \
                 ((_type *)_sc_full)[_i] = 0;                                   \
             } else {                                                           \
                 ((_type *)_sc_full)[_i] = _scount;                             \
-                ((_type *)_sd_full)[_i] =                                      \
-                    ((_type *)(_coll_args)                                     \
-                         ->args.src.info_v.displacements)[_i];                 \
+                ((_type *)_sd_full)[_i] = ((_type *)(_coll_args)               \
+                                               ->args.src.info_v               \
+                                               .displacements)[_i];            \
             }                                                                  \
             if ((_rcount * _rdt_size > (_node_thresh)) && _is_local) {         \
                 ((_type *)_rc_full)[_i] = 0;                                   \
             } else {                                                           \
                 ((_type *)_rc_full)[_i] = _rcount;                             \
-                ((_type *)_rd_full)[_i] =                                      \
-                    ((_type *)(_coll_args)                                     \
-                         ->args.dst.info_v.displacements)[_i];                 \
+                ((_type *)_rd_full)[_i] = ((_type *)(_coll_args)               \
+                                               ->args.dst.info_v               \
+                                               .displacements)[_i];            \
             }                                                                  \
         }                                                                      \
     } while (0)

--- a/src/components/cl/hier/bcast/bcast_2step.c
+++ b/src/components/cl/hier/bcast/bcast_2step.c
@@ -145,8 +145,8 @@ ucc_cl_hier_bcast_2step_init_schedule(ucc_base_coll_args_t *coll_args,
 
     if (SBGP_ENABLED(cl_team, NODE)) {
         args.args.root = root_on_local_node
-            ? find_root_node_rank(root, cl_team)
-            : core_team->topo->node_leader_rank_id;
+                             ? find_root_node_rank(root, cl_team)
+                             : UCC_TEAM_TOPO(core_team)->node_leader_rank_id;
         status =
             ucc_coll_init(SCORE_MAP(cl_team, NODE), &args, &tasks[n_tasks]);
         if (ucc_unlikely(UCC_OK != status)) {

--- a/src/components/cl/hier/cl_hier.c
+++ b/src/components/cl/hier/cl_hier.c
@@ -128,4 +128,7 @@ __attribute__((constructor)) static void cl_hier_iface_init(void)
         ucc_cl_hier_bcast_algs;
     ucc_cl_hier.super.alg_info[ucc_ilog2(UCC_COLL_TYPE_ALLGATHERV)] =
         ucc_cl_hier_allgatherv_algs;
+    /* Wire update_id (left NULL by UCC_BASE_IFACE_DECLARE): CL/HIER holds
+       per-sbgp UCP TL teams whose tag domains must be re-seated on id change. */
+    ucc_cl_hier.super.team.update_id = ucc_cl_hier_team_update_id;
 }

--- a/src/components/cl/hier/cl_hier.h
+++ b/src/components/cl/hier/cl_hier.h
@@ -124,6 +124,8 @@ ucc_status_t ucc_cl_hier_coll_init(ucc_base_coll_args_t *coll_args,
                                    ucc_base_team_t      *team,
                                    ucc_coll_task_t     **task);
 
+void         ucc_cl_hier_team_update_id(ucc_base_team_t *cl_team, uint16_t id);
+
 #define UCC_CL_HIER_TEAM_CTX(_team)                                            \
     (ucc_derived_of((_team)->super.super.context, ucc_cl_hier_context_t))
 

--- a/src/components/cl/hier/cl_hier_team.c
+++ b/src/components/cl/hier/cl_hier_team.c
@@ -47,13 +47,13 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
     ucc_tl_lib_t              *tl_lib;
     ucc_base_lib_attr_t        attr;
 
-    if (!params->team->topo) {
+    if (!UCC_TEAM_TOPO(params->team)) {
         cl_debug(cl_context->lib,
                 "can't create hier team without topology data");
         return UCC_ERR_INVALID_PARAM;
     }
 
-    if (ucc_topo_is_single_node(params->team->topo)) {
+    if (ucc_topo_is_single_node(UCC_TEAM_TOPO(params->team))) {
         cl_debug(cl_context->lib, "skipping single node team");
         return UCC_ERR_INVALID_PARAM;
     }
@@ -65,7 +65,8 @@ UCC_CLASS_INIT_FUNC(ucc_cl_hier_team_t, ucc_base_context_t *cl_context,
     for (i = 0; i < UCC_HIER_SBGP_LAST; i++) {
         hs = &self->sbgps[i];
         if (hs->state == UCC_HIER_SBGP_ENABLED) {
-            hs->sbgp = ucc_topo_get_sbgp(params->team->topo, hs->sbgp_type);
+            hs->sbgp = ucc_topo_get_sbgp(
+                UCC_TEAM_TOPO(params->team), hs->sbgp_type);
             if (hs->sbgp->status != UCC_SBGP_ENABLED) {
                 /* SBGP of that type either not exists or the calling process
                  * is not part of subgroup
@@ -192,6 +193,27 @@ UCC_CLASS_CLEANUP_FUNC(ucc_cl_hier_team_t)
 
 UCC_CLASS_DEFINE_DELETE_FUNC(ucc_cl_hier_team_t, ucc_base_team_t);
 UCC_CLASS_DEFINE(ucc_cl_hier_team_t, ucc_cl_team_t);
+
+void ucc_cl_hier_team_update_id(ucc_base_team_t *cl_team, uint16_t id)
+{
+    ucc_cl_hier_team_t *team = ucc_derived_of(cl_team, ucc_cl_hier_team_t);
+    ucc_hier_sbgp_t    *hs;
+    ucc_tl_team_t      *tl;
+    int                 s, t;
+
+    /* Re-seat every per-sbgp TL team's tag domain to the new core team id.
+       HIER nests TL teams per subgroup (sbgps[].tl_teams[]); only UCP TLs
+       expose scoll.update_id, others are skipped. */
+    for (s = 0; s < UCC_HIER_SBGP_LAST; s++) {
+        hs = &team->sbgps[s];
+        for (t = 0; t < hs->n_tls; t++) {
+            tl = hs->tl_teams[t];
+            if (tl && UCC_TL_TEAM_IFACE(tl)->scoll.update_id) {
+                UCC_TL_TEAM_IFACE(tl)->scoll.update_id(&tl->super, id);
+            }
+        }
+    }
+}
 
 ucc_status_t ucc_cl_hier_team_destroy(ucc_base_team_t *cl_team)
 {

--- a/src/components/tl/cuda/tl_cuda_team.c
+++ b/src/components/tl/cuda/tl_cuda_team.c
@@ -338,7 +338,7 @@ ucc_status_t ucc_tl_cuda_team_create_test(ucc_base_team_t *tl_team)
         team->scratch.rem[i] = NULL;
     }
 
-    if (!ucc_topo_has_device_info(UCC_TL_CORE_TEAM(team)->topo)) {
+    if (!ucc_topo_has_device_info(UCC_TEAM_TOPO(UCC_TL_CORE_TEAM(team)))) {
         tl_debug(tl_team->context->lib,
                  "not all ranks have visible GPU device info; "
                  "skipping TL/CUDA team creation");

--- a/src/components/tl/cuda/tl_cuda_team_topo.c
+++ b/src/components/tl/cuda/tl_cuda_team_topo.c
@@ -342,7 +342,7 @@ static ucc_status_t
 ucc_tl_cuda_team_topo_init_matrix(const ucc_tl_cuda_team_t *team,
                                   ucc_rank_t *matrix)
 {
-    ucc_topo_t          *topo      = UCC_TL_CORE_TEAM(team)->topo;
+    ucc_topo_t          *topo      = UCC_TEAM_TOPO(UCC_TL_CORE_TEAM(team));
     ucc_proc_info_t     *procs     = topo->topo->procs;
     ucc_device_id_t     *dev_ids   = topo->device_map.device_ids;
     int                  size      = UCC_TL_TEAM_SIZE(team);
@@ -406,7 +406,7 @@ ucc_status_t ucc_tl_cuda_team_topo_create(const ucc_tl_team_t *cuda_team,
      * connectivity. This handles NVSwitch, fabric clique, and direct NVLink
      * connections consistently and avoids rescanning the matrix for zeros. */
     {
-        ucc_topo_t *utopo   = UCC_TL_CORE_TEAM(team)->topo;
+        ucc_topo_t *utopo   = UCC_TEAM_TOPO(UCC_TL_CORE_TEAM(team));
         ucc_sbgp_t *node_sg = ucc_topo_get_sbgp(utopo, UCC_SBGP_NODE);
         topo->is_fully_connected =
             ucc_topo_is_nvlink_fully_connected(utopo, node_sg);

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -19,8 +19,10 @@ static ucc_status_t ucc_tl_mlx5_topo_init(ucc_tl_mlx5_team_t *team)
     ucc_subset_t subset;
     ucc_status_t status;
 
-    status = ucc_ep_map_create_nested(&UCC_TL_CORE_TEAM(team)->ctx_map,
-                                      &UCC_TL_TEAM_MAP(team), &team->ctx_map);
+    status = ucc_ep_map_create_nested(
+        &UCC_TEAM_CTX_MAP(UCC_TL_CORE_TEAM(team)),
+        &UCC_TL_TEAM_MAP(team),
+        &team->ctx_map);
     if (UCC_OK != status) {
         tl_debug(UCC_TL_TEAM_LIB(team), "failed to create ctx map");
         return status;

--- a/src/components/tl/sharp/tl_sharp_team.c
+++ b/src/components/tl/sharp/tl_sharp_team.c
@@ -37,9 +37,10 @@ UCC_CLASS_INIT_FUNC(ucc_tl_sharp_team_t, ucc_base_context_t *tl_context,
     set.map    = UCC_TL_TEAM_MAP(self);
 
     if (UCC_TL_SHARP_TEAM_LIB(self)->cfg.use_internal_oob) {
-        status = ucc_ep_map_create_nested(&UCC_TL_CORE_TEAM(self)->ctx_map,
-                                 &UCC_TL_TEAM_MAP(self),
-                                 &self->oob_ctx.subset.map);
+        status = ucc_ep_map_create_nested(
+            &UCC_TEAM_CTX_MAP(UCC_TL_CORE_TEAM(self)),
+            &UCC_TL_TEAM_MAP(self),
+            &self->oob_ctx.subset.map);
         if (status != UCC_OK) {
             return status;
         }

--- a/src/components/tl/ucc_tl.c
+++ b/src/components/tl/ucc_tl.c
@@ -188,7 +188,7 @@ static ucc_status_t ucc_tl_is_reachable(const ucc_base_team_params_t *params,
     for (i = 0; i < params->size; i++) {
         rank = ucc_ep_map_eval(params->map, i);
         if (use_ctx) {
-            rank = ucc_ep_map_eval(core_team->ctx_map, rank);
+            rank = ucc_ep_map_eval(UCC_TEAM_CTX_MAP(core_team), rank);
         }
         addr_header = UCC_ADDR_STORAGE_RANK_HEADER(addr_storage, rank);
         for (j = 0; j < addr_header->n_components; j++) {

--- a/src/components/tl/ucp/tl_ucp_tag.h
+++ b/src/components/tl/ucp/tl_ucp_tag.h
@@ -48,6 +48,10 @@
 #define UCC_TL_UCP_MAX_COLL_TAG   (UCC_TL_UCP_MAX_TAG - UCC_TL_UCP_RESERVED_TAGS)
 #define UCC_TL_UCP_SERVICE_TAG    (UCC_TL_UCP_MAX_COLL_TAG + 1)
 #define UCC_TL_UCP_ACTIVE_SET_TAG (UCC_TL_UCP_MAX_COLL_TAG + 2)
+/* Reserved tags MAX_COLL_TAG+3 .. +7 are currently unused. The team-cache
+ * agreement vote reuses UCC_TL_UCP_SERVICE_TAG, safe because ctx->service_team
+ * ops are strictly sequential per team and only one create is outstanding per
+ * context (see ucc_team.c). */
 #define UCC_TL_UCP_MAX_SENDER      UCC_MASK(UCC_TL_UCP_SENDER_BITS)
 #define UCC_TL_UCP_MAX_ID          UCC_MASK(UCC_TL_UCP_ID_BITS)
 

--- a/src/components/tl/ucp/tl_ucp_team.c
+++ b/src/components/tl/ucp/tl_ucp_team.c
@@ -23,9 +23,13 @@ static inline ucc_status_t ucc_tl_ucp_get_topo(ucc_tl_ucp_team_t *team)
         return UCC_OK;
     }
 
-    status = ucc_ep_map_create_nested(&UCC_TL_CORE_TEAM(team)->ctx_map,
-                                      &UCC_TL_TEAM_MAP(team),
-                                      &team->ctx_map);
+    /* Alias the core team's shared ctx_map: the nested map stores a raw pointer to
+       &artifacts->ctx_map, which must stay at a stable address for this TL team's
+       lifetime. The refcounted artifacts holder guarantees that. */
+    status = ucc_ep_map_create_nested(
+        &UCC_TEAM_CTX_MAP(UCC_TL_CORE_TEAM(team)),
+        &UCC_TL_TEAM_MAP(team),
+        &team->ctx_map);
     if (UCC_OK != status) {
         tl_error(UCC_TL_TEAM_LIB(team), "failed to create ctx map");
         return status;

--- a/src/components/topo/ucc_topo.c
+++ b/src/components/topo/ucc_topo.c
@@ -323,6 +323,55 @@ ucc_sbgp_t *ucc_topo_get_sbgp(ucc_topo_t *topo, ucc_sbgp_type_t type)
     return &topo->sbgps[type];
 }
 
+/* Only an allocation failure is fatal to shared-topo prep: it can leave a field
+   NULL so a later first-touch would retry it (the race the guard prevents). A
+   grouping that simply does not apply records a terminal status and never retries. */
+#define UCC_TOPO_PREP_FATAL(_status) ((_status) == UCC_ERR_NO_MEMORY)
+
+ucc_status_t ucc_topo_prepare_shared(ucc_topo_t *topo)
+{
+    ucc_sbgp_t  *sbgps;
+    ucc_rank_t  *node_leaders;
+    ucc_status_t status;
+    int          n_sbgps, i;
+
+    if (!topo) {
+        return UCC_OK;
+    }
+
+    /* Build every local sbgp (also fills the layout scalars). Each sets a terminal
+       status even on failure, so a failed sbgp is never lazily retried - best-effort. */
+    for (i = 0; i < UCC_SBGP_LAST; i++) {
+        (void)ucc_topo_get_sbgp(topo, (ucc_sbgp_type_t)i);
+    }
+
+    /* The on-demand all-sub-group arrays DO leave state NULL (and thus retryable)
+       on failure, so surface a real allocation failure to the caller. */
+    status = ucc_topo_get_all_sockets(topo, &sbgps, &n_sbgps);
+    if (UCC_TOPO_PREP_FATAL(status)) {
+        return status;
+    }
+    status = ucc_topo_get_all_numas(topo, &sbgps, &n_sbgps);
+    if (UCC_TOPO_PREP_FATAL(status)) {
+        return status;
+    }
+    status = ucc_topo_get_all_nodes(topo, &sbgps, &n_sbgps);
+    if (UCC_TOPO_PREP_FATAL(status)) {
+        return status;
+    }
+
+    /* Node-leaders map is only defined for multi-node teams (the accessor
+       asserts nnodes > 1); single-node never exercises the lazy path either. */
+    if (topo->topo->nnodes > 1) {
+        status = ucc_topo_get_node_leaders(topo, &node_leaders);
+        if (UCC_TOPO_PREP_FATAL(status)) {
+            return status;
+        }
+    }
+
+    return UCC_OK;
+}
+
 int ucc_topo_is_single_node(ucc_topo_t *topo)
 {
     ucc_sbgp_t *sbgp;

--- a/src/components/topo/ucc_topo.h
+++ b/src/components/topo/ucc_topo.h
@@ -108,6 +108,14 @@ ucc_status_t ucc_topo_init(
 
 void ucc_topo_cleanup(ucc_topo_t *subset_topo);
 
+/*
+ * Force-materialize every lazily-filled topo field (sbgps[], all_*, node_leaders,
+ * layout scalars) once at team-create, so a topo shared read-only across derived
+ * teams cannot race those lazy fills under THREAD_MULTIPLE. A non-existent
+ * grouping stays NOT_EXISTS (valid); a real materialization failure is propagated
+ * so the caller can decline to share/cache rather than leave a half-built topo. */
+ucc_status_t      ucc_topo_prepare_shared(ucc_topo_t *topo);
+
 ucc_sbgp_t *ucc_topo_get_sbgp(ucc_topo_t *topo, ucc_sbgp_type_t type);
 
 int ucc_topo_is_single_node(ucc_topo_t *topo);

--- a/src/core/ucc_context.c
+++ b/src/core/ucc_context.c
@@ -6,6 +6,8 @@
 
 #include "config.h"
 #include "ucc_context.h"
+#include "ucc_team.h"
+#include "ucc_team_cache.h"
 #include "utils/ucc_proc_info.h"
 #include "components/cl/ucc_cl.h"
 #include "components/tl/ucc_tl.h"
@@ -17,51 +19,149 @@
 #include "utils/ucc_debug.h"
 #include "ucc_progress_queue.h"
 
+/* IDs kept free in the team-ID pool (capacity = pool_size*64 - 1, ID 0 reserved)
+ * so a pre-ACTIVE ucc_team_alloc_id never hits an exhausted pool. Cache max_size
+ * is clamped to capacity - headroom. E.g. pool_size=32 -> capacity=2047 -> 2039. */
+#define UCC_TEAM_CACHE_ID_HEADROOM 8U
+
 static uint32_t ucc_context_seq_num = 0;
 static ucc_config_field_t ucc_context_config_table[] = {
-    {"ESTIMATED_NUM_EPS", "0",
+    {"ESTIMATED_NUM_EPS",
+     "0",
      "An optimization hint of how many endpoints will be created on this "
      "context",
      ucc_offsetof(ucc_context_config_t, estimated_num_eps),
      UCC_CONFIG_TYPE_UINT},
 
-    {"LOCK_FREE_PROGRESS_Q", "0",
+    {"LOCK_FREE_PROGRESS_Q",
+     "0",
      "Enable lock free progress queue optimization",
      ucc_offsetof(ucc_context_config_t, lock_free_progress_q),
      UCC_CONFIG_TYPE_UINT},
 
-    {"ESTIMATED_NUM_PPN", "0",
+    {"ESTIMATED_NUM_PPN",
+     "0",
      "An optimization hint of how many endpoints created on this context reside"
      " on the same node",
      ucc_offsetof(ucc_context_config_t, estimated_num_ppn),
      UCC_CONFIG_TYPE_UINT},
 
-    {"TEAM_IDS_POOL_SIZE", "32",
+    {"TEAM_IDS_POOL_SIZE",
+     "32",
      "Defines the size of the team_id_pool. The number of coexisting unique "
      "team ids for a single process is team_ids_pool_size*64. This parameter "
      "is relevant when internal team id allocation takes place.",
      ucc_offsetof(ucc_context_config_t, team_ids_pool_size),
      UCC_CONFIG_TYPE_UINT},
 
-    {"INTERNAL_OOB", "1",
+    {"TEAM_CACHE_ENABLE",
+     "n",
+     "Enable caching and reuse of ucc_team structures with identical "
+     "membership, "
+     "so repeated team creation with matching params may reuse a previously "
+     "built "
+     "team. Experimental, default off.",
+     ucc_offsetof(ucc_context_config_t, team_cache_enable),
+     UCC_CONFIG_TYPE_BOOL},
+
+    {"TEAM_CACHE_MAX_SIZE",
+     "128",
+     "Maximum number of teams retained in the per-context team cache. Cached "
+     "dormant teams each hold a team-id, so the effective limit is also "
+     "clamped "
+     "by UCC_TEAM_IDS_POOL_SIZE.",
+     ucc_offsetof(ucc_context_config_t, team_cache_max_size),
+     UCC_CONFIG_TYPE_UINT},
+
+    {"TEAM_CACHE_EVICTION",
+     "fifo",
+     "Eviction policy when the team cache is at capacity (only dormant teams "
+     "are "
+     "evictable): none (never evict, new team stays uncached), fifo (oldest "
+     "dormant), lfu (fewest collectives served, by seq_num), lru (alias for "
+     "lfu; "
+     "UCC has no wall-clock recency).",
+     ucc_offsetof(ucc_context_config_t, team_cache_eviction),
+     UCC_CONFIG_TYPE_ENUM(ucc_team_cache_eviction_names)},
+
+    {"TEAM_CACHE_DISABLE_LINEAR_CHECK",
+     "n",
+     "Trust the 64-bit identity hash alone in lookup, skipping the exact "
+     "rank-array membership compare. Faster, but a hash collision would yield "
+     "an "
+     "incorrect team reuse. Default off (safe).",
+     ucc_offsetof(ucc_context_config_t, team_cache_disable_linear_check),
+     UCC_CONFIG_TYPE_BOOL},
+
+    {"TEAM_CACHE_DUMP_STATS",
+     "n",
+     "Dump team-cache statistics (lookups, hits and hit rate, misses, inserts, "
+     "evictions) to the log at context destroy. Default off.",
+     ucc_offsetof(ucc_context_config_t, team_cache_dump_stats),
+     UCC_CONFIG_TYPE_BOOL},
+
+    {"TEAM_CACHE_DERIVED",
+     "y",
+     "Cache and reuse derived teams: when a create duplicates the membership "
+     "of a "
+     "still-live cached team (e.g. MPI_Comm_dup), build it with its own "
+     "team-id "
+     "but borrow the parent's shared membership/topology artifacts. When off, "
+     "such "
+     "a create is an independent full build. No effect unless "
+     "UCC_TEAM_CACHE_ENABLE is set.",
+     ucc_offsetof(ucc_context_config_t, team_cache_derived),
+     UCC_CONFIG_TYPE_BOOL},
+
+    {"TEAM_CACHE_RESEAT",
+     "n",
+     "Experimental: re-adopt a cached dormant derived team of identical "
+     "membership but a different external id (drifted MPI context-id) by "
+     "re-seating "
+     "its id/tag domain instead of rebuilding. Requires "
+     "UCC_TEAM_CACHE_DERIVED. "
+     "Default off.",
+     ucc_offsetof(ucc_context_config_t, team_cache_reseat),
+     UCC_CONFIG_TYPE_BOOL},
+
+    {"TEAM_CACHE_AGREEMENT",
+     "y",
+     "Run a cross-rank agreement on every cacheable team create so all members "
+     "reach an identical reuse-vs-fresh decision, making reuse safe for "
+     "overlapping "
+     "subcommunicators (adds one small member-scoped allreduce per cacheable "
+     "create). Default on; set to n only when communicator scopes never "
+     "overlap. "
+     "No effect unless UCC_TEAM_CACHE_ENABLE is set.",
+     ucc_offsetof(ucc_context_config_t, team_cache_agreement),
+     UCC_CONFIG_TYPE_BOOL},
+
+    {"INTERNAL_OOB",
+     "1",
      "Use internal OOB transport for team creation. Available for ucc_context "
      "is configured with OOB (global mode). 0 - disable, 1 - try, 2 - force.",
-     ucc_offsetof(ucc_context_config_t, internal_oob), UCC_CONFIG_TYPE_UINT},
+     ucc_offsetof(ucc_context_config_t, internal_oob),
+     UCC_CONFIG_TYPE_UINT},
 
-    {"THROTTLE_PROGRESS", "1000",
+    {"THROTTLE_PROGRESS",
+     "1000",
      "Throttle UCC progress to every <n>th invocation",
      ucc_offsetof(ucc_context_config_t, throttle_progress),
      UCC_CONFIG_TYPE_UINT},
 
-    {"NET_DEVICES", "all",
+    {"NET_DEVICES",
+     "all",
      "Specifies which network device(s) to use. The order is not meaningful.\n"
      "\"all\" would use all available devices. Only TLs that support this "
      "parameter will be affected. The parameter is only supported by UCX TL.",
-     ucc_offsetof(ucc_context_config_t, net_devices), UCC_CONFIG_TYPE_STRING_ARRAY},
+     ucc_offsetof(ucc_context_config_t, net_devices),
+     UCC_CONFIG_TYPE_STRING_ARRAY},
 
-    {"NODE_LOCAL_ID", "auto",
+    {"NODE_LOCAL_ID",
+     "auto",
      "An optimization hint for the local identificator on a single node.",
-     ucc_offsetof(ucc_context_config_t, node_local_id), UCC_CONFIG_TYPE_ULUNITS},
+     ucc_offsetof(ucc_context_config_t, node_local_id),
+     UCC_CONFIG_TYPE_ULUNITS},
 
     {NULL}};
 UCC_CONFIG_REGISTER_TABLE(ucc_context_config_table, "UCC context", NULL,
@@ -740,6 +840,60 @@ ucc_status_t ucc_context_create_proc_info(
     ctx->rank              = UCC_RANK_MAX;
     ctx->lib               = lib;
     ctx->ids.pool_size     = config->team_ids_pool_size;
+    /* ctx is calloc'd, so team_cache is already NULL; init it when enabled */
+    if (config->team_cache_enable) {
+        /* Clamp cache max_size so dormant cached teams can't exhaust the ID pool
+         * before the next pre-ACTIVE ucc_team_alloc_id. External-ID teams don't
+         * draw from the pool, so the headroom covers only pool-allocated teams.
+         * Compute in 64-bit: pool_size*64 can overflow uint32, and pool_size==0
+         * must yield safe_max 0 (not an underflowed huge value). */
+        uint64_t pool_capacity = (uint64_t)config->team_ids_pool_size * 64U;
+        uint32_t safe_max      = (pool_capacity >
+                             (uint64_t)UCC_TEAM_CACHE_ID_HEADROOM + 1U)
+                                     ? (uint32_t)(pool_capacity - 1U -
+                                             UCC_TEAM_CACHE_ID_HEADROOM)
+                                     : 0U; /* -1 for the reserved ID 0 */
+        uint32_t cache_max     = config->team_cache_max_size;
+
+        if (cache_max > safe_max) {
+            ucc_info(
+                "UCC_TEAM_CACHE_MAX_SIZE=%u exceeds the safe bound "
+                "derived from UCC_TEAM_IDS_POOL_SIZE=%u "
+                "(pool_capacity=%llu, headroom=%u, safe_max=%u); "
+                "clamping cache to %u entries. "
+                "Raise UCC_TEAM_IDS_POOL_SIZE to raise the safe ceiling.",
+                cache_max,
+                config->team_ids_pool_size,
+                (unsigned long long)pool_capacity,
+                UCC_TEAM_CACHE_ID_HEADROOM,
+                safe_max,
+                safe_max);
+            cache_max = safe_max;
+        }
+
+        status = ucc_team_cache_init(
+            &ctx->team_cache,
+            cache_max,
+            (ucc_team_cache_eviction_policy_t)config->team_cache_eviction,
+            config->team_cache_disable_linear_check);
+        if (UCC_OK != status) {
+            ucc_warn("failed to init team cache, caching will be disabled");
+            ctx->team_cache = NULL;
+        } else {
+            ctx->team_cache->dump_stats = config->team_cache_dump_stats;
+            ctx->team_cache->derived    = config->team_cache_derived;
+            ctx->team_cache->reseat     = config->team_cache_reseat;
+            ctx->team_cache->agreement  = config->team_cache_agreement;
+            /* cache_gen (per-instance cookie generation) is seeded after
+               ctx->id.seq_num is assigned below. */
+        }
+        ucc_debug(
+            "team cache %s (max_size=%u)",
+            ctx->team_cache ? "enabled" : "disabled (init failed)",
+            cache_max);
+    } else {
+        ucc_debug("team cache disabled by configuration");
+    }
     ucc_list_head_init(&ctx->progress_list);
     ucc_copy_context_params(&ctx->params, params);
     ucc_copy_context_params(&b_params.params, params);
@@ -836,6 +990,13 @@ ucc_status_t ucc_context_create_proc_info(
     }
     ctx->id.pi      = *proc_info;
     ctx->id.seq_num = ucc_atomic_fadd32(&ucc_context_seq_num, 1);
+    /* Seed the per-instance cookie generation non-zero and distinct per context
+       (context seq_num in the high bits) so cookies are never 0 (the unstamped
+       sentinel) and do not collide across a process's contexts. Seeded here, after
+       ctx->id.seq_num is assigned. */
+    if (ctx->team_cache != NULL) {
+        ctx->team_cache->cache_gen = ((uint64_t)ctx->id.seq_num << 32);
+    }
     if (params->mask & UCC_CONTEXT_PARAM_FIELD_OOB &&
         params->oob.n_oob_eps > 1) {
         do {
@@ -875,6 +1036,74 @@ ucc_status_t ucc_context_create_proc_info(
                 ucc_debug("context service team cannot be created");
             }
         }
+    }
+
+    /* Cross-rank cache-availability agreement. The cache's per-create vote runs
+       over ctx->service_team, so caching is usable only if every context rank has
+       both a live cache and a service team. Gate on the symmetric knob (not on the
+       local ctx->team_cache pointer, which is NULL on a rank whose cache-init
+       failed - that rank must still enter the allgather and contribute 0, or it
+       would drop out of the collective and hang). If any rank is not viable, all
+       ranks disable the cache (else the enabled ranks hit the very hit/miss
+       divergence the vote prevents). */
+    if (config->team_cache_enable &&
+        (params->mask & UCC_CONTEXT_PARAM_FIELD_OOB) &&
+        params->oob.n_oob_eps > 1) {
+        size_t   n        = params->oob.n_oob_eps;
+        uint8_t  local_ok = (ctx->team_cache != NULL &&
+                            ctx->service_team != NULL)
+                                ? 1
+                                : 0;
+        uint8_t *all_ok;
+        void    *oob_req   = NULL;
+        int      global_ok = 1;
+        size_t   vi;
+
+        all_ok = ucc_malloc(n, "cache_avail_vote");
+        if (!all_ok) {
+            ucc_error(
+                "failed to allocate %zu bytes for cache-availability vote", n);
+            goto error_ctx_create;
+        }
+        status = params->oob.allgather(
+            &local_ok,
+            all_ok,
+            sizeof(local_ok),
+            params->oob.coll_info,
+            &oob_req);
+        if (UCC_OK == status) {
+            while (UCC_INPROGRESS == (status = params->oob.req_test(oob_req))) {
+            }
+            params->oob.req_free(oob_req);
+        }
+        if (UCC_OK != status) {
+            ucc_error(
+                "cache-availability agreement allgather failed: %s",
+                ucc_status_string(status));
+            ucc_free(all_ok);
+            goto error_ctx_create;
+        }
+        for (vi = 0; vi < n; vi++) {
+            if (!all_ok[vi]) {
+                global_ok = 0;
+                break;
+            }
+        }
+        ucc_free(all_ok);
+        if (!global_ok) {
+            ucc_info(
+                "team cache disabled: not all ranks have a usable cache and "
+                "context service team (required for the consistency "
+                "agreement)");
+            ucc_team_cache_destroy(ctx->team_cache); /* NULL-safe */
+            ctx->team_cache = NULL;
+        }
+    } else if (ctx->team_cache && ctx->service_team == NULL) {
+        /* No peers to diverge from (single rank / no context OOB), but still no
+           service team: disable the cache locally - trivially symmetric. */
+        ucc_info("team cache disabled: no context service team available");
+        ucc_team_cache_destroy(ctx->team_cache);
+        ctx->team_cache = NULL;
     }
 
     n_tl_ctx = ctx->n_tl_ctx;
@@ -936,6 +1165,9 @@ error_ctx_create:
     }
     ucc_free(ctx->cl_ctx);
 error_ctx:
+    /* This path runs before any team is created, so the cache holds no dormant
+       entries - destroy it directly (no drain needed). Safe on NULL. */
+    ucc_team_cache_destroy(ctx->team_cache);
     ucc_free(ctx);
 error:
     return status;
@@ -969,6 +1201,17 @@ ucc_status_t ucc_context_destroy(ucc_context_t *context)
 
     if (UCC_OK != ucc_context_free_attr(&context->attr)) {
         ucc_error("failed to free context attributes");
+    }
+    /* Drain dormant cached teams FIRST, before CL/TL context and service-team
+       teardown below: a dormant team still holds CL/TL/service refs and a
+       team-id, and the drain walks the registry, so it must precede destroy. */
+    if (context->team_cache) {
+        if (context->team_cache->dump_stats) {
+            ucc_team_cache_dump_stats(context->team_cache);
+        }
+        ucc_team_cache_drain(context);
+        ucc_team_cache_destroy(context->team_cache);
+        context->team_cache = NULL;
     }
     for (i = 0; i < context->n_cl_ctx; i++) {
         cl_ctx = context->cl_ctx[i];

--- a/src/core/ucc_context.h
+++ b/src/core/ucc_context.h
@@ -13,6 +13,9 @@
 #include "utils/ucc_proc_info.h"
 #include "components/topo/ucc_topo.h"
 
+/* Forward declaration - avoids pulling in ucc_team_cache.h from context callers */
+typedef struct ucc_team_cache ucc_team_cache_t;
+
 #define UCC_MEM_MAP_TL_NAME_LEN 8
 
 typedef struct ucc_lib_info          ucc_lib_info_t;
@@ -81,6 +84,7 @@ typedef struct ucc_context {
     uint64_t                 cl_flags;
     ucc_tl_team_t           *service_team;
     int32_t                  throttle_progress;
+    ucc_team_cache_t        *team_cache;
 } ucc_context_t;
 
 typedef struct ucc_context_config {
@@ -90,6 +94,14 @@ typedef struct ucc_context_config {
     int                       n_cl_cfg;
     int                       n_tl_cfg;
     uint32_t                  team_ids_pool_size;
+    uint32_t                  team_cache_enable;
+    uint32_t                  team_cache_max_size;
+    uint32_t                  team_cache_eviction;
+    uint32_t                  team_cache_disable_linear_check;
+    uint32_t                  team_cache_dump_stats;
+    uint32_t                  team_cache_derived;
+    uint32_t                  team_cache_reseat;
+    uint32_t                  team_cache_agreement;
     uint32_t                  estimated_num_eps;
     uint32_t                  estimated_num_ppn;
     uint32_t                  lock_free_progress_q;

--- a/src/core/ucc_service_coll.c
+++ b/src/core/ucc_service_coll.c
@@ -18,7 +18,56 @@ uint64_t ucc_service_coll_map_cb(uint64_t ep, void *cb_ctx)
     ucc_rank_t              team_rank;
 
     team_rank = ucc_ep_map_eval(req->subset.map, (ucc_rank_t)ep);
-    return ucc_ep_map_eval(team->ctx_map, team_rank);
+    return ucc_ep_map_eval(UCC_TEAM_CTX_MAP(team), team_rank);
+}
+
+/* Single-level map for ucc_service_allreduce_ctx: @subset.map already yields the
+   context rank for each agreement-member index, so no ctx_map indirection (which
+   is not yet built when the vote runs). */
+uint64_t ucc_service_coll_map_cb_direct(uint64_t ep, void *cb_ctx)
+{
+    ucc_service_coll_req_t *req = cb_ctx;
+
+    return ucc_ep_map_eval(req->subset.map, (ucc_rank_t)ep);
+}
+
+ucc_status_t ucc_service_allreduce_ctx(
+    ucc_team_t *team, ucc_service_coll_req_t *req, void *sbuf, void *rbuf,
+    ucc_datatype_t dt, size_t count, ucc_reduction_op_t op, ucc_subset_t subset)
+{
+    ucc_context_t  *ctx = team->contexts[0];
+    ucc_tl_team_t  *steam;
+    ucc_tl_iface_t *tl_iface;
+    ucc_status_t    status;
+
+    /* The vote requires the persistent context service team (spanning all ctx
+       ranks, 1:1 with service-team ranks). Symmetric cache enablement guarantees
+       it exists whenever caching is on, so a missing service team here is a bug. */
+    ucc_assert(ctx->service_team != NULL);
+
+    req->team            = team;
+    req->subset          = subset;
+    req->embedded        = 1;
+    req->data            = NULL;
+
+    /* Route the agreement over ctx->service_team, mapping agreement index ->
+       ctx rank (== service-team rank) directly. */
+    subset.map.type      = UCC_EP_MAP_CB;
+    subset.map.cb.cb     = ucc_service_coll_map_cb_direct;
+    subset.map.cb.cb_ctx = req;
+
+    steam                = ctx->service_team;
+    tl_iface             = UCC_TL_TEAM_IFACE(steam);
+    status               = tl_iface->scoll.allreduce(
+        &steam->super, sbuf, rbuf, dt, count, op, subset, &req->task);
+    if (status < 0) {
+        ucc_error(
+            "failed to start service agreement allreduce for team %p: %s",
+            (void *)team,
+            ucc_status_string(status));
+        return status;
+    }
+    return UCC_OK;
 }
 
 static inline ucc_status_t
@@ -36,8 +85,9 @@ ucc_service_coll_req_init(ucc_team_t *team, ucc_subset_t *subset,
                   sizeof(*req));
         return UCC_ERR_NO_MEMORY;
     }
-    req->team   = team;
-    req->subset = *subset;
+    req->team     = team;
+    req->subset   = *subset;
+    req->embedded = 0;
 
     if (ctx->service_team) {
         *service_team         = ctx->service_team;
@@ -146,9 +196,14 @@ ucc_status_t ucc_service_coll_test(ucc_service_coll_req_t *req)
 ucc_status_t ucc_service_coll_finalize(ucc_service_coll_req_t *req)
 {
     ucc_status_t status;
+    uint8_t      embedded = req->embedded;
 
     status = ucc_collective_finalize_internal(req->task);
-    ucc_free(req);
+    /* Embedded req storage (e.g. the vote req inside ucc_team_t) is caller-owned;
+       only heap-allocated reqs are freed here. */
+    if (!embedded) {
+        ucc_free(req);
+    }
     return status;
 }
 

--- a/src/core/ucc_service_coll.h
+++ b/src/core/ucc_service_coll.h
@@ -14,12 +14,28 @@ typedef struct ucc_service_coll_req {
     ucc_team_t      *team;
     void *           data;
     ucc_subset_t     subset;
+    uint8_t embedded; /* 1: req storage is caller-owned, not heap; test/
+                         finalize must not ucc_free it (e.g. the vote req) */
 } ucc_service_coll_req_t;
 
 ucc_status_t ucc_service_allreduce(ucc_team_t *team, void *sbuf, void *rbuf,
                                    ucc_datatype_t dt, size_t count,
                                    ucc_reduction_op_t op, ucc_subset_t subset,
                                    ucc_service_coll_req_t **req);
+
+/**
+ * Member-scoped service allreduce whose @subset map already resolves each
+ * agreement-member index directly to a CONTEXT rank (built from params.ep_map),
+ * so it does NOT depend on the team's ctx_map being materialized. Runs over the
+ * persistent ctx->service_team (which must exist) and writes into the
+ * caller-provided embedded @req storage (never heap-freed). Used by the
+ * cache-action agreement vote before ADDR_EXCHANGE has built the team. A post
+ * failure must be treated as fatal by the caller (a silent local fallback would
+ * re-introduce cross-rank divergence). */
+ucc_status_t ucc_service_allreduce_ctx(
+    ucc_team_t *team, ucc_service_coll_req_t *req, void *sbuf, void *rbuf,
+    ucc_datatype_t dt, size_t count, ucc_reduction_op_t op,
+    ucc_subset_t subset);
 
 ucc_status_t ucc_service_allgather(ucc_team_t *team, void *sbuf, void *rbuf,
                                    size_t msgsize, ucc_subset_t subset,

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -11,9 +11,14 @@
 #include "components/cl/ucc_cl.h"
 #include "components/tl/ucc_tl.h"
 #include "ucc_service_coll.h"
+#include <inttypes.h>
 
 static ucc_status_t ucc_team_alloc_id(ucc_team_t *team);
 static void ucc_team_release_id(ucc_team_t *team);
+static ucc_status_t ucc_team_destroy_single(ucc_team_h team);
+static ucc_status_t ucc_team_teardown_for_rebuild(ucc_team_t *team);
+static ucc_status_t ucc_team_reset_for_rebuild(
+    ucc_context_t *context, ucc_team_t *team);
 
 void ucc_copy_team_params(ucc_team_params_t *dst, const ucc_team_params_t *src)
 {
@@ -33,6 +38,196 @@ void ucc_copy_team_params(ucc_team_params_t *dst, const ucc_team_params_t *src)
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_TEAM_PARAM_FIELD_MEM_PARAMS,
                             mem_params);
     UCC_COPY_PARAM_BY_FIELD(dst, src, UCC_TEAM_PARAM_FIELD_EP_MAP, ep_map);
+}
+
+ucc_team_artifacts_t *ucc_team_artifacts_alloc(void)
+{
+    ucc_team_artifacts_t *a;
+
+    a = ucc_calloc(1, sizeof(*a), "team_artifacts");
+    if (!a) {
+        ucc_error(
+            "failed to allocate %zd bytes for team artifacts", sizeof(*a));
+        return NULL;
+    }
+    a->refcount = 1;
+    a->heap     = 1;
+    ucc_spinlock_init(&a->lock, 0);
+    return a;
+}
+
+/* Initialize an embedded (non-heap) holder in place: used for teams that will
+   never be cached or shared, so no separate allocation is made. Same refcount/
+   lock lifecycle as a heap holder, but ucc_team_artifacts_put cleans its
+   contents without freeing the struct (it lives inside the ucc_team_t). */
+void ucc_team_artifacts_init_inline(ucc_team_artifacts_t *a)
+{
+    memset(a, 0, sizeof(*a));
+    a->refcount = 1;
+    a->heap     = 0;
+    ucc_spinlock_init(&a->lock, 0);
+}
+
+int ucc_team_artifacts_refcount(ucc_team_artifacts_t *artifacts)
+{
+    int refcount;
+
+    ucc_assert(artifacts != NULL);
+    ucc_spin_lock(&artifacts->lock);
+    refcount = artifacts->refcount;
+    ucc_spin_unlock(&artifacts->lock);
+    return refcount;
+}
+
+ucc_team_artifacts_t *ucc_team_artifacts_get(ucc_team_artifacts_t *artifacts)
+{
+    ucc_assert(artifacts != NULL);
+    ucc_spin_lock(&artifacts->lock);
+    ucc_assert(artifacts->refcount > 0);
+    artifacts->refcount++;
+    ucc_spin_unlock(&artifacts->lock);
+    return artifacts;
+}
+
+void ucc_team_artifacts_put(ucc_team_artifacts_t *artifacts)
+{
+    int refcount;
+
+    if (!artifacts) {
+        return;
+    }
+    ucc_spin_lock(&artifacts->lock);
+    ucc_assert(artifacts->refcount > 0);
+    refcount = --artifacts->refcount;
+    ucc_spin_unlock(&artifacts->lock);
+
+    if (refcount > 0) {
+        return;
+    }
+
+    /* Last reference: free what the holder owns. topo teardown moved here from
+       terminal teardown; ctx_ranks is the UCC-owned backing array (NULL when
+       ctx_map aliases params->ep_map). ctx_map is POD, nothing to free. */
+    ucc_topo_cleanup(artifacts->topo);
+    ucc_free(artifacts->ctx_ranks);
+    ucc_spinlock_destroy(&artifacts->lock);
+    /* Embedded holders live inside their ucc_team_t and are freed with it; only
+       heap holders are freed here. */
+    if (artifacts->heap) {
+        ucc_free(artifacts);
+    }
+}
+
+int ucc_team_can_derive_from(const ucc_team_t *parent)
+{
+    /* Derivable iff fully built with a shareable holder: ctx_map built
+       (ADDR_EXCHANGE ran) and, for size > 1, the topo materialized (build-once
+       in ucc_team_create_cls). A size-1 team has no topo, so require topo only
+       for size > 1. These are reused as-is, never recomputed. */
+    if (parent == NULL || parent->artifacts == NULL) {
+        return 0;
+    }
+    if (parent->state != UCC_TEAM_ACTIVE) {
+        return 0;
+    }
+    if (parent->size > 1 && parent->artifacts->ctx_map.ep_num == 0) {
+        /* ctx_map never filled (zero-initialized holder, e.g. a per-team
+           addr_storage team that took the ucc_core_addr_exchange branch). A
+           built multi-rank ctx_map always has ep_num == size >= 2. Not
+           shareable - fall back to a full create. */
+        return 0;
+    }
+    if (parent->size > 1 && parent->artifacts->topo == NULL) {
+        return 0;
+    }
+    return 1;
+}
+
+/* Re-adopt guard for a DORMANT derived team: its borrowed holder is valid only
+   while the parent stays live. Under the held cache->lock, checks a live
+   membership-matching parent still exists AND the holder is still shared
+   (refcount > 1). Either failing means full-create. */
+static int ucc_team_derived_reuse_valid(
+    ucc_team_cache_t *cache, const ucc_team_t *derived,
+    ucc_team_cache_identity_t *id)
+{
+    ucc_team_t *parent;
+
+    ucc_assert(derived->is_derived);
+    if (derived->artifacts == NULL) {
+        return 0;
+    }
+    parent = ucc_team_cache_lookup_live(cache, id);
+    if (parent == NULL || parent == derived) {
+        /* No live sibling parent pins the borrowed holder anymore. */
+        return 0;
+    }
+    /* refcount > 1: at least the live parent + this dormant child reference the
+       shared holder, so the borrowed pointer is not stale.  Read under the
+       artifacts lock that guards refcount writes (ucc_team_artifacts_get/put);
+       cache->lock does not synchronize those. */
+    return ucc_team_artifacts_refcount(derived->artifacts) > 1;
+}
+
+/* Re-seat a DORMANT derived team's external id to @new_ext_id and fan it out to
+   every CL/TL team (via update_id) plus the service team, so the team can be
+   re-adopted for a same-membership create whose cid drifted (experimental RESEAT
+   path). The new cid is unique among live comms, so the re-seated tags cannot
+   alias. */
+static void ucc_team_reseat_id(ucc_team_t *team, uint16_t new_ext_id)
+{
+    int i;
+
+    ucc_assert(team->is_derived);
+
+    team->id                    = new_ext_id;
+    team->bp.id                 = new_ext_id;
+    team->cache_identity.ext_id = new_ext_id;
+
+    if (team->service_team) {
+        UCC_TL_TEAM_IFACE(team->service_team)
+            ->scoll.update_id(&team->service_team->super, new_ext_id);
+    }
+    for (i = 0; i < team->n_cl_teams; i++) {
+        ucc_base_team_iface_t *cl_iface;
+
+        if (!team->cl_teams[i]) {
+            continue;
+        }
+        cl_iface = &UCC_CL_TEAM_IFACE(team->cl_teams[i])->team;
+        if (cl_iface->update_id) {
+            cl_iface->update_id(&team->cl_teams[i]->super, new_ext_id);
+        }
+    }
+}
+
+ucc_status_t ucc_team_init_derived(
+    ucc_team_t *team, ucc_team_artifacts_t *held_artifacts, uint16_t parent_id)
+{
+    /* @held_artifacts is the parent's holder, already refcount-bumped by the
+       caller under cache->lock; we CONSUME that reference here (the parent's
+       lifetime is now irrelevant). Free the fresh unused holder create_post
+       allocated for this team, since a derived team never rebuilds its
+       artifacts. The last put (in ucc_team_destroy_single) frees the shared
+       holder once every borrowing team is gone. */
+    ucc_team_artifacts_put(team->artifacts);
+    team->artifacts  = held_artifacts;
+    team->is_derived = 1;
+    team->parent_id  = parent_id;
+
+    /* Derived teams are cached: the pending-insert marker set by create_post
+       makes the generic ACTIVE-insert path chain this team onto the parent's
+       bucket keyed by its OWN cid. It then takes the LIVE->DORMANT retain path
+       and is re-adopted on the next identical create while the parent stays live
+       and pins the holder; its eventual destroy puts the ref. */
+
+    ucc_debug(
+        "team %p: derived-create (shared artifacts %p, parent id=%u) - "
+        "skipping ADDR_EXCHANGE + topo build",
+        (void *)team,
+        (void *)team->artifacts,
+        parent_id);
+    return UCC_OK;
 }
 
 ucc_status_t ucc_team_get_attr(ucc_team_h team, ucc_team_attr_t *team_attr)
@@ -96,9 +291,326 @@ static ucc_status_t ucc_team_create_post_single(ucc_context_t *context,
     team->bp.team                 = team;
     team->bp.map.type             = UCC_EP_MAP_FULL;
     team->bp.map.ep_num           = team->size;
-    team->state                   = (team->size > 1) ? UCC_TEAM_ADDR_EXCHANGE
-                                                     : UCC_TEAM_CL_CREATE;
+    if (team->is_derived) {
+        /* Derived team: artifacts were borrowed, so ctx_map/topo are already
+           materialized. Skip UCC_TEAM_ADDR_EXCHANGE (which builds ctx_map) and
+           start at UCC_TEAM_SERVICE_TEAM: it STILL runs ALLOC_ID (own team-id ->
+           own tag/seq domain), CL/TL team creation, and score_map build. A
+           size-1 team has no exchange regardless, so its start state is
+           unchanged. */
+        team->state = (team->size > 1) ? UCC_TEAM_SERVICE_TEAM
+                                       : UCC_TEAM_CL_CREATE;
+    } else {
+        team->state = (team->size > 1) ? UCC_TEAM_ADDR_EXCHANGE
+                                       : UCC_TEAM_CL_CREATE;
+    }
     team->last_team_create_posted = -1;
+    return UCC_OK;
+}
+
+/* Allocate and initialize a fresh ucc_team shell (no CL/TL build yet): artifacts
+   holder (heap when @id_built - shareable/cacheable; else embedded inline),
+   contexts array, base params, external id. On @id_built the built identity is
+   MOVED onto the team (caller's @id is zeroed) and cache_pending_insert is set.
+   Returns the team, or NULL with *status_out set (all its own allocations freed).
+   The caller still owns any pinned derive_artifacts. Shared by the direct-reuse
+   miss path and the agreement path. */
+static ucc_team_t *ucc_team_alloc_shell(
+    ucc_context_h *contexts, uint32_t num_contexts,
+    const ucc_team_params_t *params, uint64_t team_size, uint64_t team_rank,
+    int id_built, ucc_team_cache_identity_t *id, ucc_status_t *status_out)
+{
+    ucc_team_t *team;
+
+    team = ucc_calloc(1, sizeof(ucc_team_t), "ucc_team");
+    if (!team) {
+        ucc_error(
+            "failed to allocate %zd bytes for ucc team", sizeof(ucc_team_t));
+        *status_out = UCC_ERR_NO_MEMORY;
+        return NULL;
+    }
+    if (id_built) {
+        team->artifacts = ucc_team_artifacts_alloc();
+        if (!team->artifacts) {
+            ucc_free(team);
+            *status_out = UCC_ERR_NO_MEMORY;
+            return NULL;
+        }
+    } else {
+        team->artifacts = &team->artifacts_inline;
+        ucc_team_artifacts_init_inline(team->artifacts);
+    }
+    team->runtime_oob  = params->oob;
+    team->num_contexts = num_contexts;
+    team->size         = (ucc_rank_t)team_size;
+    team->rank         = (ucc_rank_t)team_rank;
+    team->seq_num      = 0;
+    team->refcount     = 1;
+    if (id_built) {
+        team->cache_identity = *id; /* move: caller's id owns nothing now */
+        team->cache_pending_insert = 1;
+        memset(id, 0, sizeof(*id));
+    } else {
+        memset(&team->cache_identity, 0, sizeof(team->cache_identity));
+        team->cache_pending_insert = 0;
+    }
+    ucc_list_head_init(&team->cache_link);
+    ucc_list_head_init(&team->bucket_link);
+    team->cache_state = UCC_TEAM_CACHE_STATE_NONE;
+    team->contexts    = ucc_malloc(
+        sizeof(ucc_context_t *) * num_contexts, "ucc_team_ctx");
+    if (!team->contexts) {
+        ucc_error(
+            "failed to allocate %zd bytes for ucc team contexts array",
+            sizeof(ucc_context_t *) * num_contexts);
+        ucc_team_cache_identity_free(&team->cache_identity);
+        ucc_team_artifacts_put(team->artifacts);
+        ucc_free(team);
+        *status_out = UCC_ERR_NO_MEMORY;
+        return NULL;
+    }
+    memcpy(team->contexts, contexts, sizeof(ucc_context_t *) * num_contexts);
+    ucc_copy_team_params(&team->bp.params, params);
+    if ((params->mask & UCC_TEAM_PARAM_FIELD_ID) &&
+        (params->id <= UCC_TEAM_ID_MAX)) {
+        team->id = ((uint16_t)params->id) | UCC_TEAM_ID_EXTERNAL_BIT;
+    }
+    *status_out = UCC_OK;
+    return team;
+}
+
+/* Evict a stale dormant-derived candidate (its live parent is gone): detach from
+   the table and registry, free its identity, park it for teardown, and rebook the
+   lookup's provisional hit as a miss. Caller holds cache->lock. */
+static void ucc_team_cache_evict_stale_derived(
+    ucc_team_cache_t *cache, ucc_team_t *cached)
+{
+    ucc_team_cache_table_erase(cache, cached);
+    ucc_team_cache_registry_remove(cache, cached);
+    ucc_team_cache_identity_free(&cached->cache_identity);
+    cached->cache_state = UCC_TEAM_CACHE_STATE_NONE;
+    ucc_list_add_tail(&cache->pending_destroy, &cached->cache_link);
+    cache->stats.evictions++;
+    ucc_assert(cache->stats.hits > 0);
+    cache->stats.hits--;
+    cache->stats.misses++;
+}
+
+/* Rebook a lookup miss as a hit: a dormant-derived reseat reused a cached team the
+   exact lookup had missed (cid drift). Caller holds cache->lock. */
+static void ucc_team_cache_rebook_miss_as_hit(ucc_team_cache_t *cache)
+{
+    ucc_assert(cache->stats.misses > 0);
+    cache->stats.misses--;
+    cache->stats.hits++;
+}
+
+/* Undo a posted-vote setup on a fatal post failure. EXACT: return the reserved
+   candidate to DORMANT (refcount was never bumped). DERIVED/MISS: release any
+   pinned parent artifacts and free the fresh shell. */
+static void ucc_team_agreement_rollback(
+    ucc_team_cache_t *cache, ucc_team_t *handle, ucc_team_cache_action_t action)
+{
+    if (action == UCC_TEAM_CACHE_ACTION_EXACT_REUSE ||
+        action == UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED) {
+        /* Both reserved a DORMANT candidate; return it to DORMANT (refcount was
+           never bumped). A RESEAT_DERIVED candidate is NOT re-seated until the
+           vote agrees, so its id/tag domain is unchanged and needs no undo. */
+        ucc_spin_lock(&cache->lock);
+        handle->cache_state = UCC_TEAM_CACHE_STATE_DORMANT;
+        ucc_team_cache_registry_make_dormant(cache, handle);
+        ucc_spin_unlock(&cache->lock);
+        return;
+    }
+    if (action == UCC_TEAM_CACHE_ACTION_DERIVED_FROM_LIVE &&
+        handle->cache_derive_artifacts) {
+        ucc_team_artifacts_put(handle->cache_derive_artifacts);
+        handle->cache_derive_artifacts = NULL;
+    }
+    ucc_team_destroy_single(handle);
+}
+
+/* Agreement create path (cacheable size>1 team). Classify locally, RESERVE a
+   dormant EXACT candidate or allocate a fresh shell (DERIVED/MISS), then POST a
+   member-scoped vote (progressed in ucc_team_create_test). Returns @new_team set
+   to the handle, or an error on fatal vote-post failure. Identity-build failure is
+   non-fatal: this rank still posts a MISS vote so peers do not hang. */
+static ucc_status_t ucc_team_agreement_create_post(
+    ucc_context_h *contexts, uint32_t num_contexts,
+    const ucc_team_params_t *params, uint64_t team_size, uint64_t team_rank,
+    ucc_team_cache_t *cache, ucc_team_h *new_team)
+{
+    ucc_team_cache_identity_t id;
+    int                       id_built = 0;
+    ucc_team_t               *cached   = NULL;
+    ucc_team_t               *handle;
+    ucc_team_artifacts_t     *derive_artifacts = NULL;
+    uint16_t                  derive_parent_id = 0;
+    ucc_team_cache_action_t   action           = UCC_TEAM_CACHE_ACTION_MISS;
+    uint64_t                  key              = 0;
+    /* Per-instance cookie vote payload. @cookie proves cross-rank agreement on the
+       reuse/reseat candidate instance; @parent_cookie the derive/reseat parent's;
+       @proposed_cookie carries rank-0's fresh-instance proposal. */
+    uint64_t                  cookie           = 0;
+    uint64_t                  parent_cookie    = 0;
+    uint16_t                  reseat_new_id    = 0;
+    int                       is_rank0         = (team_rank == 0);
+    uint64_t                  proposed_cookie  = 0;
+    ucc_subset_t              subset;
+    ucc_status_t              status;
+
+    if (ucc_team_cache_identity_build(params, &id) == UCC_OK) {
+        id_built = 1;
+        ucc_spin_lock(&cache->lock);
+        /* Rank 0 always reserves a fresh cookie so a MISS outcome has a value to
+           adopt; it is distributed via the vote's lane [9]. Non-fresh outcomes
+           (EXACT/DERIVED/RESEAT) simply keep the candidate/instance cookie, so
+           the reserved value is harmlessly skipped (monotonic, never recycled). */
+        if (is_rank0) {
+            proposed_cookie = ucc_team_cache_next_cookie(cache);
+        }
+        cached = ucc_team_cache_lookup(cache, &id);
+        if (cached != NULL && cached->is_derived &&
+            !ucc_team_derived_reuse_valid(cache, cached, &id)) {
+            /* Stale dormant-derived (parent gone): evict, classify as miss. */
+            ucc_team_cache_evict_stale_derived(cache, cached);
+            cached = NULL;
+        }
+        if (cached != NULL) {
+            /* EXACT reuse: full membership+ext_id match. RESERVE for the vote
+               (off dormant, refcount unchanged). The instance cookie is NOT
+               needed here - the exact identity (incl. ext_id) already pins the
+               instance - so vote lane [5] stays 0/all-ones. */
+            action = UCC_TEAM_CACHE_ACTION_EXACT_REUSE;
+            key    = cached->id;
+            ucc_team_cache_registry_make_reserved(cache, cached);
+            cached->cache_state = UCC_TEAM_CACHE_STATE_RESERVED;
+        } else if (
+            cache->reseat &&
+            (cached = ucc_team_cache_lookup_dormant_derived(cache, &id)) !=
+                NULL &&
+            cached->cache_identity.instance_cookie != 0 &&
+            ucc_team_derived_reuse_valid(cache, cached, &id)) {
+            /* RESEAT_DERIVED (UCC_TEAM_CACHE_RESEAT, experimental, default off):
+               the exact lookup missed (cid drifted) but a DORMANT derived team of
+               the same membership exists with a still-valid holder. Agreement-safe
+               only because the vote reconciles the candidate's per-instance cookie:
+               a membership-only lookup can return different physical instances per
+               rank (cids recycle), so the cookie proves all ranks picked the same
+               one. Decline candidates with cookie==0: those are from the direct/
+               size==1 path and lack a per-instance stamp, so the cookie vote would
+               accept any zero from any candidate - defeating the proof. The reseat
+               is committed under the lock in create_test only on unanimous agreement. */
+            action        = UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED;
+            key           = cached->id;
+            cookie        = cached->cache_identity.instance_cookie;
+            parent_cookie = cached->cache_parent_instance_cookie;
+            reseat_new_id = id.ext_id;
+            ucc_team_cache_registry_make_reserved(cache, cached);
+            cached->cache_state = UCC_TEAM_CACHE_STATE_RESERVED;
+            /* A global-MISS rollback in create_test re-corrects this to a miss. */
+            ucc_team_cache_rebook_miss_as_hit(cache);
+        } else {
+            ucc_team_t *live;
+
+            cached = NULL; /* dormant-derived probe above may have set it */
+            live   = cache->derived ? ucc_team_cache_lookup_live(cache, &id)
+                                    : NULL;
+            if (live != NULL && ucc_team_can_derive_from(live)) {
+                action           = UCC_TEAM_CACHE_ACTION_DERIVED_FROM_LIVE;
+                key              = live->id;
+                parent_cookie    = live->cache_identity.instance_cookie;
+                derive_artifacts = ucc_team_artifacts_get(live->artifacts);
+                derive_parent_id = live->id;
+            }
+        }
+        ucc_spin_unlock(&cache->lock);
+    }
+
+    if (action == UCC_TEAM_CACHE_ACTION_EXACT_REUSE ||
+        action == UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED) {
+        handle = cached;
+        ucc_team_cache_identity_free(
+            &id); /* candidate carries its own identity */
+        handle->cache_reseat_new_id = reseat_new_id;
+        /* Refresh the membership map so a global-miss rebuild (ucc_team_exchange)
+           reads a valid ep_map, not the candidate's stale one from a since-freed
+           communicator. On reuse this is not read operationally (owned ctx_map). */
+        handle->bp.params.ep_map    = params->ep_map;
+        handle->bp.params.mask |= UCC_TEAM_PARAM_FIELD_EP_MAP;
+    } else {
+        handle = ucc_team_alloc_shell(
+            contexts,
+            num_contexts,
+            params,
+            team_size,
+            team_rank,
+            id_built,
+            &id,
+            &status);
+        if (handle == NULL) {
+            if (id_built) {
+                ucc_team_cache_identity_free(&id);
+            }
+            if (derive_artifacts) {
+                ucc_team_artifacts_put(derive_artifacts);
+            }
+            return status;
+        }
+        status = ucc_team_create_post_single(contexts[0], handle);
+        if (status < 0) {
+            if (derive_artifacts) {
+                ucc_team_artifacts_put(derive_artifacts);
+            }
+            ucc_team_destroy_single(handle);
+            return status;
+        }
+        if (action == UCC_TEAM_CACHE_ACTION_DERIVED_FROM_LIVE) {
+            handle->cache_derive_artifacts       = derive_artifacts;
+            handle->cache_derive_parent_id       = derive_parent_id;
+            handle->cache_parent_instance_cookie = parent_cookie;
+        }
+    }
+
+    handle->cache_local_action = action;
+    /* Fill the vote: cookie/parent_cookie lanes prove same-instance selection for
+       RESEAT/DERIVED; rank-0 proposes the fresh-instance cookie on lane [9]. */
+    ucc_team_cache_vote_fill(
+        handle->cache_vote_in,
+        action != UCC_TEAM_CACHE_ACTION_MISS,
+        action,
+        key,
+        cookie,
+        parent_cookie,
+        is_rank0,
+        proposed_cookie);
+    subset.myrank = handle->rank;
+    subset
+        .map = params
+                   ->ep_map; /* member index -> ctx rank (valid this create) */
+    /* This vote and the later UCC_TEAM_ALLOC_ID allreduce both ride
+       ctx->service_team on the shared UCC_TL_UCP_SERVICE_TAG but never alias: per
+       team the vote is finalized before the state machine reaches ALLOC_ID (strictly
+       sequential), and the ucc.h contract permits only one outstanding create/destroy
+       per context, so no concurrent create adds another service op. */
+    status = ucc_service_allreduce_ctx(
+        handle,
+        &handle->cache_vote_req,
+        handle->cache_vote_in,
+        handle->cache_vote_out,
+        UCC_DT_UINT64,
+        UCC_TEAM_CACHE_VOTE_LANES,
+        UCC_OP_BAND,
+        subset);
+    if (status < 0) {
+        ucc_team_agreement_rollback(cache, handle, action);
+        return status;
+    }
+    handle->state = UCC_TEAM_CACHE_AGREE;
+    *new_team     = handle;
+    /* create_post returns UCC_OK (the vote is posted); the async work - the vote
+       and the resulting build/reuse - is driven by ucc_team_create_test, which
+       returns UCC_INPROGRESS until the team reaches ACTIVE. */
     return UCC_OK;
 }
 
@@ -106,10 +618,21 @@ ucc_status_t ucc_team_create_post(ucc_context_h *contexts, uint32_t num_contexts
                                   const ucc_team_params_t *params,
                                   ucc_team_h *new_team)
 {
-    uint64_t     team_size = 0;
-    uint64_t     team_rank = UINT64_MAX;
-    ucc_team_t  *team;
-    ucc_status_t status;
+    uint64_t                  team_size = 0;
+    uint64_t                  team_rank = UINT64_MAX;
+    ucc_team_cache_t         *cache     = NULL;
+    ucc_team_cache_identity_t id;
+    int                       id_built         = 0;
+    /* Held (refcount-bumped) reference to a coexisting LIVE parent's shared
+       artifacts, captured under cache->lock so it cannot be freed across the
+       unlock; consumed by ucc_team_init_derived or released on a pre-init
+       failure path. No pointer to the parent team is kept. */
+    ucc_team_artifacts_t     *derive_artifacts = NULL;
+    uint16_t                  derive_parent_id = 0;
+    int                       reseat_needed    = 0;
+    uint16_t                  reseat_new_id    = 0;
+    ucc_team_t               *team;
+    ucc_status_t              status;
 
     if (num_contexts < 1) {
         return UCC_ERR_INVALID_PARAM;
@@ -188,40 +711,172 @@ ucc_status_t ucc_team_create_post(ucc_context_h *contexts, uint32_t num_contexts
         return UCC_ERR_INVALID_PARAM;
     }
 
-    team = ucc_calloc(1, sizeof(ucc_team_t), "ucc_team");
-    if (!team) {
-        ucc_error("failed to allocate %zd bytes for ucc team",
-                  sizeof(ucc_team_t));
-        return UCC_ERR_NO_MEMORY;
-    }
-    team->runtime_oob  = params->oob;
-    team->num_contexts = num_contexts;
-    team->size         = (ucc_rank_t)team_size;
-    team->rank         = (ucc_rank_t)team_rank;
-    team->seq_num      = 0;
-    team->contexts     = ucc_malloc(sizeof(ucc_context_t *) * num_contexts,
-                                    "ucc_team_ctx");
-    if (!team->contexts) {
-        ucc_error("failed to allocate %zd bytes for ucc team contexts array",
-                  sizeof(ucc_context_t) * num_contexts);
-        status = UCC_ERR_NO_MEMORY;
-        goto err_ctx_alloc;
+    /* Cross-rank agreement (UCC_TEAM_CACHE_AGREEMENT, default on): for a cacheable
+       size>1 team on a cache-enabled context, every member votes on the cache
+       action so all reach an identical reuse-vs-fresh decision (no split hit/miss
+       deadlock). EP_MAP is required (the membership source and the vote's
+       member->ctx-rank map); teams without it are uncacheable and fall through. The
+       vote is posted here and progressed in ucc_team_create_test. When the knob is
+       off, size>1 cacheable teams take the direct-reuse path below (faster, but
+       unsafe for overlapping subcommunicators - the caller opted out). */
+    cache = ((ucc_context_t *)contexts[0])->team_cache;
+    if (cache != NULL && cache->agreement &&
+        ucc_team_cache_is_cacheable(params) && team_size > 1 &&
+        (params->mask & UCC_TEAM_PARAM_FIELD_EP_MAP)) {
+        return ucc_team_agreement_create_post(
+            contexts,
+            num_contexts,
+            params,
+            team_size,
+            team_rank,
+            cache,
+            new_team);
     }
 
-    memcpy(team->contexts, contexts, sizeof(ucc_context_t *) * num_contexts);
-    ucc_copy_team_params(&team->bp.params, params);
-    /* check if user provides team id and if it is not too large */
-    if ((params->mask & UCC_TEAM_PARAM_FIELD_ID) &&
-        (params->id <= UCC_TEAM_ID_MAX)) {
-        team->id = ((uint16_t)params->id) | UCC_TEAM_ID_EXTERNAL_BIT;
+    /* Direct-reuse path (size==1 or non-cacheable, or agreement off): build the
+       identity and look up a DORMANT identical-membership team. On a hit, re-adopt
+       the same team object; on a miss, fall through to a normal create and remember
+       the identity so it is inserted once ACTIVE. */
+    if (cache != NULL && ucc_team_cache_is_cacheable(params)) {
+        status = ucc_team_cache_identity_build(params, &id);
+        if (status == UCC_OK) {
+            ucc_team_t *cached;
+
+            id_built = 1;
+
+            /* Lookup + adopt MUST be atomic under a single held cache->lock so a
+               concurrent create cannot adopt the same dormant team twice and a
+               concurrent destroy cannot free/re-adopt it mid-window.
+               ucc_team_cache_lookup / _get / registry_make_live all require the
+               lock held; drop it before any drain work. */
+            ucc_spin_lock(&cache->lock);
+            cached = ucc_team_cache_lookup(cache, &id);
+            if (cached != NULL && cached->is_derived &&
+                !ucc_team_derived_reuse_valid(cache, cached, &id)) {
+                /* Dormant derived hit whose parent is gone (stale holder): evict
+                   and fall through to a full create. */
+                ucc_debug(
+                    "team cache: dormant derived team %p parent gone - "
+                    "evicting stale child, falling back to full create",
+                    (void *)cached);
+                ucc_team_cache_evict_stale_derived(cache, cached);
+                cached = NULL;
+            }
+            if (cache->reseat && cached == NULL) {
+                /* RESEAT (UCC_TEAM_CACHE_RESEAT, experimental, default off): the
+                   exact lookup missed. Re-adopt a DORMANT DERIVED team of the same
+                   membership whose ext_id (cid) drifted, if its borrowed holder is
+                   still valid; re-seat its id/tag domain to the new cid below. */
+                ucc_team_t *reseat = ucc_team_cache_lookup_dormant_derived(
+                    cache, &id);
+
+                if (reseat != NULL &&
+                    ucc_team_derived_reuse_valid(cache, reseat, &id)) {
+                    cached        = reseat;
+                    reseat_needed = 1;
+                    reseat_new_id = id.ext_id;
+                    ucc_team_cache_rebook_miss_as_hit(cache);
+                }
+            }
+            if (cached != NULL) {
+                /* DORMANT hit: claim the team (refcount++ -> LIVE) and move it
+                   dormant -> live under the lock. A re-adopted derived team keeps
+                   its borrowed holder and its own team id. */
+                ucc_team_cache_get(cached);
+                ucc_team_cache_registry_make_live(cache, cached);
+
+                /* RESEAT: re-adopted a same-membership derived team whose cid
+                   drifted. Re-seat its id and TL/service tag domains to the new cid
+                   under cache->lock so no user observes a half-reseated team.
+                   update_id does scalar writes only; seq_num is NOT reset. */
+                if (reseat_needed &&
+                    cached->cache_identity.ext_id != reseat_new_id) {
+                    ucc_debug(
+                        "team cache: reseat team %p id 0x%x -> 0x%x "
+                        "(cid drift, same membership)",
+                        (void *)cached,
+                        (unsigned)cached->cache_identity.ext_id,
+                        (unsigned)reseat_new_id);
+                    ucc_team_reseat_id(cached, reseat_new_id);
+                }
+            } else {
+                /* No DORMANT match: a LIVE identical-membership match means a
+                   second simultaneously-live comm over the same members (e.g.
+                   MPI_Comm_dup) -> derived-create. Classified under the same lock
+                   as the dormant lookup. Gated by UCC_TEAM_CACHE_DERIVED (default
+                   on); when off or not derivable, this is a normal full create. */
+                ucc_team_t *live = cache->derived
+                                       ? ucc_team_cache_lookup_live(cache, &id)
+                                       : NULL;
+
+                if (live != NULL && ucc_team_can_derive_from(live)) {
+                    /* Pin the parent's artifacts under the lock (keep only the held
+                       holder + parent id, never the parent pointer); consumed by
+                       ucc_team_init_derived or released on a pre-init failure. */
+                    derive_artifacts = ucc_team_artifacts_get(live->artifacts);
+                    derive_parent_id = live->id;
+                }
+            }
+            ucc_spin_unlock(&cache->lock);
+
+            if (cached != NULL) {
+                ucc_debug(
+                    "team cache: dormant reuse / hit, team %p (hash=0x%" PRIx64
+                    ")",
+                    (void *)cached,
+                    id.hash);
+                /* The built identity only keyed the lookup; the cached team carries
+                   its own (re-seated above if the cid drifted). */
+                ucc_team_cache_identity_free(&id);
+
+                /* No drain needed: the UCC API forbids collectives after
+                   ucc_team_destroy, so a dormant team has no in-flight work; the
+                   context progress queue is deliberately NOT drained (it is global
+                   and could block on unrelated teams). seq_num is not reset, so it
+                   keeps advancing and cannot alias the reused team's fresh tags.
+                   The team is already ACTIVE, so ucc_team_create_test
+                   short-circuits; bp.params is left as-is (identical membership). */
+                *new_team = cached;
+                return UCC_OK;
+            }
+            /* Miss: keep `id` (id_built stays set) and move it onto the new
+               team below so it can be inserted at ACTIVE. */
+        } else {
+            /* Unbuildable identity (e.g. no EP_MAP): uncached create. */
+            cache = NULL;
+        }
+    } else {
+        cache = NULL;
+    }
+
+    team = ucc_team_alloc_shell(
+        contexts,
+        num_contexts,
+        params,
+        team_size,
+        team_rank,
+        id_built,
+        &id,
+        &status);
+    if (team == NULL) {
+        if (id_built) { /* freed here if the failure was before the id move */
+            ucc_team_cache_identity_free(&id);
+        }
+        if (derive_artifacts) { /* release the pinned parent artifacts */
+            ucc_team_artifacts_put(derive_artifacts);
+        }
+        return status;
+    }
+    /* Derived-create: a coexisting LIVE identical-membership parent was found and
+       its artifacts pinned above. Borrow them and take the shortened create path
+       (skip ADDR_EXCHANGE + topo build). Applies to EXTERNAL-id teams too (e.g.
+       MPI_Comm_dup). Must run BEFORE ucc_team_create_post_single, which reads
+       team->is_derived. */
+    if (derive_artifacts != NULL) {
+        ucc_team_init_derived(team, derive_artifacts, derive_parent_id);
     }
     status    = ucc_team_create_post_single(contexts[0], team);
     *new_team = team;
-    return status;
-
-err_ctx_alloc:
-    *new_team = NULL;
-    ucc_free(team);
     return status;
 }
 
@@ -277,14 +932,35 @@ static ucc_status_t ucc_team_create_cls(ucc_context_t *context,
     ucc_subset_t     subset;
     int              i;
 
-    if (context->topo && !team->topo && team->size > 1) {
+    if (context->topo && !UCC_TEAM_TOPO(team) && team->size > 1) {
         /* Context->topo is not NULL if any of the enabled CLs
            reported topo_required through the lib_attr */
-        subset.map    = team->ctx_map;
+        subset.map    = UCC_TEAM_CTX_MAP(team);
         subset.myrank = team->rank;
-        status        = ucc_topo_init(subset, context->topo, &team->topo);
+        status = ucc_topo_init(subset, context->topo, &UCC_TEAM_TOPO(team));
         if (UCC_OK != status) {
             ucc_warn("failed to init team topo");
+        } else if (team->cache_pending_insert) {
+            /* Build-once guard, only for teams that will actually be cached/shared
+               (cache_pending_insert): materialize the lazily-filled sbgp/layout
+               state now, while create_post is serialized per context, so the topo
+               is effectively immutable and a derived team can share it read-only
+               without racing on first-touch lazy writes under THREAD_MULTIPLE.
+               Ordinary (non-cacheable / cache-disabled) teams keep the original
+               lazy first-touch behavior - no eager work, no new failure modes. */
+            status = ucc_topo_prepare_shared(UCC_TEAM_TOPO(team));
+            if (UCC_OK != status) {
+                /* Could not fully materialize the shared topo. Don't cache/share
+                   a half-built topo: fall back to a normal, un-shared team whose
+                   remaining sbgps fill lazily on first touch (single-user, so no
+                   THREAD_MULTIPLE race). */
+                ucc_warn(
+                    "failed to prepare shared topo (%s); team %p will not "
+                    "be cached",
+                    ucc_status_string(status),
+                    (void *)team);
+                team->cache_pending_insert = 0;
+            }
         }
     }
 
@@ -346,22 +1022,65 @@ static inline ucc_status_t ucc_team_exchange(ucc_context_t *context,
     /* We only need to exchange ctx_ranks and build map to ctx array */
     ucc_assert(context->addr_storage.storage != NULL);
     if (team->bp.params.mask & UCC_TEAM_PARAM_FIELD_EP_MAP) {
-        team->ctx_map = team->bp.params.ep_map;
+        if (team->cache_pending_insert) {
+            /* A cacheable team can outlive the caller's communicator (it is
+               retained dormant and re-adopted after MPI_Comm_free). The caller's
+               params.ep_map may be a UCC_EP_MAP_CB closure whose cb_ctx IS that
+               communicator (OMPI coll/ucc passes cb_ctx = comm), so aliasing it
+               would leave the operational map dangling once the comm is freed.
+               Materialize the membership into a UCC-owned ctx_ranks array NOW
+               (while the caller map is still valid) and build a self-contained map
+               over it; ownership then lives in the artifacts holder, freed by
+               ucc_team_artifacts_put. ucc_ep_map_from_array collapses a
+               contiguous/full pattern to a STRIDED/FULL map (freeing ctx_ranks) or
+               keeps the owned array in an ARRAY map - either way no caller pointer
+               is retained. */
+            ucc_rank_t i;
+
+            if (!UCC_TEAM_CTX_RANKS(team)) {
+                UCC_TEAM_CTX_RANKS(team) = ucc_malloc(
+                    team->size * sizeof(ucc_rank_t), "ctx_ranks");
+                if (!UCC_TEAM_CTX_RANKS(team)) {
+                    ucc_error(
+                        "failed to allocate %zd bytes for ctx ranks array",
+                        team->size * sizeof(ucc_rank_t));
+                    return UCC_ERR_NO_MEMORY;
+                }
+                for (i = 0; i < team->size; i++) {
+                    UCC_TEAM_CTX_RANKS(team)
+                    [i] = (ucc_rank_t)ucc_ep_map_eval(
+                        team->bp.params.ep_map, i);
+                }
+            }
+            UCC_TEAM_CTX_MAP(team) = ucc_ep_map_from_array(
+                &UCC_TEAM_CTX_RANKS(team),
+                team->size,
+                context->addr_storage.size,
+                1);
+        } else {
+            /* Non-cacheable team: the caller guarantees params.ep_map outlives the
+               team, so aliasing is safe and skips materialization. */
+            UCC_TEAM_CTX_MAP(team) = team->bp.params.ep_map;
+        }
     } else {
-        if (!team->ctx_ranks) {
-            team->ctx_ranks =
-                ucc_malloc(team->size * sizeof(ucc_rank_t), "ctx_ranks");
-            if (!team->ctx_ranks) {
+        if (!UCC_TEAM_CTX_RANKS(team)) {
+            UCC_TEAM_CTX_RANKS(team) = ucc_malloc(
+                team->size * sizeof(ucc_rank_t), "ctx_ranks");
+            if (!UCC_TEAM_CTX_RANKS(team)) {
                 ucc_error("failed to allocate %zd bytes for ctx ranks array",
                           team->size * sizeof(ucc_rank_t));
                 return UCC_ERR_NO_MEMORY;
             }
-            status = oob.allgather(&context->rank, team->ctx_ranks,
-                                   sizeof(ucc_rank_t), oob.coll_info,
-                                   &team->oob_req);
+            status = oob.allgather(
+                &context->rank,
+                UCC_TEAM_CTX_RANKS(team),
+                sizeof(ucc_rank_t),
+                oob.coll_info,
+                &team->oob_req);
             if (UCC_OK != status) {
                 ucc_error("failed to start oob allgather for proc info exchange");
-                ucc_free(team->ctx_ranks);
+                ucc_free(UCC_TEAM_CTX_RANKS(team));
+                UCC_TEAM_CTX_RANKS(team) = NULL;
                 return status;
             }
         }
@@ -375,11 +1094,18 @@ static inline ucc_status_t ucc_team_exchange(ucc_context_t *context,
         }
         oob.req_free(team->oob_req);
         ucc_assert(team->size >= 2);
-        team->ctx_map = ucc_ep_map_from_array(&team->ctx_ranks, team->size,
-                                              context->addr_storage.size, 1);
+        UCC_TEAM_CTX_MAP(team) = ucc_ep_map_from_array(
+            &UCC_TEAM_CTX_RANKS(team),
+            team->size,
+            context->addr_storage.size,
+            1);
     }
-    ucc_debug("team %p rank %d, ctx_rank %d, map_type %d", team, team->rank,
-              context->rank, team->ctx_map.type);
+    ucc_debug(
+        "team %p rank %d, ctx_rank %d, map_type %d",
+        team,
+        team->rank,
+        context->rank,
+        UCC_TEAM_CTX_MAP(team).type);
     return UCC_OK;
 }
 
@@ -422,12 +1148,211 @@ static ucc_status_t ucc_team_build_score_map(ucc_team_t *team)
     return status;
 }
 
+/* Insert a freshly-built (miss-path), now-ACTIVE team into its context's cache:
+   stamp its per-instance cookie, reclaim completed evictions, evict a victim if at
+   capacity, then insert and transition DORMANT -> LIVE (directly, refcount is
+   already 1). A full/collision insert leaves the team uncached but functional. */
+static void ucc_team_cache_admit(ucc_team_t *team)
+{
+    ucc_context_t    *ctx   = team->contexts[0];
+    ucc_team_cache_t *cache = ctx->team_cache;
+    uint64_t          new_cookie;
+
+    team->cache_pending_insert = 0;
+
+    /* Adopt the instance cookie every member agreed on: the vote's distribution
+       lane carried team-rank 0's proposal (a real value is neither 0 nor all-ones;
+       the direct/size==1 path leaves the vote zeroed, which reuse never consults). */
+    new_cookie = ucc_team_cache_vote_new_cookie(team->cache_vote_out);
+    if (new_cookie != 0 && new_cookie != ~(uint64_t)0) {
+        team->cache_identity.instance_cookie = new_cookie;
+    }
+
+    if (cache == NULL) {
+        return;
+    }
+
+    /* Reclaim completed evictions, then make room at capacity by evicting the
+       victim. evict_one / progress_pending take cache->lock themselves and drive
+       teardown outside it, so they run before the insert critical section.
+       cache->max_size is clamped against the team-ID pool at context create
+       (UCC_TEAM_CACHE_ID_HEADROOM), so a free pool ID is guaranteed. If nothing is
+       evictable (all cached teams live), the new team is admitted un-cached. */
+    ucc_team_cache_progress_pending(cache);
+
+    if (cache->eviction != UCC_TEAM_CACHE_EVICTION_NONE &&
+        cache->size >= cache->max_size) {
+        if (UCC_ERR_NO_RESOURCE == ucc_team_cache_evict_one(cache)) {
+            ucc_debug(
+                "team cache at pool-safe capacity (size=%u/%u), all entries "
+                "live; admitting team %p (hash=0x%" PRIx64 ") un-cached",
+                cache->size,
+                cache->max_size,
+                (void *)team,
+                team->cache_identity.hash);
+        }
+    }
+
+    ucc_spin_lock(&cache->lock);
+    if (UCC_OK == ucc_team_cache_insert(cache, team) &&
+        team->cache_state == UCC_TEAM_CACHE_STATE_DORMANT) {
+        ucc_list_del(&team->cache_link);
+        team->cache_state = UCC_TEAM_CACHE_STATE_LIVE;
+        ucc_team_cache_registry_add_live(cache, team);
+        ucc_debug(
+            "team cache: insert (hash=0x%" PRIx64 ") team %p -> LIVE "
+            "refcount=%d",
+            team->cache_identity.hash,
+            (void *)team,
+            team->refcount);
+    } else if (team->cache_state == UCC_TEAM_CACHE_STATE_NONE) {
+        /* Cache full or hash collision: team stays uncached and functional. */
+        ucc_debug(
+            "team cache: insert skipped (hash=0x%" PRIx64 ") team %p stays "
+            "uncached",
+            team->cache_identity.hash,
+            (void *)team);
+    }
+    ucc_spin_unlock(&cache->lock);
+}
+
+/* Promote a RESERVED reuse candidate to LIVE under cache->lock after a unanimous
+   vote. When @reseat, also re-seat the team's id/tag domain to the new cid
+   (experimental RESEAT); the instance cookie is unchanged (same physical instance). */
+static void ucc_team_agreement_promote_reserved(
+    ucc_context_t *context, ucc_team_t *team, int reseat)
+{
+    ucc_team_cache_t *cache = context->team_cache;
+
+    ucc_spin_lock(&cache->lock);
+    ucc_team_cache_get(team); /* refcount 0 -> 1, RESERVED -> LIVE */
+    ucc_team_cache_registry_make_live(cache, team);
+    if (reseat && team->cache_identity.ext_id != team->cache_reseat_new_id) {
+        ucc_debug(
+            "team cache: agreed RESEAT team %p id 0x%x -> 0x%x",
+            (void *)team,
+            (unsigned)team->cache_identity.ext_id,
+            (unsigned)team->cache_reseat_new_id);
+        ucc_team_reseat_id(team, team->cache_reseat_new_id);
+    }
+    ucc_spin_unlock(&cache->lock);
+}
+
 ucc_status_t ucc_team_create_test_single(ucc_context_t *context,
                                          ucc_team_t    *team)
 {
-    ucc_status_t status = UCC_OK;
+    ucc_status_t            status = UCC_OK;
+    ucc_team_cache_action_t agreed;
 
     switch (team->state) {
+    case UCC_TEAM_CACHE_AGREE:
+        /* Progress the member vote posted in create_post. On completion, commit
+           the unanimously-agreed action or fall to a fresh build. */
+        status = ucc_service_coll_test(&team->cache_vote_req);
+        if (status == UCC_INPROGRESS) {
+            return UCC_INPROGRESS;
+        }
+        if (status < 0) {
+            ucc_service_coll_finalize(&team->cache_vote_req);
+            ucc_error(
+                "team cache: agreement vote failed: %s",
+                ucc_status_string(status));
+            goto out;
+        }
+        ucc_service_coll_finalize(&team->cache_vote_req);
+        agreed = ucc_team_cache_vote_result(team->cache_vote_out);
+
+        if (agreed == UCC_TEAM_CACHE_ACTION_EXACT_REUSE &&
+            team->cache_local_action == UCC_TEAM_CACHE_ACTION_EXACT_REUSE) {
+            /* Unanimous reuse: promote the RESERVED candidate to LIVE. */
+            ucc_team_agreement_promote_reserved(context, team, 0);
+            ucc_debug("team cache: agreed EXACT reuse, team %p", (void *)team);
+            team->state = UCC_TEAM_ACTIVE;
+            return UCC_OK;
+        }
+        if (agreed == UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED &&
+            team->cache_local_action == UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED) {
+            /* Unanimous RESEAT (cid drift): every member proved (via the cookie
+               lanes) it selected the same physical dormant-derived instance.
+               Promote to LIVE and re-seat to the new cid. */
+            ucc_team_agreement_promote_reserved(context, team, 1);
+            team->state = UCC_TEAM_ACTIVE;
+            return UCC_OK;
+        }
+        if (agreed == UCC_TEAM_CACHE_ACTION_DERIVED_FROM_LIVE &&
+            team->cache_local_action ==
+                UCC_TEAM_CACHE_ACTION_DERIVED_FROM_LIVE) {
+            /* Unanimous derive: borrow the parent's artifacts and build fresh. */
+            ucc_team_init_derived(
+                team,
+                team->cache_derive_artifacts,
+                team->cache_derive_parent_id);
+            team->cache_derive_artifacts = NULL;
+            team->state = (team->size > 1) ? UCC_TEAM_SERVICE_TEAM
+                                           : UCC_TEAM_CL_CREATE;
+            return UCC_INPROGRESS;
+        }
+        /* Global MISS (or a defensive action mismatch): every member fresh-builds. */
+        if (team->cache_local_action == UCC_TEAM_CACHE_ACTION_EXACT_REUSE ||
+            team->cache_local_action == UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED) {
+            /* This rank reserved a DORMANT candidate; detach it from the cache and
+               rebuild the same handle in place after draining its old CL/TL tag
+               domain. The candidate may be a derived team (an EXACT_REUSE or
+               RESEAT_DERIVED hit on a dormant derived team), so always clear
+               is_derived: the rebuild is a FRESH FULL build and must run
+               ADDR_EXCHANGE to materialize its own ctx_map/topo, not skip it as a
+               derived team would. For a RESEAT candidate the ext_id is also stale
+               (drifted cid): re-key it to the new create's cid. Under the lock the
+               candidate is off every list, so no peer sees the transient. */
+            ucc_team_cache_t *vote_cache = context->team_cache;
+            ucc_spin_lock(&vote_cache->lock);
+            ucc_team_cache_table_erase(vote_cache, team);
+            ucc_team_cache_registry_remove(vote_cache, team);
+            if (team->cache_local_action ==
+                UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED) {
+                if (UCC_TEAM_ID_IS_EXTERNAL(team)) {
+                    team->id = team->cache_reseat_new_id;
+                }
+                team->cache_identity.ext_id = team->cache_reseat_new_id;
+            }
+            team->is_derived = 0;
+            team->parent_id  = 0;
+            ucc_spin_unlock(&vote_cache->lock);
+            team->cache_state          = UCC_TEAM_CACHE_STATE_NONE;
+            team->cache_pending_insert = 1;
+            team->state                = UCC_TEAM_CACHE_MISS_TEARDOWN;
+            ucc_debug(
+                "team cache: agreement lost, rebuilding team %p in place",
+                (void *)team);
+            /* fall through to CACHE_MISS_TEARDOWN */
+        } else {
+            if (team->cache_local_action ==
+                UCC_TEAM_CACHE_ACTION_DERIVED_FROM_LIVE) {
+                ucc_team_artifacts_put(team->cache_derive_artifacts);
+                team->cache_derive_artifacts = NULL;
+            }
+            team->state = (team->size > 1) ? UCC_TEAM_ADDR_EXCHANGE
+                                           : UCC_TEAM_CL_CREATE;
+            return UCC_INPROGRESS;
+        }
+        /* fall through */
+    case UCC_TEAM_CACHE_MISS_TEARDOWN:
+        /* Poll the rejected candidate's teardown to terminal UCC_OK (the CL/TL
+           destroys are the (team_id, seq_num) wire-tag alias barrier), then reset
+           and re-enter the normal build. */
+        status = ucc_team_teardown_for_rebuild(team);
+        if (status == UCC_INPROGRESS) {
+            ucc_context_progress(context);
+            return UCC_INPROGRESS;
+        }
+        if (status < 0) {
+            goto out;
+        }
+        status = ucc_team_reset_for_rebuild(context, team);
+        if (status < 0) {
+            goto out;
+        }
+        return UCC_INPROGRESS; /* re-enter at the reset start state */
     case UCC_TEAM_ADDR_EXCHANGE:
         status = ucc_team_exchange(context, team);
         if (UCC_OK != status) {
@@ -451,11 +1376,19 @@ ucc_status_t ucc_team_create_test_single(ucc_context_t *context,
         team->state = UCC_TEAM_ALLOC_ID;
         /* fall through */
     case UCC_TEAM_ALLOC_ID:
+        /* ucc_team_alloc_id runs a service allreduce over the shared
+           UCC_TL_UCP_SERVICE_TAG; it cannot alias the agreement vote - see the note
+           at the vote-post site in ucc_team_agreement_create_post. */
         if (context->cl_flags & UCC_BASE_LIB_FLAG_TEAM_ID_REQUIRED) {
             status = ucc_team_alloc_id(team);
             if (UCC_OK != status) {
                 goto out;
             }
+        }
+        /* A derived team must get its own team-id, distinct from the parent whose
+           artifacts it borrows, so it owns an independent TL/UCP tag/seq domain. */
+        if (team->is_derived && team->id != 0) {
+            ucc_assert(team->id != team->parent_id);
         }
         team->bp.id = team->id;
         team->state = UCC_TEAM_CL_CREATE;
@@ -486,8 +1419,12 @@ out:
                                       ucc_global_config.log_component.log_level);
         ucc_info("================================================");
     }
-    /* TODO: add team/coll selection and check if some teams are never
-             used after selection and clean them up */
+    /* Insert the freshly-built (miss-path) team into the cache once it is ACTIVE
+       and the score map is built. Re-adopted (hit-path) teams short-circuit
+       earlier and never reach here. */
+    if (UCC_OK == status && team->cache_pending_insert) {
+        ucc_team_cache_admit(team);
+    }
     return status;
 }
 
@@ -505,7 +1442,14 @@ ucc_status_t ucc_team_create_test(ucc_team_h team)
     return ucc_team_create_test_single(team->contexts[0], team);
 }
 
-static ucc_status_t ucc_team_destroy_single(ucc_team_h team)
+/* Tear down a team's components (service/CL/TL teams, artifacts, score_map,
+   addr_storage, team-id). When @for_rebuild is set (global-miss rebuild of a
+   rejected EXACT candidate), drives every component destroy to terminal UCC_OK
+   - including the CL/TL destroys that are the (team_id, seq_num) wire-tag alias
+   barrier - but KEEPS the struct-lifetime allocations (cl_teams array, contexts,
+   cache_identity, the team struct itself) so ucc_team_reset_for_rebuild can
+   rebuild the same handle in place. Otherwise it is the terminal full teardown. */
+static ucc_status_t ucc_team_destroy_single_ex(ucc_team_h team, int for_rebuild)
 {
     ucc_cl_iface_t *cl_iface;
     int             i;
@@ -530,7 +1474,13 @@ static ucc_status_t ucc_team_destroy_single(ucc_team_h team)
         team->cl_teams[i] = NULL;
     }
 
-    ucc_topo_cleanup(team->topo);
+    /* Drop this team's reference to the shared artifacts holder. A solo team is
+       the sole reference (1 -> 0), so topo and ctx_ranks are torn down here; a
+       derived team only decrements and the last team out frees them. Done before
+       ctx teardown because the TL nested maps aliasing &artifacts->ctx_map are
+       already destroyed by the CL/TL team destroys above. */
+    ucc_team_artifacts_put(team->artifacts);
+    team->artifacts = NULL;
 
     if (team->contexts[0]->service_team && team->size > 1) {
         ucc_internal_oob_finalize(&team->bp.params.oob);
@@ -542,13 +1492,85 @@ static ucc_status_t ucc_team_destroy_single(ucc_team_h team)
     }
 
     ucc_coll_score_free_map(team->score_map);
+    team->score_map = NULL;
     ucc_free(team->addr_storage.storage);
-    ucc_free(team->ctx_ranks);
+    /* team->ctx_ranks (now the holder's ctx_ranks) was freed by
+       ucc_team_artifacts_put above at the last reference. */
     ucc_team_release_id(team);
+    if (for_rebuild) {
+        /* Keep contexts, cache_identity, and the struct itself: the handle is
+           reused and rebuilt in place. Free the cl_teams array (create_post_single
+           re-allocates it) and clear addr_storage. All transport is now drained
+           and the team-id released, so ucc_team_reset_for_rebuild + the normal
+           build can safely redraw an id without tag aliasing. */
+        ucc_free(team->cl_teams);
+        team->cl_teams = NULL;
+        memset(&team->addr_storage, 0, sizeof(team->addr_storage));
+        return UCC_OK;
+    }
     ucc_free(team->cl_teams);
     ucc_free(team->contexts);
+    /* Free the cache identity at terminal teardown. Cached paths free it before
+     * driving the destroy (zeroing members makes this an idempotent no-op), and
+     * never-cached teams have a zeroed identity. This is the ONLY free for a team
+     * that built an identity on the miss path but was admitted un-cached (cache
+     * full with no evictable victim, or a hash collision). */
+    ucc_team_cache_identity_free(&team->cache_identity);
     ucc_free(team);
     return UCC_OK;
+}
+
+static ucc_status_t ucc_team_destroy_single(ucc_team_h team)
+{
+    return ucc_team_destroy_single_ex(team, 0);
+}
+
+/* Global-miss recovery. Drive the rejected EXACT candidate's components to
+   terminal UCC_OK (polled - returns UCC_INPROGRESS until every CL/TL/service
+   destroy completes, the wire-tag alias barrier), keeping the struct. */
+static ucc_status_t ucc_team_teardown_for_rebuild(ucc_team_t *team)
+{
+    return ucc_team_destroy_single_ex(team, 1);
+}
+
+/* Restore a torn-down (for_rebuild) team to the pristine pre-build state so the
+   normal state machine rebuilds it in place, re-inserting under its retained
+   cache_identity. Membership (contexts/size/rank) and cache_identity are kept. */
+static ucc_status_t ucc_team_reset_for_rebuild(
+    ucc_context_t *context, ucc_team_t *team)
+{
+    ucc_assert(team->service_team == NULL);
+    ucc_assert(team->sreq == NULL);
+
+    team->n_cl_teams = 0; /* cl_teams array was freed by teardown */
+    team->seq_num    = 0;
+    /* External-id teams keep their id (ucc_team_alloc_id preserves it); internal
+       ids were released to the pool and must be redrawn, so zero them. */
+    if (!UCC_TEAM_ID_IS_EXTERNAL(team)) {
+        team->id = 0;
+    }
+    team->bp.id       = 0;
+    team->oob_req     = NULL;
+    team->refcount    = 1;
+    team->cache_state = UCC_TEAM_CACHE_STATE_NONE;
+    team->cache_pending_insert =
+        1; /* rebuilt team re-inserts under its identity */
+    team->cache_derive_artifacts = NULL;
+    ucc_list_head_init(&team->cache_link);
+    ucc_list_head_init(&team->bucket_link);
+
+    /* A fresh heap holder (the old one was released by teardown). Cacheable teams
+       always use a heap (shareable) holder. */
+    team->artifacts = ucc_team_artifacts_alloc();
+    if (!team->artifacts) {
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    /* Re-run the per-create setup: re-allocs cl_teams, re-inits internal OOB,
+       repopulates bp, sets last_team_create_posted and the start state. The
+       global-MISS branch cleared team->is_derived, so it starts at ADDR_EXCHANGE
+       (size>1) and rebuilds its own ctx_map/topo. */
+    return ucc_team_create_post_single(context, team);
 }
 
 ucc_status_t ucc_team_destroy(ucc_team_h team)
@@ -565,11 +1587,228 @@ ucc_status_t ucc_team_destroy(ucc_team_h team)
 
     /* we don't support multiple contexts per team yet */
     ucc_assert(team->num_contexts == 1);
+
+    /* Cache-aware destroy, on team->cache_state:
+     *   - NONE : never cached; fall straight through to ucc_team_destroy_single.
+     *   - LIVE : cached and backing this communicator. Put the refcount (1 -> 0)
+     *            to DORMANT, move it live -> dormant on the registry, and return
+     *            UCC_OK IMMEDIATELY without tearing it down; the dormant team
+     *            keeps its team-id and CL/TL teams for a later re-adopt. Teardown
+     *            is deferred to eviction / the context-finalize drain.
+     *   - DORMANT : unreachable (the state guard rejects a non-ACTIVE handle);
+     *            fall through to _single defensively.
+     *
+     * The put + make_dormant happen under cache->lock, the SAME lock the re-adopt
+     * takes, so a concurrent create cannot re-adopt a team mid-transition and a
+     * dormant team is atomically eligible for the next lookup. */
+    if (team->cache_state == UCC_TEAM_CACHE_STATE_LIVE) {
+        ucc_context_t    *ctx   = team->contexts[0];
+        ucc_team_cache_t *cache = ctx->team_cache;
+        int               n;
+
+        ucc_assert(cache != NULL);
+        ucc_spin_lock(&cache->lock);
+        n = ucc_team_cache_put(team); /* 1 -> 0, sets cache_state = DORMANT */
+        ucc_team_cache_registry_make_dormant(cache, team);
+        ucc_spin_unlock(&cache->lock);
+
+        ucc_debug(
+            "team cache: team %p now dormant, retained for reuse "
+            "(hash=0x%" PRIx64 ", live_users=%d)",
+            (void *)team,
+            team->cache_identity.hash,
+            n);
+        /* Return UCC_OK immediately: callers spin on UCC_INPROGRESS, so a
+         * retained dormant team must NOT stay INPROGRESS. */
+        return UCC_OK;
+    }
+
     return ucc_team_destroy_single(team);
 }
 
-static inline int
-find_first_set_and_zero(uint64_t *value) {
+/* Terminal teardown-failure handling: ucc_team_destroy_single returned a hard
+ * error, so the team is only partially destroyed and some CL/TL/service state may
+ * still alias the shared artifacts holder. Freeing the struct or putting the
+ * artifacts could dangle/double-free that state, so we do not. We do reclaim the
+ * scarce team-id pool bit (a local bit-clear, safe regardless of component state)
+ * so a failed teardown cannot starve id allocation, and log loudly. The team is
+ * already detached from every cache list, so it can never be re-observed; its
+ * component memory is an accepted, bounded leak. */
+static void ucc_team_cache_abandon_failed(ucc_team_t *team, ucc_status_t status)
+{
+    ucc_error(
+        "cached team %p teardown failed terminally (%s); reclaiming "
+        "team-id %u and abandoning partially destroyed component state",
+        (void *)team,
+        ucc_status_string(status),
+        (unsigned)team->id);
+    ucc_team_release_id(team);
+}
+
+void ucc_team_cache_drain(ucc_context_t *context)
+{
+    ucc_team_cache_t *cache = context->team_cache;
+    ucc_team_t       *team, *tmp;
+    ucc_status_t      status;
+
+    if (cache == NULL) {
+        return;
+    }
+
+    /* Reap every remaining DORMANT team, single-threaded at context teardown
+     * (no concurrent create/destroy, so no cache lock needed to walk). Runs
+     * BEFORE CL/TL context destroy and the shared service-team teardown, because
+     * a dormant team still holds CL/TL/service refs and a team-id. For each team:
+     * detach from both registries and the khash bucket, and free the cache
+     * identity HERE while `team` is valid (a cache-only field _single never
+     * reads), then drive the (possibly async) teardown to completion - _single
+     * releases the team-id and frees the struct only on terminal UCC_OK. */
+    ucc_list_for_each_safe (team, tmp, &cache->dormant, cache_link) {
+        ucc_assert(team->cache_state == UCC_TEAM_CACHE_STATE_DORMANT);
+
+        ucc_team_cache_registry_remove(cache, team);
+        ucc_team_cache_table_erase(cache, team);
+        ucc_team_cache_identity_free(&team->cache_identity);
+
+        while (UCC_INPROGRESS == (status = ucc_team_destroy_single(team))) {
+            ucc_context_progress(context);
+        }
+        if (status < 0) {
+            ucc_team_cache_abandon_failed(team, status);
+        }
+    }
+
+    ucc_assert(ucc_list_is_empty(&cache->dormant));
+
+    /* An evicted victim may still be mid-teardown on the pending-destroy list;
+     * flush it to UCC_OK now so nothing lingers before CL/TL ctx destroy runs. */
+    while (!ucc_list_is_empty(&cache->pending_destroy)) {
+        ucc_team_cache_progress_pending(cache);
+        if (!ucc_list_is_empty(&cache->pending_destroy)) {
+            ucc_context_progress(context);
+        }
+    }
+}
+
+/*
+ * Pending-destroy state machine.
+ *
+ * ucc_team_destroy_single early-returns UCC_INPROGRESS while a CL/TL destroy is
+ * in flight and releases the team-id + frees the struct only on terminal UCC_OK,
+ * so an evicted victim cannot be torn down in one shot; it is parked on
+ * cache->pending_destroy and progressed to UCC_OK by this driver.
+ *
+ * LOCK DISCIPLINE: ucc_team_destroy_single may call ucc_context_progress and MUST
+ * NOT run under cache->lock. This detaches the whole pending list under the lock,
+ * drops it, drives one destroy attempt per team outside the lock, then re-parks
+ * the still-UCC_INPROGRESS teams under the lock. A team on pending_destroy is off
+ * the table and both registries, so no other thread can observe or re-adopt it
+ * mid-destroy.
+ */
+ucc_status_t ucc_team_cache_progress_pending(ucc_team_cache_t *cache)
+{
+    ucc_list_link_t work;
+    ucc_team_t     *team, *tmp;
+    ucc_status_t    status;
+
+    if (cache == NULL) {
+        return UCC_OK;
+    }
+
+    /* Detach the whole pending list under the lock so the destroys below run
+     * OUTSIDE cache->lock. */
+    ucc_list_head_init(&work);
+    ucc_spin_lock(&cache->lock);
+    ucc_list_for_each_safe (team, tmp, &cache->pending_destroy, cache_link) {
+        ucc_list_del(&team->cache_link);
+        ucc_list_add_tail(&work, &team->cache_link);
+    }
+    ucc_spin_unlock(&cache->lock);
+
+    ucc_list_for_each_safe (team, tmp, &work, cache_link) {
+        /* Capture id and pointer BEFORE destroy: on UCC_OK the struct is freed
+         * and must not be accessed afterwards; on UCC_INPROGRESS it is re-parked
+         * below. */
+        void    *team_ptr = (void *)team;
+        uint16_t team_id  = team->id;
+
+        ucc_list_del(&team->cache_link);
+        status = ucc_team_destroy_single(team);
+        if (status == UCC_INPROGRESS) {
+            ucc_spin_lock(&cache->lock);
+            ucc_list_add_tail(&cache->pending_destroy, &team->cache_link);
+            ucc_spin_unlock(&cache->lock);
+        } else if (status < 0) {
+            ucc_team_cache_abandon_failed(team, status);
+        } else {
+            /* UCC_OK: ucc_team_release_id returned any pool bit, restoring the
+             * clamp headroom (external-ID teams hold no pool bit). */
+            ucc_debug(
+                "team cache: evicted team %p destroy complete "
+                "(UCC_OK, id=%u); team-id pool headroom restored",
+                team_ptr,
+                (unsigned)team_id);
+        }
+    }
+
+    return UCC_OK;
+}
+
+ucc_status_t ucc_team_cache_evict_one(ucc_team_cache_t *cache)
+{
+    ucc_team_t *victim;
+    uint64_t    hash;
+
+    ucc_spin_lock(&cache->lock);
+
+    victim = ucc_team_cache_pick_lru_victim(cache);
+    if (victim == NULL) {
+        /* All cached teams are live (pinned by a live communicator); nothing is
+         * evictable.  Sentinel so the admission path leaves the new team
+         * uncached but fully functional. */
+        ucc_spin_unlock(&cache->lock);
+        return UCC_ERR_NO_RESOURCE;
+    }
+    /* Only DORMANT teams are ever evicted. The victim may differ per rank (under
+     * LFU/LRU, or under FIFO with overlapping scopes); no consensus is needed here
+     * because the cache-action agreement (UCC_TEAM_CACHE_AGREEMENT) reconciles any
+     * resulting hit/miss split into a consistent fresh build. */
+    ucc_assert(victim->cache_state == UCC_TEAM_CACHE_STATE_DORMANT);
+    hash = victim->cache_identity.hash;
+
+    /* Detach the victim entirely (erase the khash bucket, unlink from the dormant
+     * registry) and free cache_identity here under the lock, BEFORE parking it on
+     * pending_destroy: once parked, a concurrent progress_pending may claim and
+     * destroy it, so touching victim after the unlock would be a use-after-free.
+     * A team on pending_destroy is on neither the table nor any registry, so
+     * lookup can never find it. */
+    ucc_team_cache_table_erase(cache, victim);
+    ucc_team_cache_registry_remove(cache, victim);
+    ucc_team_cache_identity_free(&victim->cache_identity);
+    victim->cache_state = UCC_TEAM_CACHE_STATE_NONE;
+    ucc_list_add_tail(&cache->pending_destroy, &victim->cache_link);
+    cache->stats.evictions++;
+
+    ucc_debug(
+        "team cache %p: evicting dormant team %p (hash=0x%" PRIx64
+        ", size now %u, evictions=%" PRIu64 ")",
+        (void *)cache,
+        (void *)victim,
+        hash,
+        cache->size,
+        cache->stats.evictions);
+
+    ucc_spin_unlock(&cache->lock);
+
+    /* Drive the (nonblocking) teardown OUTSIDE the lock. */
+    ucc_team_cache_progress_pending(cache);
+    return UCC_OK;
+}
+
+/* Non-static (declared in ucc_team.h) so the id-pool boundary math can be unit
+   tested directly; see test/gtest/core/test_team_cache.cc. */
+int ucc_team_id_pool_ffs_clear(uint64_t *value)
+{
     int i;
     for (i=0; i<64; i++) {
         if (*value & ((uint64_t)1 << i)) {
@@ -580,10 +1819,14 @@ find_first_set_and_zero(uint64_t *value) {
     return 0;
 }
 
-static inline void
-set_id_bit(uint64_t *local, int id) {
-    int map_pos = id / 64;
-    int pos = (id-1) % 64;
+void ucc_team_id_pool_set_bit(uint64_t *local, int id)
+{
+    /* Inverse of the allocation layout in ucc_team_alloc_id: a bit at index
+       (pos-1) of word i encodes id = i*64 + pos (pos in 1..64), so id maps back
+       to word (id-1)/64, bit (id-1)%64.  Using id/64 for the word mis-indexes
+       every multiple of 64 (e.g. id 64 -> word 1 instead of word 0). */
+    int map_pos = (id - 1) / 64;
+    int pos     = (id - 1) % 64;
     ucc_assert(id >= 1);
     local[map_pos] |= ((uint64_t)1 << pos);
 }
@@ -640,7 +1883,7 @@ static ucc_status_t ucc_team_alloc_id(ucc_team_t *team)
     memcpy(local, global, ctx->ids.pool_size*sizeof(uint64_t));
     pos = 0;
     for (i=0; i<ctx->ids.pool_size; i++) {
-        if ((pos = find_first_set_and_zero(&local[i])) > 0) {
+        if ((pos = ucc_team_id_pool_ffs_clear(&local[i])) > 0) {
             break;
         }
     }
@@ -662,6 +1905,6 @@ static void ucc_team_release_id(ucc_team_t *team)
     ucc_context_t *ctx = team->contexts[0];
     /* release the id pool bit if it was not provided by user */
     if (0 != team->id && !UCC_TEAM_ID_IS_EXTERNAL(team)) {
-        set_id_bit(ctx->ids.pool, team->id);
+        ucc_team_id_pool_set_bit(ctx->ids.pool, team->id);
     }
 }

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -10,21 +10,98 @@
 #include "ucc/api/ucc.h"
 #include "utils/ucc_datastruct.h"
 #include "utils/ucc_coll_utils.h"
+#include "utils/ucc_list.h"
+#include "utils/ucc_spinlock.h"
 #include "ucc_context.h"
+#include "ucc_team_cache.h"
 #include "utils/ucc_math.h"
 #include "components/base/ucc_base_iface.h"
 #include "components/cl/ucc_cl.h"
 #include "components/tl/ucc_tl.h"
 #include "coll_score/ucc_coll_score.h"
+#include "ucc_service_coll.h" /* full ucc_service_coll_req_t for the embedded vote req */
 
 typedef struct ucc_service_coll_req ucc_service_coll_req_t;
 typedef enum {
-    UCC_TEAM_ADDR_EXCHANGE,
+    UCC_TEAM_ADDR_EXCHANGE, /* value 0: freshly calloc'd default */
     UCC_TEAM_SERVICE_TEAM,
     UCC_TEAM_ALLOC_ID,
     UCC_TEAM_CL_CREATE,
     UCC_TEAM_ACTIVE,
+    /* Agreement states for a cacheable size>1 team; appended so ADDR_EXCHANGE
+       stays the calloc-zero default. */
+    UCC_TEAM_CACHE_AGREE,         /* vote in flight; commit on completion */
+    UCC_TEAM_CACHE_MISS_TEARDOWN, /* vote lost: drain the rejected EXACT
+                                     candidate to terminal UCC_OK, then rebuild */
 } ucc_team_state_t;
+
+/*
+ * Cache-state marker for ucc_team_t. All transitions are taken under cache->lock.
+ *
+ *   NONE --insert--> DORMANT --reserve--> RESERVED --agree-PASS--> LIVE
+ *                       ^                     |
+ *                       +----agree-FAIL-------+
+ *   LIVE --put-to-0--> DORMANT
+ *
+ * RESERVED is a re-adopt candidate pinned for an in-flight agreement vote: off
+ * the live/dormant lists but still in the bucket, refcount unchanged, so a
+ * vote-FAIL rolls back to DORMANT with no race. team->refcount tracks the live
+ * communicators backing a cached team.
+ */
+typedef enum ucc_team_cache_state {
+    UCC_TEAM_CACHE_STATE_NONE    = 0, /* never cached (safe default) */
+    UCC_TEAM_CACHE_STATE_DORMANT = 1, /* cached, no live backing comm */
+    UCC_TEAM_CACHE_STATE_RESERVED =
+        2,                         /* pinned for an in-flight agreement vote */
+    UCC_TEAM_CACHE_STATE_LIVE = 3, /* cached, backing one live comm */
+} ucc_team_cache_state_t;
+
+/*
+ * Refcounted, read-only shared team artifacts (ctx_map, ctx_ranks, topo) that a
+ * cached team and its derived team(s) share through one heap instance instead of
+ * recomputing. The topo is materialized build-once (ucc_topo_prepare_shared)
+ * before sharing to avoid lazy write races under THREAD_MULTIPLE. TL nested maps
+ * store a raw &holder->ctx_map, so the holder must never be copied by value.
+ * Created at refcount 1; get() adds a ref, put() frees the holder at 0. The
+ * spinlock guards the refcount (reachable from >1 live team).
+ */
+typedef struct ucc_team_artifacts {
+    ucc_ep_map_t   ctx_map;   /*< map to the ctx ranks, defined if CTX type is
+                                  global (oob provided) */
+    ucc_rank_t    *ctx_ranks; /*< UCC-owned backing array of ctx_map, or NULL */
+    ucc_topo_t    *topo;     /*< subset topology, materialized before sharing */
+    int            refcount; /*< number of live teams pointing at this holder */
+    ucc_spinlock_t lock;     /*< guards refcount (THREAD_MULTIPLE) */
+    uint8_t        heap;     /*< 1: heap-allocated (shareable, freed at refcount
+                                 0); 0: embedded in a ucc_team_t (never shared,
+                                 contents cleaned but struct not freed) */
+} ucc_team_artifacts_t;
+
+/* Allocate a heap holder at refcount 1 with zero-initialized artifacts (the team
+   fills them during create_test). Heap holders are shareable by derived teams.
+   Returns NULL on OOM. */
+ucc_team_artifacts_t *ucc_team_artifacts_alloc(void);
+
+/* Initialize an embedded (non-heap, non-shareable) holder in place, at refcount
+   1. Used for teams that will never be cached or shared, avoiding a heap
+   allocation. Never freed by ucc_team_artifacts_put (lives inside ucc_team_t). */
+void                  ucc_team_artifacts_init_inline(ucc_team_artifacts_t *a);
+
+/* Add a reference; returns the same pointer for call-site convenience. */
+ucc_team_artifacts_t *ucc_team_artifacts_get(ucc_team_artifacts_t *artifacts);
+
+/* Drop one reference; frees the holder and all it owns at refcount 0. No-op on
+   NULL. */
+void                  ucc_team_artifacts_put(ucc_team_artifacts_t *artifacts);
+
+/* Read the refcount under the artifacts lock (the same lock get/put use). Use
+   this instead of touching ->refcount directly from outside the lock. */
+int ucc_team_artifacts_refcount(ucc_team_artifacts_t *artifacts);
+
+/* Accessors for the shared artifacts (make the sharing indirection explicit). */
+#define UCC_TEAM_CTX_MAP(_team)   ((_team)->artifacts->ctx_map)
+#define UCC_TEAM_CTX_RANKS(_team) ((_team)->artifacts->ctx_ranks)
+#define UCC_TEAM_TOPO(_team)      ((_team)->artifacts->topo)
 
 typedef struct ucc_team {
     ucc_team_state_t        state;
@@ -41,13 +118,47 @@ typedef struct ucc_team {
     ucc_tl_team_t *         service_team;
     ucc_service_coll_req_t *sreq;
     ucc_addr_storage_t      addr_storage; /*< addresses of team endpoints */
-    ucc_rank_t *            ctx_ranks;
     void *                  oob_req;
-    ucc_ep_map_t            ctx_map; /*< map to the ctx ranks, defined if CTX
-                                  type is global (oob provided) */
-    ucc_topo_t             *topo;
-    ucc_score_map_t        *score_map; /*< score map of CLs */
+    /* Shared holder for ctx_map/ctx_ranks/topo; access via UCC_TEAM_CTX_MAP /
+       UCC_TEAM_CTX_RANKS / UCC_TEAM_TOPO. Points at a heap holder for
+       cacheable/shareable teams, else at @artifacts_inline. */
+    ucc_team_artifacts_t   *artifacts;
+    /* Embedded holder for non-cacheable teams (no extra heap allocation). */
+    ucc_team_artifacts_t    artifacts_inline;
+    ucc_score_map_t *score_map; /*< score map of CLs (per-team, NOT shared) */
     uint32_t                seq_num;
+    int                       refcount;
+    ucc_team_cache_identity_t cache_identity;
+    ucc_list_link_t           cache_link; /* LRU/registry list */
+    /* Intrusive ring chaining same-membership-hash teams off the khash bucket
+       head; orthogonal to cache_link (bucket = hash collision chain). */
+    ucc_list_link_t           bucket_link;
+    ucc_team_cache_state_t
+             cache_state; /* NONE/DORMANT/RESERVED/LIVE - see enum */
+    /* Set after identity build on a cache miss, cleared at ACTIVE; distinguishes
+       "cacheable but not yet inserted" from cache_state NONE. */
+    int      cache_pending_insert;
+    /* Derived-team marker: a second team for identical membership that borrows the
+       parent's shared artifacts while getting its own id/CL/TL/score_map. Set only
+       by ucc_team_init_derived. parent_id records the borrowed-from id. */
+    int      is_derived;
+    uint16_t parent_id;
+    /* Cross-rank cache-action agreement: populated in create_post for a cacheable
+       size>1 team, consumed by the CACHE_AGREE create_test state. */
+    ucc_team_cache_action_t cache_local_action; /* this rank's classification */
+    ucc_service_coll_req_t  cache_vote_req; /* embedded (non-heap) vote req */
+    uint64_t                cache_vote_in[UCC_TEAM_CACHE_VOTE_LANES];
+    uint64_t                cache_vote_out[UCC_TEAM_CACHE_VOTE_LANES];
+    /* DERIVED_FROM_LIVE pin held across the vote; consumed by ucc_team_init_derived
+       on a PASS, released on a global-MISS. */
+    ucc_team_artifacts_t   *cache_derive_artifacts;
+    uint16_t                cache_derive_parent_id;
+    /* Experimental RESEAT (UCC_TEAM_CACHE_RESEAT): the drifted ext_id (new cid) to
+       re-seat the reused DORMANT derived candidate to, and the parent's per-instance
+       cookie used by the reseat vote. Meaningful only for RESEAT_DERIVED / derived
+       teams respectively. */
+    uint16_t                cache_reseat_new_id;
+    uint64_t                cache_parent_instance_cookie;
 } ucc_team_t;
 
 /* If the bit is set then team_id is provided by the user */
@@ -56,6 +167,43 @@ typedef struct ucc_team {
 #define UCC_TEAM_ID_MAX ((uint16_t)UCC_BIT(15) - 1)
 
 void ucc_copy_team_params(ucc_team_params_t *dst, const ucc_team_params_t *src);
+
+/* Team-id pool bit helpers (internal; exposed for unit testing the id<->bit
+   boundary math). The pool is 1-indexed: bit (pos-1) of word i encodes id
+   i*64+pos (pos in 1..64). ucc_team_id_pool_ffs_clear returns the 1-based index
+   of the lowest set bit and clears it (0 if none); ucc_team_id_pool_set_bit
+   restores the bit for @id to word (id-1)/64. */
+int  ucc_team_id_pool_ffs_clear(uint64_t *value);
+void ucc_team_id_pool_set_bit(uint64_t *local, int id);
+
+/*
+ * Derived-team create mechanism. A derived team reuses a parent (cached, LIVE)
+ * team's shared artifacts (ctx_map + topo) while allocating its own team-id,
+ * CL/TL objects, and score_map, so two coexisting live comms (e.g. MPI_Comm_dup)
+ * are cheaper than a full create and each keeps an independent tag/seq domain.
+ *
+ * ucc_team_can_derive_from(parent): non-zero iff @parent is a shareable source
+ * (ACTIVE, materialized ctx_map/topo); otherwise the team takes a full create.
+ * ucc_team_init_derived(team, held_artifacts, parent_id): CONSUMES the caller's
+ * already-bumped reference on the parent's holder. Must be called BEFORE
+ * ucc_team_create_post_single; always returns UCC_OK.
+ */
+int  ucc_team_can_derive_from(const ucc_team_t *parent);
+ucc_status_t ucc_team_init_derived(
+    ucc_team_t *team, ucc_team_artifacts_t *held_artifacts, uint16_t parent_id);
+
+/* Reap all DORMANT cached teams held by @context. Must be called at the START of
+   ucc_context_destroy, BEFORE CL/TL context destroy and the shared service-team
+   teardown, because a dormant team still holds CL/TL/service refs and a team-id.
+   Drives each team's (possibly async) teardown to completion with
+   ucc_context_progress. No-op if the context has no team cache; on return the
+   dormant registry is empty. */
+void         ucc_team_cache_drain(ucc_context_t *context);
+
+/* Pending-destroy state machine. Defined in ucc_team.c (not ucc_team_cache.c) so
+   they can reuse the file-local ucc_team_destroy_single teardown. */
+ucc_status_t ucc_team_cache_progress_pending(ucc_team_cache_t *cache);
+ucc_status_t ucc_team_cache_evict_one(ucc_team_cache_t *cache);
 
 /* Returns addressing information for "rank" in a team.
    If ucc context was created with OOB then addr storage is located on context.
@@ -71,10 +219,11 @@ ucc_get_team_ep_header(ucc_context_t *context, ucc_team_t *team,
     ucc_addr_storage_t *storage      = context->addr_storage.storage
                                            ? &context->addr_storage
                                            : &team->addr_storage;
-    ucc_rank_t          storage_rank =
-        context->addr_storage.storage
-                     ? (team ? ucc_ep_map_eval(team->ctx_map, rank) : rank)
-                     : rank;
+    ucc_rank_t          storage_rank = context->addr_storage.storage
+                                           ? (team ? ucc_ep_map_eval(
+                                                UCC_TEAM_CTX_MAP(team), rank)
+                                                   : rank)
+                                           : rank;
 
     return UCC_ADDR_STORAGE_RANK_HEADER(storage, storage_rank);
 }
@@ -103,12 +252,14 @@ static inline void *ucc_get_team_ep_addr(ucc_context_t *context,
 
 static inline ucc_rank_t ucc_get_ctx_rank(ucc_team_t *team, ucc_rank_t team_rank)
 {
-    return ucc_ep_map_eval(team->ctx_map, team_rank);
+    return ucc_ep_map_eval(UCC_TEAM_CTX_MAP(team), team_rank);
 }
 
 static inline ucc_host_id_t ucc_team_rank_host_id(ucc_rank_t rank, ucc_team_t *team)
 {
-    return team->topo->topo->procs[ucc_get_ctx_rank(team, rank)].host_id;
+    return UCC_TEAM_TOPO(team)
+        ->topo->procs[ucc_get_ctx_rank(team, rank)]
+        .host_id;
 }
 
 static inline int ucc_team_ranks_on_same_node(ucc_rank_t rank1, ucc_rank_t rank2,

--- a/src/core/ucc_team_cache.c
+++ b/src/core/ucc_team_cache.c
@@ -1,0 +1,632 @@
+/**
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "ucc_team_cache.h"
+#include "ucc_team.h"
+#include "utils/ucc_malloc.h"
+#include "utils/ucc_log.h"
+#include "utils/ucc_coll_utils.h"
+#include "utils/ucc_compiler_def.h"
+#include "utils/khash.h"
+#include <inttypes.h>
+#include <string.h>
+
+/* uint64_t -> ucc_team_t* map local to this TU (handle stored as void* in the
+   cache). Each key holds the chain head; same-hash teams are threaded into a ring
+   via team->bucket_link, orthogonal to cache_link (the live/dormant registry). */
+KHASH_MAP_INIT_INT64(ucc_team_cache_map, ucc_team_t *)
+
+/* Walk the bucket ring headed by @_head, stopping when it returns to @_head. Do
+   NOT unlink @_it inside this loop (table_erase uses its own safe walk). */
+#define UCC_TEAM_CACHE_BUCKET_FOR_EACH(_it, _head)                             \
+    for ((_it) = (_head); (_it) != NULL;                                       \
+         (_it) = ((_it)->bucket_link.next == &(_head)->bucket_link)            \
+                     ? NULL                                                    \
+                     : ucc_container_of(                                       \
+                           (_it)->bucket_link.next, ucc_team_t, bucket_link))
+
+/* Indexed by ucc_team_cache_eviction_policy_t; NULL-terminated. Order MUST match
+   the enum in ucc_team_cache.h. */
+const char *ucc_team_cache_eviction_names[] = {
+    [UCC_TEAM_CACHE_EVICTION_NONE] = "none",
+    [UCC_TEAM_CACHE_EVICTION_FIFO] = "fifo",
+    [UCC_TEAM_CACHE_EVICTION_LFU]  = "lfu",
+    [UCC_TEAM_CACHE_EVICTION_LRU]  = "lru", /* alias for lfu */
+    NULL};
+
+ucc_status_t ucc_team_cache_init(
+    ucc_team_cache_t **cache, uint32_t max_size,
+    ucc_team_cache_eviction_policy_t eviction, uint32_t disable_linear_check)
+{
+    ucc_team_cache_t *c;
+
+    c = ucc_calloc(1, sizeof(*c), "ucc_team_cache");
+    if (ucc_unlikely(!c)) {
+        ucc_error("failed to allocate ucc_team_cache_t");
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    c->table = kh_init(ucc_team_cache_map);
+    if (ucc_unlikely(!c->table)) {
+        ucc_error("failed to allocate ucc_team_cache hash table");
+        goto err;
+    }
+
+    ucc_list_head_init(&c->live);
+    ucc_list_head_init(&c->dormant);
+    ucc_list_head_init(&c->reserved);
+    ucc_list_head_init(&c->pending_destroy);
+    ucc_spinlock_init(&c->lock, 0);
+
+    c->max_size             = max_size;
+    c->eviction             = eviction;
+    c->disable_linear_check = disable_linear_check;
+
+    ucc_debug(
+        "ucc_team_cache created: %p, max_size=%u, eviction=%s, "
+        "disable_linear_check=%u",
+        (void *)c,
+        max_size,
+        ucc_team_cache_eviction_names[eviction],
+        disable_linear_check);
+    *cache = c;
+    return UCC_OK;
+
+err:
+    ucc_free(c);
+    return UCC_ERR_NO_MEMORY;
+}
+
+void ucc_team_cache_destroy(ucc_team_cache_t *cache)
+{
+    if (!cache) {
+        return;
+    }
+
+    if (cache->size != 0) {
+        ucc_warn(
+            "ucc_team_cache_destroy called with %u entries still present",
+            cache->size);
+    }
+
+    if (!ucc_list_is_empty(&cache->pending_destroy)) {
+        ucc_warn(
+            "ucc_team_cache_destroy called with pending-destroy entries "
+            "still present (eviction teardown not flushed)");
+    }
+
+    /* Context destroy runs after all teams are quiesced, so no vote is in flight. */
+    ucc_assert(ucc_list_is_empty(&cache->reserved));
+
+    void *cache_ptr = (void *)cache;
+
+    kh_destroy(ucc_team_cache_map, (khash_t(ucc_team_cache_map) *)cache->table);
+    ucc_spinlock_destroy(&cache->lock);
+    ucc_free(cache);
+    ucc_debug("ucc_team_cache destroyed: %p", cache_ptr);
+}
+
+void ucc_team_cache_dump_stats(ucc_team_cache_t *cache)
+{
+    double hit_rate = 0.0;
+
+    if (!cache) {
+        return;
+    }
+
+    if (cache->stats.lookups > 0) {
+        hit_rate = (cache->stats.hits * 100.0) / cache->stats.lookups;
+    }
+
+    ucc_info(
+        "team_cache stats: lookups=%" PRIu64 " hits=%" PRIu64 " (%.1f%%) "
+        "misses=%" PRIu64 " inserts=%" PRIu64 " evictions=%" PRIu64,
+        cache->stats.lookups,
+        cache->stats.hits,
+        hit_rate,
+        cache->stats.misses,
+        cache->stats.inserts,
+        cache->stats.evictions);
+}
+
+/* FNV-1a over {size, self_ep, members} as a single stream, so prefix length and
+   byte order both influence every bit. Used only as an O(1) bucket key; lookup
+   still verifies with ucc_team_cache_identity_equal(). */
+#define UCC_TEAM_CACHE_FNV1A_OFFSET 0xcbf29ce484222325ULL
+#define UCC_TEAM_CACHE_FNV1A_PRIME  0x00000100000001b3ULL
+
+static void ucc_team_cache_fnv1a_accumulate(
+    uint64_t *h, const void *data, size_t len)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    size_t         b;
+
+    for (b = 0; b < len; b++) {
+        *h ^= (uint64_t)p[b];
+        *h *= UCC_TEAM_CACHE_FNV1A_PRIME;
+    }
+}
+
+ucc_status_t ucc_team_cache_identity_build(
+    const ucc_team_params_t *params, ucc_team_cache_identity_t *identity)
+{
+    ucc_rank_t  size;
+    ucc_rank_t  self_ep;
+    ucc_rank_t *members;
+    ucc_rank_t  i;
+    uint64_t    h;
+
+    if (!(params->mask & UCC_TEAM_PARAM_FIELD_EP_MAP)) {
+        /* Without a materializable map there is no concrete membership to key on. */
+        ucc_debug("team cache identity: no EP_MAP in params, not cacheable");
+        return UCC_ERR_INVALID_PARAM;
+    }
+
+    size    = (ucc_rank_t)params->ep_map.ep_num;
+    self_ep = (params->mask & UCC_TEAM_PARAM_FIELD_EP) ? (ucc_rank_t)params->ep
+                                                       : UCC_RANK_INVALID;
+
+    /* A caller-supplied external id defines a distinct id/tag domain, so it is
+       part of the identity; a recycled id must not reuse a stale cached team.
+       Non-external (pool-id) teams share ext_id==0. */
+    identity->ext_id = ((params->mask & UCC_TEAM_PARAM_FIELD_ID) &&
+                        (params->id <= UCC_TEAM_ID_MAX))
+                           ? (uint16_t)(((uint16_t)params->id) |
+                                        UCC_TEAM_ID_EXTERNAL_BIT)
+                           : 0;
+
+    if (size < 1) {
+        ucc_debug("team cache identity: empty ep_map");
+        return UCC_ERR_INVALID_PARAM;
+    }
+
+    members = ucc_malloc(size * sizeof(*members), "team_cache_members");
+    if (ucc_unlikely(!members)) {
+        ucc_error(
+            "failed to allocate %zu bytes for team cache members",
+            size * sizeof(*members));
+        return UCC_ERR_NO_MEMORY;
+    }
+
+    /* Materialize the map into our own array so the identity never aliases the
+       caller's CB/cb_ctx or user array (params may be freed after create). */
+    for (i = 0; i < size; i++) {
+        members[i] = ucc_ep_map_eval(params->ep_map, i);
+    }
+
+    identity->size            = size;
+    identity->self_ep         = self_ep;
+    identity->members         = members;
+    /* Stamped collectively at cache insert (from the vote), not here; 0 = unstamped. */
+    identity->instance_cookie = 0;
+
+    /* self_ep distinguishes the same member set as seen by different ranks;
+       ext_id is deliberately not hashed (membership-only bucket). */
+    h                         = UCC_TEAM_CACHE_FNV1A_OFFSET;
+    ucc_team_cache_fnv1a_accumulate(&h, &size, sizeof(size));
+    ucc_team_cache_fnv1a_accumulate(&h, &self_ep, sizeof(self_ep));
+    ucc_team_cache_fnv1a_accumulate(
+        &h, members, (size_t)size * sizeof(*members));
+    identity->hash = h;
+
+    return UCC_OK;
+}
+
+int ucc_team_cache_identity_equal(
+    const ucc_team_cache_identity_t *a, const ucc_team_cache_identity_t *b)
+{
+    /* Full match for DORMANT reuse: membership AND external id/tag domain. */
+    return ucc_team_cache_identity_equal_membership(a, b) &&
+           a->ext_id == b->ext_id;
+}
+
+int ucc_team_cache_identity_equal_membership(
+    const ucc_team_cache_identity_t *a, const ucc_team_cache_identity_t *b)
+{
+    if (a->hash != b->hash || a->size != b->size || a->self_ep != b->self_ep) {
+        return 0;
+    }
+    return memcmp(
+               a->members, b->members, (size_t)a->size * sizeof(*a->members)) ==
+           0;
+}
+
+void ucc_team_cache_identity_free(ucc_team_cache_identity_t *identity)
+{
+    if (!identity) {
+        return;
+    }
+    ucc_free(identity->members);
+    memset(identity, 0, sizeof(*identity));
+}
+
+uint64_t ucc_team_cache_next_cookie(ucc_team_cache_t *cache)
+{
+    /* team-rank 0 only, under cache->lock. Skip 0 (unstamped sentinel). */
+    uint64_t c = ++cache->cache_gen;
+    if (ucc_unlikely(c == 0)) {
+        c = ++cache->cache_gen;
+    }
+    return c;
+}
+
+void ucc_team_cache_vote_fill(
+    uint64_t *v, int prepared, ucc_team_cache_action_t action, uint64_t key,
+    uint64_t cookie, uint64_t parent_cookie, int is_rank0,
+    uint64_t proposed_cookie)
+{
+    if (!prepared) {
+        /* Miss rank: prepared=0 and all-ones equality lanes (a BAND no-op). */
+        v[0] = 0;
+        v[1] = ~(uint64_t)0;
+        v[2] = ~(uint64_t)0;
+        v[3] = ~(uint64_t)0;
+        v[4] = ~(uint64_t)0;
+        v[5] = ~(uint64_t)0;
+        v[6] = ~(uint64_t)0;
+        v[7] = ~(uint64_t)0;
+        v[8] = ~(uint64_t)0;
+    } else {
+        v[0] = 1;
+        v[1] = (uint64_t)action;
+        v[2] = ~(uint64_t)action;
+        v[3] = key;
+        v[4] = ~key;
+        v[5] = cookie;
+        v[6] = ~cookie;
+        v[7] = parent_cookie;
+        v[8] = ~parent_cookie;
+    }
+    /* Distribution lane: rank 0 contributes its proposed new-instance cookie;
+       others contribute all-ones (BAND identity), so all read rank-0's value. */
+    v[9] = is_rank0 ? proposed_cookie : ~(uint64_t)0;
+}
+
+ucc_team_cache_action_t ucc_team_cache_vote_result(const uint64_t *v)
+{
+    int all_prepared  = (v[0] == 1);
+    int action_agree  = (v[1] == ~v[2]);
+    int key_agree     = (v[3] == ~v[4]);
+    int cookie_agree  = (v[5] == ~v[6]);
+    int pcookie_agree = (v[7] == ~v[8]);
+
+    if (all_prepared && action_agree && key_agree && cookie_agree &&
+        pcookie_agree) {
+        return (ucc_team_cache_action_t)v[1];
+    }
+    return UCC_TEAM_CACHE_ACTION_MISS;
+}
+
+uint64_t ucc_team_cache_vote_new_cookie(const uint64_t *v)
+{
+    return v[9];
+}
+
+int ucc_team_cache_is_cacheable(const ucc_team_params_t *params)
+{
+    /* Refuse to cache teams requesting optional behavioral semantics: those
+       fields are not part of the identity, so a cached team could be reused with
+       different semantics. FLAGS is not copied by ucc_copy_team_params. */
+    uint64_t optional = UCC_TEAM_PARAM_FIELD_ORDERING |
+                        UCC_TEAM_PARAM_FIELD_OUTSTANDING_COLLS |
+                        UCC_TEAM_PARAM_FIELD_SYNC_TYPE |
+                        UCC_TEAM_PARAM_FIELD_P2P_CONN |
+                        UCC_TEAM_PARAM_FIELD_MEM_PARAMS;
+
+    return (params->mask & optional) == 0;
+}
+
+/* Per-context team registry helpers: the single source of truth for live/dormant
+   list moves. Callers hold cache->lock; a cached team is on exactly one of
+   live/dormant while cached, and on neither once reaped. */
+
+void ucc_team_cache_registry_add_live(ucc_team_cache_t *cache, ucc_team_t *team)
+{
+    ucc_list_add_tail(&cache->live, &team->cache_link);
+}
+
+void ucc_team_cache_registry_make_dormant(
+    ucc_team_cache_t *cache, ucc_team_t *team)
+{
+    ucc_list_del(&team->cache_link);
+    ucc_list_add_tail(&cache->dormant, &team->cache_link);
+}
+
+void ucc_team_cache_registry_make_live(
+    ucc_team_cache_t *cache, ucc_team_t *team)
+{
+    ucc_list_del(&team->cache_link);
+    ucc_list_add_tail(&cache->live, &team->cache_link);
+}
+
+void ucc_team_cache_registry_make_reserved(
+    ucc_team_cache_t *cache, ucc_team_t *team)
+{
+    /* Pin a DORMANT re-adopt candidate for an in-flight vote: move it off dormant
+       onto reserved. It stays in the bucket (chain order undisturbed) but no
+       lookup/eviction/drain/destroy can reach it; refcount is left unchanged so a
+       vote-FAIL can roll it back to DORMANT without a refcount race. */
+    ucc_list_del(&team->cache_link);
+    ucc_list_add_tail(&cache->reserved, &team->cache_link);
+}
+
+void ucc_team_cache_registry_remove(ucc_team_cache_t *cache, ucc_team_t *team)
+{
+    (void)cache;
+    ucc_list_del(&team->cache_link);
+}
+
+void ucc_team_cache_table_erase(ucc_team_cache_t *cache, ucc_team_t *team)
+{
+    khash_t(
+        ucc_team_cache_map) *h = (khash_t(ucc_team_cache_map) *)cache->table;
+    uint64_t    hash           = team->cache_identity.hash;
+    khiter_t    k;
+    ucc_team_t *head, *it, *found = NULL;
+
+    /* Unlink @team from its bucket ring; every cached team (head or sibling)
+       counts toward cache->size, so a successful erase decrements it once. A team
+       skipped at insert (full/collision) is on no ring: no-op. */
+    k = kh_get(ucc_team_cache_map, h, hash);
+    if (k == kh_end(h)) {
+        return;
+    }
+    head = kh_value(h, k);
+
+    UCC_TEAM_CACHE_BUCKET_FOR_EACH(it, head)
+    {
+        if (it == team) {
+            found = team;
+            break;
+        }
+    }
+    if (!found) {
+        return;
+    }
+
+    if (team != head) {
+        /* Non-head sibling: unlink from the ring, head untouched. */
+        ucc_list_del(&team->bucket_link);
+        ucc_list_head_init(&team->bucket_link);
+    } else if (ucc_list_is_empty(&head->bucket_link)) {
+        /* Single-entry chain: drop the whole bucket. */
+        kh_del(ucc_team_cache_map, h, k);
+    } else {
+        /* Head with siblings: promote the next sibling, preserving ring order. */
+        ucc_team_t *next = ucc_container_of(
+            head->bucket_link.next, ucc_team_t, bucket_link);
+        ucc_list_del(&head->bucket_link);
+        ucc_list_head_init(&head->bucket_link);
+        kh_value(h, k) = next;
+    }
+    ucc_assert(cache->size > 0);
+    cache->size--;
+}
+
+/*
+ * Cache API (lookup / insert / get / put) - all operate under cache->lock held by
+ * the caller. State machine (ucc_team_cache_state_t in ucc_team.h):
+ *   NONE --insert--> DORMANT --get--> LIVE --put-to-0--> DORMANT
+ * Same-hash teams are chained on the bucket ring, tail-appended (insertion order).
+ */
+
+/* Walk the bucket for @id->hash and return the first team matching the requested
+   filter, or NULL. @match_ext_id also requires an ext_id match (exact reuse);
+   @want_state restricts by cache_state; @require_derived additionally requires a
+   derived team. Chain order is cross-rank identical, so every rank picks the same
+   team. Caller holds cache->lock. */
+static ucc_team_t *ucc_team_cache_bucket_find(
+    ucc_team_cache_t *cache, const ucc_team_cache_identity_t *id,
+    int match_ext_id, ucc_team_cache_state_t want_state, int require_derived)
+{
+    khash_t(
+        ucc_team_cache_map) *h = (khash_t(ucc_team_cache_map) *)cache->table;
+    khiter_t    k;
+    ucc_team_t *head, *team;
+
+    k = kh_get(ucc_team_cache_map, h, id->hash);
+    if (k == kh_end(h)) {
+        return NULL;
+    }
+    head = kh_value(h, k);
+
+    UCC_TEAM_CACHE_BUCKET_FOR_EACH(team, head)
+    {
+        if (match_ext_id && team->cache_identity.ext_id != id->ext_id) {
+            continue;
+        }
+        if (!cache->disable_linear_check &&
+            !ucc_team_cache_identity_equal_membership(
+                &team->cache_identity, id)) {
+            continue;
+        }
+        if (team->cache_state != want_state) {
+            continue;
+        }
+        if (require_derived && !team->is_derived) {
+            continue;
+        }
+        return team;
+    }
+    return NULL;
+}
+
+ucc_team_t *ucc_team_cache_lookup(
+    ucc_team_cache_t *cache, const ucc_team_cache_identity_t *id)
+{
+    ucc_team_t *team;
+
+    cache->stats.lookups++;
+    /* DORMANT-only, exact identity (ext_id compared): never return a LIVE team,
+       which already backs a communicator. */
+    team = ucc_team_cache_bucket_find(
+        cache, id, 1, UCC_TEAM_CACHE_STATE_DORMANT, 0);
+    if (team) {
+        cache->stats.hits++;
+        ucc_debug(
+            "team_cache %p: lookup HIT team %p (hash=0x%" PRIx64 ")",
+            (void *)cache,
+            (void *)team,
+            id->hash);
+    } else {
+        cache->stats.misses++;
+        ucc_debug(
+            "team_cache %p: lookup miss (hash=0x%" PRIx64 ")",
+            (void *)cache,
+            id->hash);
+    }
+    return team;
+}
+
+ucc_team_t *ucc_team_cache_lookup_live(
+    ucc_team_cache_t *cache, const ucc_team_cache_identity_t *id)
+{
+    /* Membership-only (a derived child has a different ext_id than its live
+       parent); does not count stats. */
+    return ucc_team_cache_bucket_find(
+        cache, id, 0, UCC_TEAM_CACHE_STATE_LIVE, 0);
+}
+
+ucc_team_t *ucc_team_cache_lookup_dormant_derived(
+    ucc_team_cache_t *cache, const ucc_team_cache_identity_t *id)
+{
+    /* Membership-only, dormant, derived: a derived team's cid drifts across MPI
+       context-id reuse, so the exact lookup misses it. Does not count stats. */
+    return ucc_team_cache_bucket_find(
+        cache, id, 0, UCC_TEAM_CACHE_STATE_DORMANT, 1);
+}
+
+ucc_status_t ucc_team_cache_insert(ucc_team_cache_t *cache, ucc_team_t *team)
+{
+    khash_t(
+        ucc_team_cache_map) *h = (khash_t(ucc_team_cache_map) *)cache->table;
+    uint64_t hash              = team->cache_identity.hash;
+    khiter_t k;
+    int      ret;
+
+    /* Caller must hold cache->lock. */
+    if (cache->size >= cache->max_size) {
+        ucc_info(
+            "team_cache %p: full (size=%u, max=%u) - team %p not cached",
+            (void *)cache,
+            cache->size,
+            cache->max_size,
+            (void *)team);
+        /* cache_state stays NONE so the destroy path leaves it be. */
+        return UCC_OK;
+    }
+
+    /* An existing bucket may hold a rare hash collision or same-membership teams
+       with a different ext_id/state (e.g. a derived team coexisting with its live
+       parent). Chain those; refuse only an exact-identity duplicate (lookup would
+       have re-adopted it). */
+    k = kh_get(ucc_team_cache_map, h, hash);
+    if (k != kh_end(h)) {
+        ucc_team_t *head = kh_value(h, k);
+        ucc_team_t *it;
+
+        UCC_TEAM_CACHE_BUCKET_FOR_EACH(it, head)
+        {
+            if (ucc_team_cache_identity_equal(
+                    &it->cache_identity, &team->cache_identity)) {
+                ucc_info(
+                    "team_cache %p: duplicate identity (hash=0x%" PRIx64
+                    ") - team %p not re-inserted",
+                    (void *)cache,
+                    hash,
+                    (void *)team);
+                return UCC_OK;
+            }
+        }
+
+        /* Tail-append: chain order = insertion (collective) order. */
+        ucc_list_add_tail(&head->bucket_link, &team->bucket_link);
+        ucc_debug(
+            "team_cache %p: chained team %p onto bucket "
+            "(hash=0x%" PRIx64 ")",
+            (void *)cache,
+            (void *)team,
+            hash);
+    } else {
+        k = kh_put(ucc_team_cache_map, h, hash, &ret);
+        if (ucc_unlikely(ret < 0)) {
+            ucc_error(
+                "team_cache %p: kh_put failed for hash=0x%" PRIx64,
+                (void *)cache,
+                hash);
+            return UCC_ERR_NO_MEMORY;
+        }
+        /* First team for this key becomes the chain head (self-linked ring). */
+        kh_value(h, k) = team;
+    }
+
+    /* Insert as DORMANT at the dormant FIFO tail (MRU). The caller immediately
+       transitions it DORMANT -> LIVE via registry_make_live. */
+    ucc_list_add_tail(&cache->dormant, &team->cache_link);
+
+    team->cache_state = UCC_TEAM_CACHE_STATE_DORMANT;
+    cache->size++;
+    cache->stats.inserts++;
+
+    ucc_debug(
+        "team_cache %p: inserted team %p (hash=0x%" PRIx64 ", size=%u)",
+        (void *)cache,
+        (void *)team,
+        hash,
+        cache->size);
+    return UCC_OK;
+}
+
+void ucc_team_cache_get(ucc_team_t *team)
+{
+    /* Under cache->lock. DORMANT -> LIVE. */
+    team->refcount++;
+    team->cache_state = UCC_TEAM_CACHE_STATE_LIVE;
+}
+
+int ucc_team_cache_put(ucc_team_t *team)
+{
+    int rc;
+
+    /* Under cache->lock. On rc==0: LIVE -> DORMANT (ready for re-adoption). */
+    ucc_assert(team->refcount > 0); /* catch a double-put in debug builds */
+    rc = --team->refcount;
+    if (rc == 0) {
+        team->cache_state = UCC_TEAM_CACHE_STATE_DORMANT;
+    }
+    return rc;
+}
+
+ucc_team_t *ucc_team_cache_pick_lru_victim(ucc_team_cache_t *cache)
+{
+    ucc_team_t *victim, *tmp, *best = NULL;
+
+    /* Caller MUST hold cache->lock. All dormant-list entries are DORMANT. */
+    if (ucc_list_is_empty(&cache->dormant)) {
+        ucc_debug(
+            "team_cache %p: pick_victim - dormant list empty", (void *)cache);
+        return NULL;
+    }
+
+    if (!UCC_TEAM_CACHE_EVICTION_IS_USAGE_BASED(cache->eviction)) {
+        /* FIFO (and NONE): the dormant-list head is the oldest inserted. */
+        return ucc_list_head(&cache->dormant, ucc_team_t, cache_link);
+    }
+
+    /* Usage-based (LFU / LRU alias): least-used = smallest seq_num, tie-broken by
+       list position (strictly-less keeps the earlier/oldest entry). */
+    ucc_list_for_each_safe (victim, tmp, &cache->dormant, cache_link) {
+        if (best == NULL || victim->seq_num < best->seq_num) {
+            best = victim;
+        }
+    }
+    ucc_debug(
+        "team_cache %p: pick_victim LFU -> team %p (seq_num=%u)",
+        (void *)cache,
+        (void *)best,
+        best->seq_num);
+    return best;
+}

--- a/src/core/ucc_team_cache.h
+++ b/src/core/ucc_team_cache.h
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TEAM_CACHE_H_
+#define UCC_TEAM_CACHE_H_
+
+#include "config.h"
+#include "ucc/api/ucc.h"
+#include "ucc/api/ucc_status.h"
+#include "utils/ucc_datastruct.h"
+#include "utils/ucc_list.h"
+#include "utils/ucc_spinlock.h"
+#include <stdint.h>
+
+/* Forward declaration to avoid pulling ucc_team.h and its heavy include chain */
+typedef struct ucc_team    ucc_team_t;
+typedef struct ucc_context ucc_context_t;
+
+/* Eviction policy (UCC_TEAM_CACHE_EVICTION). Enum order MUST match
+   ucc_team_cache_eviction_names[]. LFU/LRU evict the dormant team with the
+   smallest team->seq_num (fewest collectives served); UCC has no wall-clock
+   recency, so LRU is an accepted alias for LFU. */
+typedef enum ucc_team_cache_eviction_policy {
+    UCC_TEAM_CACHE_EVICTION_NONE =
+        0, /* never evict; skip admission at capacity */
+    UCC_TEAM_CACHE_EVICTION_FIFO = 1, /* evict oldest dormant (default) */
+    UCC_TEAM_CACHE_EVICTION_LFU =
+        2, /* evict least-used dormant (min seq_num) */
+    UCC_TEAM_CACHE_EVICTION_LRU = 3, /* accepted alias for LFU */
+} ucc_team_cache_eviction_policy_t;
+
+/* Non-zero iff @p is a usage-based (min seq_num) policy: LFU or its LRU alias. */
+#define UCC_TEAM_CACHE_EVICTION_IS_USAGE_BASED(_p)                             \
+    ((_p) == UCC_TEAM_CACHE_EVICTION_LFU || (_p) == UCC_TEAM_CACHE_EVICTION_LRU)
+
+/* String choices for UCC_TEAM_CACHE_EVICTION, indexed by the enum; NULL-terminated. */
+extern const char *ucc_team_cache_eviction_names[];
+
+/* Normalized team-cache identity built from a team's materialized membership.
+   @hash is membership-only so all same-membership teams share one bucket;
+   @ext_id and @instance_cookie are compared but not hashed. */
+typedef struct ucc_team_cache_identity {
+    uint64_t   hash;    /* membership-only bucket key; not a reuse guarantee */
+    ucc_rank_t size;    /* number of endpoints */
+    ucc_rank_t self_ep; /* caller's own endpoint (params->ep) */
+    uint16_t
+        ext_id; /* external id, or 0 for pool-id teams; compared not hashed */
+    /* Collectively-assigned, never-recycled stamp identifying the physical team
+       instance (MPI cids recycle; team->id alone cannot distinguish). Proposed by
+       team-rank 0 and distributed via the agreement vote; used only by the RESEAT /
+       dormant-derived path. 0 = unstamped. Compared by the agreement vote (not by
+       identity_equal), never hashed. */
+    uint64_t instance_cookie;
+    ucc_rank_t
+        *members; /* heap-owned, length == size; exact-compare material */
+} ucc_team_cache_identity_t;
+
+/* Build a normalized identity from team-create params (materializes membership
+   and computes the hash). On success @identity owns @members; free with
+   ucc_team_cache_identity_free(). Returns UCC_ERR_INVALID_PARAM if no usable map
+   is present, UCC_ERR_NO_MEMORY on allocation failure. */
+ucc_status_t ucc_team_cache_identity_build(
+    const ucc_team_params_t *params, ucc_team_cache_identity_t *identity);
+
+/* Exact compare (hash, size, self_ep, full members array): non-zero if equal. */
+int ucc_team_cache_identity_equal(
+    const ucc_team_cache_identity_t *a, const ucc_team_cache_identity_t *b);
+
+/* Membership-only compare (ignores ext_id): non-zero if @a and @b describe the
+   same member set. Used by lookup_live for coexistence/derived detection. */
+int ucc_team_cache_identity_equal_membership(
+    const ucc_team_cache_identity_t *a, const ucc_team_cache_identity_t *b);
+
+/* Release the owned @members array and zero the identity. Safe on a zeroed
+   identity and idempotent. */
+void ucc_team_cache_identity_free(ucc_team_cache_identity_t *identity);
+
+/* Non-zero iff a team is cacheable: every optional behavioral field (ORDERING,
+   OUTSTANDING_COLLS, SYNC_TYPE, P2P_CONN, MEM_PARAMS) is unset in params->mask. */
+int  ucc_team_cache_is_cacheable(const ucc_team_params_t *params);
+
+/* Cache action classified locally in create_post and reconciled across a team's
+   members by the agreement vote. RESEAT_DERIVED re-adopts a DORMANT derived team
+   by membership only (its cid drifted); it is gated by UCC_TEAM_CACHE_RESEAT
+   (default off, experimental) and relies on the vote reconciling the per-instance
+   cookie so all ranks selected the same physical instance. */
+typedef enum ucc_team_cache_action {
+    UCC_TEAM_CACHE_ACTION_MISS              = 0, /* fresh full build */
+    UCC_TEAM_CACHE_ACTION_EXACT_REUSE       = 1, /* re-adopt a DORMANT team */
+    UCC_TEAM_CACHE_ACTION_DERIVED_FROM_LIVE = 2, /* derive from a LIVE parent */
+    UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED = 3, /* re-adopt+reseat DORMANT derived
+                                                 (membership-only, cid drift) */
+} ucc_team_cache_action_t;
+
+/* Agreement vote: one UCC_OP_BAND allreduce over the team's members reconciles
+   the locally-classified action so every member reaches the same reuse-vs-fresh
+   decision. Lanes [1..8] are equality pairs (value, ~value) for action/key/cookie/
+   parent-cookie; lane [0] is "prepared"; lane [9] distributes rank-0's proposed
+   new cookie. A non-preparing rank contributes a BAND no-op (all-ones). */
+#define UCC_TEAM_CACHE_VOTE_LANES 10
+
+/* Fill a vote buffer for one preparing rank before the BAND allreduce. @cookie is
+   the candidate instance cookie (0 for EXACT_REUSE/MISS); @parent_cookie is the
+   parent's cookie for DERIVED/RESEAT (0 otherwise). @proposed_cookie is written to
+   the distribution lane by team-rank 0 only (others pass 0 with is_rank0=0). */
+void ucc_team_cache_vote_fill(
+    uint64_t *v, int prepared, ucc_team_cache_action_t action, uint64_t key,
+    uint64_t cookie, uint64_t parent_cookie, int is_rank0,
+    uint64_t proposed_cookie);
+
+/* Evaluate a BAND-reduced vote buffer; returns the agreed action, or MISS if the
+   members did not unanimously agree on action, key, and instance cookies. */
+ucc_team_cache_action_t ucc_team_cache_vote_result(const uint64_t *v);
+
+/* Read the distributed new-instance cookie (rank-0's proposed value) from a
+   BAND-reduced vote buffer. Valid on every member after the allreduce. */
+uint64_t                ucc_team_cache_vote_new_cookie(const uint64_t *v);
+
+/* Per-cache statistics counters. */
+typedef struct ucc_team_cache_stats {
+    uint64_t lookups;
+    uint64_t hits;
+    uint64_t misses;
+    uint64_t evictions;
+    uint64_t inserts;
+} ucc_team_cache_stats_t;
+
+/* Opaque communicator-cache container. All fields are protected by @lock. A team
+   on pending_destroy is on none of table/live/dormant, so lookup cannot re-adopt
+   it. Local eviction determinism is not required for correctness: the agreement
+   vote reconciles any per-rank hit/miss split into a consistent decision. */
+typedef struct ucc_team_cache {
+    void           *table; /* khash key64 -> ucc_team_t* */
+    ucc_list_link_t live;  /* LIVE teams by identity */
+    ucc_list_link_t
+        dormant; /* DORMANT teams; head = oldest (victim), tail = MRU */
+    ucc_list_link_t reserved; /* RESERVED teams pinned for an in-flight vote */
+    ucc_list_link_t
+                   pending_destroy; /* evicted teams awaiting UCC_OK teardown */
+    ucc_spinlock_t lock;
+    uint32_t       max_size;
+    uint32_t       size;
+    ucc_team_cache_eviction_policy_t eviction;
+    uint32_t disable_linear_check; /* UCC_TEAM_CACHE_DISABLE_LINEAR_CHECK */
+    uint32_t dump_stats;           /* UCC_TEAM_CACHE_DUMP_STATS */
+    uint32_t derived;              /* UCC_TEAM_CACHE_DERIVED (default on) */
+    uint32_t reseat;               /* UCC_TEAM_CACHE_RESEAT (default off) */
+    uint32_t agreement;            /* UCC_TEAM_CACHE_AGREEMENT (default on) */
+    /* Monotonic generation for per-instance cookies; bumped under @lock when
+       team-rank 0 stamps a fresh instance, seeded non-zero from the context
+       seq_num so cookies are distinct across contexts and never recycled. */
+    uint64_t cache_gen;
+    ucc_team_cache_stats_t stats;
+} ucc_team_cache_t;
+
+/* Reserve and return the next per-instance cookie from @cache->cache_gen. Called
+   only by team-rank 0 under @cache->lock; never returns 0 and never repeats. */
+uint64_t     ucc_team_cache_next_cookie(ucc_team_cache_t *cache);
+
+/* Allocate and initialise a new team cache. @disable_linear_check trusts the
+   64-bit hash alone in lookup (skips the exact rank-array compare). Returns
+   UCC_ERR_NO_MEMORY on allocation failure. */
+ucc_status_t ucc_team_cache_init(
+    ucc_team_cache_t **cache, uint32_t max_size,
+    ucc_team_cache_eviction_policy_t eviction, uint32_t disable_linear_check);
+
+/* Look up a DORMANT cached team by exact identity, or NULL on a miss. A LIVE team
+   is never returned (inactive-only reuse). Does not touch refcount. The caller
+   MUST hold @cache->lock across this and the following ucc_team_cache_get() so the
+   lookup->adopt window is atomic. */
+ucc_team_t *ucc_team_cache_lookup(
+    ucc_team_cache_t *cache, const ucc_team_cache_identity_t *id);
+
+/* Look up a LIVE cached team by identity (derived-create path): the parent whose
+   shared artifacts a derived team borrows. Does not touch refcount/state or stats.
+   While holding @cache->lock the caller MUST pin the parent's artifacts via
+   ucc_team_artifacts_get() and thereafter use only that holder plus parent->id. */
+ucc_team_t *ucc_team_cache_lookup_live(
+    ucc_team_cache_t *cache, const ucc_team_cache_identity_t *id);
+
+/* Look up a DORMANT DERIVED team by membership only, ignoring ext_id (RESEAT): a
+   dormant derived team keyed by a drifted cid is missed by the exact lookup. The
+   caller re-seats the returned team's id/tag domain to the new cid. Restricted to
+   derived dormant teams. Does not touch refcount/state or stats. Under @cache->lock. */
+ucc_team_t *ucc_team_cache_lookup_dormant_derived(
+    ucc_team_cache_t *cache, const ucc_team_cache_identity_t *id);
+
+/* Insert a team as DORMANT under its cache_identity (the caller immediately
+   re-adopts it to LIVE via ucc_team_cache_get()). A full cache skips the insert
+   and returns UCC_OK with cache_state left NONE. A hash-key collision chains the
+   team onto the bucket via team->bucket_link (tail-append = insertion order); an
+   exact-identity duplicate is refused. Under @cache->lock. Returns UCC_ERR_NO_MEMORY
+   if the khash table cannot grow. */
+ucc_status_t ucc_team_cache_insert(ucc_team_cache_t *cache, ucc_team_t *team);
+
+/* Adopt a DORMANT cached team: refcount++ and cache_state = LIVE. Forms the atomic
+   lookup->adopt step with ucc_team_cache_lookup(). Under @cache->lock. */
+void         ucc_team_cache_get(ucc_team_t *team);
+
+/* Release a LIVE cached team: refcount--. At zero, cache_state = DORMANT so a later
+   lookup can re-adopt it. Returns the new refcount. Under @cache->lock. */
+int          ucc_team_cache_put(ucc_team_t *team);
+
+/* Drain and free a team cache. Warns (does not assert) on residual entries; the
+   caller guarantees a full drain first. May be NULL (no-op). */
+void         ucc_team_cache_destroy(ucc_team_cache_t *cache);
+
+/* Pick the eviction victim from the dormant list per cache->eviction: FIFO returns
+   the list head (oldest); LFU/LRU returns the min-seq_num team (tie-break on the
+   older list position). NULL if the list is empty. The victim may differ per rank
+   under the usage-based policy, which the agreement vote reconciles. Under cache->lock. */
+ucc_team_t  *ucc_team_cache_pick_lru_victim(ucc_team_cache_t *cache);
+
+/* Per-context team registry helpers: the single source of truth for moves between
+   the live and dormant lists. Callers hold cache->lock; a cached team is on exactly
+   one of live/dormant, and on neither once removed. */
+
+/* Add @team to the LIVE registry (ACTIVE-insert and re-adopt paths). The team must
+   not already be on any list. Under cache->lock. */
+void         ucc_team_cache_registry_add_live(
+            ucc_team_cache_t *cache, ucc_team_t *team);
+
+/* Move @team from LIVE to DORMANT (intercepted destroy path). Under cache->lock. */
+void ucc_team_cache_registry_make_dormant(
+    ucc_team_cache_t *cache, ucc_team_t *team);
+
+/* Move @team from DORMANT to LIVE (re-adopt path). Under cache->lock. */
+void ucc_team_cache_registry_make_live(
+    ucc_team_cache_t *cache, ucc_team_t *team);
+
+/* Move @team from DORMANT to RESERVED, pinning it for an in-flight agreement vote.
+   It stays in the khash bucket with refcount unchanged so a vote-FAIL can roll it
+   back to DORMANT without a refcount race. Under cache->lock. */
+void ucc_team_cache_registry_make_reserved(
+    ucc_team_cache_t *cache, ucc_team_t *team);
+
+/* Remove @team from whichever registry list it is on (eviction / teardown drain).
+   After this the team is on neither list. Under cache->lock. */
+void ucc_team_cache_registry_remove(ucc_team_cache_t *cache, ucc_team_t *team);
+
+/* Erase @team from the khash bucket table and decrement cache->size (the registry_*
+   helpers only touch the list links). No-op if not present. Under cache->lock. */
+void ucc_team_cache_table_erase(ucc_team_cache_t *cache, ucc_team_t *team);
+
+/*
+ * The pending-destroy state machine (ucc_team_cache_evict_one and
+ * ucc_team_cache_progress_pending) is declared in ucc_team.h and defined in
+ * ucc_team.c, next to ucc_team_cache_drain, so it can reuse the file-local
+ * ucc_team_destroy_single teardown.
+ */
+
+/* Dump team-cache hit/miss/eviction counters to a single ucc_info line. Intended
+   for context destroy when UCC_TEAM_CACHE_DUMP_STATS is enabled. */
+void ucc_team_cache_dump_stats(ucc_team_cache_t *cache);
+
+#endif /* UCC_TEAM_CACHE_H_ */

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -765,11 +765,14 @@ void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len,
 
     if (verbosity >= UCC_LOG_LEVEL_DEBUG) {
         char task_info[64];
-        ucc_snprintf_safe(task_info, sizeof(task_info),
-                          " rank %u, ctx_rank %u, seq_num %d, req %p",
-                          team->rank,
-                          ucc_ep_map_eval(team->ctx_map, team->rank),
-                          task->seq_num, task);
+        ucc_snprintf_safe(
+            task_info,
+            sizeof(task_info),
+            " rank %u, ctx_rank %u, seq_num %d, req %p",
+            team->rank,
+            ucc_ep_map_eval(UCC_TEAM_CTX_MAP(team), team->rank),
+            task->seq_num,
+            task);
         strncat(str, task_info, len - strlen(str));
     }
 }

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -77,6 +77,7 @@ gtest_SOURCES =                           \
 	core/test_mc.cc                       \
 	core/test_mc_reduce.cc                \
 	core/test_team.cc                     \
+	core/test_team_cache.cc               \
 	core/test_schedule.cc                 \
 	core/test_topo.cc                     \
 	core/test_service_coll.cc             \

--- a/test/gtest/core/test_team_cache.cc
+++ b/test/gtest/core/test_team_cache.cc
@@ -1,0 +1,1985 @@
+/**
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+extern "C" {
+#include "core/ucc_team_cache.h"
+#include "core/ucc_team.h"
+#include "core/ucc_context.h"
+#include "utils/ucc_spinlock.h"
+}
+#include <common/test.h>
+#include <common/test_ucc.h>
+#include <vector>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <atomic>
+#include <random>
+
+/* Unit tests for the team-cache identity (build/hash/equal/free), the
+   cacheability policy, the locked cache API, eviction, and the agreement vote,
+   with no MPI job. */
+
+/* CB closure returning member[ep] from a heap vector (mimics OMPI coll/ucc's
+   rank_map_cb); freeable after build to prove identity does not retain it. */
+struct cb_ctx {
+    std::vector<ucc_rank_t> members;
+};
+
+static uint64_t member_cb(uint64_t ep, void *ctx)
+{
+    cb_ctx *c = static_cast<cb_ctx *>(ctx);
+    return (uint64_t)c->members[ep];
+}
+
+static ucc_team_params_t make_cb_params(cb_ctx *ctx, ucc_rank_t self_ep)
+{
+    ucc_team_params_t p;
+    memset(&p, 0, sizeof(p));
+    p.mask             = UCC_TEAM_PARAM_FIELD_EP_MAP | UCC_TEAM_PARAM_FIELD_EP;
+    p.ep               = self_ep;
+    p.ep_map.type      = UCC_EP_MAP_CB;
+    p.ep_map.ep_num    = ctx->members.size();
+    p.ep_map.cb.cb     = member_cb;
+    p.ep_map.cb.cb_ctx = ctx;
+    return p;
+}
+
+/* ARRAY+OOB style (UCC_EP_MAP_ARRAY): caller-owned array, no closure. */
+static ucc_team_params_t make_array_params(
+    ucc_rank_t *arr, ucc_rank_t size, ucc_rank_t self_ep)
+{
+    ucc_team_params_t p;
+    memset(&p, 0, sizeof(p));
+    p.mask             = UCC_TEAM_PARAM_FIELD_EP_MAP | UCC_TEAM_PARAM_FIELD_EP;
+    p.ep               = self_ep;
+    p.ep_map.type      = UCC_EP_MAP_ARRAY;
+    p.ep_map.ep_num    = size;
+    p.ep_map.array.map = arr;
+    p.ep_map.array.elem_size = sizeof(ucc_rank_t);
+    return p;
+}
+
+static ucc_team_params_t make_strided_params(
+    uint64_t start, int64_t stride, ucc_rank_t size, ucc_rank_t self_ep)
+{
+    ucc_team_params_t p;
+    memset(&p, 0, sizeof(p));
+    p.mask          = UCC_TEAM_PARAM_FIELD_EP_MAP | UCC_TEAM_PARAM_FIELD_EP;
+    p.ep            = self_ep;
+    p.ep_map.type   = UCC_EP_MAP_STRIDED;
+    p.ep_map.ep_num = size;
+    p.ep_map.strided.start  = start;
+    p.ep_map.strided.stride = stride;
+    return p;
+}
+
+/* ARRAY membership plus a caller-supplied external team id (FIELD_ID), as an
+   MPI communicator passes its context id. */
+static ucc_team_params_t make_array_id_params(
+    ucc_rank_t *arr, ucc_rank_t size, ucc_rank_t self_ep, uint64_t id)
+{
+    ucc_team_params_t p = make_array_params(arr, size, self_ep);
+    p.mask |= UCC_TEAM_PARAM_FIELD_ID;
+    p.id = id;
+    return p;
+}
+
+/* Zero-init an identity and build it from @p, asserting success.  Callers must
+   ucc_team_cache_identity_free the result. */
+static void build_identity(
+    const ucc_team_params_t &p, ucc_team_cache_identity_t &id)
+{
+    memset(&id, 0, sizeof(id));
+    ASSERT_EQ(UCC_OK, ucc_team_cache_identity_build(&p, &id));
+}
+
+/* Build a lookup key from ARRAY membership + external id. */
+static void build_id_key(
+    ucc_rank_t *arr, ucc_rank_t size, ucc_rank_t self_ep, uint64_t id,
+    ucc_team_cache_identity_t &key)
+{
+    ucc_team_params_t p = make_array_id_params(arr, size, self_ep, id);
+    build_identity(p, key);
+}
+
+/* Assert two params materialize to an equal identity (same hash AND
+   exact-compare equal).  Frees both identities. */
+static void expect_identities_equal(
+    const ucc_team_params_t &pa, const ucc_team_params_t &pb)
+{
+    ucc_team_cache_identity_t a, b;
+    build_identity(pa, a);
+    build_identity(pb, b);
+    EXPECT_EQ(a.hash, b.hash);
+    EXPECT_NE(0, ucc_team_cache_identity_equal(&a, &b));
+    ucc_team_cache_identity_free(&a);
+    ucc_team_cache_identity_free(&b);
+}
+
+/* RAII wrapper for ucc_team_cache_init/destroy; args match ucc_team_cache_init.
+   Implicitly usable as a ucc_team_cache_t*. */
+struct ScopedCache {
+    ucc_team_cache_t *cache = nullptr;
+
+    ScopedCache(
+        uint32_t max_size, ucc_team_cache_eviction_policy_t evict,
+        int disable_linear_check)
+    {
+        EXPECT_EQ(
+            UCC_OK,
+            ucc_team_cache_init(&cache, max_size, evict, disable_linear_check));
+    }
+    ~ScopedCache()
+    {
+        ucc_team_cache_destroy(cache);
+    }
+
+    operator ucc_team_cache_t *() const
+    {
+        return cache;
+    }
+    ucc_team_cache_t *operator->() const
+    {
+        return cache;
+    }
+};
+
+/* Save/restore an environment variable across a scope. */
+struct ScopedEnv {
+    std::string name;
+    std::string saved;
+    bool        had;
+
+    ScopedEnv(const char *n) : name(n)
+    {
+        const char *v = getenv(n);
+        had           = (v != nullptr);
+        if (had) {
+            saved = v;
+        }
+    }
+    ~ScopedEnv()
+    {
+        if (had) {
+            setenv(name.c_str(), saved.c_str(), 1);
+        } else {
+            unsetenv(name.c_str());
+        }
+    }
+};
+
+class test_team_cache : public ucc::test {};
+
+/* Identical membership + DIFFERENT external ids must NOT be full-equal (no
+   dormant reuse across id/tag domains), but must stay membership-equal so
+   coexistence/derived detection finds the live parent.  Same id -> fully equal. */
+UCC_TEST_F(test_team_cache, external_id_isolates_dormant_reuse)
+{
+    ucc_rank_t                arr[4] = {0, 1, 2, 3};
+    ucc_team_params_t         p3     = make_array_id_params(arr, 4, 1, 3);
+    ucc_team_params_t         p3b    = make_array_id_params(arr, 4, 1, 3);
+    ucc_team_params_t         p5     = make_array_id_params(arr, 4, 1, 5);
+
+    ucc_team_cache_identity_t a, b, c;
+    build_identity(p3, a);
+    build_identity(p3b, b);
+    build_identity(p5, c);
+
+    /* Membership-only hash: all three share a khash bucket. */
+    EXPECT_EQ(a.hash, b.hash);
+    EXPECT_EQ(a.hash, c.hash);
+
+    /* Same members + same id -> full match; different id -> no full match. */
+    EXPECT_NE(0, ucc_team_cache_identity_equal(&a, &b));
+    EXPECT_EQ(0, ucc_team_cache_identity_equal(&a, &c));
+    /* Membership matches regardless of id (derived/coexistence detection). */
+    EXPECT_NE(0, ucc_team_cache_identity_equal_membership(&a, &c));
+
+    ucc_team_cache_identity_free(&a);
+    ucc_team_cache_identity_free(&b);
+    ucc_team_cache_identity_free(&c);
+}
+
+/* Identity ignores ep_map style / closure pointers: two CB closures, CB vs
+   ARRAY, and FULL/STRIDED(0,1) vs ARRAY [0..size) all produce an equal identity. */
+UCC_TEST_F(test_team_cache, cross_style_cb_vs_array_equal)
+{
+    ucc_rank_t same[4] = {3, 5, 7, 9};
+    expect_identities_equal(
+        make_array_params(same, 4, 1), make_array_params(same, 4, 1));
+
+    /* Two distinct CB closures materializing the same members. */
+    cb_ctx c1, c2;
+    c1.members = {2, 4, 6, 8};
+    c2.members = {2, 4, 6, 8};
+    expect_identities_equal(make_cb_params(&c1, 0), make_cb_params(&c2, 0));
+
+    /* Cross-style: EP_MAP CB vs EP_MAP_ARRAY — same membership, different map type. */
+    cb_ctx c;
+    c.members          = {10, 20, 30};
+    ucc_rank_t arr3[3] = {10, 20, 30};
+    expect_identities_equal(
+        make_cb_params(&c, 2), make_array_params(arr3, 3, 2));
+
+    /* CB / ARRAY / FULL / STRIDED(0,1) over [0..5) must all be equal. */
+    ucc_rank_t arr[5] = {0, 1, 2, 3, 4};
+    cb_ctx     c5;
+    c5.members             = {0, 1, 2, 3, 4};
+    ucc_team_params_t pcb  = make_cb_params(&c5, 0);
+    ucc_team_params_t parr = make_array_params(arr, 5, 0);
+    ucc_team_params_t pstr = make_strided_params(0, 1, 5, 0);
+
+    ucc_team_params_t pfull;
+    memset(&pfull, 0, sizeof(pfull));
+    pfull.mask          = UCC_TEAM_PARAM_FIELD_EP_MAP | UCC_TEAM_PARAM_FIELD_EP;
+    pfull.ep            = 0;
+    pfull.ep_map.type   = UCC_EP_MAP_FULL;
+    pfull.ep_map.ep_num = 5;
+
+    ucc_team_cache_identity_t cb, a, b, full;
+    build_identity(pcb, cb);
+    build_identity(parr, a);
+    build_identity(pstr, b);
+    build_identity(pfull, full);
+
+    EXPECT_NE(0, ucc_team_cache_identity_equal(&a, &cb));
+    EXPECT_NE(0, ucc_team_cache_identity_equal(&a, &b));
+    EXPECT_NE(0, ucc_team_cache_identity_equal(&a, &full));
+
+    ucc_team_cache_identity_free(&cb);
+    ucc_team_cache_identity_free(&a);
+    ucc_team_cache_identity_free(&b);
+    ucc_team_cache_identity_free(&full);
+}
+
+/* Freeing/mutating the caller's closure and user array after build does not
+   change the identity (params are materialized, not retained). */
+UCC_TEST_F(test_team_cache, identity_owns_materialized_members)
+{
+    cb_ctx *c       = new cb_ctx();
+    c->members      = {11, 13, 17, 19};
+
+    ucc_rank_t *arr = (ucc_rank_t *)malloc(4 * sizeof(ucc_rank_t));
+    ASSERT_NE(nullptr, arr);
+    arr[0]          = 11;
+    arr[1]          = 13;
+    arr[2]          = 17;
+    arr[3]          = 19;
+
+    ucc_team_params_t         pcb  = make_cb_params(c, 3);
+    ucc_team_params_t         parr = make_array_params(arr, 4, 3);
+
+    ucc_team_cache_identity_t from_cb, from_arr, ref;
+    build_identity(pcb, from_cb);
+    build_identity(parr, from_arr);
+
+    ucc_rank_t        refarr[4] = {11, 13, 17, 19};
+    ucc_team_params_t pref      = make_array_params(refarr, 4, 3);
+    build_identity(pref, ref);
+
+    /* Destroy/mutate the caller-owned inputs. */
+    delete c;
+    arr[0] = 999;
+    arr[2] = 42;
+    free(arr);
+
+    EXPECT_EQ(ref.hash, from_cb.hash);
+    EXPECT_EQ(ref.hash, from_arr.hash);
+    EXPECT_NE(0, ucc_team_cache_identity_equal(&ref, &from_cb));
+    EXPECT_NE(0, ucc_team_cache_identity_equal(&ref, &from_arr));
+
+    ucc_team_cache_identity_free(&from_cb);
+    ucc_team_cache_identity_free(&from_arr);
+    ucc_team_cache_identity_free(&ref);
+}
+
+/* Differing membership -> not equal (size, self_ep, array contents, stride). */
+UCC_TEST_F(test_team_cache, differing_membership_not_equal)
+{
+    ucc_rank_t                base[4]     = {1, 2, 3, 4};
+    ucc_rank_t                diff_val[4] = {1, 2, 3, 5};
+    ucc_rank_t                diff_len[3] = {1, 2, 3};
+
+    ucc_team_params_t         pbase       = make_array_params(base, 4, 1);
+    ucc_team_params_t         pval        = make_array_params(diff_val, 4, 1);
+    ucc_team_params_t         plen        = make_array_params(diff_len, 3, 1);
+    ucc_team_params_t         pep         = make_array_params(base, 4, 2);
+    ucc_team_params_t         pstr1       = make_strided_params(0, 1, 4, 0);
+    ucc_team_params_t         pstr2       = make_strided_params(0, 2, 4, 0);
+
+    ucc_team_cache_identity_t base_id, val_id, len_id, ep_id, s1, s2;
+    build_identity(pbase, base_id);
+    build_identity(pval, val_id);
+    build_identity(plen, len_id);
+    build_identity(pep, ep_id);
+    build_identity(pstr1, s1);
+    build_identity(pstr2, s2);
+
+    EXPECT_EQ(0, ucc_team_cache_identity_equal(&base_id, &val_id));
+    EXPECT_EQ(0, ucc_team_cache_identity_equal(&base_id, &len_id));
+    EXPECT_EQ(0, ucc_team_cache_identity_equal(&base_id, &ep_id));
+    EXPECT_EQ(0, ucc_team_cache_identity_equal(&s1, &s2));
+
+    ucc_team_cache_identity_free(&base_id);
+    ucc_team_cache_identity_free(&val_id);
+    ucc_team_cache_identity_free(&len_id);
+    ucc_team_cache_identity_free(&ep_id);
+    ucc_team_cache_identity_free(&s1);
+    ucc_team_cache_identity_free(&s2);
+}
+
+/* Agreement vote: a UCC_OP_BAND allreduce over the members' fill buffers.  These
+   tests reduce N per-rank buffers with a local BAND and check vote_result +
+   vote_new_cookie without any network. */
+static void vote_band_reduce(
+    const std::vector<std::vector<uint64_t>> &in, uint64_t *out)
+{
+    for (int l = 0; l < UCC_TEAM_CACHE_VOTE_LANES; l++) {
+        out[l] = ~(uint64_t)0;
+    }
+    for (const auto &v : in) {
+        for (int l = 0; l < UCC_TEAM_CACHE_VOTE_LANES; l++) {
+            out[l] &= v[l];
+        }
+    }
+}
+
+/* All-hit agreement: RESEAT_DERIVED with a shared candidate cookie distributes
+   rank-0's new cookie; EXACT_REUSE ignores the cookie lane and still agrees. */
+UCC_TEST_F(test_team_cache, vote_agreement_and_cookie)
+{
+    uint64_t out[UCC_TEAM_CACHE_VOTE_LANES];
+
+    /* RESEAT_DERIVED, same cookie on every rank -> agree, cookie distributed. */
+    {
+        const int                          n = 4;
+        std::vector<std::vector<uint64_t>> in(
+            n, std::vector<uint64_t>(UCC_TEAM_CACHE_VOTE_LANES));
+        for (int r = 0; r < n; r++) {
+            ucc_team_cache_vote_fill(
+                in[r].data(),
+                /*prepared=*/1,
+                UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED,
+                /*key=*/0x1234,
+                /*cookie=*/0xABCDEF,
+                /*parent_cookie=*/0x77,
+                /*is_rank0=*/(r == 0),
+                /*proposed_cookie=*/0xFEED);
+        }
+        vote_band_reduce(in, out);
+        EXPECT_EQ(
+            UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED,
+            ucc_team_cache_vote_result(out));
+        EXPECT_EQ((uint64_t)0xFEED, ucc_team_cache_vote_new_cookie(out));
+    }
+
+    /* EXACT_REUSE with cookie=0 everywhere still agrees (ext_id pins instance). */
+    {
+        std::vector<std::vector<uint64_t>> in(
+            3, std::vector<uint64_t>(UCC_TEAM_CACHE_VOTE_LANES));
+        for (int r = 0; r < 3; r++) {
+            ucc_team_cache_vote_fill(
+                in[r].data(),
+                1,
+                UCC_TEAM_CACHE_ACTION_EXACT_REUSE,
+                0x55,
+                /*cookie=*/0,
+                /*parent_cookie=*/0,
+                /*is_rank0=*/(r == 0),
+                0x1);
+        }
+        vote_band_reduce(in, out);
+        EXPECT_EQ(
+            UCC_TEAM_CACHE_ACTION_EXACT_REUSE, ucc_team_cache_vote_result(out));
+    }
+}
+
+/* Two members hold DIFFERENT candidate cookies for the same membership -> the
+   cookie equality lane breaks -> global MISS, so no false reuse. */
+UCC_TEST_F(test_team_cache, vote_reseat_different_cookie_misses)
+{
+    std::vector<std::vector<uint64_t>> in(
+        2, std::vector<uint64_t>(UCC_TEAM_CACHE_VOTE_LANES));
+    uint64_t out[UCC_TEAM_CACHE_VOTE_LANES];
+
+    ucc_team_cache_vote_fill(
+        in[0].data(),
+        1,
+        UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED,
+        0x1234,
+        /*cookie=*/0xAAAA,
+        0x77,
+        /*is_rank0=*/1,
+        0xFEED);
+    ucc_team_cache_vote_fill(
+        in[1].data(),
+        1,
+        UCC_TEAM_CACHE_ACTION_RESEAT_DERIVED,
+        0x1234,
+        /*cookie=*/0xBBBB,
+        0x77,
+        /*is_rank0=*/0,
+        0);
+    vote_band_reduce(in, out);
+    EXPECT_EQ(UCC_TEAM_CACHE_ACTION_MISS, ucc_team_cache_vote_result(out));
+}
+
+/* A single miss rank (prepared=0) forces a global MISS even if every other rank
+   agrees, and rank-0's new-cookie proposal still survives for the fresh build. */
+UCC_TEST_F(test_team_cache, vote_one_miss_rank_forces_miss_keeps_cookie)
+{
+    std::vector<std::vector<uint64_t>> in(
+        3, std::vector<uint64_t>(UCC_TEAM_CACHE_VOTE_LANES));
+    uint64_t out[UCC_TEAM_CACHE_VOTE_LANES];
+
+    ucc_team_cache_vote_fill(
+        in[0].data(),
+        1,
+        UCC_TEAM_CACHE_ACTION_EXACT_REUSE,
+        0x1234,
+        0,
+        0,
+        /*is_rank0=*/1,
+        /*proposed_cookie=*/0x900D);
+    ucc_team_cache_vote_fill(
+        in[1].data(),
+        1,
+        UCC_TEAM_CACHE_ACTION_EXACT_REUSE,
+        0x1234,
+        0,
+        0,
+        /*is_rank0=*/0,
+        0);
+    ucc_team_cache_vote_fill(
+        in[2].data(),
+        /*prepared=*/0,
+        UCC_TEAM_CACHE_ACTION_MISS,
+        0,
+        0,
+        0,
+        /*is_rank0=*/0,
+        0);
+    vote_band_reduce(in, out);
+    EXPECT_EQ(UCC_TEAM_CACHE_ACTION_MISS, ucc_team_cache_vote_result(out));
+    EXPECT_EQ((uint64_t)0x900D, ucc_team_cache_vote_new_cookie(out));
+}
+
+/* next_cookie is strictly monotonic and never returns 0. */
+UCC_TEST_F(test_team_cache, next_cookie_monotonic_nonzero)
+{
+    ucc_team_cache_t c;
+    memset(&c, 0, sizeof(c));
+    c.cache_gen = 0;
+    uint64_t a  = ucc_team_cache_next_cookie(&c);
+    uint64_t b  = ucc_team_cache_next_cookie(&c);
+    EXPECT_NE((uint64_t)0, a);
+    EXPECT_NE((uint64_t)0, b);
+    EXPECT_LT(a, b);
+}
+
+static bool team_on_list(ucc_list_link_t *head, ucc_team_t *team)
+{
+    ucc_team_t *t;
+    ucc_list_for_each (t, head, cache_link) {
+        if (t == team) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Registry list-surgery matrix: add-live -> make-dormant -> make-live -> remove.
+   Asserts the team is on exactly one list (or none after remove) at each step. */
+UCC_TEST_F(test_team_cache, registry_add_dormant_live_remove)
+{
+    ScopedCache cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    ucc_team_t  team;
+    memset(&team, 0, sizeof(team));
+    ucc_list_head_init(&team.cache_link);
+
+    EXPECT_FALSE(team_on_list(&cache->live, &team));
+    EXPECT_FALSE(team_on_list(&cache->dormant, &team));
+
+    ucc_team_cache_registry_add_live(cache, &team);
+    EXPECT_TRUE(team_on_list(&cache->live, &team));
+    EXPECT_FALSE(team_on_list(&cache->dormant, &team));
+    EXPECT_FALSE(ucc_list_is_empty(&cache->live));
+
+    ucc_team_cache_registry_make_dormant(cache, &team);
+    EXPECT_FALSE(team_on_list(&cache->live, &team));
+    EXPECT_TRUE(team_on_list(&cache->dormant, &team));
+    EXPECT_TRUE(ucc_list_is_empty(&cache->live));
+    EXPECT_FALSE(ucc_list_is_empty(&cache->dormant));
+
+    ucc_team_cache_registry_make_live(cache, &team);
+    EXPECT_TRUE(team_on_list(&cache->live, &team));
+    EXPECT_FALSE(team_on_list(&cache->dormant, &team));
+
+    ucc_team_cache_registry_remove(cache, &team);
+    EXPECT_FALSE(team_on_list(&cache->live, &team));
+    EXPECT_FALSE(team_on_list(&cache->dormant, &team));
+    EXPECT_TRUE(ucc_list_is_empty(&cache->live));
+    EXPECT_TRUE(ucc_list_is_empty(&cache->dormant));
+}
+
+/* Cache API tests (lookup / insert / get / put) use bare stub teams with only
+   the cache-related fields initialized; they never call create_post. */
+
+/* Allocate and minimally initialize a stub team. refcount starts at 0 to match
+   the production convention for a cached DORMANT team; a test adopts it with
+   ucc_team_cache_get() (0 -> 1, LIVE) before releasing it with _put(). */
+static ucc_team_t *alloc_stub_team(void)
+{
+    ucc_team_t *t = (ucc_team_t *)calloc(1, sizeof(*t));
+    if (!t) {
+        return nullptr;
+    }
+    t->refcount    = 0; /* DORMANT convention (calloc already zeroes this) */
+    t->cache_state = UCC_TEAM_CACHE_STATE_NONE;
+    ucc_list_head_init(&t->cache_link);
+    ucc_list_head_init(&t->bucket_link);
+    memset(&t->cache_identity, 0, sizeof(t->cache_identity));
+    return t;
+}
+
+static void free_stub_team(ucc_team_t *t)
+{
+    ucc_team_cache_identity_free(&t->cache_identity);
+    free(t);
+}
+
+/* Detach a stub team from the table + registry.  Caller must hold cache->lock. */
+static void erase_stub(ucc_team_cache_t *cache, ucc_team_t *t)
+{
+    ucc_team_cache_table_erase(cache, t);
+    ucc_team_cache_registry_remove(cache, t);
+}
+
+/* Lock, erase, unlock, and free each team - the common stub teardown. */
+static void erase_and_free(
+    ucc_team_cache_t *cache, std::initializer_list<ucc_team_t *> teams)
+{
+    ucc_spin_lock(&cache->lock);
+    for (ucc_team_t *t : teams) {
+        erase_stub(cache, t);
+    }
+    ucc_spin_unlock(&cache->lock);
+    for (ucc_team_t *t : teams) {
+        free_stub_team(t);
+    }
+}
+
+/* lookup does NOT return a LIVE team: insert -> get (DORMANT->LIVE) -> miss. */
+UCC_TEST_F(test_team_cache, lookup_does_not_return_live)
+{
+    ScopedCache       cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    ucc_rank_t        arr[3] = {2, 4, 6};
+    ucc_team_params_t p      = make_array_params(arr, 3, 0);
+
+    ucc_team_t       *team   = alloc_stub_team();
+    ASSERT_NE(nullptr, team);
+    ASSERT_EQ(UCC_OK, ucc_team_cache_identity_build(&p, &team->cache_identity));
+
+    ucc_team_cache_identity_t key;
+    build_identity(p, key);
+
+    ucc_spin_lock(&cache->lock);
+    ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, team));
+    ucc_team_cache_get(team);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, team->cache_state);
+    ucc_team_t *found = ucc_team_cache_lookup(cache, &key);
+    ucc_spin_unlock(&cache->lock);
+
+    EXPECT_EQ(nullptr, found);
+    EXPECT_EQ(0u, cache->stats.hits);
+
+    ucc_team_cache_identity_free(&key);
+    erase_and_free(cache, {team});
+}
+
+/* Full-cache skip: second insert into a full max_size==1 cache stays NONE. */
+UCC_TEST_F(test_team_cache, full_cache_skip)
+{
+    ScopedCache       cache(1, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    ucc_rank_t        arr1[2] = {0, 1};
+    ucc_rank_t        arr2[2] = {2, 3};
+    ucc_team_params_t p1      = make_array_params(arr1, 2, 0);
+    ucc_team_params_t p2      = make_array_params(arr2, 2, 0);
+
+    ucc_team_t       *t1      = alloc_stub_team();
+    ucc_team_t       *t2      = alloc_stub_team();
+    ASSERT_NE(nullptr, t1);
+    ASSERT_NE(nullptr, t2);
+
+    ASSERT_EQ(UCC_OK, ucc_team_cache_identity_build(&p1, &t1->cache_identity));
+    ASSERT_EQ(UCC_OK, ucc_team_cache_identity_build(&p2, &t2->cache_identity));
+
+    ucc_spin_lock(&cache->lock);
+    EXPECT_EQ(UCC_OK, ucc_team_cache_insert(cache, t1));
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, t1->cache_state);
+    EXPECT_EQ(1u, cache->size);
+
+    EXPECT_EQ(UCC_OK, ucc_team_cache_insert(cache, t2));
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_NONE, t2->cache_state);
+    EXPECT_EQ(1u, cache->size);
+    ucc_spin_unlock(&cache->lock);
+
+    erase_and_free(cache, {t1}); /* t1 was inserted (DORMANT); remove before free */
+    free_stub_team(t2);          /* t2 was not inserted (NONE); free directly */
+}
+
+/* get/put refcount arithmetic and LIVE<->DORMANT transitions, using the
+   production convention (a cached DORMANT team has refcount 0):
+   insert->DORMANT rc=0; get->LIVE rc=1; put->DORMANT rc=0; then a two-user cycle
+   get,get->rc=2; put->LIVE rc=1; put->DORMANT rc=0. */
+UCC_TEST_F(test_team_cache, get_put_refcount_and_state)
+{
+    ScopedCache       cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    ucc_rank_t        arr[2] = {0, 1};
+    ucc_team_params_t p      = make_array_params(arr, 2, 0);
+
+    ucc_team_t       *team   = alloc_stub_team(); /* refcount 0 (DORMANT) */
+    ASSERT_NE(nullptr, team);
+    ASSERT_EQ(UCC_OK, ucc_team_cache_identity_build(&p, &team->cache_identity));
+
+    ucc_team_cache_identity_t key;
+    build_identity(p, key);
+
+    ucc_spin_lock(&cache->lock);
+    ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, team));
+    EXPECT_EQ(0, team->refcount);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, team->cache_state);
+
+    /* Adopt the dormant team: 0 -> 1, LIVE. */
+    ucc_team_cache_get(team);
+    ucc_team_cache_registry_make_live(cache, team);
+    EXPECT_EQ(1, team->refcount);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, team->cache_state);
+
+    /* Last user drops: 1 -> 0, DORMANT. */
+    EXPECT_EQ(0, ucc_team_cache_put(team));
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, team->cache_state);
+    ucc_team_cache_registry_make_dormant(cache, team);
+
+    /* A team that went LIVE then back to DORMANT is look-up-able again. */
+    EXPECT_EQ(team, ucc_team_cache_lookup(cache, &key));
+
+    /* Two live users need two puts to return to DORMANT. */
+    ucc_team_cache_get(team);
+    ucc_team_cache_registry_make_live(cache, team);
+    ucc_team_cache_get(team);
+    EXPECT_EQ(2, team->refcount);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, team->cache_state);
+
+    EXPECT_EQ(1, ucc_team_cache_put(team));
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, team->cache_state);
+    EXPECT_EQ(0, ucc_team_cache_put(team));
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, team->cache_state);
+    ucc_team_cache_registry_make_dormant(cache, team);
+    ucc_spin_unlock(&cache->lock);
+
+    ucc_team_cache_identity_free(&key);
+    erase_and_free(cache, {team});
+}
+
+/* is_cacheable: true when only EP_MAP/EP/OOB/etc are set; false when any
+   optional behavioral field is set.  FLAGS is ignored. */
+UCC_TEST_F(test_team_cache, is_cacheable_policy)
+{
+    ucc_rank_t        arr[2] = {0, 1};
+    ucc_team_params_t p      = make_array_params(arr, 2, 0);
+
+    EXPECT_NE(0, ucc_team_cache_is_cacheable(&p));
+
+    ucc_team_params_t pflags = p;
+    pflags.mask |= UCC_TEAM_PARAM_FIELD_FLAGS;
+    pflags.flags = 0x1;
+    EXPECT_NE(0, ucc_team_cache_is_cacheable(&pflags));
+
+    const uint64_t optional[] = {
+        UCC_TEAM_PARAM_FIELD_ORDERING,
+        UCC_TEAM_PARAM_FIELD_OUTSTANDING_COLLS,
+        UCC_TEAM_PARAM_FIELD_SYNC_TYPE,
+        UCC_TEAM_PARAM_FIELD_P2P_CONN,
+        UCC_TEAM_PARAM_FIELD_MEM_PARAMS,
+    };
+    for (size_t i = 0; i < sizeof(optional) / sizeof(optional[0]); i++) {
+        ucc_team_params_t po = p;
+        po.mask |= optional[i];
+        EXPECT_EQ(0, ucc_team_cache_is_cacheable(&po))
+            << "optional field index " << i << " should block caching";
+    }
+}
+
+/* Team-id pool bit helpers must be exact inverses at word boundaries: set one
+   boundary id, scan it back out, and the pool must be clear again.  (The
+   historical bug used id/64 for the release word, leaking multiples of 64.) */
+UCC_TEST_F(test_team_cache, id_pool_bit_boundaries)
+{
+    const int ids[] = {1, 63, 64, 65, 127, 128, 129, 191, 192};
+
+    for (int id : ids) {
+        uint64_t pool[4] = {0, 0, 0, 0}; /* covers ids 1..256 */
+
+        ucc_team_id_pool_set_bit(pool, id);
+
+        int set_words = 0;
+        for (int w = 0; w < 4; w++) {
+            if (pool[w]) {
+                set_words++;
+            }
+        }
+        EXPECT_EQ(1, set_words) << "id " << id << " set bits in multiple words";
+
+        int found = 0, pos = 0;
+        for (int w = 0; w < 4; w++) {
+            if ((pos = ucc_team_id_pool_ffs_clear(&pool[w])) > 0) {
+                found = w * 64 + pos;
+                break;
+            }
+        }
+        EXPECT_EQ(id, found)
+            << "released id " << id << " re-scanned as " << found;
+
+        for (int w = 0; w < 4; w++) {
+            EXPECT_EQ((uint64_t)0, pool[w])
+                << "id " << id << " left residue in word " << w;
+        }
+    }
+}
+
+/* Eviction correctness.  White-box tests drive pick_lru_victim directly under
+   cache->lock; integration tests use the real EP_MAP create path. */
+
+/* Build a stub team with @arr membership and insert it into @cache as DORMANT. */
+static ucc_team_t *insert_stub_dormant(
+    ucc_team_cache_t *cache, ucc_rank_t *arr, ucc_rank_t n, ucc_rank_t self_ep)
+{
+    ucc_team_params_t p = make_array_params(arr, n, self_ep);
+
+    ucc_team_t       *t = alloc_stub_team();
+    if (!t) {
+        return nullptr;
+    }
+    if (UCC_OK != ucc_team_cache_identity_build(&p, &t->cache_identity)) {
+        free_stub_team(t);
+        return nullptr;
+    }
+
+    ucc_spin_lock(&cache->lock);
+    ucc_status_t st = ucc_team_cache_insert(cache, t);
+    ucc_spin_unlock(&cache->lock);
+
+    if (st != UCC_OK || t->cache_state != UCC_TEAM_CACHE_STATE_DORMANT) {
+        free_stub_team(t);
+        return nullptr;
+    }
+    return t;
+}
+
+/* Insert three distinct-membership DORMANT stub teams (list order A,B,C). */
+static void insert_three_dormant(
+    ucc_team_cache_t *cache, ucc_team_t **tA, ucc_team_t **tB, ucc_team_t **tC)
+{
+    ucc_rank_t mA[3] = {10, 20, 30};
+    ucc_rank_t mB[3] = {11, 21, 31};
+    ucc_rank_t mC[3] = {12, 22, 32};
+    *tA              = insert_stub_dormant(cache, mA, 3, 0);
+    *tB              = insert_stub_dormant(cache, mB, 3, 0);
+    *tC              = insert_stub_dormant(cache, mC, 3, 0);
+    ASSERT_NE(nullptr, *tA);
+    ASSERT_NE(nullptr, *tB);
+    ASSERT_NE(nullptr, *tC);
+}
+
+/* RESERVED state (the agreement-vote pin): a DORMANT candidate moved to RESERVED
+   is off the dormant/live lists (lookup can't return it) but stays in the bucket
+   with refcount unchanged, so a vote-FAIL rolls it back to DORMANT and a vote-PASS
+   promotes it to LIVE via get (0 -> 1). */
+UCC_TEST_F(test_team_cache, reserved_state_pin_and_rollback)
+{
+    ScopedCache       cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+    ucc_rank_t        arr[3] = {10, 20, 30};
+    ucc_team_params_t p      = make_array_params(arr, 3, 0);
+
+    ucc_team_t *t = insert_stub_dormant(cache, arr, 3, 0); /* DORMANT rc=0 */
+    ASSERT_NE(nullptr, t);
+
+    ucc_team_cache_identity_t key;
+    build_identity(p, key);
+
+    ucc_spin_lock(&cache->lock);
+    ASSERT_EQ(t, ucc_team_cache_lookup(cache, &key));
+
+    /* Pin for an in-flight vote: DORMANT -> RESERVED, refcount untouched. */
+    ucc_team_cache_registry_make_reserved(cache, t);
+    t->cache_state = UCC_TEAM_CACHE_STATE_RESERVED;
+    EXPECT_EQ(0, t->refcount);
+    /* lookup is DORMANT-only: a RESERVED team must not be returned. */
+    EXPECT_EQ(nullptr, ucc_team_cache_lookup(cache, &key));
+
+    /* Vote FAIL: roll back RESERVED -> DORMANT, re-adoptable. */
+    ucc_team_cache_registry_make_dormant(cache, t);
+    t->cache_state = UCC_TEAM_CACHE_STATE_DORMANT;
+    EXPECT_EQ(t, ucc_team_cache_lookup(cache, &key));
+
+    /* Vote PASS: RESERVED -> LIVE via get (0 -> 1). */
+    ucc_team_cache_registry_make_reserved(cache, t);
+    t->cache_state = UCC_TEAM_CACHE_STATE_RESERVED;
+    ucc_team_cache_get(t);
+    ucc_team_cache_registry_make_live(cache, t);
+    EXPECT_EQ(1, t->refcount);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, t->cache_state);
+    EXPECT_EQ(
+        nullptr, ucc_team_cache_lookup(cache, &key)); /* LIVE not returned */
+    ucc_spin_unlock(&cache->lock);
+
+    ucc_team_cache_identity_free(&key);
+    erase_and_free(cache, {t});
+}
+
+/* Victim selection across policies: FIFO returns the insertion head and ignores
+   seq_num; LFU and its LRU alias return the least-used team (min seq_num) and
+   break ties by dormant-list order (earliest wins). */
+UCC_TEST_F(test_team_cache, evict_victim_selection)
+{
+    const struct {
+        ucc_team_cache_eviction_policy_t policy;
+        const char                      *name;
+    } cases[] = {
+        {UCC_TEAM_CACHE_EVICTION_FIFO, "fifo"},
+        {UCC_TEAM_CACHE_EVICTION_LFU, "lfu"},
+        {UCC_TEAM_CACHE_EVICTION_LRU, "lru"},
+    };
+
+    for (auto &c : cases) {
+        SCOPED_TRACE(c.name);
+        ScopedCache cache(8, c.policy, 0);
+
+        ucc_team_t *tA, *tB, *tC;
+        insert_three_dormant(cache, &tA, &tB, &tC);
+        ASSERT_EQ(3u, cache->size);
+
+        /* B is least-used. */
+        tA->seq_num = 10;
+        tB->seq_num = 3;
+        tC->seq_num = 20;
+
+        ucc_spin_lock(&cache->lock);
+        ucc_team_t *victim = ucc_team_cache_pick_lru_victim(cache);
+        ucc_spin_unlock(&cache->lock);
+
+        ucc_team_t *expect = (c.policy == UCC_TEAM_CACHE_EVICTION_FIFO) ? tA
+                                                                        : tB;
+        EXPECT_EQ(expect, victim);
+
+        /* Tie on the minimum: the usage policies pick the earliest dormant
+           entry (A); FIFO still returns the head. */
+        tA->seq_num = 3;
+        tB->seq_num = 3;
+        ucc_spin_lock(&cache->lock);
+        victim = ucc_team_cache_pick_lru_victim(cache);
+        ucc_spin_unlock(&cache->lock);
+        EXPECT_EQ(tA, victim);
+
+        erase_and_free(cache, {tA, tB, tC});
+    }
+}
+
+/* pick_lru_victim skips LIVE teams: adopt both -> dormant empty -> NULL;
+   release both -> a victim is returned. */
+UCC_TEST_F(test_team_cache, evict_skips_live_returns_no_resource)
+{
+    ScopedCache cache(8, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    ucc_rank_t  mA[2] = {100, 200};
+    ucc_rank_t  mB[2] = {101, 201};
+
+    ucc_team_t *tA    = insert_stub_dormant(cache, mA, 2, 0);
+    ucc_team_t *tB    = insert_stub_dormant(cache, mB, 2, 0);
+    ASSERT_NE(nullptr, tA);
+    ASSERT_NE(nullptr, tB);
+
+    ucc_spin_lock(&cache->lock);
+    ucc_team_cache_get(tA);
+    ucc_team_cache_registry_make_live(cache, tA);
+    ucc_team_cache_get(tB);
+    ucc_team_cache_registry_make_live(cache, tB);
+
+    EXPECT_EQ(nullptr, ucc_team_cache_pick_lru_victim(cache));
+
+    ucc_team_cache_put(tA);
+    ucc_team_cache_registry_make_dormant(cache, tA);
+    ucc_team_cache_put(tB);
+    ucc_team_cache_registry_make_dormant(cache, tB);
+
+    EXPECT_NE(nullptr, ucc_team_cache_pick_lru_victim(cache));
+    ucc_spin_unlock(&cache->lock);
+
+    erase_and_free(cache, {tA, tB});
+}
+
+/* Linear-check knob: disable_linear_check controls whether lookup runs the exact
+   rank-array compare after a hash match.  Collisions are injected by overwriting
+   the lookup key's hash. */
+
+/* disable=0 (safe): the exact compare rejects a collision as MISS.
+   disable=1 (trust-hash): the compare is skipped and the hash match returns. */
+UCC_TEST_F(test_team_cache, linear_check_on_rejects_collision)
+{
+    auto run_collision = [](int disable_linear_check, bool expect_hit) {
+        SCOPED_TRACE(
+            disable_linear_check ? "disable_linear_check=1 (trust-hash)"
+                                 : "disable_linear_check=0 (safe)");
+        ScopedCache cache(
+            16, UCC_TEAM_CACHE_EVICTION_FIFO, disable_linear_check);
+
+        ucc_rank_t  arrA[3] = {1, 2, 3};
+        ucc_team_t *teamA   = alloc_stub_team();
+        ASSERT_NE(nullptr, teamA);
+        ucc_team_params_t pA = make_array_params(arrA, 3, 0);
+        ASSERT_EQ(
+            UCC_OK, ucc_team_cache_identity_build(&pA, &teamA->cache_identity));
+
+        ucc_spin_lock(&cache->lock);
+        ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, teamA));
+        ucc_spin_unlock(&cache->lock);
+        EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, teamA->cache_state);
+
+        /* Lookup key {7,8,9}; hash overridden to teamA's to force a collision. */
+        ucc_rank_t                arrB[3] = {7, 8, 9};
+        ucc_team_params_t         pB      = make_array_params(arrB, 3, 0);
+        ucc_team_cache_identity_t keyB;
+        build_identity(pB, keyB);
+
+        ASSERT_NE(teamA->cache_identity.hash, keyB.hash);
+        keyB.hash = teamA->cache_identity.hash;
+
+        ucc_spin_lock(&cache->lock);
+        ucc_team_t *found = ucc_team_cache_lookup(cache, &keyB);
+        ucc_spin_unlock(&cache->lock);
+
+        if (expect_hit) {
+            EXPECT_EQ(teamA, found);
+            EXPECT_EQ(1u, cache->stats.hits);
+            EXPECT_EQ(0u, cache->stats.misses);
+        } else {
+            EXPECT_EQ(nullptr, found);
+            EXPECT_EQ(1u, cache->stats.misses);
+            EXPECT_EQ(0u, cache->stats.hits);
+        }
+
+        ucc_team_cache_identity_free(&keyB);
+        erase_and_free(cache, {teamA});
+    };
+
+    run_collision(/*disable_linear_check=*/0, /*expect_hit=*/false);
+    run_collision(/*disable_linear_check=*/1, /*expect_hit=*/true);
+}
+
+/* Trust-hash mode skips the membership compare but NOT the ext_id compare, so a
+   dormant team under one ext_id is not re-adopted for a different ext_id. */
+UCC_TEST_F(test_team_cache, linear_check_off_still_honors_ext_id)
+{
+    ScopedCache cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 1);
+
+    ucc_rank_t  arr[3] = {1, 2, 3};
+    ucc_team_t *teamA  = alloc_stub_team();
+    ASSERT_NE(nullptr, teamA);
+    ucc_team_params_t pA = make_array_id_params(arr, 3, 0, 7);
+    ASSERT_EQ(
+        UCC_OK, ucc_team_cache_identity_build(&pA, &teamA->cache_identity));
+
+    ucc_spin_lock(&cache->lock);
+    ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, teamA));
+    ucc_spin_unlock(&cache->lock);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, teamA->cache_state);
+
+    /* Same membership, DIFFERENT external id -> same hash, different ext_id. */
+    ucc_team_cache_identity_t keyB;
+    build_id_key(arr, 3, 0, 8, keyB);
+
+    ASSERT_EQ(teamA->cache_identity.hash, keyB.hash);
+    ASSERT_NE(teamA->cache_identity.ext_id, keyB.ext_id);
+
+    ucc_spin_lock(&cache->lock);
+    ucc_team_t *found = ucc_team_cache_lookup(cache, &keyB);
+    ucc_spin_unlock(&cache->lock);
+
+    EXPECT_EQ(nullptr, found)
+        << "trust-hash mode must still reject a differing ext_id";
+    EXPECT_EQ(1u, cache->stats.misses);
+    EXPECT_EQ(0u, cache->stats.hits);
+
+    ucc_team_cache_identity_free(&keyB);
+    erase_and_free(cache, {teamA});
+}
+
+/* All counters start zeroed; insert/hit/miss/hit-after-put accumulate them as
+   expected.  Also folds the insert->DORMANT + size==1 postcondition. */
+UCC_TEST_F(test_team_cache, stats_accumulate_correctly)
+{
+    ScopedCache cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    EXPECT_EQ(0u, cache->stats.lookups);
+    EXPECT_EQ(0u, cache->stats.hits);
+    EXPECT_EQ(0u, cache->stats.misses);
+    EXPECT_EQ(0u, cache->stats.inserts);
+    EXPECT_EQ(0u, cache->stats.evictions);
+
+    ucc_rank_t        arr1[2] = {0, 1};
+    ucc_rank_t        arr2[3] = {0, 1, 2};
+    ucc_team_params_t p1      = make_array_params(arr1, 2, 0);
+    ucc_team_params_t p2      = make_array_params(arr2, 3, 0);
+
+    ucc_team_t       *t1      = alloc_stub_team();
+    ucc_team_t       *t2      = alloc_stub_team();
+    ASSERT_NE(nullptr, t1);
+    ASSERT_NE(nullptr, t2);
+
+    ASSERT_EQ(UCC_OK, ucc_team_cache_identity_build(&p1, &t1->cache_identity));
+    ASSERT_EQ(UCC_OK, ucc_team_cache_identity_build(&p2, &t2->cache_identity));
+
+    ucc_team_cache_identity_t k1, k2;
+    build_identity(p1, k1);
+    build_identity(p2, k2);
+
+    ucc_spin_lock(&cache->lock);
+
+    /* Insert t1: DORMANT, size 1, one insert, no lookup counted. */
+    EXPECT_EQ(UCC_OK, ucc_team_cache_insert(cache, t1));
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, t1->cache_state);
+    EXPECT_EQ(1u, cache->size);
+    EXPECT_EQ(1u, cache->stats.inserts);
+    EXPECT_EQ(0u, cache->stats.lookups);
+
+    /* Lookup t1 (hit). */
+    EXPECT_EQ(t1, ucc_team_cache_lookup(cache, &k1));
+    EXPECT_EQ(1u, cache->stats.lookups);
+    EXPECT_EQ(1u, cache->stats.hits);
+    EXPECT_EQ(0u, cache->stats.misses);
+
+    /* Lookup t2 identity (miss, not inserted). */
+    EXPECT_EQ(nullptr, ucc_team_cache_lookup(cache, &k2));
+    EXPECT_EQ(2u, cache->stats.lookups);
+    EXPECT_EQ(1u, cache->stats.hits);
+    EXPECT_EQ(1u, cache->stats.misses);
+
+    /* Insert t2. */
+    EXPECT_EQ(UCC_OK, ucc_team_cache_insert(cache, t2));
+    EXPECT_EQ(2u, cache->stats.inserts);
+
+    /* Lookup t1 again (another hit). */
+    EXPECT_EQ(t1, ucc_team_cache_lookup(cache, &k1));
+    EXPECT_EQ(3u, cache->stats.lookups);
+    EXPECT_EQ(2u, cache->stats.hits);
+    EXPECT_EQ(1u, cache->stats.misses);
+
+    ucc_spin_unlock(&cache->lock);
+
+    ucc_team_cache_identity_free(&k1);
+    ucc_team_cache_identity_free(&k2);
+    erase_and_free(cache, {t1, t2});
+}
+
+/* dump_stats executes without fault (indirectly validates the format string),
+   including the zero-lookups divide-by-zero guard and the NULL no-op. */
+UCC_TEST_F(test_team_cache, dump_stats_prints_all_fields)
+{
+    ScopedCache cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    ucc_spin_lock(&cache->lock);
+    cache->stats.lookups   = 100;
+    cache->stats.hits      = 80;
+    cache->stats.misses    = 20;
+    cache->stats.inserts   = 50;
+    cache->stats.evictions = 10;
+    ucc_spin_unlock(&cache->lock);
+    ucc_team_cache_dump_stats(cache);
+
+    ucc_spin_lock(&cache->lock);
+    cache->stats.lookups = 0;
+    ucc_spin_unlock(&cache->lock);
+    ucc_team_cache_dump_stats(cache);
+
+    ucc_team_cache_dump_stats(nullptr);
+}
+
+/* Cache-concurrency stress: overlapping create_post on the same context is
+   invalid; cache->lock guards concurrent DESTROY/LOOKUP/CREATE on different
+   contexts.  These tests drive the locked cache API directly from std::threads.
+   Gated on >= 2 OS threads (the cache spinlock is compiled unconditionally). */
+static bool cache_concurrency_runnable(void)
+{
+    unsigned hw = std::thread::hardware_concurrency();
+    return (hw == 0) || (hw >= 2);
+}
+
+/* Build @n stub teams with pairwise-distinct membership (rank[j] = i*@stride + j,
+   size 2 + i % @size_mod) and refcount 0.  Identities are built but the teams are
+   not inserted.  members[] backs the identities and must outlive the teams. */
+static void build_distinct_stub_teams(
+    std::vector<ucc_team_t *>            &teams,
+    std::vector<std::vector<ucc_rank_t>> &members, int n, int stride,
+    int size_mod)
+{
+    for (int i = 0; i < n; i++) {
+        int sz = 2 + (i % size_mod);
+        members[i].resize(sz);
+        for (int j = 0; j < sz; j++) {
+            members[i][j] = (ucc_rank_t)(i * stride + j);
+        }
+        ucc_team_params_t p = make_array_params(
+            members[i].data(), (ucc_rank_t)sz, 0);
+
+        teams[i] = alloc_stub_team();
+        ASSERT_NE(nullptr, teams[i]);
+        teams[i]->refcount = 0;
+        ASSERT_EQ(
+            UCC_OK,
+            ucc_team_cache_identity_build(&p, &teams[i]->cache_identity));
+    }
+}
+
+/* Erase each resident stub under the lock and free it - concurrency teardown. */
+static void drain_stub_teams(
+    ucc_team_cache_t *cache, std::vector<ucc_team_t *> &teams)
+{
+    for (auto *t : teams) {
+        ucc_spin_lock(&cache->lock);
+        erase_stub(cache, t);
+        ucc_spin_unlock(&cache->lock);
+        free_stub_team(t);
+    }
+}
+
+/* Contended DESTROY + LOOKUP path.  A pool of DORMANT stub teams; N threads
+   race, each iteration under cache->lock: lookup, adopt on a DORMANT hit
+   (get + make_live), then release (put + make_dormant on last drop).  A LIVE team
+   is never handed out twice (tracked via a per-team owner flag).  After join:
+   every team DORMANT, refcount 0, cache->size unchanged. */
+UCC_TEST_F(test_team_cache, concurrent_lookup_adopt_release_stress)
+{
+    if (!cache_concurrency_runnable()) {
+        GTEST_SKIP() << "host lacks >= 2 concurrent threads for cache stress";
+    }
+
+    const char *iters_env   = std::getenv("UCC_GTEST_CACHE_STRESS_ITERS");
+    const char *threads_env = std::getenv("UCC_GTEST_CACHE_STRESS_THREADS");
+    const int   n_iters     = iters_env ? std::atoi(iters_env) : 500;
+    const int   n_threads   = threads_env ? std::atoi(threads_env) : 8;
+    const int   n_teams     = 16;
+
+    ScopedCache cache(64, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    std::vector<ucc_team_t *>              teams(n_teams);
+    std::vector<ucc_team_cache_identity_t> keys(n_teams);
+    std::vector<std::vector<ucc_rank_t>>   members(n_teams);
+    std::vector<std::atomic<bool>>         owned(n_teams);
+
+    build_distinct_stub_teams(
+        teams,
+        members,
+        n_teams,
+        /*stride=*/0,
+        /*size_mod=*/n_teams);
+    for (int i = 0; i < n_teams; i++) {
+        ucc_spin_lock(&cache->lock);
+        ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, teams[i]));
+        ucc_spin_unlock(&cache->lock);
+        ASSERT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, teams[i]->cache_state);
+
+        ucc_team_params_t p = make_array_params(
+            members[i].data(), (ucc_rank_t)members[i].size(), 0);
+        build_identity(p, keys[i]);
+        owned[i].store(false);
+    }
+
+    const uint32_t    size_before = cache->size;
+
+    std::atomic<bool> double_adopt{false};
+    std::atomic<bool> bad_refcount{false};
+
+    auto              worker = [&](int seed) {
+        std::mt19937 rng((unsigned)(seed * 2654435761u + 1));
+        for (int it = 0; it < n_iters; it++) {
+            int idx = rng() % n_teams;
+
+            /* Adopt phase: lookup -> get -> make_live, all under the lock. */
+            ucc_spin_lock(&cache->lock);
+            ucc_team_t *t = ucc_team_cache_lookup(cache, &keys[idx]);
+            if (t != nullptr) {
+                if (t->cache_state != UCC_TEAM_CACHE_STATE_DORMANT ||
+                    t->refcount != 0) {
+                    bad_refcount.store(true);
+                }
+                ucc_team_cache_get(t);
+                ucc_team_cache_registry_make_live(cache, t);
+            }
+            ucc_spin_unlock(&cache->lock);
+
+            if (t == nullptr) {
+                continue; /* another thread holds it live: legal miss */
+            }
+
+            /* Only one thread may hold this team live at a time. */
+            if (owned[idx].exchange(true)) {
+                double_adopt.store(true);
+            }
+            std::this_thread::yield();
+            owned[idx].store(false);
+
+            /* Release phase: put -> make_dormant on last drop. */
+            ucc_spin_lock(&cache->lock);
+            int rc = ucc_team_cache_put(t);
+            if (rc < 0) {
+                bad_refcount.store(true);
+            }
+            if (rc == 0) {
+                ucc_team_cache_registry_make_dormant(cache, t);
+            }
+            ucc_spin_unlock(&cache->lock);
+        }
+    };
+
+    std::vector<std::thread> pool;
+    for (int i = 0; i < n_threads; i++) {
+        pool.emplace_back(worker, i);
+    }
+    for (auto &th : pool) {
+        th.join();
+    }
+
+    EXPECT_FALSE(double_adopt.load())
+        << "a LIVE team was adopted by two threads concurrently";
+    EXPECT_FALSE(bad_refcount.load())
+        << "cache refcount/state invariant violated under concurrency";
+
+    EXPECT_EQ(size_before, cache->size);
+    for (int i = 0; i < n_teams; i++) {
+        EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, teams[i]->cache_state)
+            << "team " << i << " must settle back to DORMANT";
+        EXPECT_EQ(0, teams[i]->refcount)
+            << "team " << i << " refcount must settle to 0";
+    }
+
+    for (int i = 0; i < n_teams; i++) {
+        ucc_team_cache_identity_free(&keys[i]);
+    }
+    drain_stub_teams(cache, teams);
+}
+
+/* Chained-bucket invariants and derived-team lookups (stub teams + identity
+   injection). */
+
+/* Allocate a stub team with @arr membership and external id @ext_id. */
+static ucc_team_t *alloc_stub_team_with_id(
+    ucc_rank_t *arr, ucc_rank_t n, ucc_rank_t self_ep, uint64_t ext_id)
+{
+    ucc_team_params_t p = make_array_id_params(arr, n, self_ep, ext_id);
+
+    ucc_team_t       *t = alloc_stub_team();
+    if (!t) {
+        return nullptr;
+    }
+    if (UCC_OK != ucc_team_cache_identity_build(&p, &t->cache_identity)) {
+        free(t);
+        return nullptr;
+    }
+    return t;
+}
+
+/* Allocate an is_derived stub team with @arr membership and external id @ext_id. */
+static ucc_team_t *alloc_stub_derived_team(
+    ucc_rank_t *arr, ucc_rank_t n, ucc_rank_t self_ep, uint64_t ext_id)
+{
+    ucc_team_t *t = alloc_stub_team_with_id(arr, n, self_ep, ext_id);
+    if (t) {
+        t->is_derived = 1;
+    }
+    return t;
+}
+
+/* Same membership, different ext_ids chain in one membership-only bucket: each
+   insert increments size (not de-duped), full-identity lookup finds each by
+   ext_id, and head + sibling erase collapse the chain and drop size correctly. */
+UCC_TEST_F(test_team_cache, chained_bucket_same_membership_different_ext_id)
+{
+    ScopedCache cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    ucc_rank_t  arr[3] = {1, 2, 3};
+
+    ucc_team_t *t10    = alloc_stub_team_with_id(arr, 3, 0, 10);
+    ucc_team_t *t20    = alloc_stub_team_with_id(arr, 3, 0, 20);
+    ucc_team_t *t30    = alloc_stub_team_with_id(arr, 3, 0, 30);
+    ASSERT_NE(nullptr, t10);
+    ASSERT_NE(nullptr, t20);
+    ASSERT_NE(nullptr, t30);
+
+    ASSERT_EQ(t10->cache_identity.hash, t20->cache_identity.hash);
+    ASSERT_EQ(t10->cache_identity.hash, t30->cache_identity.hash);
+    ASSERT_NE(t10->cache_identity.ext_id, t20->cache_identity.ext_id);
+    ASSERT_NE(t10->cache_identity.ext_id, t30->cache_identity.ext_id);
+
+    ucc_spin_lock(&cache->lock);
+
+    EXPECT_EQ(UCC_OK, ucc_team_cache_insert(cache, t10));
+    EXPECT_EQ(1u, cache->size);
+    EXPECT_EQ(UCC_OK, ucc_team_cache_insert(cache, t20));
+    EXPECT_EQ(2u, cache->size);
+    EXPECT_EQ(UCC_OK, ucc_team_cache_insert(cache, t30));
+    EXPECT_EQ(3u, cache->size);
+
+    ucc_team_cache_identity_t key10, key20, key30;
+    build_id_key(arr, 3, 0, 10, key10);
+    build_id_key(arr, 3, 0, 20, key20);
+    build_id_key(arr, 3, 0, 30, key30);
+
+    /* Each is independently reachable, and repeated lookups are side-effect free. */
+    EXPECT_EQ(t10, ucc_team_cache_lookup(cache, &key10));
+    EXPECT_EQ(t20, ucc_team_cache_lookup(cache, &key20));
+    EXPECT_EQ(t30, ucc_team_cache_lookup(cache, &key30));
+    EXPECT_EQ(t10, ucc_team_cache_lookup(cache, &key10));
+    EXPECT_EQ(t30, ucc_team_cache_lookup(cache, &key30));
+
+    /* Erase the chain head (t10): t20 is promoted; size drops by one. */
+    ucc_team_cache_table_erase(cache, t10);
+    EXPECT_EQ(2u, cache->size);
+    EXPECT_EQ(nullptr, ucc_team_cache_lookup(cache, &key10));
+    EXPECT_EQ(t20, ucc_team_cache_lookup(cache, &key20));
+    EXPECT_EQ(t30, ucc_team_cache_lookup(cache, &key30));
+
+    /* Erase a non-head sibling (t30). */
+    ucc_team_cache_table_erase(cache, t30);
+    EXPECT_EQ(1u, cache->size);
+    EXPECT_EQ(nullptr, ucc_team_cache_lookup(cache, &key30));
+    EXPECT_EQ(t20, ucc_team_cache_lookup(cache, &key20));
+
+    /* Erase the last entry (t20): bucket removed. */
+    ucc_team_cache_table_erase(cache, t20);
+    EXPECT_EQ(0u, cache->size);
+    EXPECT_EQ(nullptr, ucc_team_cache_lookup(cache, &key20));
+
+    ucc_spin_unlock(&cache->lock);
+
+    ucc_team_cache_identity_free(&key10);
+    ucc_team_cache_identity_free(&key20);
+    ucc_team_cache_identity_free(&key30);
+    free_stub_team(t10);
+    free_stub_team(t20);
+    free_stub_team(t30);
+}
+
+/* lookup_live returns a LIVE same-membership sibling (skipping the dormant one),
+   and returns NULL once no live sibling remains (the parent-gone guard). */
+UCC_TEST_F(test_team_cache, lookup_live_returns_live_sibling)
+{
+    ScopedCache cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    ucc_rank_t  arr[3]    = {10, 20, 30};
+
+    ucc_team_t *t_dormant = alloc_stub_team_with_id(arr, 3, 0, 10);
+    ucc_team_t *t_live    = alloc_stub_team_with_id(arr, 3, 0, 20);
+    ASSERT_NE(nullptr, t_dormant);
+    ASSERT_NE(nullptr, t_live);
+    ASSERT_EQ(t_dormant->cache_identity.hash, t_live->cache_identity.hash);
+
+    ucc_spin_lock(&cache->lock);
+
+    ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, t_dormant));
+    ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, t_live));
+    EXPECT_EQ(2u, cache->size);
+
+    ucc_team_cache_get(t_live);
+    ucc_team_cache_registry_make_live(cache, t_live);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, t_live->cache_state);
+
+    ucc_team_cache_identity_t key;
+    build_id_key(arr, 3, 0, 10, key);
+
+    /* Full-identity lookup returns the DORMANT team; lookup_live returns the
+       LIVE sibling, skipping the dormant one. */
+    EXPECT_EQ(t_dormant, ucc_team_cache_lookup(cache, &key));
+    EXPECT_EQ(t_live, ucc_team_cache_lookup_live(cache, &key));
+
+    /* Release the live sibling to dormant: no live sibling -> lookup_live NULL. */
+    ucc_team_cache_put(t_live);
+    ucc_team_cache_registry_make_dormant(cache, t_live);
+    EXPECT_EQ(nullptr, ucc_team_cache_lookup_live(cache, &key));
+
+    erase_stub(cache, t_dormant);
+    erase_stub(cache, t_live);
+    ucc_spin_unlock(&cache->lock);
+
+    ucc_team_cache_identity_free(&key);
+    free_stub_team(t_dormant);
+    free_stub_team(t_live);
+}
+
+/* lookup_dormant_derived returns the FIRST dormant derived team in chain
+   (insertion) order, skipping LIVE derived teams and non-derived base teams, and
+   advances deterministically as heads are erased, then returns NULL when empty. */
+UCC_TEST_F(test_team_cache, lookup_dormant_derived_selection)
+{
+    ScopedCache cache(16, UCC_TEAM_CACHE_EVICTION_FIFO, 0);
+
+    ucc_rank_t  arr[4]         = {10, 20, 30, 40};
+
+    /* Non-derived dormant base (ineligible), LIVE derived (ineligible), and two
+       DORMANT derived teams that are the valid targets, in insertion order. */
+    ucc_team_t *t_base         = alloc_stub_team_with_id(arr, 4, 0, 10);
+    ucc_team_t *t_live_derived = alloc_stub_derived_team(arr, 4, 0, 20);
+    ucc_team_t *t_d1           = alloc_stub_derived_team(arr, 4, 0, 30);
+    ucc_team_t *t_d2           = alloc_stub_derived_team(arr, 4, 0, 40);
+    ASSERT_NE(nullptr, t_base);
+    ASSERT_NE(nullptr, t_live_derived);
+    ASSERT_NE(nullptr, t_d1);
+    ASSERT_NE(nullptr, t_d2);
+    t_base->is_derived = 0;
+
+    ASSERT_EQ(t_base->cache_identity.hash, t_live_derived->cache_identity.hash);
+    ASSERT_EQ(t_base->cache_identity.hash, t_d1->cache_identity.hash);
+    ASSERT_EQ(t_base->cache_identity.hash, t_d2->cache_identity.hash);
+
+    ucc_spin_lock(&cache->lock);
+
+    ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, t_base));
+    ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, t_live_derived));
+    ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, t_d1));
+    ASSERT_EQ(UCC_OK, ucc_team_cache_insert(cache, t_d2));
+    EXPECT_EQ(4u, cache->size);
+
+    ucc_team_cache_get(t_live_derived);
+    ucc_team_cache_registry_make_live(cache, t_live_derived);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, t_live_derived->cache_state);
+
+    /* Drifted key: same membership, ext_id=99 (no exact match). */
+    ucc_team_cache_identity_t key;
+    build_id_key(arr, 4, 0, 99, key);
+
+    /* Exact lookup misses (membership matches but full identity does not). */
+    EXPECT_EQ(nullptr, ucc_team_cache_lookup(cache, &key));
+
+    /* Only the DORMANT derived teams are eligible; the first in chain order is
+       returned, skipping the LIVE derived and the non-derived base. */
+    ucc_team_t *found = ucc_team_cache_lookup_dormant_derived(cache, &key);
+    EXPECT_EQ(t_d1, found);
+    ASSERT_NE(nullptr, found);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, found->cache_state);
+    EXPECT_EQ(1, found->is_derived);
+    EXPECT_NE(t_live_derived, found);
+    EXPECT_NE(t_base, found);
+
+    /* Idempotent without mutation. */
+    EXPECT_EQ(t_d1, ucc_team_cache_lookup_dormant_derived(cache, &key));
+
+    /* Consuming the head advances to the next dormant derived, then NULL. */
+    erase_stub(cache, t_d1);
+    EXPECT_EQ(t_d2, ucc_team_cache_lookup_dormant_derived(cache, &key));
+    erase_stub(cache, t_d2);
+    EXPECT_EQ(nullptr, ucc_team_cache_lookup_dormant_derived(cache, &key))
+        << "no eligible target: only a LIVE derived and a non-derived base "
+           "remain";
+
+    ucc_team_cache_put(t_live_derived);
+    ucc_team_cache_registry_make_dormant(cache, t_live_derived);
+    erase_stub(cache, t_base);
+    erase_stub(cache, t_live_derived);
+    ucc_spin_unlock(&cache->lock);
+
+    ucc_team_cache_identity_free(&key);
+    free_stub_team(t_base);
+    free_stub_team(t_live_derived);
+    free_stub_team(t_d1);
+    free_stub_team(t_d2);
+}
+
+/* Integration tests: full create->use->destroy->recreate cycle through
+   UccJob/UccTeam (real create_post / create_test / destroy).  White-box access
+   to ucc_team_t.cache_state and ucc_context_t.team_cache asserts dormant-reuse
+   invariants.  Caching is enabled per-test via the UccJob env-var mechanism. */
+class test_team_cache_integration : public ucc::test {};
+
+/* Return the underlying ucc_team_t* from a per-process team handle. */
+static ucc_team_t *team_ptr(UccTeam_h &team, int proc_idx = 0)
+{
+    return (ucc_team_t *)team->procs[proc_idx].team;
+}
+
+/* Return the ucc_context_t* for the given process in a team. */
+static ucc_context_t *ctx_ptr(UccTeam_h &team, int proc_idx = 0)
+{
+    return (ucc_context_t *)team->procs[proc_idx].p.get()->ctx_h;
+}
+
+/* Run a single barrier collective on a team and assert it completes. */
+static void run_barrier(UccTeam_h &team)
+{
+    ucc_coll_args_t coll;
+    coll.mask      = 0;
+    coll.coll_type = UCC_COLL_TYPE_BARRIER;
+    UccReq req(team, &coll);
+    req.start();
+    ASSERT_EQ(UCC_OK, req.wait());
+}
+
+/* create->barrier->destroy->recreate-identical must re-adopt the SAME
+   ucc_team_t (pointer + team-id preserved) and record a hit on the second
+   create, then drive a second lifetime cycle. */
+UCC_TEST_F(test_team_cache_integration, dormant_reuse)
+{
+    UccJob job(
+        4,
+        UccJob::UCC_JOB_CTX_GLOBAL,
+        {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "y")});
+
+    UccTeam_h   t1         = job.create_team(2, /*use_team_ep_map=*/true);
+
+    ucc_team_t *tp0_before = team_ptr(t1, 0);
+    ucc_team_t *tp1_before = team_ptr(t1, 1);
+    uint16_t    id0_before = tp0_before->id;
+
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, tp0_before->cache_state);
+
+    ucc_context_t *ctx0 = ctx_ptr(t1, 0);
+    ASSERT_NE(nullptr, ctx0->team_cache);
+
+    /* First create: a miss, no hit, one insert. */
+    EXPECT_GE(ctx0->team_cache->stats.lookups, 1u);
+    EXPECT_EQ(0u, ctx0->team_cache->stats.hits);
+    EXPECT_EQ(1u, ctx0->team_cache->stats.inserts);
+
+    run_barrier(t1);
+
+    t1.reset();
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, tp0_before->cache_state);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, tp1_before->cache_state);
+
+    /* Second team, IDENTICAL membership -> re-adopt the dormant team. */
+    UccTeam_h   t2        = job.create_team(2, /*use_team_ep_map=*/true);
+
+    ucc_team_t *tp0_after = team_ptr(t2, 0);
+    ucc_team_t *tp1_after = team_ptr(t2, 1);
+
+    EXPECT_EQ(tp0_before, tp0_after) << "team not reused";
+    EXPECT_EQ(tp1_before, tp1_after) << "team not reused";
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, tp0_after->cache_state);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, tp1_after->cache_state);
+    EXPECT_EQ(id0_before, tp0_after->id)
+        << "re-adopted team must retain its original team ID";
+
+    /* Second create: one more lookup, exactly one hit, no extra insert. */
+    EXPECT_GE(ctx0->team_cache->stats.lookups, 2u);
+    EXPECT_EQ(1u, ctx0->team_cache->stats.hits);
+    EXPECT_EQ(1u, ctx0->team_cache->stats.inserts);
+
+    run_barrier(t2);
+
+    t2.reset();
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, tp0_after->cache_state);
+}
+
+/* With UCC_TEAM_CACHE_ENABLE=n, create->destroy->recreate produces DISTINCT
+   ucc_team_t pointers; a team without EP_MAP is never cacheable. */
+UCC_TEST_F(test_team_cache_integration, knob_off)
+{
+    UccJob job(
+        4,
+        UccJob::UCC_JOB_CTX_GLOBAL,
+        {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "n")});
+
+    UccTeam_h      t1        = job.create_team(2, /*use_team_ep_map=*/true);
+    ucc_team_t    *tp_before = team_ptr(t1, 0);
+
+    ucc_context_t *ctx0      = ctx_ptr(t1, 0);
+    EXPECT_EQ(nullptr, ctx0->team_cache)
+        << "team_cache must be NULL when caching is disabled";
+
+    run_barrier(t1);
+
+    /* Create t2 while t1 is still live so pointer-distinctness is meaningful. */
+    UccTeam_h   t2       = job.create_team(2, /*use_team_ep_map=*/true);
+    ucc_team_t *tp_after = team_ptr(t2, 0);
+
+    EXPECT_NE(tp_before, tp_after);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_NONE, tp_after->cache_state);
+
+    run_barrier(t2);
+    t1.reset();
+
+    /* A team created WITHOUT EP_MAP is never cacheable (identity_build requires
+       FIELD_EP_MAP): cache_state==NONE and distinct pointers. */
+    UccTeam_h   n1  = job.create_team(2, /*use_team_ep_map=*/false);
+    ucc_team_t *np1 = team_ptr(n1, 0);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_NONE, np1->cache_state);
+    run_barrier(n1);
+
+    UccTeam_h   n2  = job.create_team(2, /*use_team_ep_map=*/false);
+    ucc_team_t *np2 = team_ptr(n2, 0);
+    EXPECT_NE(np1, np2);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_NONE, np2->cache_state);
+    run_barrier(n2);
+    n1.reset();
+}
+
+/* Two simultaneously-LIVE identical-membership teams (parent + derived) with
+   distinct team-ids run interleaved-order collectives.  A shared id would
+   cross-match in the (team_id, src_rank, seq_num) tag space and produce a wrong
+   result or hang; the derived team's own id keeps the streams isolated.
+   gtest limitation: the in-process UCP path can't re-adopt >= 4-proc teams after
+   dormancy, so these use <= 3-proc teams (the MPI leg covers the rest). */
+
+/* One in-flight per-proc collective: request + owned buffers + expected. */
+struct coll_op {
+    ucc_coll_req_h req;
+    ucc_context_h  ctx;
+    int64_t        sbuf;
+    int64_t        rbuf;
+    int64_t        expect;
+    bool           is_allreduce;
+};
+
+static void set_int64_host_buf(ucc_coll_buffer_info_t &info, int64_t *buf)
+{
+    info.buffer   = buf;
+    info.count    = 1;
+    info.datatype = UCC_DT_INT64;
+    info.mem_type = UCC_MEMORY_TYPE_HOST;
+}
+
+/* init + post @args as @op's request on proc @p of @team. */
+static void post_op(UccTeam_h &team, int p, ucc_coll_args_t &args, coll_op &op)
+{
+    op.ctx = ctx_ptr(team, p);
+    ASSERT_EQ(UCC_OK, ucc_collective_init(&args, &op.req, team->procs[p].team));
+    ASSERT_EQ(UCC_OK, ucc_collective_post(op.req));
+}
+
+/* Post an allreduce(SUM) of a single int64 on proc @p; result must equal @expect. */
+static void post_allreduce(
+    UccTeam_h &team, int p, int64_t val, int64_t expect, coll_op &op)
+{
+    op.sbuf         = val;
+    op.rbuf         = 0;
+    op.expect       = expect;
+    op.is_allreduce = true;
+
+    ucc_coll_args_t args;
+    memset(&args, 0, sizeof(args));
+    args.coll_type = UCC_COLL_TYPE_ALLREDUCE;
+    args.op        = UCC_OP_SUM;
+    set_int64_host_buf(args.src.info, &op.sbuf);
+    set_int64_host_buf(args.dst.info, &op.rbuf);
+
+    post_op(team, p, args, op);
+}
+
+/* Post a bcast of a single int64 from root proc 0 on proc @p. */
+static void post_bcast(UccTeam_h &team, int p, int64_t val, coll_op &op)
+{
+    op.rbuf         = (p == 0) ? val : 0;
+    op.expect       = val;
+    op.is_allreduce = false;
+
+    ucc_coll_args_t args;
+    memset(&args, 0, sizeof(args));
+    args.coll_type = UCC_COLL_TYPE_BCAST;
+    args.root      = 0;
+    set_int64_host_buf(args.src.info, &op.rbuf);
+
+    post_op(team, p, args, op);
+}
+
+/* Drive a set of in-flight per-proc collectives to completion, finalize, and
+   validate each.  Every participating context is pumped each round. */
+static void drive_and_check(std::vector<coll_op *> ops)
+{
+    bool all_done = false;
+    while (!all_done) {
+        all_done = true;
+        for (auto *op : ops) {
+            ucc_status_t st = ucc_collective_test(op->req);
+            ASSERT_GE(st, 0);
+            if (st != UCC_OK) {
+                all_done = false;
+            }
+        }
+        for (auto *op : ops) {
+            ucc_context_progress(op->ctx);
+        }
+    }
+    for (auto *op : ops) {
+        ASSERT_EQ(UCC_OK, ucc_collective_finalize(op->req));
+        ASSERT_EQ(op->expect, op->rbuf)
+            << (op->is_allreduce ? "allreduce" : "bcast") << " wrong result";
+    }
+}
+
+/* Parent (LIVE) + derived team, identical 2-proc membership, distinct team-ids.
+   Each rank posts on each team in OPPOSITE relative order; distinct tag domains
+   keep this correct where a shared id would cross-match. */
+UCC_TEST_F(test_team_cache_integration, derived_coexist_interleaved)
+{
+    UccJob job(
+        4,
+        UccJob::UCC_JOB_CTX_GLOBAL,
+        {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "y")});
+
+    UccTeam_h   t1 = job.create_team(2, /*use_team_ep_map=*/true);
+
+    ucc_team_t *p0 = team_ptr(t1, 0);
+    ucc_team_t *p1 = team_ptr(t1, 1);
+    ASSERT_EQ(UCC_TEAM_CACHE_STATE_LIVE, p0->cache_state);
+    EXPECT_EQ(0, p0->is_derived);
+    ASSERT_NE(nullptr, p0->artifacts);
+    run_barrier(t1);
+
+    UccTeam_h   t2 = job.create_team(2, /*use_team_ep_map=*/true);
+
+    ucc_team_t *d0 = team_ptr(t2, 0);
+    ucc_team_t *d1 = team_ptr(t2, 1);
+
+    /* Derivation fired: distinct object per proc, is_derived, not itself cached
+       (NONE), sharing the parent's artifacts holder. */
+    ASSERT_EQ(1, d0->is_derived);
+    EXPECT_EQ(1, d1->is_derived);
+    EXPECT_NE(p0, d0);
+    EXPECT_NE(p1, d1);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_NONE, d0->cache_state);
+    EXPECT_EQ(p0->artifacts, d0->artifacts);
+    EXPECT_EQ(p1->artifacts, d1->artifacts);
+    EXPECT_GE(d0->artifacts->refcount, 2);
+
+    /* Distinct team-ids => distinct tag/seq domains.  ASSERT so a shared id
+       fails fast instead of hanging the loop below. */
+    ASSERT_NE(p0->id, d0->id);
+    ASSERT_NE(team_ptr(t1, 1)->id, team_ptr(t2, 1)->id);
+
+    const int kIters = 40;
+    for (int it = 0; it < kIters; it++) {
+        int64_t ar_val = 100 + it;
+        int64_t ar_exp = ar_val * 2;
+        int64_t bc_val = 900000 + it;
+
+        coll_op p0_ar, p0_bc, p1_ar, p1_bc;
+
+        /* proc 0: t1.allreduce then t2.bcast; proc 1: opposite order. */
+        post_allreduce(t1, 0, ar_val, ar_exp, p0_ar);
+        post_bcast(t2, 0, bc_val, p0_bc);
+        post_bcast(t2, 1, bc_val, p1_bc);
+        post_allreduce(t1, 1, ar_val, ar_exp, p1_ar);
+
+        drive_and_check({&p0_ar, &p1_ar, &p0_bc, &p1_bc});
+    }
+
+    /* Teardown: derived first, parent last.  Parent must remain LIVE + usable. */
+    t2.reset();
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, p0->cache_state);
+    run_barrier(t1);
+    t1.reset();
+}
+
+/* Real UccJob, 2-slot FIFO cache.  Create/destroy T1{2p}, T2{3p} (both DORMANT,
+   cache full), then create T3{4p}: admission evicts T1 and drains its destroy
+   synchronously; T3 lands in the freed slot.  Asserts evictions >= 1 and
+   size <= max_size. */
+UCC_TEST_F(test_team_cache_integration, evict_id_release_on_evict)
+{
+    UccJob job(
+        4,
+        UccJob::UCC_JOB_CTX_GLOBAL,
+        {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "y"),
+         ucc_env_var_t("UCC_TEAM_CACHE_MAX_SIZE", "2"),
+         ucc_env_var_t("UCC_TEAM_CACHE_EVICTION", "fifo"),
+         ucc_env_var_t("UCC_TEAM_IDS_POOL_SIZE", "1")});
+
+    UccTeam_h t1 = job.create_team(2, /*use_team_ep_map=*/true);
+    ASSERT_NE(nullptr, t1);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, team_ptr(t1)->cache_state);
+    run_barrier(t1);
+    t1.reset(); /* T1 -> DORMANT (slot 1) */
+
+    UccTeam_h t2 = job.create_team(3, /*use_team_ep_map=*/true);
+    ASSERT_NE(nullptr, t2);
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, team_ptr(t2)->cache_state);
+    run_barrier(t2);
+
+    ucc_context_t    *ctx0  = ctx_ptr(t2, 0);
+    ucc_team_cache_t *cache = ctx0->team_cache;
+    ASSERT_NE(nullptr, cache);
+    uint64_t evictions_before = cache->stats.evictions;
+
+    t2.reset(); /* T2 -> DORMANT (slot 2, cache full) */
+
+    UccTeam_h t3 = job.create_team(4, /*use_team_ep_map=*/true);
+    ASSERT_NE(nullptr, t3);
+    run_barrier(t3);
+
+    EXPECT_GT(cache->stats.evictions, evictions_before)
+        << "inserting T3 into a full cache must evict";
+    EXPECT_LE(cache->size, cache->max_size);
+    EXPECT_TRUE(ucc_list_is_empty(&cache->pending_destroy))
+        << "pending destroys must complete synchronously in gtest context";
+}
+
+/* Pool-pressure headroom: six DISTINCT-membership teams churned through a 2-slot
+   cache + size-1 ID pool.  Needs a 16-proc job so sizes 2..7 are all distinct. */
+UCC_TEST_F(test_team_cache_integration, id_pool_headroom_with_dormant_teams)
+{
+    UccJob job(
+        16,
+        UccJob::UCC_JOB_CTX_GLOBAL,
+        {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "y"),
+         ucc_env_var_t("UCC_TEAM_CACHE_MAX_SIZE", "2"),
+         ucc_env_var_t("UCC_TEAM_CACHE_EVICTION", "fifo"),
+         ucc_env_var_t("UCC_TEAM_IDS_POOL_SIZE", "1")});
+
+    ucc_context_t    *ctx0   = nullptr;
+    ucc_team_cache_t *cache  = nullptr;
+
+    const int         kTeams = 6;
+    for (int i = 0; i < kTeams; i++) {
+        int sz = 2 + i; /* sizes 2..7, all distinct, all fit in a 16-proc job */
+        UccTeam_h t = job.create_team(sz, /*use_team_ep_map=*/true);
+        ASSERT_NE(nullptr, t)
+            << "create_team must succeed (no UCC_ERR_NO_RESOURCE) at team "
+            << i;
+        if (i == 0) {
+            ctx0  = ctx_ptr(t, 0);
+            cache = ctx0->team_cache;
+        }
+        run_barrier(t);
+        t.reset();
+    }
+
+    ASSERT_NE(nullptr, cache);
+    EXPECT_LE(cache->size, cache->max_size);
+    EXPECT_GT(cache->stats.evictions, 0u)
+        << "eviction must fire across " << kTeams << " distinct teams";
+}
+
+/* With UCC_TEAM_CACHE_DUMP_STATS=y the knob is wired onto the cache struct and
+   the destroy path dumps stats; the knob-off leg reads back zero. */
+UCC_TEST_F(test_team_cache_integration, dump_stats_integration_knob_on)
+{
+    UccJob job(
+        4,
+        UccJob::UCC_JOB_CTX_GLOBAL,
+        {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "y"),
+         ucc_env_var_t("UCC_TEAM_CACHE_DUMP_STATS", "y")});
+
+    UccTeam_h t = job.create_team(2, /*use_team_ep_map=*/true);
+    ASSERT_NE(nullptr, t);
+
+    ucc_context_t *ctx = ctx_ptr(t, 0);
+    ASSERT_NE(nullptr, ctx->team_cache);
+    EXPECT_NE(0u, ctx->team_cache->dump_stats);
+
+    run_barrier(t);
+    t.reset(); /* destroy triggers dump before drain */
+
+    UccJob job_off(
+        4,
+        UccJob::UCC_JOB_CTX_GLOBAL,
+        {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "y"),
+         ucc_env_var_t("UCC_TEAM_CACHE_DUMP_STATS", "n")});
+
+    UccTeam_h t_off = job_off.create_team(2, /*use_team_ep_map=*/true);
+    ASSERT_NE(nullptr, t_off);
+
+    ucc_context_t *ctx_off = ctx_ptr(t_off, 0);
+    ASSERT_NE(nullptr, ctx_off->team_cache);
+    EXPECT_EQ(0u, ctx_off->team_cache->dump_stats);
+
+    run_barrier(t_off);
+    t_off.reset();
+}
+
+/* With DISABLE_LINEAR_CHECK=y the hash-trust path is used; for non-colliding
+   membership it produces the same dormant reuse as the safe path. */
+UCC_TEST_F(test_team_cache_integration, disable_linear_check_accepted)
+{
+    UccJob job(
+        4,
+        UccJob::UCC_JOB_CTX_GLOBAL,
+        {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "y"),
+         ucc_env_var_t("UCC_TEAM_CACHE_DISABLE_LINEAR_CHECK", "y")});
+
+    UccTeam_h t1 = job.create_team(2, /*use_team_ep_map=*/true);
+    ASSERT_NE(nullptr, t1);
+
+    ucc_team_t    *tp0_before = team_ptr(t1, 0);
+    ucc_context_t *ctx0       = ctx_ptr(t1, 0);
+
+    ASSERT_NE(nullptr, ctx0->team_cache);
+    EXPECT_NE(0u, ctx0->team_cache->disable_linear_check);
+
+    run_barrier(t1);
+    t1.reset();
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_DORMANT, tp0_before->cache_state);
+
+    UccTeam_h t2 = job.create_team(2, /*use_team_ep_map=*/true);
+    ASSERT_NE(nullptr, t2);
+
+    ucc_team_t *tp0_after = team_ptr(t2, 0);
+    EXPECT_EQ(tp0_before, tp0_after)
+        << "hash-trust re-adopt must return the same ucc_team_t pointer";
+    EXPECT_EQ(UCC_TEAM_CACHE_STATE_LIVE, tp0_after->cache_state);
+    EXPECT_GE(ctx0->team_cache->stats.hits, 1u);
+
+    run_barrier(t2);
+}
+
+/* Knob defaults and overrides: unset -> derived ON, reseat OFF; explicit
+   derived=n / reseat=y reach the cache struct. */
+UCC_TEST_F(test_team_cache_integration, derived_reseat_knob_defaults)
+{
+    {
+        UccJob job(
+            4,
+            UccJob::UCC_JOB_CTX_GLOBAL,
+            {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "y")});
+
+        UccTeam_h t1 = job.create_team(2, /*use_team_ep_map=*/true);
+        ASSERT_NE(nullptr, t1);
+        ucc_context_t *ctx0 = ctx_ptr(t1, 0);
+        ASSERT_NE(nullptr, ctx0->team_cache);
+
+        EXPECT_NE(0u, ctx0->team_cache->derived)
+            << "UCC_TEAM_CACHE_DERIVED must default ON";
+        EXPECT_EQ(0u, ctx0->team_cache->reseat)
+            << "UCC_TEAM_CACHE_RESEAT must default OFF (opt-in)";
+        run_barrier(t1);
+    }
+
+    /* The UccJob env mechanism only restores pre-existing vars, so guard these
+       ourselves to avoid leaking DERIVED=n into later tests. */
+    ScopedEnv derived_guard("UCC_TEAM_CACHE_DERIVED");
+    ScopedEnv reseat_guard("UCC_TEAM_CACHE_RESEAT");
+
+    {
+        UccJob job(
+            4,
+            UccJob::UCC_JOB_CTX_GLOBAL,
+            {ucc_env_var_t("UCC_TEAM_CACHE_ENABLE", "y"),
+             ucc_env_var_t("UCC_TEAM_CACHE_DERIVED", "n"),
+             ucc_env_var_t("UCC_TEAM_CACHE_RESEAT", "y")});
+
+        UccTeam_h t1 = job.create_team(2, /*use_team_ep_map=*/true);
+        ASSERT_NE(nullptr, t1);
+        ucc_context_t *ctx0 = ctx_ptr(t1, 0);
+        ASSERT_NE(nullptr, ctx0->team_cache);
+
+        EXPECT_EQ(0u, ctx0->team_cache->derived)
+            << "UCC_TEAM_CACHE_DERIVED=n must clear the cache flag";
+        EXPECT_NE(0u, ctx0->team_cache->reseat)
+            << "UCC_TEAM_CACHE_RESEAT=y must set the cache flag";
+        run_barrier(t1);
+    }
+}

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -29,7 +29,8 @@ ucc_test_mpi_SOURCES = \
 	test_gatherv.cc         \
 	test_scatter.cc         \
 	test_scatterv.cc        \
-	test_mem_map.cc
+	test_mem_map.cc         \
+	test_team_cache.cc
 
 CXX=$(MPICXX)
 LD=$(MPICXX)

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -5,6 +5,7 @@
  * See file LICENSE for terms.
  */
 
+#include <cctype>
 #include <getopt.h>
 #include <sstream>
 #include <algorithm>
@@ -795,6 +796,19 @@ int main(int argc, char *argv[])
     }
 
 test_exit:
+    /* Team-cache correctness tests: run when explicitly requested. Set
+     * UCC_TEAM_CACHE_CORRECTNESS_TESTS=y in the environment to activate. These
+     * tests manage team create/destroy lifecycle directly and require
+     * UCC_TEAM_CACHE_ENABLE=y to be set as well. */
+    if (test && !test->teams.empty()) {
+        const char *cache_tests_env = getenv(
+            "UCC_TEAM_CACHE_CORRECTNESS_TESTS");
+        if (cache_tests_env &&
+            (tolower((unsigned char)cache_tests_env[0]) == 'y' ||
+             cache_tests_env[0] == '1')) {
+            run_team_cache_tests(test->teams[0].ctx, rank, size);
+        }
+    }
     delete test;
 mpi_exit:
     MPI_Finalize();

--- a/test/mpi/run_cache_equivalence.sh
+++ b/test/mpi/run_cache_equivalence.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# run_cache_equivalence.sh - cache enabled-vs-disabled equivalence test.
+#
+# Runs ucc_test_mpi over the same team/collective set with the cache on (pass A)
+# and off (pass B), using its built-in per-collective correctness checks as the
+# equivalence oracle (no cross-run diffing). Exits non-zero if any run fails.
+#
+# Usage: bash test/mpi/run_cache_equivalence.sh [NP]
+#
+# NP defaults to 8; --oversubscribe keeps it usable on a single-host container.
+# Pass a larger NP when a bigger cluster is available.
+
+set -eE
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+
+MPIRUN="${MPIRUN:-$(command -v mpirun)}"
+# EXE defaults to the ucc_test_mpi built next to this script, but may be
+# overridden (e.g. by CI, where the build tree differs from the source tree).
+EXE="${EXE:-${SCRIPT_DIR}/ucc_test_mpi}"
+NP="${1:-8}"
+
+TEAMS="world,half,odd_even,reverse"
+COLLS="barrier,allreduce,bcast,alltoall,allgather"
+MTYPES="host"
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+emit_result() {
+    local state="$1"   # CACHE_ON | CACHE_OFF
+    local team="$2"    # team label or "all"
+    local result="$3"  # PASS | FAIL
+    local detail="${4:-}"
+    if [ -n "${detail}" ]; then
+        echo "CACHE_EQUIV_RESULT state=${state} team=${team} result=${result} (${detail})"
+    else
+        echo "CACHE_EQUIV_RESULT state=${state} team=${team} result=${result}"
+    fi
+    if [ "${result}" = "PASS" ]; then
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+# run_mpi_pass <state_label> <cache_enable_val> <teams_arg>
+# Runs ucc_test_mpi over the collective suite AND the team-cache correctness suite
+# (UCC_TEAM_CACHE_CORRECTNESS_TESTS=1). The collective suite proves on-vs-off
+# equivalence; the correctness suite exercises actual reuse/derivation. For the
+# cache-on pass we also assert the correctness suite did NOT skip itself (which it
+# does when the cache is disabled), so a silently-inert cache cannot masquerade as
+# "equivalent" by never touching the cache at all. The suite MPI_Aborts on a real
+# cache failure, so a non-zero exit is caught below.
+run_mpi_pass() {
+    local label="$1" enable_val="$2" teams_arg="$3"
+
+    local rc=0
+    local log
+    log="$(mktemp)"
+    "${MPIRUN}" \
+        --allow-run-as-root \
+        -np "${NP}" \
+        --oversubscribe \
+        -x "UCC_TEAM_CACHE_ENABLE=${enable_val}" \
+        -x "UCC_TEAM_CACHE_CORRECTNESS_TESTS=1" \
+        "${EXE}" \
+        -t "${teams_arg}" \
+        -c "${COLLS}" \
+        --mtypes "${MTYPES}" \
+        > "${log}" 2>&1 || rc=$?
+    cat "${log}"
+
+    local t result="PASS"
+    [ "${rc}" -eq 0 ] || result="FAIL"
+
+    if [ "${label}" = "CACHE_ON" ] && [ "${result}" = "PASS" ]; then
+        if grep -qa "SKIP all team-cache tests" "${log}"; then
+            echo "CACHE_EQUIV: ERROR - cache-on pass did not exercise the cache" \
+                 "(correctness suite skipped itself); the cache may be inert"
+            result="FAIL"
+        fi
+    fi
+    rm -f "${log}"
+
+    IFS=',' read -ra team_list <<< "${teams_arg}"
+    for t in "${team_list[@]}"; do
+        emit_result "${label}" "${t}" "${result}"
+    done
+
+    return "${rc}"
+}
+
+# -----------------------------------------------------------------------------
+# Pre-flight
+# -----------------------------------------------------------------------------
+
+if [ ! -x "${EXE}" ]; then
+    echo "ERROR: ucc_test_mpi not found or not executable at ${EXE}"
+    exit 1
+fi
+
+echo "========================================================================"
+echo "  cache equivalence test  NP=${NP}  teams=${TEAMS}  colls=${COLLS}"
+echo "========================================================================"
+
+# -----------------------------------------------------------------------------
+# Pass A - cache ENABLED
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "--- Pass A: UCC_TEAM_CACHE_ENABLE=1 ---"
+pass_a_rc=0
+run_mpi_pass "CACHE_ON" "1" "${TEAMS}" || pass_a_rc=$?
+
+# -----------------------------------------------------------------------------
+# Pass B - cache DISABLED
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "--- Pass B: UCC_TEAM_CACHE_ENABLE=0 ---"
+pass_b_rc=0
+run_mpi_pass "CACHE_OFF" "0" "${TEAMS}" || pass_b_rc=$?
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "========================================================================"
+echo "  SUMMARY  PASS=${PASS_COUNT}  FAIL=${FAIL_COUNT}"
+echo "========================================================================"
+
+if [ "${FAIL_COUNT}" -gt 0 ] || [ "${pass_a_rc}" -ne 0 ] || [ "${pass_b_rc}" -ne 0 ]; then
+    echo "CACHE_EQUIV_OVERALL: FAIL"
+    exit 1
+else
+    echo "CACHE_EQUIV_OVERALL: PASS"
+    exit 0
+fi

--- a/test/mpi/test_mpi.h
+++ b/test/mpi/test_mpi.h
@@ -546,5 +546,17 @@ ucc_status_t compare_buffers(void *rst, void *expected, size_t count,
 ucc_status_t divide_buffer(void *expected, size_t divider, size_t count,
                            ucc_datatype_t dt);
 
+/**
+ * run_team_cache_tests - multi-rank team-cache correctness test suite.
+ *
+ * Exercises dormant reuse and eviction-under-pressure across multiple MPI ranks.
+ * Called from main() when UCC_TEAM_CACHE_CORRECTNESS_TESTS=y is set in the
+ * environment, after the standard test run completes.
+ *
+ * @param ctx         UCC context created by UccTestMpi.
+ * @param world_rank  MPI_COMM_WORLD rank.
+ * @param world_size  MPI_COMM_WORLD size.
+ */
+void run_team_cache_tests(ucc_context_h ctx, int world_rank, int world_size);
 
 #endif

--- a/test/mpi/test_team_cache.cc
+++ b/test/mpi/test_team_cache.cc
@@ -1,0 +1,947 @@
+/**
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
+/*
+ * Multi-rank team-cache correctness tests. These cover behaviors that need real
+ * multi-rank OOB collectives: derived-team dup coexistence, dormant-reuse hit
+ * counting, cid-drift re-adoption, freed-callback safety, divergent-eviction
+ * agreement, non-blocking create, and singleton teams. Single-process behavior
+ * and cache on-vs-off equivalence are covered by the gtest suite and by
+ * run_cache_equivalence.sh. Run via ucc_test_mpi with UCC_TEAM_CACHE_ENABLE=y;
+ * teams are created and destroyed directly so the recreate cycle is controlled
+ * per test.
+ */
+
+#include "test_mpi.h"
+#include "mpi_util.h"
+#include "core/ucc_context.h"
+#include "core/ucc_team.h"
+#include "core/ucc_team_cache.h"
+#include "utils/ucc_coll_utils.h"
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <unistd.h> /* usleep for the nonblocking-create-post timing test */
+
+/* create/destroy/recreate cycles used by the reuse tests. */
+static const int kReuseIters = 5;
+
+/* Read per-context team-cache counters directly (no public stats attr). Returns
+   false if caching is disabled on this context. */
+static bool      get_cache_stats(
+         ucc_context_h ctx, uint64_t *hits, uint64_t *inserts, uint64_t *evictions)
+{
+    ucc_context_t *c = (ucc_context_t *)ctx;
+    if (c->team_cache == NULL) {
+        return false;
+    }
+    if (hits) {
+        *hits = c->team_cache->stats.hits;
+    }
+    if (inserts) {
+        *inserts = c->team_cache->stats.inserts;
+    }
+    if (evictions) {
+        *evictions = c->team_cache->stats.evictions;
+    }
+    return true;
+}
+
+/* OOB allgather callbacks over an MPI communicator. */
+static ucc_status_t oob_allgather_cb(
+    void *sbuf, void *rbuf, size_t msglen, void *coll_info, void **req)
+{
+    MPI_Comm    comm = (MPI_Comm)(uintptr_t)coll_info;
+    MPI_Request request;
+    MPI_Iallgather(
+        sbuf, msglen, MPI_BYTE, rbuf, msglen, MPI_BYTE, comm, &request);
+    *req = (void *)(uintptr_t)request;
+    return UCC_OK;
+}
+
+static ucc_status_t oob_allgather_test_cb(void *req)
+{
+    MPI_Request request = (MPI_Request)(uintptr_t)req;
+    int         completed;
+    MPI_Test(&request, &completed, MPI_STATUS_IGNORE);
+    return completed ? UCC_OK : UCC_INPROGRESS;
+}
+
+static ucc_status_t oob_allgather_free_cb(void *req)
+{
+    return UCC_OK;
+}
+
+/* Pump the context until a single collective request completes; abort on error. */
+static void progress_until(
+    ucc_context_h ctx, ucc_coll_req_h req, const char *what)
+{
+    ucc_status_t st;
+    while (UCC_OK != (st = ucc_collective_test(req))) {
+        if (st < 0) {
+            std::cerr << "*** UCC TEST FAIL: " << what << " ("
+                      << ucc_status_string(st) << ")\n";
+            MPI_Abort(MPI_COMM_WORLD, -1);
+        }
+        ucc_context_progress(ctx);
+    }
+}
+
+/* Fill common team-create params (OOB over @comm, the given ep_map, optional
+   external id). Shared by create_team and the nonblocking-create-post test. */
+static void fill_team_params(
+    ucc_team_params_t *p, MPI_Comm comm, ucc_ep_map_t ep_map, uint64_t ext_id)
+{
+    int rank, size;
+
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+    memset(p, 0, sizeof(*p));
+    p->mask = UCC_TEAM_PARAM_FIELD_EP | UCC_TEAM_PARAM_FIELD_EP_RANGE |
+              UCC_TEAM_PARAM_FIELD_OOB | UCC_TEAM_PARAM_FIELD_EP_MAP;
+    p->oob.allgather = oob_allgather_cb;
+    p->oob.req_test  = oob_allgather_test_cb;
+    p->oob.req_free  = oob_allgather_free_cb;
+    p->oob.coll_info = (void *)(uintptr_t)comm;
+    p->oob.n_oob_eps = size;
+    p->oob.oob_ep    = rank;
+    p->ep            = rank;
+    p->ep_range      = UCC_COLLECTIVE_EP_RANGE_CONTIG;
+    p->ep_map        = ep_map;
+    if (ext_id != 0) {
+        p->mask |= UCC_TEAM_PARAM_FIELD_ID;
+        p->id = ext_id;
+    }
+}
+
+/* Blocking team create over @comm with the given ep_map (and optional external
+   id); pumps the context to completion and aborts on error. */
+static ucc_team_h create_team(
+    ucc_context_h ctx, MPI_Comm comm, ucc_ep_map_t ep_map, uint64_t ext_id)
+{
+    ucc_team_params_t p;
+    ucc_team_h        team;
+    ucc_status_t      status;
+
+    fill_team_params(&p, comm, ep_map, ext_id);
+    UCC_CHECK(ucc_team_create_post(&ctx, 1, &p, &team));
+    while (UCC_INPROGRESS == (status = ucc_team_create_test(team))) {
+        ucc_context_progress(ctx);
+    }
+    if (status < 0) {
+        std::cerr << "*** UCC TEST FAIL: team create ("
+                  << ucc_status_string(status) << ")\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+    return team;
+}
+
+static ucc_ep_map_t ep_map_full(int size)
+{
+    ucc_ep_map_t m;
+    memset(&m, 0, sizeof(m));
+    m.type   = UCC_EP_MAP_FULL;
+    m.ep_num = size;
+    return m;
+}
+
+/* Full-membership world team (EP_MAP FULL over MPI_COMM_WORLD). */
+static ucc_team_h create_world_team(
+    ucc_context_h ctx, int size, uint64_t ext_id = 0)
+{
+    return create_team(ctx, MPI_COMM_WORLD, ep_map_full(size), ext_id);
+}
+
+/* Subset team over @comm using an explicit team-idx -> ctx-rank array map. */
+static ucc_team_h create_array_team(
+    ucc_context_h ctx, MPI_Comm comm, ucc_rank_t *map, int nmembers)
+{
+    ucc_ep_map_t m;
+    memset(&m, 0, sizeof(m));
+    m.type            = UCC_EP_MAP_ARRAY;
+    m.ep_num          = nmembers;
+    m.array.map       = map;
+    m.array.elem_size = sizeof(ucc_rank_t);
+    return create_team(ctx, comm, m, 0);
+}
+
+/* destroy_ucc_team - blocking ucc_team_destroy with progress pump. */
+static void destroy_ucc_team(ucc_team_h team, ucc_context_h ctx)
+{
+    ucc_status_t status;
+    while (UCC_INPROGRESS == (status = ucc_team_destroy(team))) {
+        ucc_context_progress(ctx);
+    }
+    if (UCC_OK != status) {
+        std::cerr << "*** UCC TEST FAIL: ucc_team_destroy failed ("
+                  << ucc_status_string(status) << ")\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+}
+
+/* run_barrier_on_team - blocking barrier on @team; aborts on failure. */
+static void run_barrier_on_team(ucc_team_h team, ucc_context_h ctx)
+{
+    ucc_coll_args_t args;
+    ucc_coll_req_h  req;
+
+    memset(&args, 0, sizeof(args));
+    args.coll_type = UCC_COLL_TYPE_BARRIER;
+
+    UCC_CHECK(ucc_collective_init(&args, &req, team));
+    UCC_CHECK(ucc_collective_post(req));
+    progress_until(ctx, req, "barrier");
+    UCC_CHECK(ucc_collective_finalize(req));
+}
+
+/* run_allreduce_int64 - SUM allreduce of a single int64 on @team, blocking;
+   aborts on error. Returns the reduced value. */
+static int64_t run_allreduce_int64(
+    ucc_team_h team, ucc_context_h ctx, int64_t sbuf, const char *where)
+{
+    int64_t         rbuf = 0;
+    ucc_coll_args_t args;
+    ucc_coll_req_h  req;
+
+    memset(&args, 0, sizeof(args));
+    args.coll_type         = UCC_COLL_TYPE_ALLREDUCE;
+    args.op                = UCC_OP_SUM;
+    args.src.info.buffer   = &sbuf;
+    args.src.info.count    = 1;
+    args.src.info.datatype = UCC_DT_INT64;
+    args.src.info.mem_type = UCC_MEMORY_TYPE_HOST;
+    args.dst.info.buffer   = &rbuf;
+    args.dst.info.count    = 1;
+    args.dst.info.datatype = UCC_DT_INT64;
+    args.dst.info.mem_type = UCC_MEMORY_TYPE_HOST;
+
+    UCC_CHECK(ucc_collective_init(&args, &req, team));
+    UCC_CHECK(ucc_collective_post(req));
+    progress_until(ctx, req, where);
+    UCC_CHECK(ucc_collective_finalize(req));
+    return rbuf;
+}
+
+/* ==========================================================================
+ * dup_coexist_derived: a parent world team and its live derived (MPI_Comm_dup
+ * analogue) run interleaved collectives concurrently. Regression for the alias
+ * hazard where two coexisting identical-membership teams share a team id.
+ *   - ext_ids==false: implicit-id dup (the base regression).
+ *   - ext_ids==true : parent/derived carry DISTINCT external ids and must share
+ *     one artifacts holder.
+ * ========================================================================== */
+
+/* Drive one allreduce(SUM int64) + one bcast(int64 from root 0), in the given
+   order, over MPI_COMM_WORLD membership; validate both results. @order==0:
+   allreduce then bcast; @order==1: reverse. Both are posted before either
+   completes so they are in flight together (and interleave across teams). */
+static void drive_ar_bc(
+    ucc_team_h ar_team, ucc_team_h bc_team, ucc_context_h ctx, int rank,
+    int size, int iter, int order)
+{
+    int64_t         ar_send = 100 + iter;
+    int64_t         ar_recv = 0;
+    int64_t         ar_exp  = (int64_t)(100 + iter) * size;
+    int64_t         bc_buf  = (rank == 0) ? (900000 + iter) : 0;
+    int64_t         bc_exp  = 900000 + iter;
+
+    ucc_coll_args_t ar_args, bc_args;
+    ucc_coll_req_h  ar_req, bc_req;
+
+    memset(&ar_args, 0, sizeof(ar_args));
+    ar_args.coll_type         = UCC_COLL_TYPE_ALLREDUCE;
+    ar_args.op                = UCC_OP_SUM;
+    ar_args.src.info.buffer   = &ar_send;
+    ar_args.src.info.count    = 1;
+    ar_args.src.info.datatype = UCC_DT_INT64;
+    ar_args.src.info.mem_type = UCC_MEMORY_TYPE_HOST;
+    ar_args.dst.info.buffer   = &ar_recv;
+    ar_args.dst.info.count    = 1;
+    ar_args.dst.info.datatype = UCC_DT_INT64;
+    ar_args.dst.info.mem_type = UCC_MEMORY_TYPE_HOST;
+
+    memset(&bc_args, 0, sizeof(bc_args));
+    bc_args.coll_type         = UCC_COLL_TYPE_BCAST;
+    bc_args.root              = 0;
+    bc_args.src.info.buffer   = &bc_buf;
+    bc_args.src.info.count    = 1;
+    bc_args.src.info.datatype = UCC_DT_INT64;
+    bc_args.src.info.mem_type = UCC_MEMORY_TYPE_HOST;
+
+    /* Post in the requested relative order (per-rank interleave). */
+    if (order == 0) {
+        UCC_CHECK(ucc_collective_init(&ar_args, &ar_req, ar_team));
+        UCC_CHECK(ucc_collective_post(ar_req));
+        UCC_CHECK(ucc_collective_init(&bc_args, &bc_req, bc_team));
+        UCC_CHECK(ucc_collective_post(bc_req));
+    } else {
+        UCC_CHECK(ucc_collective_init(&bc_args, &bc_req, bc_team));
+        UCC_CHECK(ucc_collective_post(bc_req));
+        UCC_CHECK(ucc_collective_init(&ar_args, &ar_req, ar_team));
+        UCC_CHECK(ucc_collective_post(ar_req));
+    }
+
+    /* Progress both to completion. */
+    ucc_status_t sa, sb;
+    do {
+        sa = ucc_collective_test(ar_req);
+        sb = ucc_collective_test(bc_req);
+        if (sa < 0 || sb < 0) {
+            std::cerr << "*** UCC TEST FAIL: coll test ("
+                      << ucc_status_string(sa < 0 ? sa : sb) << ")\n";
+            MPI_Abort(MPI_COMM_WORLD, -1);
+        }
+        ucc_context_progress(ctx);
+    } while (sa != UCC_OK || sb != UCC_OK);
+
+    UCC_CHECK(ucc_collective_finalize(ar_req));
+    UCC_CHECK(ucc_collective_finalize(bc_req));
+
+    if (ar_recv != ar_exp || bc_buf != bc_exp) {
+        std::cerr << "*** UCC TEST FAIL: dup_coexist rank " << rank << " iter "
+                  << iter << ": allreduce got " << ar_recv << " (exp " << ar_exp
+                  << "), bcast got " << bc_buf << " (exp " << bc_exp << ")\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+}
+
+static void test_dup_coexist_derived(
+    ucc_context_h ctx, int world_rank, int world_size, bool ext_ids)
+{
+    const int      kIters     = ext_ids ? 8 : 6;
+    const uint64_t parent_id  = ext_ids ? 100 : 0;
+    const uint64_t derived_id = ext_ids ? 200 : 0;
+    const char    *name       = ext_ids ? "dup_coexist_derived[ext_ids]"
+                                        : "dup_coexist_derived";
+
+    /* External-id dup needs a LIVE insertable parent to derive from; drain
+       dormant squatters so the world-membership bucket is clean. */
+    if (ext_ids) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        ucc_team_cache_drain((ucc_context_t *)ctx);
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    /* Parent world team (derivable), kept live. */
+    ucc_team_h parent = create_world_team(ctx, world_size, parent_id);
+    run_barrier_on_team(parent, ctx);
+
+    /* Second identical-membership team while parent is live -> derived-create
+       path (MPI_Comm_dup analogue), with a distinct external id under ext_ids. */
+    ucc_team_h derived = create_world_team(ctx, world_size, derived_id);
+
+    /* Distinct team ids: coexisting teams must not alias tag/seq domains. */
+    if (parent->id == derived->id) {
+        std::cerr << "*** UCC TEST FAIL: coexisting teams share id "
+                  << parent->id << "\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+    /* Must actually take the derived path (a full-create regression would still
+       pass the distinct-id check above). */
+    if (!derived->is_derived) {
+        std::cerr << "*** UCC TEST FAIL: coexisting identical-membership team "
+                     "was not derived (full-create regression)\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+    /* External-id variant: derived must share the parent's artifacts holder. */
+    if (ext_ids && parent->artifacts != derived->artifacts) {
+        std::cerr << "*** UCC TEST FAIL: derived team did not share parent "
+                     "artifacts holder\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+
+    /* Interleaved-order collectives with opposite per-rank ordering across both
+       live teams: even ranks allreduce(parent)+bcast(derived), odd the reverse. */
+    for (int it = 0; it < kIters; it++) {
+        int order = (world_rank % 2 == 0) ? 0 : 1;
+        drive_ar_bc(parent, derived, ctx, world_rank, world_size, it, order);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    destroy_ucc_team(derived, ctx);
+    run_barrier_on_team(parent, ctx); /* parent still usable */
+    destroy_ucc_team(parent, ctx);
+
+    if (0 == world_rank) {
+        std::cout << "PASS " << name << "\n";
+    }
+}
+
+/* ==========================================================================
+ * dormant_reuse_stats: build a cacheable world team, destroy it (-> dormant),
+ * and recreate an identical one kReuseIters times. Each recreate after the first
+ * must be a dormant HIT. Covers the non-derived dormant-reuse path;
+ * test_derived_reuse covers the derived variant.
+ * ========================================================================== */
+static void test_dormant_reuse_stats(
+    ucc_context_h ctx, int world_rank, int world_size)
+{
+    uint64_t hits0 = 0, hitsN = 0;
+
+    if (!get_cache_stats(ctx, &hits0, NULL, NULL)) {
+        if (0 == world_rank) {
+            std::cout << "SKIP dormant_reuse_stats: cache disabled\n";
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    /* Drain dormant squatters from prior tests (a leftover would skew hits). */
+    MPI_Barrier(MPI_COMM_WORLD);
+    ucc_team_cache_drain((ucc_context_t *)ctx);
+    MPI_Barrier(MPI_COMM_WORLD);
+    get_cache_stats(ctx, &hits0, NULL, NULL);
+
+    for (int i = 0; i < kReuseIters; i++) {
+        ucc_team_h team = create_world_team(ctx, world_size);
+        run_barrier_on_team(team, ctx);
+        MPI_Barrier(MPI_COMM_WORLD);
+        destroy_ucc_team(team, ctx);
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    get_cache_stats(ctx, &hitsN, NULL, NULL);
+    /* First create is a miss+insert; the remaining recreates must be hits. */
+    if (hitsN - hits0 < (uint64_t)(kReuseIters - 1)) {
+        std::cerr << "*** UCC TEST FAIL: rank " << world_rank
+                  << " expected >=" << (kReuseIters - 1)
+                  << " dormant hits, got " << (hitsN - hits0) << "\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+    if (0 == world_rank) {
+        std::cout << "PASS dormant_reuse_stats\n";
+    }
+}
+
+/* ==========================================================================
+ * derived_reuse: a parent world team stays live while each iteration creates a
+ * derived team, runs an allreduce, then frees it (-> dormant). From iter 1 the
+ * dormant derived is re-adopted (cache HIT).
+ *   - drift==false: the derived's external id is stable, so an exact-identity
+ *     lookup re-adopts it.
+ *   - drift==true : the derived's external id drifts every iteration, so only a
+ *     membership-match re-adopt (reseat) can hit; requires
+ *     UCC_TEAM_CACHE_RESEAT and UCC_TEAM_CACHE_DERIVED, else it skips.
+ * ========================================================================== */
+static void test_derived_reuse(
+    ucc_context_h ctx, int world_rank, int world_size, bool drift)
+{
+    const char *name  = drift ? "derived_reuse[drift]" : "derived_reuse";
+    uint64_t    hits0 = 0;
+
+    if (!get_cache_stats(ctx, &hits0, NULL, NULL)) {
+        if (0 == world_rank) {
+            std::cout << "SKIP " << name << ": cache disabled\n";
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+    if (drift) {
+        ucc_team_cache_t *cache = ((ucc_context_t *)ctx)->team_cache;
+        if (!cache->reseat || !cache->derived) {
+            if (0 == world_rank) {
+                std::cout << "SKIP " << name
+                          << ": UCC_TEAM_CACHE_RESEAT/DERIVED not enabled\n";
+            }
+            MPI_Barrier(MPI_COMM_WORLD);
+            return;
+        }
+    }
+
+    /* Drain any dormant squatters from prior tests. */
+    MPI_Barrier(MPI_COMM_WORLD);
+    ucc_team_cache_drain((ucc_context_t *)ctx);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    /* Parent stays live throughout; its stable ext_id=1 is distinct from every
+       derived id used below. */
+    ucc_team_h parent = create_world_team(ctx, world_size, /*ext_id=*/1);
+    run_barrier_on_team(parent, ctx);
+
+    for (int i = 0; i < kReuseIters; i++) {
+        uint64_t hits_before = 0;
+        get_cache_stats(ctx, &hits_before, NULL, NULL);
+
+        /* Derived: same membership as parent. Under drift the ext_id changes
+           every iteration (100, 101, ...) so the exact-identity lookup misses
+           and only a reseat re-adopt can hit; otherwise ext_id=2 is stable. */
+        uint64_t   derived_id = drift ? (uint64_t)(100 + i) : 2;
+        ucc_team_h derived    = create_world_team(ctx, world_size, derived_id);
+
+        int64_t    sbuf       = (int64_t)(100 + i);
+        int64_t    exp        = sbuf * (int64_t)world_size;
+        int64_t    rbuf       = run_allreduce_int64(
+            derived, ctx, sbuf, "allreduce on derived team");
+        if (rbuf != exp) {
+            std::cerr << "*** UCC TEST FAIL: " << name << " rank " << world_rank
+                      << " iter " << i << ": allreduce got " << rbuf << " (exp "
+                      << exp << ")\n";
+            MPI_Abort(MPI_COMM_WORLD, -1);
+        }
+
+        /* From iter 1 onwards: expect a cache hit re-adopting the dormant
+           derived (via reseat under drift). */
+        if (i > 0) {
+            uint64_t hits_after = 0;
+            get_cache_stats(ctx, &hits_after, NULL, NULL);
+            if (hits_after <= hits_before) {
+                std::cerr << "*** UCC TEST FAIL: " << name << " rank "
+                          << world_rank << " iter " << i
+                          << ": no cache hit for derived re-adopt\n";
+                MPI_Abort(MPI_COMM_WORLD, -1);
+            }
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        destroy_ucc_team(derived, ctx); /* -> dormant */
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    run_barrier_on_team(parent, ctx); /* parent must still be functional */
+    destroy_ucc_team(parent, ctx);
+
+    if (0 == world_rank) {
+        std::cout << "PASS " << name << "\n";
+    }
+}
+
+/* ==========================================================================
+ * ep_map_cb_freed_after_cache: a cached team must not retain the caller's ep_map
+ * callback context past its lifetime. OMPI coll/ucc passes a UCC_EP_MAP_CB whose
+ * cb_ctx is the MPI communicator; after the comm is freed, any deref of that
+ * cb_ctx is a use-after-free. Here cb_ctx is a heap box that is POISONED+FREED
+ * after the team goes dormant; re-adopting the team and evaluating its
+ * operational map must never call back into the freed box.
+ * ========================================================================== */
+
+struct cb_ctx_box {
+    uint64_t   magic; /* CB_CTX_MAGIC while live, poisoned after free */
+    ucc_rank_t size;
+    ucc_rank_t ranks[1]; /* flexible: team ep -> ctx rank (identity here) */
+};
+static const uint64_t CB_CTX_MAGIC = 0xC0FFEE5AULL;
+
+static uint64_t       poisonable_rank_cb(uint64_t ep, void *cb_ctx)
+{
+    struct cb_ctx_box *box = (struct cb_ctx_box *)cb_ctx;
+    /* If the cache retained this (freed) context, magic no longer matches -
+       fail loudly instead of silently reading poisoned memory. */
+    if (box->magic != CB_CTX_MAGIC) {
+        std::cerr << "*** UCC TEST FAIL: use-after-free - ep_map callback "
+                     "invoked on a freed communicator context\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+    return box->ranks[ep];
+}
+
+static ucc_team_h create_cb_team(
+    ucc_context_h ctx, int size, struct cb_ctx_box *box)
+{
+    ucc_ep_map_t m;
+    memset(&m, 0, sizeof(m));
+    m.type      = UCC_EP_MAP_CB;
+    m.ep_num    = size;
+    m.cb.cb     = poisonable_rank_cb;
+    m.cb.cb_ctx = (void *)box;
+    return create_team(ctx, MPI_COMM_WORLD, m, 0);
+}
+
+static struct cb_ctx_box *alloc_cb_box(int world_size)
+{
+    size_t box_sz = sizeof(struct cb_ctx_box) +
+                    (world_size - 1) * sizeof(ucc_rank_t);
+    struct cb_ctx_box *box = (struct cb_ctx_box *)malloc(box_sz);
+
+    if (box == NULL) {
+        std::cerr << "*** UCC TEST FAIL: cb_ctx_box allocation failed\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+    box->magic             = CB_CTX_MAGIC;
+    box->size              = (ucc_rank_t)world_size;
+    for (int i = 0; i < world_size; i++) {
+        box->ranks[i] = (ucc_rank_t)i; /* world identity mapping */
+    }
+    return box;
+}
+
+static void test_ep_map_cb_freed_after_cache(
+    ucc_context_h ctx, int world_rank, int world_size)
+{
+    uint64_t hits_before = 0, hits_after = 0;
+    bool     cache_on       = get_cache_stats(ctx, &hits_before, NULL, NULL);
+    struct cb_ctx_box *box  = alloc_cb_box(world_size);
+
+    /* First create + use + destroy -> team goes dormant (cache on). */
+    ucc_team_h         team = create_cb_team(ctx, world_size, box);
+    run_barrier_on_team(team, ctx);
+    destroy_ucc_team(team, ctx);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    /* Free the callback context (as MPI_Comm_free would). A cached team that
+       still points here would now be dangling. */
+    box->magic = 0xDEADDEADULL; /* poison so a stale deref is caught */
+    free(box);
+
+    /* Re-create the identical team. On a cache hit this re-adopts the dormant
+       team whose operational map is UCC-owned, so it never touches the freed
+       box. The fresh box only satisfies the create API. */
+    box              = alloc_cb_box(world_size);
+    ucc_team_h team2 = create_cb_team(ctx, world_size, box);
+    run_barrier_on_team(team2, ctx);
+
+    /* Evaluate the re-adopted team's operational map for every endpoint - the
+       exact access TL/UCP performs when resolving a peer. With the fix the map
+       is UCC-owned, so this resolves correctly without calling back into the
+       freed box; without it, poisonable_rank_cb aborts on the poison. */
+    {
+        ucc_team_t *t = (ucc_team_t *)team2;
+        for (ucc_rank_t e = 0; e < (ucc_rank_t)world_size; e++) {
+            ucc_rank_t got = ucc_ep_map_eval(UCC_TEAM_CTX_MAP(t), e);
+            if (got != e) {
+                std::cerr << "*** UCC TEST FAIL: operational ctx_map endpoint "
+                          << (int)e << " resolved to " << (int)got
+                          << " (expected " << (int)e << ")\n";
+                MPI_Abort(MPI_COMM_WORLD, -1);
+            }
+        }
+    }
+
+    destroy_ucc_team(team2, ctx);
+    free(box);
+
+    if (cache_on) {
+        get_cache_stats(ctx, &hits_after, NULL, NULL);
+        if (hits_after <= hits_before && world_rank == 0) {
+            std::cerr << "*** UCC TEST WARN: cb_freed reuse recorded no cache "
+                         "hit (identity may not have matched)\n";
+        }
+    }
+    if (world_rank == 0) {
+        std::cout << "PASS ep_map_cb_freed_after_cache\n";
+    }
+}
+
+/* ==========================================================================
+ * overlap_agreement: overlapping subcommunicators plus a small cache force
+ * DIVERGENT per-rank eviction, which previously deadlocked (one rank re-adopts a
+ * dormant team while a peer that evicted it enters a fresh collective build and
+ * waits forever). The cross-rank agreement must reconcile the split hit/miss to
+ * a consistent fresh build. Run with UCC_TEAM_CACHE_MAX_SIZE=2 and >=3 ranks.
+ * ========================================================================== */
+static void test_overlap_agreement(
+    ucc_context_h ctx, int world_rank, int world_size)
+{
+    ucc_rank_t ranksA[2] = {0, 1};
+    ucc_rank_t ranksB[2] = {1, 2};
+    ucc_rank_t ranksD[3] = {0, 1, 2};
+    MPI_Comm   commA, commB, commD;
+    ucc_team_h t;
+
+    if (world_size < 3) {
+        if (world_rank == 0) {
+            std::cout << "SKIP overlap_agreement (needs >=3 ranks)\n";
+        }
+        return;
+    }
+
+    /* Overlapping member sets: A{0,1}, B{1,2}, D{0,1,2}. */
+    MPI_Comm_split(
+        MPI_COMM_WORLD,
+        (world_rank <= 1) ? 0 : MPI_UNDEFINED,
+        world_rank,
+        &commA);
+    MPI_Comm_split(
+        MPI_COMM_WORLD,
+        (world_rank >= 1 && world_rank <= 2) ? 0 : MPI_UNDEFINED,
+        world_rank,
+        &commB);
+    MPI_Comm_split(
+        MPI_COMM_WORLD,
+        (world_rank <= 2) ? 0 : MPI_UNDEFINED,
+        world_rank,
+        &commD);
+
+    /* 1) A dormant on {0,1}; 2) B dormant on {1,2} (rank 1 cache now full at
+       MAX_SIZE=2); 3) D on {0,1,2} evicts the oldest dormant (A) on rank 1 but
+       not on rank 0 -> divergence; 4) re-create A: rank 0 re-adopts, rank 1
+       missed. Pre-agreement this deadlocks; the vote must reconcile to a fresh
+       build on both. */
+    if (commA != MPI_COMM_NULL) {
+        t = create_array_team(ctx, commA, ranksA, 2);
+        destroy_ucc_team(t, ctx);
+    }
+    if (commB != MPI_COMM_NULL) {
+        t = create_array_team(ctx, commB, ranksB, 2);
+        destroy_ucc_team(t, ctx);
+    }
+    if (commD != MPI_COMM_NULL) {
+        t = create_array_team(ctx, commD, ranksD, 3);
+        destroy_ucc_team(t, ctx);
+    }
+    if (commA != MPI_COMM_NULL) {
+        t = create_array_team(ctx, commA, ranksA, 2);
+        run_barrier_on_team(t, ctx); /* must complete, not deadlock */
+        destroy_ucc_team(t, ctx);
+    }
+
+    if (commA != MPI_COMM_NULL) {
+        MPI_Comm_free(&commA);
+    }
+    if (commB != MPI_COMM_NULL) {
+        MPI_Comm_free(&commB);
+    }
+    if (commD != MPI_COMM_NULL) {
+        MPI_Comm_free(&commD);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (world_rank == 0) {
+        std::cout << "PASS overlap_agreement\n";
+    }
+}
+
+/* ==========================================================================
+ * derived_exact_rebuild: a DORMANT derived team re-adopted via EXACT_REUSE that
+ * then loses the cross-rank vote must rebuild as a proper FULL team - it must be
+ * de-derived so it runs ADDR_EXCHANGE (builds ctx_map/topo) rather than skipping
+ * it as a derived team would. Regression for a global-MISS rebuild that left an
+ * EXACT_REUSE candidate marked is_derived, producing a NULL topo on rebuild.
+ *
+ * Setup (needs >=3 ranks and MAX_SIZE=2 to force divergent eviction): a live
+ * parent world team (ext_id 1) plus a dormant derived world team (ext_id 2) fill
+ * the cache on every rank. A subcomm team created only on ranks {0,1} evicts the
+ * dormant derived there (FIFO), while ranks >=2 keep it. Re-creating the ext_id-2
+ * world team then splits the vote (ranks >=2 EXACT_REUSE the derived candidate,
+ * ranks {0,1} miss -> DERIVED_FROM_LIVE), forcing a global MISS and the in-place
+ * rebuild on ranks >=2. Without the de-derive fix those ranks skip ADDR_EXCHANGE
+ * and desync/crash; with it, the allreduce below completes and is_derived is 0.
+ * ========================================================================== */
+static void test_derived_exact_rebuild(
+    ucc_context_h ctx, int world_rank, int world_size)
+{
+    const char       *name = "derived_exact_rebuild";
+    ucc_team_cache_t *cache;
+
+    if (!get_cache_stats(ctx, NULL, NULL, NULL)) {
+        if (0 == world_rank) {
+            std::cout << "SKIP " << name << ": cache disabled\n";
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+    cache = ((ucc_context_t *)ctx)->team_cache;
+    if (!cache->derived || world_size < 3 || cache->max_size > 2) {
+        if (0 == world_rank) {
+            std::cout << "SKIP " << name
+                      << ": needs derived caching, >=3 ranks, MAX_SIZE<=2\n";
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    ucc_team_cache_drain((ucc_context_t *)ctx);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    /* Live parent (ext_id 1) + dormant derived (ext_id 2): 2 entries = MAX_SIZE. */
+    ucc_team_h parent = create_world_team(ctx, world_size, /*ext_id=*/1);
+    run_barrier_on_team(parent, ctx);
+    ucc_team_h derived = create_world_team(ctx, world_size, /*ext_id=*/2);
+    run_barrier_on_team(derived, ctx);
+    MPI_Barrier(MPI_COMM_WORLD);
+    destroy_ucc_team(derived, ctx); /* -> dormant derived */
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    /* Ranks {0,1} only: a subcomm team evicts the dormant derived (cache full);
+       ranks >=2 never create it and keep the dormant derived. */
+    MPI_Comm commAB;
+    MPI_Comm_split(
+        MPI_COMM_WORLD,
+        (world_rank <= 1) ? 0 : MPI_UNDEFINED,
+        world_rank,
+        &commAB);
+    if (commAB != MPI_COMM_NULL) {
+        ucc_rank_t ab[2] = {0, 1};
+        ucc_team_h t     = create_array_team(ctx, commAB, ab, 2);
+        run_barrier_on_team(t, ctx);
+        destroy_ucc_team(t, ctx);
+        MPI_Comm_free(&commAB);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    /* Re-create the ext_id-2 world team: split vote -> global MISS -> rebuild.
+       The allreduce exercises ctx_map/topo the rebuild must have populated. */
+    ucc_team_h rebuilt = create_world_team(ctx, world_size, /*ext_id=*/2);
+    int64_t    got     = run_allreduce_int64(
+        rebuilt, ctx, (int64_t)world_rank, "allreduce on rebuilt team");
+    int64_t exp = (int64_t)world_size * (world_size - 1) / 2;
+    if (got != exp) {
+        std::cerr << "*** UCC TEST FAIL: " << name << " rank " << world_rank
+                  << ": allreduce got " << got << " (exp " << exp << ")\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+    if (((ucc_team_t *)rebuilt)->is_derived != 0 ||
+        ((ucc_team_t *)rebuilt)->parent_id != 0) {
+        std::cerr << "*** UCC TEST FAIL: " << name << " rank " << world_rank
+                  << ": rebuilt team still marked derived (is_derived="
+                  << ((ucc_team_t *)rebuilt)->is_derived << ")\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    destroy_ucc_team(rebuilt, ctx);
+    run_barrier_on_team(parent, ctx); /* parent still functional */
+    destroy_ucc_team(parent, ctx);
+    ucc_team_cache_drain((ucc_context_t *)ctx);
+
+    if (0 == world_rank) {
+        std::cout << "PASS " << name << "\n";
+    }
+}
+
+/* ==========================================================================
+ * nonblocking_create_post: ucc_team_create_post must return promptly (post the
+ * vote, not block) even if one rank is late entering it. Rank 0 sleeps briefly;
+ * the other ranks call create_post and must return before rank 0 arrives.
+ * ========================================================================== */
+static void test_nonblocking_create_post(
+    ucc_context_h ctx, int world_rank, int world_size)
+{
+    ucc_team_params_t p;
+    ucc_team_h        team;
+    ucc_status_t      status;
+    /* Rank 0 sleeps kSleepMs; a non-blocking create_post on a peer returns in
+       milliseconds, a blocking one waits ~kSleepMs. Use a large sleep and a
+       threshold at half of it so oversubscribed scheduling jitter on the peer
+       (well under kThreshMs) cannot false-fail, while a real block (~kSleepMs) is
+       still caught. */
+    const int         kSleepMs  = 2000;
+    const int         kThreshMs = kSleepMs / 2;
+
+    if (world_size < 2) {
+        if (0 == world_rank) {
+            std::cout << "SKIP nonblocking_create_post (needs >=2 ranks)\n";
+        }
+        return;
+    }
+
+    /* Drain so this is a clean fresh create (the vote is posted regardless). */
+    MPI_Barrier(MPI_COMM_WORLD);
+    ucc_team_cache_drain((ucc_context_t *)ctx);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    double t_start = MPI_Wtime();
+    if (world_rank == 0) {
+        /* Delay entering create_post: peers must not be blocked waiting on us. */
+        usleep(kSleepMs * 1000);
+    }
+
+    fill_team_params(&p, MPI_COMM_WORLD, ep_map_full(world_size), 0);
+    UCC_CHECK(ucc_team_create_post(&ctx, 1, &p, &team));
+    double t_post = MPI_Wtime();
+
+    /* On a non-zero rank, create_post must have returned well before rank 0's
+       sleep elapsed - proving it posted (did not block on) the vote. */
+    if (world_rank != 0) {
+        double elapsed_ms = (t_post - t_start) * 1000.0;
+        if (elapsed_ms > (double)kThreshMs) {
+            std::cerr << "*** UCC TEST FAIL: nonblocking_create_post rank "
+                      << world_rank << " create_post blocked " << elapsed_ms
+                      << "ms (threshold " << kThreshMs << "ms, rank 0 delay "
+                      << kSleepMs << "ms)\n";
+            MPI_Abort(MPI_COMM_WORLD, -1);
+        }
+    }
+
+    /* Now drive the create to completion collectively and use it. */
+    while (UCC_INPROGRESS == (status = ucc_team_create_test(team))) {
+        ucc_context_progress(ctx);
+    }
+    if (status < 0) {
+        std::cerr << "*** UCC TEST FAIL: nonblocking_create_post create ("
+                  << ucc_status_string(status) << ")\n";
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+    run_barrier_on_team(team, ctx);
+    MPI_Barrier(MPI_COMM_WORLD);
+    destroy_ucc_team(team, ctx);
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (0 == world_rank) {
+        std::cout << "PASS nonblocking_create_post\n";
+    }
+}
+
+/* ==========================================================================
+ * singleton_team: a size-1 cacheable team creates + reuses correctly with no
+ * network vote (self-membership; the size>1 gate is not taken). Each rank builds
+ * its own {self} team independently over MPI_COMM_SELF.
+ * ========================================================================== */
+static void test_singleton_team(
+    ucc_context_h ctx, int world_rank, int world_size)
+{
+    ucc_rank_t self_map[1];
+
+    for (int i = 0; i < 3; i++) {
+        self_map[0]  = (ucc_rank_t)world_rank; /* team idx 0 -> my ctx rank */
+        ucc_team_h t = create_array_team(ctx, MPI_COMM_SELF, self_map, 1);
+        run_barrier_on_team(t, ctx);
+        destroy_ucc_team(t, ctx);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (0 == world_rank) {
+        std::cout << "PASS singleton_team\n";
+    }
+}
+
+void run_team_cache_tests(ucc_context_h ctx, int world_rank, int world_size)
+{
+    if (0 == world_rank) {
+        std::cout << "\n===== UCC Team Cache Correctness Tests =====\n";
+    }
+
+    /* These tests require caching to be enabled (they assert reuse/derivation that
+       only happens when the cache is live). If UCC_TEAM_CACHE_ENABLE was not set,
+       skip the whole suite rather than let a test MPI_Abort the job. */
+    if (((ucc_context_t *)ctx)->team_cache == NULL) {
+        if (0 == world_rank) {
+            std::cout << "SKIP all team-cache tests: caching disabled "
+                         "(set UCC_TEAM_CACHE_ENABLE=y)\n"
+                      << "===== Team Cache Tests DONE =====\n";
+        }
+        return;
+    }
+
+    test_dup_coexist_derived(ctx, world_rank, world_size, /*ext_ids=*/false);
+    MPI_Barrier(MPI_COMM_WORLD);
+    test_dup_coexist_derived(ctx, world_rank, world_size, /*ext_ids=*/true);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    test_dormant_reuse_stats(ctx, world_rank, world_size);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    test_derived_reuse(ctx, world_rank, world_size, /*drift=*/false);
+    MPI_Barrier(MPI_COMM_WORLD);
+    test_derived_reuse(ctx, world_rank, world_size, /*drift=*/true);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    test_ep_map_cb_freed_after_cache(ctx, world_rank, world_size);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    test_overlap_agreement(ctx, world_rank, world_size);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    test_derived_exact_rebuild(ctx, world_rank, world_size);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    test_nonblocking_create_post(ctx, world_rank, world_size);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    test_singleton_team(ctx, world_rank, world_size);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (0 == world_rank) {
+        std::cout << "===== Team Cache Tests DONE =====\n\n";
+    }
+}


### PR DESCRIPTION
## What

Adds transparent team caching to UCC core. When enabled
(`UCC_TEAM_CACHE_ENABLE=y`, default off), teams built for identical-membership
communicator groups are cached and reused instead of being rebuilt on every
create. No public API changes; non-cache create and destroy paths are untouched.

The main pieces:
- **Dormant reuse.** A destroyed team is retained and re-adopted when an
  identical-membership team is created again.
- **Derived teams.** A second identical-membership create while the first team
  is still live (e.g. `MPI_Comm_dup`) builds a lightweight derived team that
  borrows the parent's immutable membership and topology artifacts while getting
  its own team id and tag domain — skipping address exchange and topology build.
- **Cross-rank agreement** (`UCC_TEAM_CACHE_AGREEMENT`, default on). A small
  member-scoped allreduce reconciles each member's reuse-versus-fresh decision
  so reuse stays safe even for overlapping subcommunicators.
- **Eviction policies:** `none`, `fifo`, and `lfu` (with `lru` accepted as an
  alias), clamped against the team-id pool so cached teams cannot exhaust it.
- **Experimental cid-drift reseat** (`UCC_TEAM_CACHE_RESEAT`, default off).

New configuration knobs are documented in `docs/user_guide.md`.

## Why

Building a `ucc_team` is expensive: it involves an out-of-band address exchange,
unique team-id allocation, and per-component initialization. Workloads that
repeatedly create and destroy communicators, or that duplicate identical-membership
communicators, pay that full cost every time. Caching lets those patterns reuse
existing teams, which cuts team-management overhead substantially while keeping
collective results identical.

## How

**Identity.** A team is keyed by an FNV-1a hash over the materialized rank
membership plus the caller's own endpoint. The external id is compared but not
hashed, and lookup verifies the full membership array to guard against hash
collisions.

**Lifecycle.** A cached team moves through NONE, DORMANT, RESERVED, and LIVE
states, all under the cache lock. A destroyed team drops to DORMANT at refcount 0
and is re-adopted on a later matching create.

```mermaid
stateDiagram-v2
    direction TB

    [*] --> NONE : allocate

    NONE --> LIVE : build complete (addr-exchange + topo + CL/TL)

    LIVE --> DORMANT : destroy — refcount → 0, team retained

    DORMANT --> LIVE : direct re-adopt (size == 1 or agreement off)
    DORMANT --> RESERVED : cache hit, size > 1 — cross-rank vote posted

    RESERVED --> LIVE : vote unanimous → promote
    RESERVED --> NONE : vote lost → rebuild in place

    DORMANT --> [*] : eviction

    note right of LIVE
        DERIVED_FROM_LIVE: when a LIVE team of identical membership
        exists, a new derived team borrows the parent's ctx_map,
        ctx_ranks, and topo — skipping address exchange and topo
        build entirely. The derived team follows its own NONE→LIVE
        path; the parent stays LIVE unchanged.
    end note
```

**Artifacts refactor.** `ctx_map`, `ctx_ranks`, and `topo` are moved from direct
fields on `ucc_team_t` into a refcounted `ucc_team_artifacts_t` holder so derived
teams can safely borrow a parent's immutable data. New accessor macros
`UCC_TEAM_CTX_MAP()`, `UCC_TEAM_CTX_RANKS()`, and `UCC_TEAM_TOPO()` replace all
direct field references across CL/TL components.

**Agreement.** On a cacheable multi-rank create, every member posts a nonblocking
vote (an allreduce over the context service team) so all ranks commit the same
reuse-or-fresh action. If any rank lacks a service team, every rank disables the
cache for that create.

**Derived teams** borrow the parent's refcounted artifacts holder. The topology is
fully materialized before sharing (via `ucc_topo_prepare_shared`) so concurrent
access across the parent and its derived teams is race-free.

**Eviction** is coupled to the team-id pool. `max_size` is clamped so dormant
teams reserve id-pool headroom, and eviction runs proactively so a free id is
always available before the next pre-active allocation.

Also fixes a pre-existing bug in the team-id pool bit-manipulation: the word
index used `id/64` instead of `(id-1)/64`, causing misindexing for every
multiple-of-64 team id.

## Testing

- gtest unit coverage in `test/gtest/core/test_team_cache.cc`: identity and
  hashing, eviction policies, chained buckets, lifecycle and refcount, the
  RESERVED state, the agreement vote, and concurrency.
- MPI multi-rank correctness in `test/mpi/test_team_cache.cc`: dup coexistence,
  dormant reuse, derived rebuild, freed-callback safety, divergent-eviction
  agreement, and non-blocking create. Set `UCC_TEAM_CACHE_CORRECTNESS_TESTS=y`
  to activate. Passing at 8 ranks.
- A cache on-versus-off equivalence script (`test/mpi/run_cache_equivalence.sh`)
  that also asserts the cache was actually exercised.

## Notes for reviewers

- Disabled by default — no behavior change unless `UCC_TEAM_CACHE_ENABLE=y`.
- The RESEAT feature (`UCC_TEAM_CACHE_RESEAT`) is experimental and off by default;
  it is safe to ignore for an initial review.