### PR TITLE
CI: Replace Blue Ocean with pipeline-overview URL

### DIFF
--- a/.ci/Jenkinsfile.shlib
+++ b/.ci/Jenkinsfile.shlib
@@ -12,15 +12,15 @@
 def matrix = new com.mellanox.cicd.Matrix()
 
 def githubHelper = null
-def blueOceanUrl = ""
+def pipelineOverviewUrl = ""
 
 import ipp.blossom.*
 if (params.githubData) {
     withCredentials([usernamePassword(credentialsId: 'svcnbu-swx-hpcx-github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
         githubHelper = GithubHelper.getInstance("${GIT_PASSWORD}", githubData)
     }
-    blueOceanUrl = "${JENKINS_URL}blue/organizations/jenkins/UCC%2F${env.JOB_BASE_NAME}/detail/${env.JOB_BASE_NAME}/${env.BUILD_NUMBER}/pipeline/"
-    githubHelper.updateCommitStatus(blueOceanUrl, "Test started", GitHubCommitState.PENDING, env.JOB_BASE_NAME)
+    pipelineOverviewUrl = "${env.BUILD_URL}/pipeline-overview/"
+    githubHelper.updateCommitStatus(pipelineOverviewUrl, "Test started", GitHubCommitState.PENDING, env.JOB_BASE_NAME)
     currentBuild.description = githubHelper.getBuildDescription()
 }
 
@@ -50,6 +50,6 @@ try {
     throw ex
 } finally {
     if (params.githubData) {
-        githubHelper.updateCommitStatus(blueOceanUrl, "Test completed", currentBuild.resultIsBetterOrEqualTo('SUCCESS') ? GitHubCommitState.SUCCESS : GitHubCommitState.FAILURE, env.JOB_BASE_NAME)
+        githubHelper.updateCommitStatus(pipelineOverviewUrl, "Test completed", currentBuild.resultIsBetterOrEqualTo('SUCCESS') ? GitHubCommitState.SUCCESS : GitHubCommitState.FAILURE, env.JOB_BASE_NAME)
     }
 }

--- a/.ci/proj_jjb.yaml
+++ b/.ci/proj_jjb.yaml
@@ -183,8 +183,8 @@
       withCredentials([usernamePassword(credentialsId: 'svcnbu-swx-hpcx-github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {{
         githubHelper = GithubHelper.getInstance("${{GIT_PASSWORD}}", VARIABLE_FROM_POST)
       }}
-      def blueOceanUrl = "${{JENKINS_URL}}blue/organizations/jenkins/{jjb_folder}%2F${{env.JOB_BASE_NAME}}/detail/${{env.JOB_BASE_NAME}}/${{env.BUILD_NUMBER}}/pipeline/"
-      githubHelper.updateCommitStatus(blueOceanUrl, "Blossom CI started", GitHubCommitState.PENDING)
+      def pipelineOverviewUrl = "${{env.BUILD_URL}}/pipeline-overview/"
+      githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI started", GitHubCommitState.PENDING)
       currentBuild.description = githubHelper.getBuildDescription()
       try {{
         parallel 'ucc-build-hpcsdk': {{
@@ -218,10 +218,10 @@
                 string(name: 'githubData', value: VARIABLE_FROM_POST)
             ], propagate: false, wait: true
         }}
-        githubHelper.updateCommitStatus(blueOceanUrl, "Blossom CI ended", GitHubCommitState.SUCCESS)
+        githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI ended", GitHubCommitState.SUCCESS)
       }} catch(Exception ex) {{
           println ex
-          githubHelper.updateCommitStatus(blueOceanUrl, "Blossom CI ended", GitHubCommitState.FAILURE)
+          githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI ended", GitHubCommitState.FAILURE)
           throw ex
       }}
 


### PR DESCRIPTION
## What
Replace GitHub commit status links to point to Jenkins' pipeline-overview page instead of Blue Ocean UI.

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
