### PR TITLE
CI: Suppress credentials in logs output

### DIFF
--- a/.ci/scripts/coverity.sh
+++ b/.ci/scripts/coverity.sh
@@ -140,8 +140,10 @@ function main() {
     fi
 
     echo "Uploading to synopsys main coverity server"
+    set +x -v
     cov-commit-defects --ssl --on-new-cert trust --host coverity.mellanox.com --port 8443 \
     --user "${UCC_USERNAME}" --password "${UCC_PASSWORD}" --dir "$COV_BUILD_DIR" --stream ucc_master
+    set +v -x
     return 0
 }
 

--- a/.ci/scripts/enroot_setup.sh
+++ b/.ci/scripts/enroot_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -ve
 
 # Configure enroot credentials if provided
 if [[ -n "${ENROOT_USERNAME}" && -n "${ENROOT_PASSWORD}" ]]; then


### PR DESCRIPTION
## What
set -x would expose users and passwords in CI logs. Wrap those lines with set +x/set -x so the values are never traced, regardless of how credentials are injected.

## Why ?
[HPCINFRA-3435](https://jirasw.nvidia.com/browse/HPCINFRA-3435)

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
