### PR TITLE
TOOLS: fix in-place ReduceScatter buffer size

### DIFF
--- a/tools/perf/ucc_pt_coll_reduce_scatter.cc
+++ b/tools/perf/ucc_pt_coll_reduce_scatter.cc
@@ -54,14 +54,15 @@ ucc_status_t ucc_pt_coll_reduce_scatter::init_args(ucc_pt_test_args_t &test_args
     dst_header = nullptr;
     if (UCC_IS_INPLACE(args)) {
         args.src.info.count = 0;
-        args.dst.info.count = generator->get_dst_count();
+        /* In-place dst contains the full source buffer. */
+        args.dst.info.count = generator->get_src_count();
     } else {
         args.src.info.count = generator->get_src_count();
         args.dst.info.count = generator->get_dst_count();
     }
 
     UCCCHECK_GOTO(ucc_pt_alloc(&dst_header,
-                               generator->get_dst_count() * dt_size,
+                               args.dst.info.count * dt_size,
                                args.dst.info.mem_type),
                   exit, st);
     args.dst.info.buffer = dst_header->addr;


### PR DESCRIPTION
## Summary

- use the full source count for in-place ReduceScatter
- allocate the in-place destination from the count passed to UCC

## Rationale

For ReduceScatter, the generator destination count describes one rank's output
shard, while the source count describes the full input. In-place operation uses
the destination as the source buffer, so passing the destination shard count
makes the operation smaller than the Count/Size reported by `ucc_perftest`.

## Testing

- built UCC with the change
- verified in-place and out-of-place collective arguments at 2, 4, and 8 ranks
  with host/CUDA memory and TL/UCP ring/K-nomial
- ran 10,240 MPI-reference ReduceScatter cases: all passed
