### PR TITLE
CORE: Fix team-id pool off-by-one at 64 boundary

### DIFF
--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -568,8 +568,8 @@ ucc_status_t ucc_team_destroy(ucc_team_h team)
     return ucc_team_destroy_single(team);
 }
 
-static inline int
-find_first_set_and_zero(uint64_t *value) {
+int ucc_team_id_pool_ffs_clear(uint64_t *value)
+{
     int i;
     for (i=0; i<64; i++) {
         if (*value & ((uint64_t)1 << i)) {
@@ -580,9 +580,10 @@ find_first_set_and_zero(uint64_t *value) {
     return 0;
 }
 
-static inline void
-set_id_bit(uint64_t *local, int id) {
-    int map_pos = id / 64;
+void ucc_team_id_pool_set_bit(uint64_t *local, int id)
+{
+    /* Inverse of the layout ucc_team_alloc_id uses */
+    int map_pos = (id-1) / 64;
     int pos = (id-1) % 64;
     ucc_assert(id >= 1);
     local[map_pos] |= ((uint64_t)1 << pos);
@@ -640,7 +641,7 @@ static ucc_status_t ucc_team_alloc_id(ucc_team_t *team)
     memcpy(local, global, ctx->ids.pool_size*sizeof(uint64_t));
     pos = 0;
     for (i=0; i<ctx->ids.pool_size; i++) {
-        if ((pos = find_first_set_and_zero(&local[i])) > 0) {
+        if ((pos = ucc_team_id_pool_ffs_clear(&local[i])) > 0) {
             break;
         }
     }
@@ -662,6 +663,6 @@ static void ucc_team_release_id(ucc_team_t *team)
     ucc_context_t *ctx = team->contexts[0];
     /* release the id pool bit if it was not provided by user */
     if (0 != team->id && !UCC_TEAM_ID_IS_EXTERNAL(team)) {
-        set_id_bit(ctx->ids.pool, team->id);
+        ucc_team_id_pool_set_bit(ctx->ids.pool, team->id);
     }
 }

--- a/src/core/ucc_team.c
+++ b/src/core/ucc_team.c
@@ -582,10 +582,12 @@ int ucc_team_id_pool_ffs_clear(uint64_t *value)
 
 void ucc_team_id_pool_set_bit(uint64_t *local, int id)
 {
-    /* Inverse of the layout ucc_team_alloc_id uses */
-    int map_pos = (id-1) / 64;
-    int pos = (id-1) % 64;
+    int map_pos;
+    int pos;
+
     ucc_assert(id >= 1);
+    map_pos = (id-1) / 64;
+    pos     = (id-1) % 64;
     local[map_pos] |= ((uint64_t)1 << pos);
 }
 

--- a/src/core/ucc_team.h
+++ b/src/core/ucc_team.h
@@ -57,6 +57,10 @@ typedef struct ucc_team {
 
 void ucc_copy_team_params(ucc_team_params_t *dst, const ucc_team_params_t *src);
 
+/* Team-id pool bit helpers; bit (pos - 1) of word i encodes id i * 64 + pos */
+int  ucc_team_id_pool_ffs_clear(uint64_t *value);
+void ucc_team_id_pool_set_bit(uint64_t *local, int id);
+
 /* Returns addressing information for "rank" in a team.
    If ucc context was created with OOB then addr storage is located on context.
    In that case we need to map rank to ctx_rank first. Otherwise, addr

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -77,6 +77,7 @@ gtest_SOURCES =                           \
 	core/test_mc.cc                       \
 	core/test_mc_reduce.cc                \
 	core/test_team.cc                     \
+	core/test_team_id_pool.cc             \
 	core/test_schedule.cc                 \
 	core/test_topo.cc                     \
 	core/test_service_coll.cc             \

--- a/test/gtest/core/test_team_id_pool.cc
+++ b/test/gtest/core/test_team_id_pool.cc
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * See file LICENSE for terms.
+ */
+#include "common/test_ucc.h"
+extern "C" {
+#include "core/ucc_team.h"
+}
+
+class test_team_id_pool : public ucc::test {
+};
+
+/* Team-id pool bit helpers must be exact inverses at word boundaries. */
+UCC_TEST_F(test_team_id_pool, bit_boundaries)
+{
+    const int ids[] = {1, 63, 64, 65, 127, 128, 129, 191, 192};
+
+    for (size_t k = 0; k < sizeof(ids) / sizeof(ids[0]); k++) {
+        int      id      = ids[k];
+        uint64_t pool[4] = {0, 0, 0, 0}; /* covers ids 1..256 */
+
+        ucc_team_id_pool_set_bit(pool, id);
+
+        int set_words = 0;
+        for (int w = 0; w < 4; w++) {
+            if (pool[w]) {
+                set_words++;
+            }
+        }
+        EXPECT_EQ(1, set_words) << "id " << id << " set bits in multiple words";
+
+        int found = 0, pos = 0;
+        for (int w = 0; w < 4; w++) {
+            if ((pos = ucc_team_id_pool_ffs_clear(&pool[w])) > 0) {
+                found = w * 64 + pos;
+                break;
+            }
+        }
+        EXPECT_EQ(id, found)
+            << "released id " << id << " re-scanned as " << found;
+
+        for (int w = 0; w < 4; w++) {
+            EXPECT_EQ((uint64_t)0, pool[w])
+                << "id " << id << " left residue in word " << w;
+        }
+    }
+}


### PR DESCRIPTION
## What
Fix an off-by-one in the team-id pool release path. `ucc_team_release_id` computed `map_pos = id / 64`, which misplaces the bit for any id that is a multiple of 64: id 64 writes to word 1 bit 63 (the slot for id 128) instead of word 0 bit 63. The fix is `(id - 1) / 64`. The assert guarding `id >= 1` is also moved before the arithmetic so it fires before any signed subtraction on an invalid id.

A new `test_team_id_pool.cc` gtest covers boundary ids 1, 63, 64, 65, 127, 128, 129, 191, 192.

## Why
The allocation path produces ids via `i * 64 + pos` where `pos ∈ [1, 64]`, so multiples of 64 are valid ids. The release path missed them, leaking the id and double-freeing an unrelated slot. The bug is latent in typical workloads where fewer than 64 teams coexist, but fires reliably once more teams are live simultaneously.